### PR TITLE
Add spectrum and wavelet estimator comparison tests with reference spectra and plotting

### DIFF
--- a/doc/spectrum/spectrum-estimates-plots.tex
+++ b/doc/spectrum/spectrum-estimates-plots.tex
@@ -1,0 +1,36 @@
+\documentclass[11pt,letterpaper]{article}
+\usepackage{amsmath}
+\usepackage{amssymb}
+\usepackage{fullpage}
+\usepackage{graphicx}
+\usepackage{pgf}
+\usepackage{float}
+\providecommand{\mathdefault}[1]{#1}
+
+\title{Spectrum Estimator Charts}
+\author{Mikhail Grushinskiy}
+\date{2026}
+
+\begin{document}
+\maketitle
+
+\newcommand{\specpair}[3]{%
+\begin{figure}[H]\centering
+\begin{minipage}{0.49\textwidth}
+\resizebox{\linewidth}{!}{\input{spectrum_estimates_#1_#2_spectrum.pgf}}
+\end{minipage}\hfill
+\begin{minipage}{0.49\textwidth}
+\resizebox{\linewidth}{!}{\input{spectrum_estimates_#1_#2_timeseries.pgf}}
+\end{minipage}
+\caption{#3 estimator against simulation reference spectrum at #2 sea state. Left: final block $S_\eta(f)$ comparison. Right: $H_s$ and $T_p$ evolution over blocks.}
+\end{figure}
+}
+
+\specpair{pmstokes}{low}{PM Stokes}
+\specpair{pmstokes}{medium}{PM Stokes}
+\specpair{pmstokes}{high}{PM Stokes}
+\specpair{jonswap}{low}{JONSWAP}
+\specpair{jonswap}{medium}{JONSWAP}
+\specpair{jonswap}{high}{JONSWAP}
+
+\end{document}

--- a/doc/spectrum/spectrum-wavelets-plots.tex
+++ b/doc/spectrum/spectrum-wavelets-plots.tex
@@ -1,0 +1,36 @@
+\documentclass[11pt,letterpaper]{article}
+\usepackage{amsmath}
+\usepackage{amssymb}
+\usepackage{fullpage}
+\usepackage{graphicx}
+\usepackage{pgf}
+\usepackage{float}
+\providecommand{\mathdefault}[1]{#1}
+
+\title{Wavelet Spectrum Estimator Charts}
+\author{Mikhail Grushinskiy}
+\date{2026}
+
+\begin{document}
+\maketitle
+
+\newcommand{\specpairw}[3]{%
+\begin{figure}[H]\centering
+\begin{minipage}{0.49\textwidth}
+\resizebox{\linewidth}{!}{\input{spectrum_wavelets_estimates_#1_#2_spectrum.pgf}}
+\end{minipage}\hfill
+\begin{minipage}{0.49\textwidth}
+\resizebox{\linewidth}{!}{\input{spectrum_wavelets_estimates_#1_#2_timeseries.pgf}}
+\end{minipage}
+\caption{#3 wavelet estimator against simulation reference spectrum at #2 sea state. Left: final block $S_\eta(f)$ comparison. Right: $H_s$ and $T_p$ evolution over blocks.}
+\end{figure}
+}
+
+\specpairw{pmstokes}{low}{PM Stokes}
+\specpairw{pmstokes}{medium}{PM Stokes}
+\specpairw{pmstokes}{high}{PM Stokes}
+\specpairw{jonswap}{low}{JONSWAP}
+\specpairw{jonswap}{medium}{JONSWAP}
+\specpairw{jonswap}{high}{JONSWAP}
+
+\end{document}

--- a/plots/spectrum/draw_plots.sh
+++ b/plots/spectrum/draw_plots.sh
@@ -1,3 +1,5 @@
 #!/bin/bash -e
 
 python3 spectrum-plots.py
+python3 spectrum-estimates-plots.py
+python3 spectrum-wavelets-estimates-plots.py

--- a/plots/spectrum/spectrum-estimates-plots.py
+++ b/plots/spectrum/spectrum-estimates-plots.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+import glob
+import os
+import re
+
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from matplotlib.backends.backend_pgf import FigureCanvasPgf
+
+mpl.backend_bases.register_backend('pgf', FigureCanvasPgf)
+plt.rcParams.update({
+    "pgf.texsystem": "xelatex",
+    "font.family": "serif",
+    "text.usetex": True,
+    "pgf.rcfonts": False,
+    "pgf.preamble": "\n".join([
+        r"\usepackage{fontspec}",
+        r"\usepackage{unicode-math}",
+        r"\usepackage{amsmath}",
+        r"\setmainfont{DejaVu Serif}",
+        r"\setmathfont{Latin Modern Math}",
+        r"\providecommand{\mathdefault}[1]{#1}",
+    ]),
+})
+
+height_groups = {
+    "low": 0.27,
+    "medium": 1.50,
+    "high": 8.50,
+}
+
+fname_re = re.compile(
+    r"^spectrum_estimate_(?P<wtype>[a-z]+)_H(?P<H>[0-9.]+)_L(?P<L>[0-9.]+)_A(?P<A>[-0-9.]+)_P(?P<P>[-0-9.]+)\.csv$"
+)
+
+
+def parse_filename(fname):
+    m = fname_re.match(os.path.basename(fname))
+    if not m:
+        return None
+    return {
+        "wtype": m.group("wtype"),
+        "H": float(m.group("H")),
+        "A": float(m.group("A")),
+    }
+
+
+def save_all(fig, base):
+    fig.savefig(f"{base}.pgf", bbox_inches="tight", backend="pgf")
+    fig.savefig(f"{base}.svg", bbox_inches="tight", dpi=150)
+    with mpl.rc_context({"text.usetex": False}):
+        fig.savefig(f"{base}.png", bbox_inches="tight", dpi=300)
+
+
+def spectrum_cols(df):
+    freq_map = {}
+    for c in df.columns:
+        if c.startswith("S_eta_est_f") and "_Hz=" in c:
+            idx = int(c.split("_f")[1].split("_Hz=")[0])
+            freq_map[idx] = float(c.split("_Hz=")[1])
+    idxs = sorted(freq_map.keys())
+    est_cols = [f"S_eta_est_f{i}_Hz={freq_map[i]}" for i in idxs]
+    ref_cols = [f"S_eta_ref_f{i}" for i in idxs]
+    freqs = np.array([freq_map[i] for i in idxs])
+    return freqs, est_cols, ref_cols
+
+
+def make_plots(fname, group, meta):
+    df = pd.read_csv(fname)
+    if df.empty:
+        return
+
+    freqs, est_cols, ref_cols = spectrum_cols(df)
+    last = df.iloc[-1]
+
+    base = f"spectrum_estimates_{meta['wtype']}_{group}"
+    title = fr"{meta['wtype'].capitalize()} estimator vs reference ($H_s={meta['H']:.2f}\,\mathrm{{m}}$)"
+
+    fig, ax = plt.subplots()
+    ax.plot(freqs, last[est_cols].to_numpy(dtype=float), label="Estimator", linewidth=2)
+    ax.plot(freqs, last[ref_cols].to_numpy(dtype=float), label="Reference", linewidth=2, linestyle="--")
+    ax.set_xlabel(r"Frequency $f$ [Hz]")
+    ax.set_ylabel(r"$S_{\eta}(f)$")
+    ax.set_title(title)
+    ax.grid(True, alpha=0.3)
+    ax.legend()
+    save_all(fig, f"{base}_spectrum")
+    plt.close(fig)
+
+    fig2, ax2 = plt.subplots()
+    ax2.plot(df["time"], df["Hs"], label=r"$H_s$", linewidth=2)
+    ax2.plot(df["time"], 1.0 / np.maximum(df["Fp"], 1e-9), label=r"$T_p=1/f_p$", linewidth=2)
+    ax2.set_xlabel("Time [s]")
+    ax2.set_ylabel("Estimate")
+    ax2.set_title(title)
+    ax2.grid(True, alpha=0.3)
+    ax2.legend()
+    save_all(fig2, f"{base}_timeseries")
+    plt.close(fig2)
+
+
+if __name__ == "__main__":
+    files = glob.glob("spectrum_estimate_*.csv")
+    if not files:
+        print("No spectrum_estimate_*.csv files found.")
+        raise SystemExit(0)
+
+    for fname in sorted(files):
+        meta = parse_filename(fname)
+        if not meta:
+            continue
+        for group, target_H in height_groups.items():
+            if abs(meta["H"] - target_H) < 1e-3:
+                print(f"Processing {fname} as {group} ...")
+                make_plots(fname, group, meta)

--- a/plots/spectrum/spectrum-wavelets-estimates-plots.py
+++ b/plots/spectrum/spectrum-wavelets-estimates-plots.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+import glob
+import os
+import re
+
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from matplotlib.backends.backend_pgf import FigureCanvasPgf
+
+mpl.backend_bases.register_backend('pgf', FigureCanvasPgf)
+plt.rcParams.update({
+    "pgf.texsystem": "xelatex",
+    "font.family": "serif",
+    "text.usetex": True,
+    "pgf.rcfonts": False,
+    "pgf.preamble": "\n".join([
+        r"\usepackage{fontspec}",
+        r"\usepackage{unicode-math}",
+        r"\usepackage{amsmath}",
+        r"\setmainfont{DejaVu Serif}",
+        r"\setmathfont{Latin Modern Math}",
+        r"\providecommand{\mathdefault}[1]{#1}",
+    ]),
+})
+
+height_groups = {
+    "low": 0.27,
+    "medium": 1.50,
+    "high": 8.50,
+}
+
+fname_re = re.compile(
+    r"^spectrum_wavelets_estimate_(?P<wtype>[a-z]+)_H(?P<H>[0-9.]+)_L(?P<L>[0-9.]+)_A(?P<A>[-0-9.]+)_P(?P<P>[-0-9.]+)\.csv$"
+)
+
+
+def parse_filename(fname):
+    m = fname_re.match(os.path.basename(fname))
+    if not m:
+        return None
+    return {
+        "wtype": m.group("wtype"),
+        "H": float(m.group("H")),
+        "A": float(m.group("A")),
+    }
+
+
+def save_all(fig, base):
+    fig.savefig(f"{base}.pgf", bbox_inches="tight", backend="pgf")
+    fig.savefig(f"{base}.svg", bbox_inches="tight", dpi=150)
+    with mpl.rc_context({"text.usetex": False}):
+        fig.savefig(f"{base}.png", bbox_inches="tight", dpi=300)
+
+
+def spectrum_cols(df):
+    freq_map = {}
+    for c in df.columns:
+        if c.startswith("S_eta_est_f") and "_Hz=" in c:
+            idx = int(c.split("_f")[1].split("_Hz=")[0])
+            freq_map[idx] = float(c.split("_Hz=")[1])
+    idxs = sorted(freq_map.keys())
+    est_cols = [f"S_eta_est_f{i}_Hz={freq_map[i]}" for i in idxs]
+    ref_cols = [f"S_eta_ref_f{i}" for i in idxs]
+    freqs = np.array([freq_map[i] for i in idxs])
+    return freqs, est_cols, ref_cols
+
+
+def make_plots(fname, group, meta):
+    df = pd.read_csv(fname)
+    if df.empty:
+        return
+
+    freqs, est_cols, ref_cols = spectrum_cols(df)
+    last = df.iloc[-1]
+
+    base = f"spectrum_wavelets_estimates_{meta['wtype']}_{group}"
+    title = fr"{meta['wtype'].capitalize()} wavelet estimator vs reference ($H_s={meta['H']:.2f}\,\mathrm{{m}}$)"
+
+    fig, ax = plt.subplots()
+    ax.plot(freqs, last[est_cols].to_numpy(dtype=float), label="Wavelet estimator", linewidth=2)
+    ax.plot(freqs, last[ref_cols].to_numpy(dtype=float), label="Reference", linewidth=2, linestyle="--")
+    ax.set_xlabel(r"Frequency $f$ [Hz]")
+    ax.set_ylabel(r"$S_{\eta}(f)$")
+    ax.set_title(title)
+    ax.grid(True, alpha=0.3)
+    ax.legend()
+    save_all(fig, f"{base}_spectrum")
+    plt.close(fig)
+
+    fig2, ax2 = plt.subplots()
+    ax2.plot(df["time"], df["Hs"], label=r"$H_s$", linewidth=2)
+    ax2.plot(df["time"], 1.0 / np.maximum(df["Fp"], 1e-9), label=r"$T_p=1/f_p$", linewidth=2)
+    ax2.set_xlabel("Time [s]")
+    ax2.set_ylabel("Estimate")
+    ax2.set_title(title)
+    ax2.grid(True, alpha=0.3)
+    ax2.legend()
+    save_all(fig2, f"{base}_timeseries")
+    plt.close(fig2)
+
+
+if __name__ == "__main__":
+    files = glob.glob("spectrum_wavelets_estimate_*.csv")
+    if not files:
+        print("No spectrum_wavelets_estimate_*.csv files found.")
+        raise SystemExit(0)
+
+    for fname in sorted(files):
+        meta = parse_filename(fname)
+        if not meta:
+            continue
+        for group, target_H in height_groups.items():
+            if abs(meta["H"] - target_H) < 1e-3:
+                print(f"Processing {fname} as {group} ...")
+                make_plots(fname, group, meta)

--- a/tests/spectrum/Makefile
+++ b/tests/spectrum/Makefile
@@ -1,3 +1,33 @@
-.PHONY: all
-all:
-	@true
+CC = g++
+BASEFLAGS = -O3 -std=c++20 -funroll-loops -fno-finite-math-only -I./../../src
+
+ifneq (,$(wildcard ../../third_party/eigen/Eigen/Dense))
+    EIGEN_INC = -I./../../third_party/eigen
+else
+    EIGEN_INC = -I/usr/include/eigen3
+endif
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+    CXXFLAGS = $(BASEFLAGS) $(EIGEN_INC) -march=native
+else ifeq ($(UNAME_S),Darwin)
+    CXXFLAGS = $(BASEFLAGS) $(EIGEN_INC) -march=native
+else
+    CXXFLAGS = $(BASEFLAGS) $(EIGEN_INC)
+endif
+
+TARGETS = spectrum-estimator-sim spectrum-wavelets-estimator-sim
+
+all: $(TARGETS)
+
+spectrum-estimator-sim: spectrum-estimator-sim.o
+	$(CC) $(CXXFLAGS) -o $@ $^
+
+spectrum-wavelets-estimator-sim: spectrum-wavelets-estimator-sim.o
+	$(CC) $(CXXFLAGS) -o $@ $^
+
+%.o: %.cpp
+	$(CC) $(CXXFLAGS) -c $< -o $@
+
+clean:
+	rm -f *.o $(TARGETS) *.exe spectrum_estimate_*.csv spectrum_wavelets_estimate_*.csv

--- a/tests/spectrum/run_tests.sh
+++ b/tests/spectrum/run_tests.sh
@@ -1,3 +1,4 @@
 #!/bin/bash -e
 
-echo "Nothing to be done."
+./spectrum-estimator-sim
+./spectrum-wavelets-estimator-sim

--- a/tests/spectrum/spectrum-estimator-sim.cpp
+++ b/tests/spectrum/spectrum-estimator-sim.cpp
@@ -1,0 +1,194 @@
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <random>
+#include <set>
+#include <string>
+#include <vector>
+
+#define EIGEN_NON_ARDUINO
+#include <Eigen/Dense>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#include "util/WaveFilesSupport.h"
+#include "ahrs/FrameConversions.h"
+
+const float g_std = 9.80665f;
+
+#include "spectrum/WaveSpectrumEstimator.h"
+
+using Eigen::Vector3f;
+
+struct NoiseModel {
+    std::default_random_engine rng;
+    std::normal_distribution<float> dist;
+    Vector3f bias;
+};
+
+NoiseModel make_noise_model(float sigma, float bias_range, unsigned seed) {
+    NoiseModel m{std::default_random_engine(seed),
+                 std::normal_distribution<float>(0.0f, sigma),
+                 Vector3f::Zero()};
+    std::uniform_real_distribution<float> ub(-bias_range, bias_range);
+    m.bias = Vector3f(ub(m.rng), ub(m.rng), ub(m.rng));
+    return m;
+}
+
+Vector3f apply_noise(const Vector3f& v, NoiseModel& m) {
+    return v + m.bias + Vector3f(m.dist(m.rng), m.dist(m.rng), m.dist(m.rng));
+}
+
+std::vector<double> build_reference_1d_spectrum(const std::string& spectrum_file,
+                                                const std::array<double, 32>& freqs) {
+    std::map<double, std::vector<WaveSpectrumRecord>> by_freq;
+    WaveSpectrumCSVReader reader(spectrum_file);
+    reader.for_each_record([&](const WaveSpectrumRecord& rec) {
+        by_freq[rec.f_Hz].push_back(rec);
+    });
+
+    std::vector<double> f_ref;
+    std::vector<double> s_ref;
+    f_ref.reserve(by_freq.size());
+    s_ref.reserve(by_freq.size());
+
+    for (auto& [f, rows] : by_freq) {
+        std::sort(rows.begin(), rows.end(), [](const WaveSpectrumRecord& a, const WaveSpectrumRecord& b) {
+            return a.theta_deg < b.theta_deg;
+        });
+
+        if (rows.empty()) continue;
+
+        double integ = 0.0;
+        for (size_t i = 0; i < rows.size(); ++i) {
+            const auto& r0 = rows[i];
+            const auto& r1 = rows[(i + 1) % rows.size()];
+            double dtheta = r1.theta_deg - r0.theta_deg;
+            if (i + 1 == rows.size()) dtheta = (rows.front().theta_deg + 360.0) - r0.theta_deg;
+            dtheta = std::max(dtheta, 0.0);
+            integ += r0.E * dtheta;
+        }
+
+        f_ref.push_back(f);
+        s_ref.push_back(integ);
+    }
+
+    std::vector<double> out(freqs.size(), 0.0);
+    if (f_ref.empty()) return out;
+
+    for (size_t i = 0; i < freqs.size(); ++i) {
+        double f = freqs[i];
+        if (f <= f_ref.front()) {
+            out[i] = s_ref.front();
+            continue;
+        }
+        if (f >= f_ref.back()) {
+            out[i] = s_ref.back();
+            continue;
+        }
+        auto it = std::lower_bound(f_ref.begin(), f_ref.end(), f);
+        size_t hi = std::distance(f_ref.begin(), it);
+        size_t lo = hi - 1;
+        double t = (f - f_ref[lo]) / (f_ref[hi] - f_ref[lo]);
+        out[i] = (1.0 - t) * s_ref[lo] + t * s_ref[hi];
+    }
+
+    return out;
+}
+
+void process_wave_file(const std::string& data_file, float dt) {
+    auto parsed = WaveFileNaming::parse_to_params(data_file);
+    if (!parsed) return;
+
+    auto [kind, type, wp] = *parsed;
+    if (kind != FileKind::Data) return;
+
+    std::string spectrum_file = data_file;
+    auto pos = spectrum_file.find("wave_data_");
+    if (pos != std::string::npos) {
+        spectrum_file.replace(pos, std::string("wave_data_").size(), "wave_spectrum_");
+    }
+
+    if (!std::filesystem::exists(spectrum_file)) {
+        std::cerr << "Skipping " << data_file << " (missing ref spectrum " << spectrum_file << ")\n";
+        return;
+    }
+
+    std::cout << "Processing " << data_file
+              << " with ref=" << spectrum_file
+              << " (" << EnumTraits<WaveType>::to_string(type)
+              << "), Hs=" << wp.height << " m, Tp=" << wp.period << " s\n";
+
+    static NoiseModel accel_noise = make_noise_model(0.03f, 0.02f, 1234u);
+
+    constexpr int Nfreq = 32;
+    constexpr int Nblock = 256;
+    WaveSpectrumEstimator<Nfreq, Nblock> estimator(200.0, 30, true);
+
+    std::string outname = data_file;
+    if (pos != std::string::npos) {
+        outname.replace(pos, std::string("wave_data_").size(), "spectrum_estimate_");
+    } else {
+        outname = "spectrum_estimate_" + outname;
+    }
+
+    std::ofstream ofs(outname);
+    auto freqs = estimator.getFrequencies();
+    auto s_ref_interp = build_reference_1d_spectrum(spectrum_file, freqs);
+
+    ofs << "block,time,Hs,Fp,PM_alpha,PM_fp,PM_cost";
+    for (int i = 0; i < Nfreq; ++i) {
+        ofs << ",S_eta_est_f" << i << "_Hz=" << freqs[i]
+            << ",S_eta_ref_f" << i;
+    }
+    ofs << "\n";
+
+    int block_count = 0;
+    WaveDataCSVReader reader(data_file);
+    reader.for_each_record([&](const Wave_Data_Sample& rec) {
+        Vector3f acc_b(rec.imu.acc_bx, rec.imu.acc_by, rec.imu.acc_bz);
+        Vector3f acc_noisy = apply_noise(acc_b, accel_noise);
+        Vector3f acc_f = zu_to_ned(acc_noisy);
+        double a_vert = static_cast<double>(acc_f.z());
+
+        if (estimator.processSample(a_vert)) {
+            block_count++;
+            auto s_est = estimator.getDisplacementSpectrum();
+            auto pm = estimator.fitPiersonMoskowitz();
+
+            ofs << block_count << "," << rec.time << ","
+                << estimator.computeHs() << "," << estimator.estimateFp() << ","
+                << pm.alpha << "," << pm.fp << "," << pm.cost;
+            for (int i = 0; i < Nfreq; ++i) {
+                ofs << "," << s_est[i] << "," << s_ref_interp[i];
+            }
+            ofs << "\n";
+        }
+    });
+
+    std::cout << "Finished " << data_file << " with " << block_count
+              << " spectra -> " << outname << "\n\n";
+}
+
+int main() {
+    constexpr float dt = 1.0f / 200.0f;
+    std::cout << "Spectrum estimator simulation (IMU -> estimator vs ref spectrum files)\n";
+
+    std::vector<std::string> files;
+    for (auto& entry : std::filesystem::directory_iterator(".")) {
+        if (!entry.is_regular_file()) continue;
+        const std::string fname = entry.path().filename().string();
+        if (fname.find("wave_data_") == std::string::npos) continue;
+        auto kind = WaveFileNaming::parse_kind_only(fname);
+        if (kind && *kind == FileKind::Data) files.push_back(fname);
+    }
+
+    std::sort(files.begin(), files.end());
+    for (const auto& fname : files) process_wave_file(fname, dt);
+
+    return 0;
+}

--- a/tests/spectrum/spectrum-wavelets-estimator-sim.cpp
+++ b/tests/spectrum/spectrum-wavelets-estimator-sim.cpp
@@ -1,0 +1,191 @@
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <random>
+#include <set>
+#include <string>
+#include <vector>
+
+#define EIGEN_NON_ARDUINO
+#include <Eigen/Dense>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#include "util/WaveFilesSupport.h"
+#include "ahrs/FrameConversions.h"
+
+const float g_std = 9.80665f;
+
+#include "spectrum/WaveSpectrumEstimator_Wavelets.h"
+
+using Eigen::Vector3f;
+
+struct NoiseModel {
+    std::default_random_engine rng;
+    std::normal_distribution<float> dist;
+    Vector3f bias;
+};
+
+NoiseModel make_noise_model(float sigma, float bias_range, unsigned seed) {
+    NoiseModel m{std::default_random_engine(seed),
+                 std::normal_distribution<float>(0.0f, sigma),
+                 Vector3f::Zero()};
+    std::uniform_real_distribution<float> ub(-bias_range, bias_range);
+    m.bias = Vector3f(ub(m.rng), ub(m.rng), ub(m.rng));
+    return m;
+}
+
+Vector3f apply_noise(const Vector3f& v, NoiseModel& m) {
+    return v + m.bias + Vector3f(m.dist(m.rng), m.dist(m.rng), m.dist(m.rng));
+}
+
+std::vector<double> build_reference_1d_spectrum(const std::string& spectrum_file,
+                                                const std::array<double, 32>& freqs) {
+    std::map<double, std::vector<WaveSpectrumRecord>> by_freq;
+    WaveSpectrumCSVReader reader(spectrum_file);
+    reader.for_each_record([&](const WaveSpectrumRecord& rec) {
+        by_freq[rec.f_Hz].push_back(rec);
+    });
+
+    std::vector<double> f_ref;
+    std::vector<double> s_ref;
+
+    for (auto& [f, rows] : by_freq) {
+        std::sort(rows.begin(), rows.end(), [](const WaveSpectrumRecord& a, const WaveSpectrumRecord& b) {
+            return a.theta_deg < b.theta_deg;
+        });
+        if (rows.empty()) continue;
+
+        double integ = 0.0;
+        for (size_t i = 0; i < rows.size(); ++i) {
+            const auto& r0 = rows[i];
+            const auto& r1 = rows[(i + 1) % rows.size()];
+            double dtheta = r1.theta_deg - r0.theta_deg;
+            if (i + 1 == rows.size()) dtheta = (rows.front().theta_deg + 360.0) - r0.theta_deg;
+            dtheta = std::max(dtheta, 0.0);
+            integ += r0.E * dtheta;
+        }
+
+        f_ref.push_back(f);
+        s_ref.push_back(integ);
+    }
+
+    std::vector<double> out(freqs.size(), 0.0);
+    if (f_ref.empty()) return out;
+
+    for (size_t i = 0; i < freqs.size(); ++i) {
+        double f = freqs[i];
+        if (f <= f_ref.front()) {
+            out[i] = s_ref.front();
+            continue;
+        }
+        if (f >= f_ref.back()) {
+            out[i] = s_ref.back();
+            continue;
+        }
+        auto it = std::lower_bound(f_ref.begin(), f_ref.end(), f);
+        size_t hi = std::distance(f_ref.begin(), it);
+        size_t lo = hi - 1;
+        double t = (f - f_ref[lo]) / (f_ref[hi] - f_ref[lo]);
+        out[i] = (1.0 - t) * s_ref[lo] + t * s_ref[hi];
+    }
+
+    return out;
+}
+
+void process_wave_file(const std::string& data_file, float dt) {
+    auto parsed = WaveFileNaming::parse_to_params(data_file);
+    if (!parsed) return;
+
+    auto [kind, type, wp] = *parsed;
+    if (kind != FileKind::Data) return;
+
+    std::string spectrum_file = data_file;
+    auto pos = spectrum_file.find("wave_data_");
+    if (pos != std::string::npos) {
+        spectrum_file.replace(pos, std::string("wave_data_").size(), "wave_spectrum_");
+    }
+
+    if (!std::filesystem::exists(spectrum_file)) {
+        std::cerr << "Skipping " << data_file << " (missing ref spectrum " << spectrum_file << ")\n";
+        return;
+    }
+
+    std::cout << "Processing " << data_file
+              << " with ref=" << spectrum_file
+              << " (" << EnumTraits<WaveType>::to_string(type)
+              << "), Hs=" << wp.height << " m, Tp=" << wp.period << " s\n";
+
+    static NoiseModel accel_noise = make_noise_model(0.03f, 0.02f, 4321u);
+
+    constexpr int Nfreq = 32;
+    constexpr int Nblock = 256;
+    WaveSpectrumEstimator<Nfreq, Nblock> estimator(200.0, 30, true);
+
+    std::string outname = data_file;
+    if (pos != std::string::npos) {
+        outname.replace(pos, std::string("wave_data_").size(), "spectrum_wavelets_estimate_");
+    } else {
+        outname = "spectrum_wavelets_estimate_" + outname;
+    }
+
+    std::ofstream ofs(outname);
+    auto freqs = estimator.getFrequencies();
+    auto s_ref_interp = build_reference_1d_spectrum(spectrum_file, freqs);
+
+    ofs << "block,time,Hs,Fp,PM_alpha,PM_fp,PM_cost";
+    for (int i = 0; i < Nfreq; ++i) {
+        ofs << ",S_eta_est_f" << i << "_Hz=" << freqs[i]
+            << ",S_eta_ref_f" << i;
+    }
+    ofs << "\n";
+
+    int block_count = 0;
+    WaveDataCSVReader reader(data_file);
+    reader.for_each_record([&](const Wave_Data_Sample& rec) {
+        Vector3f acc_b(rec.imu.acc_bx, rec.imu.acc_by, rec.imu.acc_bz);
+        Vector3f acc_noisy = apply_noise(acc_b, accel_noise);
+        Vector3f acc_f = zu_to_ned(acc_noisy);
+        double a_vert = static_cast<double>(acc_f.z());
+
+        if (estimator.processSample(a_vert)) {
+            block_count++;
+            auto s_est = estimator.getDisplacementSpectrum();
+            auto pm = estimator.fitPiersonMoskowitz();
+
+            ofs << block_count << "," << rec.time << ","
+                << estimator.computeHs() << "," << estimator.estimateFp() << ","
+                << pm.alpha << "," << pm.fp << "," << pm.cost;
+            for (int i = 0; i < Nfreq; ++i) {
+                ofs << "," << s_est[i] << "," << s_ref_interp[i];
+            }
+            ofs << "\n";
+        }
+    });
+
+    std::cout << "Finished " << data_file << " with " << block_count
+              << " spectra -> " << outname << "\n\n";
+}
+
+int main() {
+    constexpr float dt = 1.0f / 200.0f;
+    std::cout << "Wavelet spectrum estimator simulation (IMU -> estimator vs ref spectrum files)\n";
+
+    std::vector<std::string> files;
+    for (auto& entry : std::filesystem::directory_iterator(".")) {
+        if (!entry.is_regular_file()) continue;
+        const std::string fname = entry.path().filename().string();
+        if (fname.find("wave_data_") == std::string::npos) continue;
+        auto kind = WaveFileNaming::parse_kind_only(fname);
+        if (kind && *kind == FileKind::Data) files.push_back(fname);
+    }
+
+    std::sort(files.begin(), files.end());
+    for (const auto& fname : files) process_wave_file(fname, dt);
+
+    return 0;
+}


### PR DESCRIPTION
### Motivation
- Provide automated comparisons between estimated spectra and simulation reference spectra using the same IMU wave streams, and produce publication-ready plots for the comparisons.
- Use the supplied simulation `wave_spectrum_*.csv` reference data instead of synthesizing a model spectrum in the test harness.
- Add a wavelet-based estimator test parallel to the existing estimator to compare algorithms under identical inputs.

### Description
- Added two test binaries under `tests/spectrum`: `spectrum-estimator-sim.cpp` (Goertzel-based estimator) and `spectrum-wavelets-estimator-sim.cpp` (wavelet estimator), which read `wave_data_*.csv`, find the matching `wave_spectrum_*.csv` reference file, build a 1D reference spectrum by integrating over direction bins, feed the same IMU-derived vertical acceleration (with noise) into the estimators, and write per-block CSV outputs (`spectrum_estimate_*.csv` and `spectrum_wavelets_estimate_*.csv`).
- Updated `tests/spectrum/Makefile` to build both binaries and added an Eigen include-path fallback to use vendored `third_party/eigen` if present or `/usr/include/eigen3` otherwise.
- Replaced the hard-generated reference spectrum in the test flow with the sim data by interpolating the simulation frequencies to the estimator frequency grid (linear interpolation) so estimator outputs and reference are comparable.
- Added plotting scripts `plots/spectrum/spectrum-estimates-plots.py` and `plots/spectrum/spectrum-wavelets-estimates-plots.py`, updated `plots/spectrum/draw_plots.sh` to run them, and added LaTeX bundles `doc/spectrum/spectrum-estimates-plots.tex` and `doc/spectrum/spectrum-wavelets-plots.tex` to collect the generated PGF figures.
- Small build/runtime fix: tests define `const float g_std = 9.80665f;` locally to resolve linkage of the gravity constant when building test binaries.

### Testing
- Ran `cd tests/spectrum && make clean && make all` and compilation completed successfully (both binaries built). — success.
- Ran `cd tests/spectrum && bash run_tests.sh` which executed both test binaries and produced the CSV estimate files. — success.
- Ran plotting via `cd plots/spectrum && bash draw_plots.sh` in the current environment and this step failed due to missing Python plotting dependencies (`pandas`, `matplotlib`) in the sandbox; the CI workflow installs these packages so plots should generate in CI. — warning (plots not generated locally due to env).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc20596fe88328ba7767ac880e9109)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated spectrum estimate visualization with side-by-side spectrum and time-series plots across multiple estimator types and sea states
  * Added wavelet spectrum estimator charts with comparative reference spectrum analysis

* **Tests**
  * Introduced spectrum and wavelet spectrum estimation simulations for validation
  * Updated test suite to execute new simulation binaries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->