### PR TITLE
Suppress adaptive low-frequency/DC leakage in spectrum estimators

### DIFF
--- a/src/spectrum/WaveSpectrumEstimator.h
+++ b/src/spectrum/WaveSpectrumEstimator.h
@@ -347,6 +347,53 @@ private:
         lastSpectrum_ = Sout;
     }
 
+    // Adaptive low-frequency/DC leak suppression.
+    // Below a peak-dependent cutoff, enforce a strongly decaying envelope and
+    // prohibit any re-growth toward DC.
+    void suppress_lowfreq_dc_leak_() {
+        if (Nfreq < 4) return;
+
+        int i_peak = 0;
+        double s_peak = std::max(0.0, (double)lastSpectrum_[0]);
+        for (int i = 1; i < Nfreq; ++i) {
+            const double v = std::max(0.0, (double)lastSpectrum_[i]);
+            if (v > s_peak) {
+                s_peak = v;
+                i_peak = i;
+            }
+        }
+        if (i_peak <= 1 || s_peak <= 0.0) return;
+
+        const double f_peak = freqs_[i_peak];
+        const double f_cut_target = 0.45 * f_peak;
+        const double f_cut_floor  = std::max(freqs_[1], 1.8 * hp_f0_hz);
+        const double f_cut_ceil   = 0.85 * f_peak;
+        const double f_cut = std::min(f_cut_ceil, std::max(f_cut_floor, f_cut_target));
+
+        int i_cut = 0;
+        for (int i = i_peak - 1; i >= 0; --i) {
+            if (freqs_[i] <= f_cut) {
+                i_cut = i;
+                break;
+            }
+        }
+
+        const double f_ref = std::max(freqs_[i_cut], 1e-9);
+        const double s_ref = std::max(0.0, (double)lastSpectrum_[i_cut]);
+
+        double prev = s_ref;
+        constexpr double shape_pow = 4.0;
+        for (int i = i_cut - 1; i >= 0; --i) {
+            const double r = std::max(0.0, freqs_[i] / f_ref);
+            const double shape_cap = s_ref * std::pow(r, shape_pow);
+            double v = std::max(0.0, (double)lastSpectrum_[i]);
+            v = std::min(v, shape_cap);
+            v = std::min(v, prev);
+            lastSpectrum_[i] = v;
+            prev = v;
+        }
+    }
+
     void buildFrequencyGrid() {
         constexpr double f_min = 0.04, f_max = 1.2;
 
@@ -470,6 +517,7 @@ private:
 
         have_ema = true;
         smooth_logfreq_3tap();
+        suppress_lowfreq_dc_leak_();
     }
 
     // Magnitude-squared frequency response of a biquad at raw Fs

--- a/src/spectrum/WaveSpectrumEstimator_Wavelets.h
+++ b/src/spectrum/WaveSpectrumEstimator_Wavelets.h
@@ -310,6 +310,53 @@ private:
         lastSpectrum_ = Sout;
     }
 
+    // Adaptive low-frequency/DC leak suppression.
+    // Below a peak-dependent cutoff, enforce a strongly decaying envelope and
+    // prohibit any re-growth toward DC.
+    void suppress_lowfreq_dc_leak_() {
+        if (Nfreq < 4) return;
+
+        int i_peak = 0;
+        double s_peak = std::max(0.0, (double)lastSpectrum_[0]);
+        for (int i = 1; i < Nfreq; ++i) {
+            const double v = std::max(0.0, (double)lastSpectrum_[i]);
+            if (v > s_peak) {
+                s_peak = v;
+                i_peak = i;
+            }
+        }
+        if (i_peak <= 1 || s_peak <= 0.0) return;
+
+        const double f_peak = freqs_[i_peak];
+        const double f_cut_target = 0.45 * f_peak;
+        const double f_cut_floor  = std::max(freqs_[1], 1.8 * hp_f0_hz);
+        const double f_cut_ceil   = 0.85 * f_peak;
+        const double f_cut = std::min(f_cut_ceil, std::max(f_cut_floor, f_cut_target));
+
+        int i_cut = 0;
+        for (int i = i_peak - 1; i >= 0; --i) {
+            if (freqs_[i] <= f_cut) {
+                i_cut = i;
+                break;
+            }
+        }
+
+        const double f_ref = std::max(freqs_[i_cut], 1e-9);
+        const double s_ref = std::max(0.0, (double)lastSpectrum_[i_cut]);
+
+        double prev = s_ref;
+        constexpr double shape_pow = 4.0;
+        for (int i = i_cut - 1; i >= 0; --i) {
+            const double r = std::max(0.0, freqs_[i] / f_ref);
+            const double shape_cap = s_ref * std::pow(r, shape_pow);
+            double v = std::max(0.0, (double)lastSpectrum_[i]);
+            v = std::min(v, shape_cap);
+            v = std::min(v, prev);
+            lastSpectrum_[i] = v;
+            prev = v;
+        }
+    }
+
     void buildFrequencyGrid() {
         constexpr double f_min = 0.04, f_max = 1.2;
 
@@ -606,6 +653,7 @@ private:
 
         have_ema = true;
         smooth_logfreq_3tap();
+        suppress_lowfreq_dc_leak_();
     }
 
     // Members / State


### PR DESCRIPTION
### Motivation
- Both the Goertzel-based and wavelet-based spectrum estimators showed DC / quasi-DC leakage that allowed the spectrum to rise again at very low frequencies after the main peak.  
- The goal is to strongly suppress that DC leakage in an adaptive way so the cutoff tracks the current wave peak while avoiding excessive suppression near physically meaningful low frequencies.

### Description
- Added `suppress_lowfreq_dc_leak_()` to `WaveSpectrumEstimator` and `WaveSpectrumEstimator_Wavelets` which finds the dominant spectral peak and derives an adaptive low-frequency cutoff from it.  
- The cutoff is computed as `f_cut = clamp(0.45*f_peak, floor=max(freqs_[1], 1.8*hp_f0_hz), ceil=0.85*f_peak)` so it tracks the peak but never goes too close to DC.  
- Below the cutoff the code enforces a strong decaying envelope (`shape_pow = 4.0`) and clamps each lower-frequency bin to prevent any re-growth toward DC.  
- The suppression is applied as a post-processing step at the end of `computeSpectrum()` (after `smooth_logfreq_3tap()`), and does not change any public APIs or build targets.

### Testing
- Built the spectrum test targets with `make all` in `tests/spectrum` and the compilation succeeded.  
- Ran the spectrum simulators with `bash run_tests.sh` in `tests/spectrum` and both simulator runs produced output successfully.  
- Attempting a repository-root `make all` failed because there is no top-level `Makefile` with the error: `make: *** No rule to make target 'all'.  Stop.`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc6332255883289ec62c788d48d464)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced spectrum estimation to suppress low-frequency noise and DC offset, improving accuracy in spectral analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->