### PR TITLE
Add RMS amplitude-error metric and %Hs quality gate to spectrum tests

### DIFF
--- a/tests/spectrum/SpectrumEstimatorSimShared.h
+++ b/tests/spectrum/SpectrumEstimatorSimShared.h
@@ -132,15 +132,15 @@ inline std::vector<double> build_reference_1d_spectrum(
 }
 
 template <typename TEstimator, int Nfreq>
-inline void process_wave_file(const std::string& data_file,
+inline bool process_wave_file(const std::string& data_file,
                               [[maybe_unused]] float dt,
                               unsigned noise_seed,
                               const std::string& output_prefix) {
     auto parsed = WaveFileNaming::parse_to_params(data_file);
-    if (!parsed) return;
+    if (!parsed) return true;
 
     auto [kind, type, wp] = *parsed;
-    if (kind != FileKind::Data) return;
+    if (kind != FileKind::Data) return true;
 
     std::string spectrum_file = data_file;
     auto pos = spectrum_file.find("wave_data_");
@@ -150,7 +150,7 @@ inline void process_wave_file(const std::string& data_file,
 
     if (!std::filesystem::exists(spectrum_file)) {
         std::cerr << "Skipping " << data_file << " (missing ref spectrum " << spectrum_file << ")\n";
-        return;
+        return true;
     }
 
     std::cout << "Processing " << data_file
@@ -184,7 +184,7 @@ inline void process_wave_file(const std::string& data_file,
     if (!has_last) {
         std::cout << "Finished " << data_file << " with " << block_count
                   << " spectra (no final snapshot)\n\n";
-        return;
+        return true;
     }
 
     const std::string waveName = EnumTraits<WaveType>::to_string(type);
@@ -209,6 +209,7 @@ inline void process_wave_file(const std::string& data_file,
 
     double cum_est = 0.0;
     double cum_ref = 0.0;
+    double sum_sq_amp_error = 0.0;
     for (int i = 0; i < Nfreq; ++i) {
         const double f_est = freqs[i];
         const double S_eta_hz = std::max(0.0, last_s_est[i]);
@@ -223,11 +224,13 @@ inline void process_wave_file(const std::string& data_file,
         const double ratio = (s_ref > 0.0) ? (S_eta_hz / s_ref) : 0.0;
         const double A_eta_est = std::sqrt(std::max(0.0, 2.0 * S_eta_hz * delta_f * f_est));
         const double A_eta_ref = std::sqrt(std::max(0.0, 2.0 * s_ref * delta_f * f_est));
+        const double A_eta_err = A_eta_est - A_eta_ref;
         const double E_eta_est = f_est * S_eta_hz;
         const double E_eta_ref = f_est * s_ref;
 
         cum_est += S_eta_hz * 2.0 * delta_f;
         cum_ref += s_ref * 2.0 * delta_f;
+        sum_sq_amp_error += A_eta_err * A_eta_err;
 
         ofs << f_est << "," << S_eta_hz << "," << s_ref << "," << ratio << ","
             << A_eta_est << "," << A_eta_ref << ","
@@ -236,8 +239,20 @@ inline void process_wave_file(const std::string& data_file,
             << hs_est << "," << fp_est << "," << tp_est << "\n";
     }
 
+    const double amp_err_rms_m = std::sqrt(sum_sq_amp_error / static_cast<double>(Nfreq));
+    const double hs_ref_m = static_cast<double>(wp.height);
+    const double amp_err_rms_pct_hs = (hs_ref_m > 0.0) ? (100.0 * amp_err_rms_m / hs_ref_m) : 0.0;
+    constexpr double AMP_ERR_RMS_LIMIT_PCT_HS = 20.0;
+    const bool quality_ok = amp_err_rms_pct_hs <= AMP_ERR_RMS_LIMIT_PCT_HS;
+
+    std::cout << "Spectrum amplitude error RMS=" << amp_err_rms_m
+              << " m (" << amp_err_rms_pct_hs << "%Hs, gate "
+              << AMP_ERR_RMS_LIMIT_PCT_HS << "%Hs) -> "
+              << (quality_ok ? "PASS" : "FAIL") << "\n";
+
     std::cout << "Finished " << data_file << " with " << block_count
               << " spectra -> " << outname << "\n\n";
+    return quality_ok;
 }
 
 inline std::vector<std::string> discover_wave_data_files() {

--- a/tests/spectrum/spectrum-estimator-sim.cpp
+++ b/tests/spectrum/spectrum-estimator-sim.cpp
@@ -17,10 +17,12 @@ int main() {
 
     std::cout << "Spectrum estimator simulation (IMU -> estimator vs ref spectrum files)\n";
 
+    bool all_quality_ok = true;
     for (const auto& fname : SpectrumEstimatorSimShared::discover_wave_data_files()) {
-        SpectrumEstimatorSimShared::process_wave_file<Estimator, Nfreq>(
-            fname, dt, 1234u, "spectrum_estimator_");
+        all_quality_ok = SpectrumEstimatorSimShared::process_wave_file<Estimator, Nfreq>(
+                             fname, dt, 1234u, "spectrum_estimator_")
+                         && all_quality_ok;
     }
 
-    return 0;
+    return all_quality_ok ? 0 : 1;
 }

--- a/tests/spectrum/spectrum-wavelets-estimator-sim.cpp
+++ b/tests/spectrum/spectrum-wavelets-estimator-sim.cpp
@@ -17,10 +17,12 @@ int main() {
 
     std::cout << "Wavelet spectrum estimator simulation (IMU -> estimator vs ref spectrum files)\n";
 
+    bool all_quality_ok = true;
     for (const auto& fname : SpectrumEstimatorSimShared::discover_wave_data_files()) {
-        SpectrumEstimatorSimShared::process_wave_file<Estimator, Nfreq>(
-            fname, dt, 4321u, "spectrum_wavelets_");
+        all_quality_ok = SpectrumEstimatorSimShared::process_wave_file<Estimator, Nfreq>(
+                             fname, dt, 4321u, "spectrum_wavelets_")
+                         && all_quality_ok;
     }
 
-    return 0;
+    return all_quality_ok ? 0 : 1;
 }


### PR DESCRIPTION
### Motivation
- Provide an automated per-file quality metric for spectrum simulations to detect amplitude mismatches between estimated and reference spectra. 
- Express the metric relative to reference wave height (`Hs`) so tests can gate on physically meaningful error magnitudes.

### Description
- Compute per-frequency amplitude as `A = sqrt(2 * S * delta_f * f)` and accumulate squared amplitude errors to produce an RMS amplitude error in meters. 
- Normalize the RMS amplitude error by the reference `Hs` to produce a percent-`Hs` metric and apply a quality gate set to `20.0%Hs`. 
- Make `process_wave_file` return a boolean pass/fail and print the RMS error and gate result for each processed wave file. 
- Aggregate per-file pass/fail in both `spectrum-estimator-sim` and `spectrum-wavelets-estimator-sim` and return non-zero exit status when any file fails the quality gate.

### Testing
- Built the project with `make all`, which completed successfully. 
- Ran the spectrum test runner with `bash tests/spectrum/run_tests.sh`, which executed both simulation binaries and completed with no quality-gate failures observed (exit status `0`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd229d57d08328bcea1cfd921da757)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Spectrum quality assessment now validates estimated amplitude against reference values with RMS error thresholds.
  * Test programs now return appropriate exit codes (success=0, failure=1) based on cumulative results across all processed files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->