### PR TITLE
Extract spectrum statistic utilities; unify peak/fp/hs calculations; improve low-frequency leak handling; add Hs/Fp/Tp to sim output

### DIFF
--- a/src/spectrum/SpectrumStats.h
+++ b/src/spectrum/SpectrumStats.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+
+namespace SpectrumStats {
+
+template <typename T>
+inline double safe_log(T v) {
+    return std::log(std::max(1e-18, static_cast<double>(v)));
+}
+
+template <int Nfreq, typename SpectrumLike>
+inline double compute_hs(const SpectrumLike& spectrum, const std::array<double, Nfreq>& df) {
+    double m0 = 0.0;
+    for (int i = 0; i < Nfreq; ++i) {
+        m0 += static_cast<double>(spectrum[i]) * df[i];
+    }
+    return 4.0 * std::sqrt(std::max(m0, 0.0));
+}
+
+template <int Nfreq, typename SpectrumLike>
+inline double estimate_fp(const SpectrumLike& spectrum, const std::array<double, Nfreq>& freqs) {
+    int k = 0;
+    double vmax = 0.0;
+    for (int i = 0; i < Nfreq; ++i) {
+        const double s = static_cast<double>(spectrum[i]);
+        if (s > vmax) {
+            vmax = s;
+            k = i;
+        }
+    }
+
+    if (k == 0 || k == Nfreq - 1) return freqs[k];
+
+    const double f0 = freqs[k - 1], f1 = freqs[k], f2 = freqs[k + 1];
+    if (f0 <= 0.0 || f1 <= 0.0 || f2 <= 0.0) return f1;
+
+    const double x0 = std::log(f0), x1 = std::log(f1), x2 = std::log(f2);
+    const double y0 = safe_log(spectrum[k - 1]);
+    const double y1 = safe_log(spectrum[k]);
+    const double y2 = safe_log(spectrum[k + 1]);
+
+    const double dx01 = x0 - x1, dx02 = x0 - x2, dx12 = x1 - x2;
+    const double denom = (dx01 * dx02 * dx12);
+    if (std::abs(denom) < 1e-18) return f1;
+
+    const double L0a = 1.0 / (dx01 * dx02);
+    const double L1a = 1.0 / ((x1 - x0) * (x1 - x2));
+    const double L2a = 1.0 / ((x2 - x0) * (x2 - x1));
+    const double a = y0 * L0a + y1 * L1a + y2 * L2a;
+
+    const double b =
+        y0 * (-(x1 + x2) * L0a) +
+        y1 * (-(x0 + x2) * L1a) +
+        y2 * (-(x0 + x1) * L2a);
+
+    if (a >= 0.0) return f1;
+
+    const double x_peak = -b / (2.0 * a);
+    const double f_peak = std::exp(x_peak);
+    if (f_peak <= std::min(f0, f2) || f_peak >= std::max(f0, f2)) return f1;
+    return f_peak;
+}
+
+template <int Nfreq, typename SpectrumLike>
+inline double estimate_tp(const SpectrumLike& spectrum, const std::array<double, Nfreq>& freqs) {
+    const double fp = estimate_fp<Nfreq>(spectrum, freqs);
+    return (fp > 0.0) ? (1.0 / fp) : 0.0;
+}
+
+} // namespace SpectrumStats

--- a/src/spectrum/WaveSpectrumEstimator.h
+++ b/src/spectrum/WaveSpectrumEstimator.h
@@ -12,6 +12,8 @@
 #include <limits>
 #include <algorithm> // for std::clamp
 
+#include "spectrum/SpectrumStats.h"
+
 #ifdef SPECTRUM_TEST
 #include <iostream>
 #include <cassert>
