### PR TITLE
Fix dead-code warnings in frame conversions, OU-III coeffs, and simulation summary

### DIFF
--- a/src/ahrs/FrameConversions.h
+++ b/src/ahrs/FrameConversions.h
@@ -44,6 +44,7 @@ static inline Vector3f ned_to_zu(const Vector3f& v) {
 
 // Aerospace → Nautical
 static inline void aero_to_nautical(float &roll, float &pitch, float &yaw) {
+    (void)yaw;
     float r_a = roll;
     float p_a = pitch;
     roll  = -p_a;  // aerospace pitch → nautical roll
@@ -53,6 +54,7 @@ static inline void aero_to_nautical(float &roll, float &pitch, float &yaw) {
 
 // Nautical → Aerospace
 static inline void nautical_to_aero(float &roll, float &pitch, float &yaw) {
+    (void)yaw;
     float r_n = roll;
     float p_n = pitch;
     roll  = -p_n;  // nautical pitch → aerospace roll

--- a/src/kalman_ou_iii/Kalman3D_Wave_OU_III.h
+++ b/src/kalman_ou_iii/Kalman3D_Wave_OU_III.h
@@ -124,7 +124,6 @@ inline OUDiscreteCoeffs<T> safe_phi_A_coeffs(T h, T tau) {
         c.phi_Sa = tau3 * (T(1.0/6.0)*x3 - T(1.0/24.0)*x4 + T(1.0/120.0)*x5);
     } else {
         // General closed-form branch
-        const T alpha  = std::exp(-x);
         const T em1    = std::expm1(-x);
         // reuse for stability
         const T phi_pa = tau2 * (x + em1);

--- a/src/util/W3dSimCommon.cpp
+++ b/src/util/W3dSimCommon.cpp
@@ -479,7 +479,6 @@ void print_summary_and_fail_if_needed(const W3dSimulationRunResult& result,
 
     const float accb_r3_pct = pct_of_max(accb_r3, acc_true_max_3d);
     const float gyrb_r3_pct = pct_of_max(gyrb_r3, gyr_true_max_3d);
-    const float magb_r3_pct = pct_of_max(magb_r3, mag_true_max_3d);
     std::cout << "Bias error RMS (% of max TRUE bias) (acc): X=" << pct_of_max(accb_rx, acc_true_max_x)
               << "% Y=" << pct_of_max(accb_ry, acc_true_max_y)
               << "% Z=" << pct_of_max(accb_rz, acc_true_max_z)


### PR DESCRIPTION
### Motivation
- Remove small dead/unused code to clean up compiler warnings discovered during a duplicate/dead-code scan and warning-enabled builds.

### Description
- Mark the `yaw` parameter as intentionally unused in `aero_to_nautical` and `nautical_to_aero` by adding `(void)yaw;` to silence unused-parameter warnings in `src/ahrs/FrameConversions.h`.
- Remove an unused local `alpha` temporary from the OU-III coefficient computation in `src/kalman_ou_iii/Kalman3D_Wave_OU_III.h`.
- Remove an unused local `magb_r3_pct` variable from simulation summary reporting in `src/util/W3dSimCommon.cpp`.

### Testing
- Ran `make all` and the full test build which completed successfully.
- Ran a warning-heavy build with `make clean && make all CXXFLAGS='-O0 -std=c++20 -I./../../src -I/usr/include/eigen3 -Wall -Wextra -Wpedantic -Wunused-function -Wunused-parameter -Wunreachable-code'` and observed that the targeted unused-variable/parameter warnings were resolved and the build succeeded.
- Re-ran `make all` after changes to confirm no regressions in the standard build and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc716573048328b70376fee37ae4fc)