### PR TITLE
Align spectrum estimator outputs with reg_spectrum format and fix reference integration

### DIFF
--- a/plots/spectrum/spectrum-estimates-plots.py
+++ b/plots/spectrum/spectrum-estimates-plots.py
@@ -2,14 +2,12 @@
 import glob
 import os
 import re
-
-import matplotlib as mpl
-import matplotlib.pyplot as plt
-import numpy as np
 import pandas as pd
-from matplotlib.backends.backend_pgf import FigureCanvasPgf
+import matplotlib.pyplot as plt
+import matplotlib as mpl
 
-mpl.backend_bases.register_backend('pgf', FigureCanvasPgf)
+# === Matplotlib PGF/LaTeX config ===
+mpl.use("pgf")
 plt.rcParams.update({
     "pgf.texsystem": "xelatex",
     "font.family": "serif",
@@ -21,97 +19,103 @@ plt.rcParams.update({
         r"\usepackage{amsmath}",
         r"\setmainfont{DejaVu Serif}",
         r"\setmathfont{Latin Modern Math}",
-        r"\providecommand{\mathdefault}[1]{#1}",
-    ]),
+        r"\providecommand{\mathdefault}[1]{#1}"
+    ])
 })
 
-height_groups = {
-    "low": 0.27,
-    "medium": 1.50,
-    "high": 8.50,
-}
+# === Height classification ===
+height_groups = {"low": 0.27, "medium": 1.50, "high": 8.50}
 