@@ -183,54 +185,12 @@ public:
     // m0 = ∫ S_eta(f) df approximated by trapezoidal rule
     // Works for both linear and log-spaced bins (uses Δf[i]).
     double computeHs() const {
-        double m0 = 0.0;
-        // trapezoidal integration over uneven frequency grid
-        for (int i = 0; i < Nfreq; i++) {
-            m0 += lastSpectrum_[i] * df_[i];
-        }
-        return 4.0 * std::sqrt(std::max(m0, 0.0));
+        return SpectrumStats::compute_hs<Nfreq>(lastSpectrum_, df_);
     }
 
     // Peak frequency using proper log-parabolic interpolation
     double estimateFp() const {
-        int k = 0; double vmax = 0.0;
-        for (int i = 0; i < Nfreq; ++i) {
-            if (lastSpectrum_[i] > vmax) { vmax = lastSpectrum_[i]; k = i; }
-        }
-        if (k == 0 || k == Nfreq - 1) return freqs_[k];
-
-        // Use log-frequency for true log-parabolic interpolation
-        const double f0 = freqs_[k-1], f1 = freqs_[k], f2 = freqs_[k+1];
-        if (f0 <= 0 || f1 <= 0 || f2 <= 0) return f1;
-
-        const double x0 = std::log(f0), x1 = std::log(f1), x2 = std::log(f2);
-        const double y0 = safeLog(lastSpectrum_[k-1]);
-        const double y1 = safeLog(lastSpectrum_[k]);
-        const double y2 = safeLog(lastSpectrum_[k+1]);
-
-        // Quadratic fit y = a x^2 + b x + c
-        const double dx01 = x0 - x1, dx02 = x0 - x2, dx12 = x1 - x2;
-        const double denom = (dx01 * dx02 * dx12);
-        if (std::abs(denom) < 1e-18) return f1;
-
-        // Lagrange-based coefficients
-        const double L0a = 1.0 / (dx01 * dx02);
-        const double L1a = 1.0 / ((x1 - x0) * (x1 - x2));
-        const double L2a = 1.0 / ((x2 - x0) * (x2 - x1));
-        const double a = y0 * L0a + y1 * L1a + y2 * L2a;
-
-        const double b =
-            y0 * (-(x1 + x2) * L0a) +
-            y1 * (-(x0 + x2) * L1a) +
-            y2 * (-(x0 + x1) * L2a);
-
-        if (a >= 0.0) return f1; // not a concave peak
-
-        const double x_peak = -b / (2.0 * a);
-        const double f_peak = std::exp(x_peak);
-
-        if (f_peak <= std::min(f0,f2) || f_peak >= std::max(f0,f2)) return f1;
-        return f_peak;
+        return SpectrumStats::estimate_fp<Nfreq>(lastSpectrum_, freqs_);
     }
 
     // Simple PM log-LS fit (α, f_p) with frequency-weighted cost
@@ -362,7 +322,24 @@ private:
                 i_peak = i;
             }
         }
-        if (i_peak <= 1 || s_peak <= 0.0) return;
+        if (s_peak <= 0.0) return;
+
+        // If the global peak is stuck in the first bins (typical DC/leak artifact),
+        // fall back to the strongest interior peak so suppression still engages.
+        if (i_peak <= 1) {
+            int i_alt = -1;
+            double s_alt = 0.0;
+            for (int i = 2; i < Nfreq; ++i) {
+                const double v = std::max(0.0, (double)lastSpectrum_[i]);
+                if (v > s_alt) {
+                    s_alt = v;
+                    i_alt = i;
+                }
+            }
+            if (i_alt < 0 || s_alt <= 0.0) return;
+            i_peak = i_alt;
+            s_peak = s_alt;
+        }
 
         const double f_peak = freqs_[i_peak];
         const double f_cut_target = 0.45 * f_peak;

--- a/src/spectrum/WaveSpectrumEstimator_Wavelets.h
+++ b/src/spectrum/WaveSpectrumEstimator_Wavelets.h
@@ -12,6 +12,8 @@
 #include <limits>
 #include <algorithm> // for std::clamp
 
+#include "spectrum/SpectrumStats.h"
+
 #ifdef SPECTRUM_TEST
 #include <iostream>
 #include <cassert>
@@ -158,47 +160,11 @@ public:
     bool ready() const { return isWarm; }
 
     double computeHs() const {
-        double m0 = 0.0;
-        for (int i = 0; i < Nfreq; i++) m0 += lastSpectrum_[i] * df_[i];
-        return 4.0 * std::sqrt(std::max(m0, 0.0));
+        return SpectrumStats::compute_hs<Nfreq>(lastSpectrum_, df_);
     }
 
     double estimateFp() const {
-        int k = 0; double vmax = 0.0;
-        for (int i = 0; i < Nfreq; ++i) {
-            if (lastSpectrum_[i] > vmax) { vmax = lastSpectrum_[i]; k = i; }
-        }
-        if (k == 0 || k == Nfreq - 1) return freqs_[k];
-
-        const double f0 = freqs_[k-1], f1 = freqs_[k], f2 = freqs_[k+1];
-        if (f0 <= 0 || f1 <= 0 || f2 <= 0) return f1;
-
-        const double x0 = std::log(f0), x1 = std::log(f1), x2 = std::log(f2);
-        const double y0 = safeLog(lastSpectrum_[k-1]);
-        const double y1 = safeLog(lastSpectrum_[k]);
-        const double y2 = safeLog(lastSpectrum_[k+1]);
-
-        const double dx01 = x0 - x1, dx02 = x0 - x2, dx12 = x1 - x2;
-        const double denom = (dx01 * dx02 * dx12);
-        if (std::abs(denom) < 1e-18) return f1;
-
-        const double L0a = 1.0 / (dx01 * dx02);
-        const double L1a = 1.0 / ((x1 - x0) * (x1 - x2));
-        const double L2a = 1.0 / ((x2 - x0) * (x2 - x1));
-        const double a = y0 * L0a + y1 * L1a + y2 * L2a;
-
-        const double b =
-            y0 * (-(x1 + x2) * L0a) +
-            y1 * (-(x0 + x2) * L1a) +
-            y2 * (-(x0 + x1) * L2a);
-
-        if (a >= 0.0) return f1;
-
-        const double x_peak = -b / (2.0 * a);
-        const double f_peak = std::exp(x_peak);
-
-        if (f_peak <= std::min(f0,f2) || f_peak >= std::max(f0,f2)) return f1;
-        return f_peak;
+        return SpectrumStats::estimate_fp<Nfreq>(lastSpectrum_, freqs_);
     }
 
     PMFitResult fitPiersonMoskowitz() const {
@@ -325,7 +291,24 @@ private:
                 i_peak = i;
             }
         }
