### PR TITLE
Use NumPy trapezoidal integration for spectrum bulk estimates

### DIFF
--- a/plots/spectrum/spectrum-estimates-plots.py
+++ b/plots/spectrum/spectrum-estimates-plots.py
@@ -6,6 +6,7 @@ import re
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
 
 mpl.use("pgf")
@@ -103,7 +104,7 @@ def estimate_bulk_from_spectrum(df):
     if len(f) < 2 or len(s) < 2:
         return None, None
 
-    m0 = s.integrate(f)
+    m0 = np.trapezoid(s.to_numpy(), f.to_numpy())
     hs = 4.0 * (m0 ** 0.5) if m0 > 0 else None
 
     fp_idx = s.idxmax() if len(s) > 0 else None


### PR DESCRIPTION
### Motivation
- Fix a runtime crash caused by calling the non-existent Pandas method `Series.integrate(...)` when computing the spectral moment `m0` from discrete frequency/spectrum samples.

### Description
- Add `import numpy as np` and replace the invalid `m0 = s.integrate(f)` with `m0 = np.trapezoid(s.to_numpy(), f.to_numpy())` in `estimate_bulk_from_spectrum` to compute `m0` using the trapezoidal rule.

### Testing
- Ran `python3 -m py_compile plots/spectrum/spectrum-estimates-plots.py`, which succeeded.
- Attempted `python3 plots/spectrum/spectrum-estimates-plots.py --mode classic`, but the run could not complete because `matplotlib` is not installed in the environment so plotting could not be exercised.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc6620ed60832891ffa88b3ff1005b)