### PR TITLE
Fix spectrum-estimate plots: plot S_eta and robust Tp extraction

### DIFF
--- a/plots/spectrum/spectrum-estimates-plots.py
+++ b/plots/spectrum/spectrum-estimates-plots.py
@@ -118,6 +118,33 @@ def estimate_bulk_from_spectrum(df):
     return hs, tp
 
 
+def estimate_tp_from_spectrum(df, min_freq_hz=0.08):
+    fcol = pick_column(df, ["freq_hz", "f_hz", "freq"])
+    scol = pick_column(df, ["S_eta_hz", "S_eta_est", "S_eta", "S_est"])
+    if fcol is None or scol is None:
+        return None
+
+    work = df[[fcol, scol]].copy()
+    work = work[np.isfinite(work[fcol]) & np.isfinite(work[scol])]
+    work = work[work[fcol] > 0.0]
+    if work.empty:
+        return None
+
+    work[scol] = work[scol].clip(lower=0.0)
+    filtered = work[work[fcol] >= min_freq_hz]
+    if filtered.empty:
+        filtered = work
+
+    if filtered[scol].max() <= 0.0:
+        return None
+
+    peak_row = filtered.loc[filtered[scol].idxmax()]
+    fp = float(peak_row[fcol])
+    if fp <= 0.0:
+        return None
+    return 1.0 / fp
+
+
 def plot_mode(mode):
     groups = collect_groups(mode)
     if not groups:
@@ -140,15 +167,14 @@ def plot_mode(mode):
             label = tracker.capitalize()
             lw = 1.8
 
-            if "A_eta_est" in df.columns:
-                axes[0].semilogx(df["freq_hz"], df["A_eta_est"], label=f"{label} est", lw=lw)
-            if "A_eta_ref" in df.columns and idx == 0:
-                axes[0].semilogx(df["freq_hz"], df["A_eta_ref"], "--", color="gray", label="Reference", lw=1.2)
+            if "S_eta_hz" in df.columns:
+                axes[0].loglog(df["freq_hz"], df["S_eta_hz"], label=f"{label} est", lw=lw)
+            if "S_ref_interp" in df.columns and idx == 0:
+                axes[0].loglog(df["freq_hz"], df["S_ref_interp"], "--", color="gray", label="Reference", lw=1.2)
 
-            if "E_eta_est" in df.columns:
-                axes[1].semilogx(df["freq_hz"], df["E_eta_est"], label=f"{label} est", lw=lw)
-            if "E_eta_ref" in df.columns and idx == 0:
-                axes[1].semilogx(df["freq_hz"], df["E_eta_ref"], "--", color="gray", label="Reference", lw=1.2)
+            if "S_ratio" in df.columns:
+                axes[1].semilogx(df["freq_hz"], df["S_ratio"], label=f"{label} est/ref", lw=lw)
+            axes[1].axhline(1.0, color="gray", ls="--", lw=1.0)
 
             if "CumVar_est" in df.columns:
                 est_norm = df["CumVar_est"] / max(df["CumVar_est"].iloc[-1], 1e-12)
@@ -157,8 +183,8 @@ def plot_mode(mode):
                 ref_norm = df["CumVar_ref"] / max(df["CumVar_ref"].iloc[-1], 1e-12)
                 axes[2].semilogx(df["freq_hz"], ref_norm, "--", color="gray", label="Reference", lw=1.2)
 
-        axes[0].set_ylabel(r"$A_\eta(f)$ [m]")
-        axes[1].set_ylabel(r"$E_\eta(f)=fS_\eta(f)$ [m$^2$]")
+        axes[0].set_ylabel(r"$S_\eta(f)$ [m$^2$/Hz]")
+        axes[1].set_ylabel(r"$S_{\eta,\mathrm{est}}/S_{\eta,\mathrm{ref}}$")
         axes[2].set_ylabel("Cumulative variance")
         axes[2].set_xlabel("Frequency [Hz]")
 
@@ -187,17 +213,31 @@ def plot_mode(mode):
 
             if hs_col is not None:
                 hs_values.append((label, float(df[hs_col].iloc[-1])))
+            tp_val = None
             if tp_col is not None:
-                tp_values.append((label, float(df[tp_col].iloc[-1])))
+                tp_val = float(df[tp_col].iloc[-1])
             elif fp_col is not None:
                 safe_fp = max(float(df[fp_col].iloc[-1]), 1e-9)
-                tp_values.append((label, 1.0 / safe_fp))
+                tp_val = 1.0 / safe_fp
 
-            if hs_col is None or (tp_col is None and fp_col is None):
+            tp_from_spec = estimate_tp_from_spectrum(df)
+            if tp_from_spec is not None:
+                if tp_val is None or not np.isfinite(tp_val) or tp_val > 20.0 or tp_val < 0.5:
+                    tp_val = tp_from_spec
+                else:
+                    fmin = float(df["freq_hz"].iloc[0]) if "freq_hz" in df.columns else None
+                    if fmin is not None and fmin > 0.0:
+                        edge_tp = 1.0 / fmin
+                        if abs(tp_val - edge_tp) / edge_tp < 0.05:
+                            tp_val = tp_from_spec
+            if tp_val is not None:
+                tp_values.append((label, tp_val))
+
+            if hs_col is None or tp_val is None:
                 hs_est, tp_est = estimate_bulk_from_spectrum(df)
                 if hs_col is None and hs_est is not None:
                     hs_values.append((label, hs_est))
-                if tp_col is None and fp_col is None and tp_est is not None:
+                if tp_val is None and tp_est is not None:
                     tp_values.append((label, tp_est))
 
         fig_hs, ax_hs = plt.subplots(figsize=(6.5, 2.8))


### PR DESCRIPTION
### Motivation
- The report plots were showing transformed amplitudes/energy which created an apparent rising low-frequency amplitude and hid true S_eta disagreement. 
- Some reported Tp bars were pegged to the lowest-frequency edge producing incorrect period bars in the PDF report.

### Description
- Modified `plots/spectrum/spectrum-estimates-plots.py` to plot the displacement spectrum `S_eta_hz` (log-log) and the reference `S_ref_interp` in the top panel instead of amplitude/energy transforms. 
- Replaced the middle panel with an explicit spectral ratio `S_ratio` and added a unity baseline line for easier low-frequency bias diagnosis. 
- Added `estimate_tp_from_spectrum()` (with `min_freq_hz=0.08` guard) and integrated logic to use this spectrum-derived Tp to override or replace invalid/edge-pegged `Tp` values before making the Tp bar chart. 
- Updated axis labels and plotting calls accordingly (see `plots/spectrum/spectrum-estimates-plots.py`).

### Testing
- Ran Python syntax check with `python3 -m py_compile plots/spectrum/spectrum-estimates-plots.py`, which passed. 
- Attempted to run `python3 plots/spectrum/spectrum-estimates-plots.py --mode classic` but full plot generation could not be executed because `matplotlib` is not installed in this environment (so PGF outputs were not produced here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc91e2f0a48328bf3299fc42c37923)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Spectrum visualization now displays spectral density in log-log format with improved reference comparisons.
  * Enhanced peak period estimation with automatic fallback mechanisms when primary data is unavailable or invalid.

* **Improvements**
  * More robust handling of peak period calculations across multiple data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->