-        if (i_peak <= 1 || s_peak <= 0.0) return;
+        if (s_peak <= 0.0) return;
+
+        // If the global peak is stuck in the first bins (typical DC/leak artifact),
+        // fall back to the strongest interior peak so suppression still engages.
+        if (i_peak <= 1) {
+            int i_alt = -1;
+            double s_alt = 0.0;
+            for (int i = 2; i < Nfreq; ++i) {
+                const double v = std::max(0.0, (double)lastSpectrum_[i]);
+                if (v > s_alt) {
+                    s_alt = v;
+                    i_alt = i;
+                }
+            }
+            if (i_alt < 0 || s_alt <= 0.0) return;
+            i_peak = i_alt;
+            s_peak = s_alt;
+        }
 
         const double f_peak = freqs_[i_peak];
         const double f_cut_target = 0.45 * f_peak;

--- a/tests/spectrum/SpectrumEstimatorSimShared.h
+++ b/tests/spectrum/SpectrumEstimatorSimShared.h
@@ -198,9 +198,14 @@ inline void process_wave_file(const std::string& data_file,
     const std::string outname = output_prefix + waveName + tail + nb.str() + ".csv";
 
     std::ofstream ofs(outname);
+    const double hs_est = estimator.computeHs();
+    const double fp_est = estimator.estimateFp();
+    const double tp_est = (fp_est > 0.0) ? (1.0 / fp_est) : 0.0;
+
     ofs << "freq_hz,S_eta_hz,S_ref_interp,S_ratio,"
            "A_eta_est,A_eta_ref,E_eta_est,E_eta_ref,"
-           "CumVar_est,CumVar_ref\n";
+           "CumVar_est,CumVar_ref,"
+           "Hs_est,Fp_est,Tp_est\n";
 
     double cum_est = 0.0;
     double cum_ref = 0.0;
@@ -227,7 +232,8 @@ inline void process_wave_file(const std::string& data_file,
         ofs << f_est << "," << S_eta_hz << "," << s_ref << "," << ratio << ","
             << A_eta_est << "," << A_eta_ref << ","
             << E_eta_est << "," << E_eta_ref << ","
-            << cum_est << "," << cum_ref << "\n";
+            << cum_est << "," << cum_ref << ","
+            << hs_est << "," << fp_est << "," << tp_est << "\n";
     }
 
     std::cout << "Finished " << data_file << " with " << block_count


### PR DESCRIPTION
### Motivation

- Centralize and deduplicate common spectral statistics (safe log, Hs, peak frequency, peak period) used by multiple estimators to reduce code duplication and ensure consistent behavior.
- Make low-frequency/DC leak suppression more robust when the global maximum is an artifact in the first bins by falling back to a stronger interior peak.
- Export summary metrics (`Hs`, `Fp`, `Tp`) from the simulation CSV output for easier analysis.

### Description

- Added new header `src/spectrum/SpectrumStats.h` which provides `safe_log`, `compute_hs`, `estimate_fp`, and `estimate_tp` as templated helpers for fixed-size frequency grids.
- Replaced in-place `computeHs()` and `estimateFp()` implementations in `src/spectrum/WaveSpectrumEstimator.h` and `src/spectrum/WaveSpectrumEstimator_Wavelets.h` with calls to the new `SpectrumStats` helpers.
- Improved `suppress_lowfreq_dc_leak_()` in both estimator headers to detect when the global peak is stuck in the first bins and select the strongest interior peak instead so suppression still engages correctly.
- Updated `tests/spectrum/SpectrumEstimatorSimShared.h` to compute `hs_est`, `fp_est`, and `tp_est` and append `Hs_est,Fp_est,Tp_est` columns to the simulation CSV output.

### Testing

- Built and ran the spectrum-related test suite under `tests/spectrum` (simulation/estimator tests), and the tests completed successfully.
- Compiled the project to ensure the new header and changed call-sites integrate cleanly, and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc81bcddc8832885089a821c56b582)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced edge case handling in low-frequency spectral suppression when global peak detection encounters boundary conditions.

* **Refactor**
  * Consolidated wave spectrum statistical calculations into shared utility module for improved consistency across estimators.
  * Updated spectrum estimators to use unified calculation methods.

* **Tests**
  * Extended test output to include estimated wave parameters (Hs, Fp, Tp) for comprehensive validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->