-fname_re = re.compile(
-    r"^spectrum_estimate_(?P<wtype>[a-z]+)_H(?P<H>[0-9.]+)_L(?P<L>[0-9.]+)_A(?P<A>[-0-9.]+)_P(?P<P>[-0-9.]+)\.csv$"
+
+def classify_height(h):
+    diffs = {lvl: abs(h - v) for lvl, v in height_groups.items()}
+    return min(diffs, key=diffs.get)
+
+
+# === Filename pattern ===
+pattern = re.compile(
+    r"reg_spectrum_"
+    r"(?P<tracker>[^_]+)_"
+    r"(?P<wave>[A-Za-z0-9]+)_"
+    r"H(?P<height>[-0-9\.]+)"
+    r"(?:_L(?P<length>[-0-9\.]+))?"
+    r"(?:_A(?P<azimuth>[-0-9\.]+))?"
+    r"(?:_P(?P<phase>[-0-9\.]+))?"
+    r"_N(?P<noise>[-0-9\.]+)"
+    r"_B(?P<bias>[-0-9\.]+)"
+    r"\.csv"
 )
 
-
-def parse_filename(fname):
-    m = fname_re.match(os.path.basename(fname))
+# === Load all files and group by (wave, height) ===
+groups = {}
+for f in sorted(glob.glob("reg_spectrum_*.csv")):
+    m = pattern.search(os.path.basename(f))
     if not m:
-        return None
-    return {
-        "wtype": m.group("wtype"),
-        "H": float(m.group("H")),
-        "A": float(m.group("A")),
-    }
+        print(f"Skipping unrecognized: {f}")
+        continue
+    wave = m.group("wave")
+    height = float(m.group("height"))
+    tracker = m.group("tracker")
+    key = (wave, height)
+    groups.setdefault(key, []).append((tracker, f))
 
+if not groups:
+    print("No recognized reg_spectrum_*.csv files found.")
+    raise SystemExit(0)
 
-def save_all(fig, base):
-    fig.savefig(f"{base}.pgf", bbox_inches="tight", backend="pgf")
-    fig.savefig(f"{base}.svg", bbox_inches="tight", dpi=150)
-    with mpl.rc_context({"text.usetex": False}):
-        fig.savefig(f"{base}.png", bbox_inches="tight", dpi=300)
+# === Plot each wave × height group with all trackers ===
+for (wave, height), tracker_files in groups.items():
+    level = classify_height(height)
+    height_str = f"H{height:.2f}".rstrip('0').rstrip('.')
+    print(f"\nPlotting {wave} {level} sea ({height_str} m) with {len(tracker_files)} trackers")
 
+    fig, axes = plt.subplots(3, 1, figsize=(6.5, 8.5), sharex=True)
+    axes = axes.flatten()
 
-def spectrum_cols(df):
-    freq_map = {}
-    for c in df.columns:
-        if c.startswith("S_eta_est_f") and "_Hz=" in c:
-            idx = int(c.split("_f")[1].split("_Hz=")[0])
-            freq_map[idx] = float(c.split("_Hz=")[1])
-    idxs = sorted(freq_map.keys())
-    est_cols = [f"S_eta_est_f{i}_Hz={freq_map[i]}" for i in idxs]
-    ref_cols = [f"S_eta_ref_f{i}" for i in idxs]
-    freqs = np.array([freq_map[i] for i in idxs])
-    return freqs, est_cols, ref_cols
+    for idx, (tracker, f) in enumerate(tracker_files):
+        df = pd.read_csv(f, comment="#")
+        if "freq_hz" not in df.columns:
+            print(f"  skipping {f} (no freq_hz)")
+            continue
 
+        label = tracker.capitalize()
+        lw = 1.8
 
-def make_plots(fname, group, meta):
-    df = pd.read_csv(fname)
-    if df.empty:
-        return
+        # 1. Amplitude spectra
+        axes[0].semilogx(df["freq_hz"], df["A_eta_est"], label=f"{label} est", lw=lw)
+        if "A_eta_ref" in df.columns and idx == 0:
+            axes[0].semilogx(df["freq_hz"], df["A_eta_ref"], "--", color="gray", label="Reference", lw=1.2)
 
-    freqs, est_cols, ref_cols = spectrum_cols(df)
-    last = df.iloc[-1]
+        # 2. Energy density
+        axes[1].semilogx(df["freq_hz"], df["E_eta_est"], label=f"{label} est", lw=lw)
+        if "E_eta_ref" in df.columns and idx == 0:
+            axes[1].semilogx(df["freq_hz"], df["E_eta_ref"], "--", color="gray", label="Reference", lw=1.2)
 
-    base = f"spectrum_estimates_{meta['wtype']}_{group}"
-    title = fr"{meta['wtype'].capitalize()} estimator vs reference ($H_s={meta['H']:.2f}\,\mathrm{{m}}$)"
+        # 3. Cumulative variance
+        if {"CumVar_est", "CumVar_ref"}.issubset(df.columns):
+            est_norm = df["CumVar_est"] / max(df["CumVar_est"].iloc[-1], 1e-12)
+            ref_norm = df["CumVar_ref"] / max(df["CumVar_ref"].iloc[-1], 1e-12)
+            axes[2].semilogx(df["freq_hz"], est_norm, label=f"{label} est", lw=lw)
+            if idx == 0:
+                axes[2].semilogx(df["freq_hz"], ref_norm, "--", color="gray", label="Reference", lw=1.2)
 
-    fig, ax = plt.subplots()
-    ax.plot(freqs, last[est_cols].to_numpy(dtype=float), label="Estimator", linewidth=2)
-    ax.plot(freqs, last[ref_cols].to_numpy(dtype=float), label="Reference", linewidth=2, linestyle="--")
-    ax.set_xlabel(r"Frequency $f$ [Hz]")
-    ax.set_ylabel(r"$S_{\eta}(f)$")
-    ax.set_title(title)
-    ax.grid(True, alpha=0.3)
-    ax.legend()
-    save_all(fig, f"{base}_spectrum")
+    # === Axis formatting ===
+    axes[0].set_ylabel(r"$A_\eta(f)$ [m]")
+    axes[1].set_ylabel(r"$E_\eta(f)=fS_\eta(f)$ [m$^2$]")
+    axes[2].set_ylabel("Cumulative variance fraction")
+    axes[2].set_xlabel("Frequency [Hz]")
+    for ax in axes:
+        ax.grid(True, which="both", lw=0.3, ls=":")
+        ax.legend(fontsize=7)
+        ax.set_xlim(left=0.02, right=2.0)
+
+    fig.suptitle(f"{wave.upper()} — {level.capitalize()} sea ($H_s={height:.2f}$ m)", fontsize=11, y=0.97)
+    fig.tight_layout(rect=[0, 0, 1, 0.96])
+
+    out_pgf = f"reg_spectrum_plot_{wave}_{level}.pgf"
+    plt.savefig(out_pgf, bbox_inches="tight")
+    print(f"  Saved → {out_pgf}")
+
     plt.close(fig)
 
-    fig2, ax2 = plt.subplots()
-    ax2.plot(df["time"], df["Hs"], label=r"$H_s$", linewidth=2)
-    ax2.plot(df["time"], 1.0 / np.maximum(df["Fp"], 1e-9), label=r"$T_p=1/f_p$", linewidth=2)
-    ax2.set_xlabel("Time [s]")
-    ax2.set_ylabel("Estimate")
-    ax2.set_title(title)
-    ax2.grid(True, alpha=0.3)
-    ax2.legend()
-    save_all(fig2, f"{base}_timeseries")
-    plt.close(fig2)
-
-
-if __name__ == "__main__":
-    files = glob.glob("spectrum_estimate_*.csv")
-    if not files:
-        print("No spectrum_estimate_*.csv files found.")
-        raise SystemExit(0)
-
-    for fname in sorted(files):
-        meta = parse_filename(fname)
-        if not meta:
-            continue
-        for group, target_H in height_groups.items():
-            if abs(meta["H"] - target_H) < 1e-3:
-                print(f"Processing {fname} as {group} ...")
-                make_plots(fname, group, meta)
+print("\nAll combined reg_spectrum plots generated successfully.")

--- a/tests/spectrum/Makefile
+++ b/tests/spectrum/Makefile
@@ -30,4 +30,4 @@ spectrum-wavelets-estimator-sim: spectrum-wavelets-estimator-sim.o
 	$(CC) $(CXXFLAGS) -c $< -o $@
 
 clean:
-	rm -f *.o $(TARGETS) *.exe spectrum_estimate_*.csv spectrum_wavelets_estimate_*.csv
+	rm -f *.o $(TARGETS) *.exe spectrum_estimate_*.csv spectrum_wavelets_estimate_*.csv reg_spectrum_*.csv

--- a/tests/spectrum/spectrum-estimator-sim.cpp
+++ b/tests/spectrum/spectrum-estimator-sim.cpp
@@ -1,11 +1,14 @@
 #include <algorithm>
 #include <filesystem>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
+#include <limits>
 #include <map>
 #include <random>
-#include <set>
+#include <regex>
 #include <string>
+#include <sstream>
 #include <vector>
 
 #define EIGEN_NON_ARDUINO
@@ -43,6 +46,33 @@ Vector3f apply_noise(const Vector3f& v, NoiseModel& m) {
     return v + m.bias + Vector3f(m.dist(m.rng), m.dist(m.rng), m.dist(m.rng));
 }
 
+static std::string normalize_numbers(const std::string& s) {
+    std::regex num_re(R"(([0-9]+\.[0-9]+))");
+    std::smatch match;
+    std::string result;
+    std::string::const_iterator searchStart(s.cbegin());
+
+    while (std::regex_search(searchStart, s.cend(), match, num_re)) {
+        result.append(match.prefix().first, match.prefix().second);
+        std::string num = match.str();
+        num.erase(num.find_last_not_of('0') + 1, std::string::npos);
+        if (!num.empty() && num.back() == '.') num.pop_back();
+        result.append(num);
+        searchStart = match.suffix().first;
+    }
+    result.append(searchStart, s.cend());
+    return result;
+}
+
+static std::string build_output_tail(const std::string& data_file) {
+    std::string stem = std::filesystem::path(data_file).filename().string();
+    auto posH = stem.find("_H");
+    std::string tail = (posH != std::string::npos) ? stem.substr(posH) : "";
+    if (tail.size() > 4 && tail.substr(tail.size() - 4) == ".csv")
+        tail = tail.substr(0, tail.size() - 4);
+    return normalize_numbers(tail);
+}
+
 std::vector<double> build_reference_1d_spectrum(const std::string& spectrum_file,
                                                 const std::array<double, 32>& freqs) {
     std::map<double, std::vector<WaveSpectrumRecord>> by_freq;
@@ -70,7 +100,7 @@ std::vector<double> build_reference_1d_spectrum(const std::string& spectrum_file
             double dtheta = r1.theta_deg - r0.theta_deg;
             if (i + 1 == rows.size()) dtheta = (rows.front().theta_deg + 360.0) - r0.theta_deg;
             dtheta = std::max(dtheta, 0.0);
-            integ += r0.E * dtheta;
+            integ += r0.E * (dtheta * M_PI / 180.0);
         }
 
         f_ref.push_back(f);
@@ -129,25 +159,12 @@ void process_wave_file(const std::string& data_file, float dt) {
     constexpr int Nblock = 256;
     WaveSpectrumEstimator<Nfreq, Nblock> estimator(200.0, 30, true);
 
-    std::string outname = data_file;
-    if (pos != std::string::npos) {
-        outname.replace(pos, std::string("wave_data_").size(), "spectrum_estimate_");
-    } else {
-        outname = "spectrum_estimate_" + outname;
-    }
-
-    std::ofstream ofs(outname);
     auto freqs = estimator.getFrequencies();
     auto s_ref_interp = build_reference_1d_spectrum(spectrum_file, freqs);
 
-    ofs << "block,time,Hs,Fp,PM_alpha,PM_fp,PM_cost";
-    for (int i = 0; i < Nfreq; ++i) {
-        ofs << ",S_eta_est_f" << i << "_Hz=" << freqs[i]
-            << ",S_eta_ref_f" << i;
-    }
-    ofs << "\n";
-
     int block_count = 0;
+    Eigen::Matrix<double, Nfreq, 1> last_s_est = Eigen::Matrix<double, Nfreq, 1>::Zero();
+    bool has_last = false;
     WaveDataCSVReader reader(data_file);
     reader.for_each_record([&](const Wave_Data_Sample& rec) {
         Vector3f acc_b(rec.imu.acc_bx, rec.imu.acc_by, rec.imu.acc_bz);
@@ -157,18 +174,59 @@ void process_wave_file(const std::string& data_file, float dt) {
 
         if (estimator.processSample(a_vert)) {
             block_count++;
-            auto s_est = estimator.getDisplacementSpectrum();
-            auto pm = estimator.fitPiersonMoskowitz();
-
-            ofs << block_count << "," << rec.time << ","
-                << estimator.computeHs() << "," << estimator.estimateFp() << ","
-                << pm.alpha << "," << pm.fp << "," << pm.cost;
-            for (int i = 0; i < Nfreq; ++i) {
-                ofs << "," << s_est[i] << "," << s_ref_interp[i];
-            }
-            ofs << "\n";
+            last_s_est = estimator.getDisplacementSpectrum();
+            has_last = true;
         }
     });
+
+    if (!has_last) {
+        std::cout << "Finished " << data_file << " with " << block_count
+                  << " spectra (no final snapshot)\n\n";
+        return;
+    }
+
+    const std::string waveName = EnumTraits<WaveType>::to_string(type);
+    const std::string tail = build_output_tail(data_file);
+    constexpr float NOISE_STDDEV = 0.03f;
+    constexpr float BIAS_MEAN = 0.02f;
+
+    std::ostringstream nb;
+    nb << "_N" << std::fixed << std::setprecision(3) << NOISE_STDDEV
+       << "_B" << std::fixed << std::setprecision(3) << BIAS_MEAN;
+    const std::string outname = "reg_spectrum_estimator_" + waveName + tail + nb.str() + ".csv";
+
+    std::ofstream ofs(outname);
+    ofs << "freq_hz,S_eta_hz,S_ref_interp,S_ratio,"
+           "A_eta_est,A_eta_ref,E_eta_est,E_eta_ref,"
+           "CumVar_est,CumVar_ref\n";
+
+    double cum_est = 0.0;
+    double cum_ref = 0.0;
+    for (int i = 0; i < Nfreq; ++i) {
+        const double f_est = freqs[i];
+        const double S_eta_hz = std::max(0.0, last_s_est[i]);
+        const double s_ref = std::max(0.0, s_ref_interp[i]);
+
+        double delta_f = 0.0;
+        if (i == 0) delta_f = 0.5 * (freqs[1] - freqs[0]);
+        else if (i == Nfreq - 1) delta_f = 0.5 * (freqs[Nfreq - 1] - freqs[Nfreq - 2]);
+        else delta_f = 0.5 * (freqs[i + 1] - freqs[i - 1]);
+        delta_f = std::max(delta_f, 0.0);
+
+        const double ratio = (s_ref > 0.0) ? (S_eta_hz / s_ref) : 0.0;
+        const double A_eta_est = std::sqrt(std::max(0.0, 2.0 * S_eta_hz * delta_f * f_est));
+        const double A_eta_ref = std::sqrt(std::max(0.0, 2.0 * s_ref * delta_f * f_est));
+        const double E_eta_est = f_est * S_eta_hz;
+        const double E_eta_ref = f_est * s_ref;
+
+        cum_est += S_eta_hz * 2.0 * delta_f;
+        cum_ref += s_ref * 2.0 * delta_f;
+
+        ofs << f_est << "," << S_eta_hz << "," << s_ref << "," << ratio << ","
+            << A_eta_est << "," << A_eta_ref << ","
+            << E_eta_est << "," << E_eta_ref << ","
+            << cum_est << "," << cum_ref << "\n";
+    }
 
     std::cout << "Finished " << data_file << " with " << block_count
               << " spectra -> " << outname << "\n\n";

--- a/tests/spectrum/spectrum-wavelets-estimator-sim.cpp
+++ b/tests/spectrum/spectrum-wavelets-estimator-sim.cpp
@@ -1,11 +1,14 @@
 #include <algorithm>
 #include <filesystem>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
+#include <limits>
 #include <map>
 #include <random>
-#include <set>
+#include <regex>
 #include <string>
+#include <sstream>
 #include <vector>
 
 #define EIGEN_NON_ARDUINO
@@ -43,6 +46,33 @@ Vector3f apply_noise(const Vector3f& v, NoiseModel& m) {
     return v + m.bias + Vector3f(m.dist(m.rng), m.dist(m.rng), m.dist(m.rng));
 }
 
+static std::string normalize_numbers(const std::string& s) {
+    std::regex num_re(R"(([0-9]+\.[0-9]+))");
+    std::smatch match;
+    std::string result;
+    std::string::const_iterator searchStart(s.cbegin());
+
+    while (std::regex_search(searchStart, s.cend(), match, num_re)) {
+        result.append(match.prefix().first, match.prefix().second);
+        std::string num = match.str();
+        num.erase(num.find_last_not_of('0') + 1, std::string::npos);
+        if (!num.empty() && num.back() == '.') num.pop_back();
+        result.append(num);
+        searchStart = match.suffix().first;
+    }
+    result.append(searchStart, s.cend());
+    return result;
+}
+
+static std::string build_output_tail(const std::string& data_file) {
+    std::string stem = std::filesystem::path(data_file).filename().string();
+    auto posH = stem.find("_H");
+    std::string tail = (posH != std::string::npos) ? stem.substr(posH) : "";
+    if (tail.size() > 4 && tail.substr(tail.size() - 4) == ".csv")
+        tail = tail.substr(0, tail.size() - 4);
+    return normalize_numbers(tail);
+}
+
 std::vector<double> build_reference_1d_spectrum(const std::string& spectrum_file,
                                                 const std::array<double, 32>& freqs) {
     std::map<double, std::vector<WaveSpectrumRecord>> by_freq;
@@ -67,7 +97,7 @@ std::vector<double> build_reference_1d_spectrum(const std::string& spectrum_file
             double dtheta = r1.theta_deg - r0.theta_deg;
             if (i + 1 == rows.size()) dtheta = (rows.front().theta_deg + 360.0) - r0.theta_deg;
             dtheta = std::max(dtheta, 0.0);
-            integ += r0.E * dtheta;
+            integ += r0.E * (dtheta * M_PI / 180.0);
         }
 
         f_ref.push_back(f);
@@ -126,25 +156,12 @@ void process_wave_file(const std::string& data_file, float dt) {
     constexpr int Nblock = 256;
     WaveSpectrumEstimator<Nfreq, Nblock> estimator(200.0, 30, true);
 
-    std::string outname = data_file;
-    if (pos != std::string::npos) {
-        outname.replace(pos, std::string("wave_data_").size(), "spectrum_wavelets_estimate_");
-    } else {
-        outname = "spectrum_wavelets_estimate_" + outname;
-    }
-
-    std::ofstream ofs(outname);
     auto freqs = estimator.getFrequencies();
     auto s_ref_interp = build_reference_1d_spectrum(spectrum_file, freqs);
 
-    ofs << "block,time,Hs,Fp,PM_alpha,PM_fp,PM_cost";
-    for (int i = 0; i < Nfreq; ++i) {
-        ofs << ",S_eta_est_f" << i << "_Hz=" << freqs[i]
-            << ",S_eta_ref_f" << i;
-    }
-    ofs << "\n";
-
     int block_count = 0;
+    Eigen::Matrix<double, Nfreq, 1> last_s_est = Eigen::Matrix<double, Nfreq, 1>::Zero();
+    bool has_last = false;
     WaveDataCSVReader reader(data_file);
     reader.for_each_record([&](const Wave_Data_Sample& rec) {
         Vector3f acc_b(rec.imu.acc_bx, rec.imu.acc_by, rec.imu.acc_bz);
@@ -154,18 +171,59 @@ void process_wave_file(const std::string& data_file, float dt) {
 
         if (estimator.processSample(a_vert)) {
             block_count++;
-            auto s_est = estimator.getDisplacementSpectrum();
-            auto pm = estimator.fitPiersonMoskowitz();
-
-            ofs << block_count << "," << rec.time << ","
-                << estimator.computeHs() << "," << estimator.estimateFp() << ","
-                << pm.alpha << "," << pm.fp << "," << pm.cost;
-            for (int i = 0; i < Nfreq; ++i) {
-                ofs << "," << s_est[i] << "," << s_ref_interp[i];
-            }
-            ofs << "\n";
+            last_s_est = estimator.getDisplacementSpectrum();
+            has_last = true;
         }
     });
+
+    if (!has_last) {
+        std::cout << "Finished " << data_file << " with " << block_count
+                  << " spectra (no final snapshot)\n\n";
+        return;
+    }
+
+    const std::string waveName = EnumTraits<WaveType>::to_string(type);
+    const std::string tail = build_output_tail(data_file);
+    constexpr float NOISE_STDDEV = 0.03f;
+    constexpr float BIAS_MEAN = 0.02f;
+
+    std::ostringstream nb;
+    nb << "_N" << std::fixed << std::setprecision(3) << NOISE_STDDEV
+       << "_B" << std::fixed << std::setprecision(3) << BIAS_MEAN;
+    const std::string outname = "reg_spectrum_wavelets_" + waveName + tail + nb.str() + ".csv";
+
+    std::ofstream ofs(outname);
+    ofs << "freq_hz,S_eta_hz,S_ref_interp,S_ratio,"
+           "A_eta_est,A_eta_ref,E_eta_est,E_eta_ref,"
+           "CumVar_est,CumVar_ref\n";
+
+    double cum_est = 0.0;
+    double cum_ref = 0.0;
+    for (int i = 0; i < Nfreq; ++i) {
+        const double f_est = freqs[i];
+        const double S_eta_hz = std::max(0.0, last_s_est[i]);
+        const double s_ref = std::max(0.0, s_ref_interp[i]);
+
+        double delta_f = 0.0;
+        if (i == 0) delta_f = 0.5 * (freqs[1] - freqs[0]);
+        else if (i == Nfreq - 1) delta_f = 0.5 * (freqs[Nfreq - 1] - freqs[Nfreq - 2]);
+        else delta_f = 0.5 * (freqs[i + 1] - freqs[i - 1]);
+        delta_f = std::max(delta_f, 0.0);
+
+        const double ratio = (s_ref > 0.0) ? (S_eta_hz / s_ref) : 0.0;
+        const double A_eta_est = std::sqrt(std::max(0.0, 2.0 * S_eta_hz * delta_f * f_est));
+        const double A_eta_ref = std::sqrt(std::max(0.0, 2.0 * s_ref * delta_f * f_est));
+        const double E_eta_est = f_est * S_eta_hz;
+        const double E_eta_ref = f_est * s_ref;
+
+        cum_est += S_eta_hz * 2.0 * delta_f;
+        cum_ref += s_ref * 2.0 * delta_f;
+
+        ofs << f_est << "," << S_eta_hz << "," << s_ref << "," << ratio << ","
+            << A_eta_est << "," << A_eta_ref << ","
+            << E_eta_est << "," << E_eta_ref << ","
+            << cum_est << "," << cum_ref << "\n";
+    }
 
     std::cout << "Finished " << data_file << " with " << block_count
               << " spectra -> " << outname << "\n\n";


### PR DESCRIPTION
### Motivation
- Spectrum-estimate tests showed large scale mismatch vs reference; the reference directional integration and output format were inconsistent with the regularity-spectrum plotting pipeline. 

### Description
- Emit final-spectrum CSVs from both estimators in the `reg_spectrum_*` format (fields: `freq_hz,S_eta_hz,S_ref_interp,S_ratio,A_eta_est,A_eta_ref,E_eta_est,E_eta_ref,CumVar_est,CumVar_ref`) by changing `tests/spectrum/spectrum-estimator-sim.cpp` and `tests/spectrum/spectrum-wavelets-estimator-sim.cpp`. 
- Fix the 1D reference integration bug by converting directional bin widths from degrees to radians (multiply `dtheta` by `pi/180`), removing the major scaling error in the reference spectrum. 
- Add filename tail normalization and stable `_N..._B...` suffix generation so produced `reg_spectrum_*` files group correctly for plotting, and switch to using `Eigen::Matrix` for intermediate spectrum storage. 
- Replace the plotting logic in `plots/spectrum/spectrum-estimates-plots.py` to load and group `reg_spectrum_*.csv` files and produce the requested stacked semilog plots (amplitude, energy-density, cumulative variance), and update `tests/spectrum/Makefile` clean rule to remove `reg_spectrum_*.csv` outputs.

### Testing
- Ran `make all` in `tests/spectrum` which compiled both simulators successfully (passed). 
- Ran the test runner with `bash run_tests.sh` in `tests/spectrum`, which executed both simulators without errors (no waveform data files present in the environment so no per-file spectra were produced). 
- Attempting `./run_tests.sh` failed due to script permission bits (permission denied) but invoking it with `bash run_tests.sh` succeeded. 
- Running `make all` at the repository root is not applicable here and reported `No rule to make target 'all'`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc2f133e608328be3447a9c37f920b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated spectrum analysis input/output file naming patterns and formats
  * Modified result collection to produce consolidated final snapshots with frequency-level metrics instead of incremental per-block outputs
  * Enhanced result data structure to include derived amplitude, energy, and cumulative variance calculations
  * Streamlined visualization workflow to consolidate results into grouped semilog plots

<!-- end of auto-generated comment: release notes by coderabbit.ai -->