### PR TITLE
Fix NumPy trapezoid fallback in spectrum estimate plotting

### DIFF
--- a/plots/spectrum/spectrum-estimates-plots.py
+++ b/plots/spectrum/spectrum-estimates-plots.py
@@ -104,7 +104,8 @@ def estimate_bulk_from_spectrum(df):
     if len(f) < 2 or len(s) < 2:
         return None, None
 
-    m0 = np.trapezoid(s.to_numpy(), f.to_numpy())
+    trapz = getattr(np, "trapezoid", np.trapz)
+    m0 = trapz(s.to_numpy(), f.to_numpy())
     hs = 4.0 * (m0 ** 0.5) if m0 > 0 else None
 
     fp_idx = s.idxmax() if len(s) > 0 else None


### PR DESCRIPTION
### Motivation
- Prevent runtime crashes in environments with older NumPy where `numpy.trapezoid` does not exist by providing a backward-compatible fallback.

### Description
- Replace the direct call to `np.trapezoid(s.to_numpy(), f.to_numpy())` with a compatibility fallback using `trapz = getattr(np, "trapezoid", np.trapz)` and `m0 = trapz(...)` inside `estimate_bulk_from_spectrum` in `plots/spectrum/spectrum-estimates-plots.py`.

### Testing
- Ran `make all` which completed successfully; an attempted Python smoke call to `estimate_bulk_from_spectrum` could not be executed because `pandas` is not installed in the environment (automated invocation failed with `ModuleNotFoundError`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc74cd2cfc8328934f881793459830)