### PR TITLE
Add top-level CMakeLists.txt for project test binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(ocean_imu LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Match existing Makefile optimization profile.
+add_compile_options(-O3 -funroll-loops -fno-finite-math-only)
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang" AND NOT WIN32)
+  add_compile_options(-march=native)
+endif()
+
+set(OCEAN_IMU_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src")
+set(OCEAN_IMU_TESTS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/tests")
+
+# Include project headers.
+include_directories("${OCEAN_IMU_SRC_DIR}")
+
+# Eigen include fallback: vendored copy first, then system path.
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/third_party/eigen")
+  include_directories("${CMAKE_CURRENT_SOURCE_DIR}/third_party/eigen")
+else()
+  include_directories("/usr/include/eigen3")
+endif()
+
+set(W3D_SIM_COMMON "${OCEAN_IMU_SRC_DIR}/util/W3dSimCommon.cpp")
+
+add_executable(ahrs-qmekf-sim "${OCEAN_IMU_TESTS_DIR}/ahrs/ahrs-qmekf-sim.cpp" ${W3D_SIM_COMMON})
+add_executable(detrend-basic-test "${OCEAN_IMU_TESTS_DIR}/detrend/detrend-basic-test.cpp")
+add_executable(freq-track "${OCEAN_IMU_TESTS_DIR}/freq/freq-track.cpp")
+add_executable(imu_calibrate-test "${OCEAN_IMU_TESTS_DIR}/imu_calibrate/imu_calibrate-test.cpp")
+add_executable(kalman_ou_ii-sim "${OCEAN_IMU_TESTS_DIR}/kalman_ou_ii/kalman_ou_ii-sim.cpp" ${W3D_SIM_COMMON})
+add_executable(kalman_ou_iii-sim "${OCEAN_IMU_TESTS_DIR}/kalman_ou_iii/kalman_ou_iii-sim.cpp" ${W3D_SIM_COMMON})
+add_executable(pii_observer-adaptive "${OCEAN_IMU_TESTS_DIR}/pii_observer/pii_observer-adaptive.cpp" ${W3D_SIM_COMMON})


### PR DESCRIPTION
### Motivation
- Provide a top-level CMake entry so the repository can be configured and built with CMake in addition to the existing per-test `Makefile` targets. 
- Preserve the existing compilation profile and optimization flags used by the `tests/*/Makefile` files. 
- Make Eigen headers discoverable in environments where system include paths differ by preferring a vendored `third_party/eigen` and falling back to `/usr/include/eigen3`.

### Description
- Add a new `CMakeLists.txt` that sets C++20 and compiler options and mirrors the Makefile optimization profile with `-O3 -funroll-loops -fno-finite-math-only` and adds `-march=native` for GNU/Clang on non-Windows. 
- Configure project include paths to `src/` and implement an Eigen include fallback that uses `third_party/eigen` if present or `/usr/include/eigen3` otherwise. 
- Define top-level CMake targets for the existing test executables and include `src/util/W3dSimCommon.cpp` in targets that need it. 
- Keep the change minimal and do not modify public APIs, filenames, or existing Make-based test workflows.

### Testing
- Running `make all` at the repository root fails because there is no top-level Makefile, which is unchanged by this PR. 
- Configured and built with `cmake -S . -B build && cmake --build build -j4`, which succeeded and produced the test binaries `ahrs-qmekf-sim`, `detrend-basic-test`, `freq-track`, `imu_calibrate-test`, `pii_observer-adaptive`, `kalman_ou_ii-sim`, and `kalman_ou_iii-sim`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca0d9707d48328b3af6889b3d9cd14)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build system configuration to support project compilation with optimized compiler settings and enable multiple test and simulation tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->