### PR TITLE
Add top-level Makefile to build and clean test directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.PHONY: all clean
+
+TEST_DIRS := \
+	tests/ahrs \
+	tests/detrend \
+	tests/freq \
+	tests/imu_calibrate \
+	tests/kalman_ou_ii \
+	tests/kalman_ou_iii \
+	tests/pii_observer \
+	tests/spectrum \
+	tests/wave_sim
+
+all:
+	@set -e; \
+	for d in $(TEST_DIRS); do \
+		$(MAKE) -C $$d all; \
+	done
+
+clean:
+	@set -e; \
+	for d in $(TEST_DIRS); do \
+		$(MAKE) -C $$d clean >/dev/null 2>&1 || true; \
+	done


### PR DESCRIPTION
### Motivation
- Provide a single top-level `Makefile` to build and clean all test subdirectories from the repository root to simplify running test builds.

### Description
- Add a root `Makefile` that defines `TEST_DIRS` and implements `all` and `clean` targets which loop over each test directory and invoke `make -C` for build and cleanup; `clean` suppresses errors.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc6a8af7408328952aeeb0e27a4e7b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added top-level `Makefile` with `all` and `clean` targets to streamline build and cleanup operations across subdirectories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->