### PR TITLE
Make wavelets plot LaTeX resilient to missing PGF files

### DIFF
--- a/doc/spectrum/spectrum-wavelets-plots.tex
+++ b/doc/spectrum/spectrum-wavelets-plots.tex
@@ -14,13 +14,21 @@
 \begin{document}
 \maketitle
 
+\newcommand{\safeplotinput}[1]{%
+\IfFileExists{#1}{\resizebox{\linewidth}{!}{\input{#1}}}{%
+\fbox{\begin{minipage}[c][0.55\linewidth][c]{0.92\linewidth}\centering
+\textbf{Missing plot file}\\\texttt{#1}
+\end{minipage}}%
+}%
+}
+
 \newcommand{\specpairw}[3]{%
 \begin{figure}[H]\centering
 \begin{minipage}{0.49\textwidth}
-\resizebox{\linewidth}{!}{\input{spectrum_wavelets_estimates_#1_#2_spectrum.pgf}}
+\safeplotinput{spectrum_wavelets_estimates_#1_#2_spectrum.pgf}
 \end{minipage}\hfill
 \begin{minipage}{0.49\textwidth}
-\resizebox{\linewidth}{!}{\input{spectrum_wavelets_estimates_#1_#2_timeseries.pgf}}
+\safeplotinput{spectrum_wavelets_estimates_#1_#2_timeseries.pgf}
 \end{minipage}
 \caption{#3 wavelet estimator against simulation reference spectrum at #2 sea state. Left: final block $S_\eta(f)$ comparison. Right: $H_s$ and $T_p$ evolution over blocks.}
 \end{figure}


### PR DESCRIPTION
### Motivation
- Prevent LaTeX from hard-failing when generated `.pgf` chart files are absent so documentation can be built (or at least rendered partially) without all plot outputs present.

### Description
- Add a `\safeplotinput{...}` helper to `doc/spectrum/spectrum-wavelets-plots.tex` that uses `\IfFileExists` to input a `.pgf` when present or render a framed placeholder with the missing filename when not.
- Replace direct `\resizebox{...}{!}{\input{...}}` calls with `\safeplotinput{...}` for both the spectrum and timeseries panels in the same file.

### Testing
- Attempted to compile the document with `cd doc/spectrum && latexmk -lualatex -interaction=nonstopmode -halt-on-error spectrum-wavelets-plots.tex`, but the run could not complete because `latexmk` is not available in the environment (`latexmk: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc48f832408328b820a479eba716a3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved robustness of spectrum documentation to gracefully handle missing plot files with informative placeholders instead of broken rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->