### PR TITLE
Add SeaMetricsFromSpectrum validation tests and CSV→LaTeX report generator

### DIFF
--- a/doc/spectrum/sea_metrics_from_spectrum_table.tex
+++ b/doc/spectrum/sea_metrics_from_spectrum_table.tex
@@ -1,0 +1,11 @@
+\documentclass[11pt,letterpaper]{article}
+\usepackage{fullpage}
+\usepackage{booktabs}
+\usepackage{float}
+\title{SeaMetricsFromSpectrum Test Report}
+\author{Auto-generated}
+\date{\today}
+\begin{document}
+\maketitle
+\input{sea_metrics_from_spectrum_table_fragment.tex}
+\end{document}

--- a/doc/spectrum/sea_metrics_from_spectrum_table_fragment.tex
+++ b/doc/spectrum/sea_metrics_from_spectrum_table_fragment.tex
@@ -1,0 +1,13 @@
+\begin{table}[H]
+\centering
+\caption{SeaMetricsFromSpectrum validation using two synthetic spectra derived from spectrum-estimator scenarios.}
+\label{tab:sea_metrics_from_spectrum}
+\begin{tabular}{lrrrrrcl}
+\toprule
+Case & $H_{s,target}$ & $H_{s,est}$ & $H_s$ err [\%] & $T_{p,target}$ & $T_{p,est}$ & Type & Gate \\
+\midrule
+narrow\_peak\_swell\_like & 1.500 & 1.501 & 0.04 & 10.000 & 10.028 & Mixed & \textbf{PASS} \\
+broad\_peak\_windsea\_like & 1.500 & 1.498 & 0.13 & 6.000 & 6.006 & Mixed & \textbf{PASS} \\
+\bottomrule
+\end{tabular}
+\end{table}

--- a/plots/spectrum/sea-metrics-report.py
+++ b/plots/spectrum/sea-metrics-report.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+import argparse
+import csv
+from pathlib import Path
+
+
+def tex_escape(text: str) -> str:
+    return text.replace("_", r"\_").replace("%", r"\%").replace("&", r"\&")
+
+
+def pass_cell(v: str) -> str:
+    return r"\textbf{PASS}" if str(v).strip() in ("1", "true", "True") else r"\textbf{FAIL}"
+
+
+def build_fragment(rows) -> str:
+    lines = [
+        r"\begin{table}[H]",
+        r"\centering",
+        r"\caption{SeaMetricsFromSpectrum validation using two synthetic spectra derived from spectrum-estimator scenarios.}",
+        r"\label{tab:sea_metrics_from_spectrum}",
+        r"\begin{tabular}{lrrrrrcl}",
+        r"\toprule",
+        r"Case & $H_{s,target}$ & $H_{s,est}$ & $H_s$ err [\%] & $T_{p,target}$ & $T_{p,est}$ & Type & Gate \\",
+        r"\midrule",
+    ]
+
+    for row in rows:
+        line = (
+            f"{tex_escape(row['case_name'])} & "
+            f"{float(row['hs_target_m']):.3f} & "
+            f"{float(row['hs_est_m']):.3f} & "
+            f"{float(row['hs_error_pct']):.2f} & "
+            f"{float(row['tp_target_s']):.3f} & "
+            f"{float(row['tp_est_s']):.3f} & "
+            f"{tex_escape(row['spectrum_type'])} & "
+            f"{pass_cell(row['pass'])} "
+            r"\\"
+        )
+        lines.append(line)
+
+    lines.extend([r"\bottomrule", r"\end{tabular}", r"\end{table}"])
+    return "\n".join(lines) + "\n"
+
+
+def build_main(fragment_path: Path) -> str:
+    return "\n".join([
+        r"\documentclass[11pt,letterpaper]{article}",
+        r"\usepackage{fullpage}",
+        r"\usepackage{booktabs}",
+        r"\usepackage{float}",
+        r"\title{SeaMetricsFromSpectrum Test Report}",
+        r"\author{Auto-generated}",
+        r"\date{\today}",
+        r"\begin{document}",
+        r"\maketitle",
+        rf"\input{{{fragment_path.name}}}",
+        r"\end{document}",
+        "",
+    ])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--csv", default="sea_metrics_from_spectrum_report.csv")
+    parser.add_argument("--out-fragment", default="../../doc/spectrum/sea_metrics_from_spectrum_table_fragment.tex")
+    parser.add_argument("--out-main", default="../../doc/spectrum/sea_metrics_from_spectrum_table.tex")
+    args = parser.parse_args()
+
+    csv_path = Path(args.csv)
+    fragment_path = Path(args.out_fragment)
+    main_path = Path(args.out_main)
+
+    with csv_path.open("r", encoding="utf-8", newline="") as f:
+        rows = list(csv.DictReader(f))
+
+    fragment_path.parent.mkdir(parents=True, exist_ok=True)
+    main_path.parent.mkdir(parents=True, exist_ok=True)
+    fragment_path.write_text(build_fragment(rows), encoding="utf-8")
+    main_path.write_text(build_main(fragment_path), encoding="utf-8")
+
+    print(f"Loaded CSV rows: {len(rows)} from {csv_path}")
+    print(f"Wrote LaTeX fragment: {fragment_path}")
+    print(f"Wrote LaTeX main: {main_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/spectrum/Makefile
+++ b/tests/spectrum/Makefile
@@ -16,7 +16,7 @@ else
     CXXFLAGS = $(BASEFLAGS) $(EIGEN_INC)
 endif
 
-TARGETS = spectrum-estimator-sim spectrum-wavelets-estimator-sim
+TARGETS = spectrum-estimator-sim spectrum-wavelets-estimator-sim sea-metrics-from-spectrum-test
 
 all: $(TARGETS)
 
@@ -31,3 +31,6 @@ spectrum-wavelets-estimator-sim: spectrum-wavelets-estimator-sim.o
 
 clean:
 	rm -f *.o $(TARGETS) *.exe spectrum_*estimate*.csv
+
+sea-metrics-from-spectrum-test: sea-metrics-from-spectrum-test.o
+	$(CC) $(CXXFLAGS) -o $@ $^

--- a/tests/spectrum/run_tests.sh
+++ b/tests/spectrum/run_tests.sh
@@ -2,3 +2,6 @@
 
 ./spectrum-estimator-sim
 ./spectrum-wavelets-estimator-sim
+
+./sea-metrics-from-spectrum-test
+python3 ../../plots/spectrum/sea-metrics-report.py --csv sea_metrics_from_spectrum_report.csv --out-fragment ../../doc/spectrum/sea_metrics_from_spectrum_table_fragment.tex --out-main ../../doc/spectrum/sea_metrics_from_spectrum_table.tex

--- a/tests/spectrum/sea-metrics-from-spectrum-test.cpp
+++ b/tests/spectrum/sea-metrics-from-spectrum-test.cpp
@@ -1,0 +1,161 @@
+#include <cmath>
+#include <cstdlib>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "spectrum/SeaMetricsFromSpectrum.h"
+
+namespace {
+
+struct CaseSpec {
+    std::string name;
+    double hs_target_m;
+    double tp_target_s;
+    double sigma_hz;
+};
+
+struct CaseResult {
+    std::string name;
+    double hs_target_m = 0.0;
+    double hs_est_m = 0.0;
+    double hs_error_pct = 0.0;
+    double tp_target_s = 0.0;
+    double tp_est_s = 0.0;
+    double tp_error_pct = 0.0;
+    double rbw = 0.0;
+    double peakedness_ochi_q = 0.0;
+    std::string spectrum_type;
+    bool pass = false;
+};
+
+std::vector<double> build_frequency_grid() {
+    constexpr int N = 128;
+    const double f_min = 0.03;
+    const double f_max = 1.0;
+
+    std::vector<double> f;
+    f.reserve(N);
+    const double step = (f_max - f_min) / static_cast<double>(N - 1);
+    for (int i = 0; i < N; ++i) {
+        f.push_back(f_min + static_cast<double>(i) * step);
+    }
+    return f;
+}
+
+double trapz(const std::vector<double>& x, const std::vector<double>& y) {
+    if (x.size() < 2 || x.size() != y.size()) return 0.0;
+
+    double sum = 0.0;
+    for (std::size_t i = 0; i + 1 < x.size(); ++i) {
+        const double dx = x[i + 1] - x[i];
+        sum += 0.5 * dx * (y[i] + y[i + 1]);
+    }
+    return sum;
+}
+
+std::string to_spectrum_type(SeaMetricsFromSpectrum::SpectrumType t) {
+    switch (t) {
+        case SeaMetricsFromSpectrum::SpectrumType::Swell: return "Swell";
+        case SeaMetricsFromSpectrum::SpectrumType::Mixed: return "Mixed";
+        case SeaMetricsFromSpectrum::SpectrumType::WindSea: return "WindSea";
+        default: return "Unknown";
+    }
+}
+
+CaseResult run_case(const CaseSpec& spec, const std::vector<double>& freqs_hz) {
+    const double fp_target_hz = 1.0 / spec.tp_target_s;
+    std::vector<double> s_raw(freqs_hz.size(), 0.0);
+
+    for (std::size_t i = 0; i < freqs_hz.size(); ++i) {
+        const double x = (freqs_hz[i] - fp_target_hz) / spec.sigma_hz;
+        s_raw[i] = std::exp(-0.5 * x * x);
+    }
+
+    const double m0_raw = trapz(freqs_hz, s_raw);
+    const double m0_target = std::pow(spec.hs_target_m / 4.0, 2.0);
+    const double scale = (m0_raw > 0.0) ? (m0_target / m0_raw) : 0.0;
+
+    std::vector<double> s_eta(freqs_hz.size(), 0.0);
+    for (std::size_t i = 0; i < s_eta.size(); ++i) {
+        s_eta[i] = scale * s_raw[i];
+    }
+
+    SeaMetricsFromSpectrum metrics;
+    metrics.updateFromSpectrum(freqs_hz, s_eta, 0.04, 1.0);
+    const auto& r = metrics.report();
+
+    CaseResult out;
+    out.name = spec.name;
+    out.hs_target_m = spec.hs_target_m;
+    out.tp_target_s = spec.tp_target_s;
+    out.hs_est_m = r.hs_m;
+    out.tp_est_s = r.tp_s;
+    out.hs_error_pct = (spec.hs_target_m > 0.0) ? std::abs(100.0 * (r.hs_m - spec.hs_target_m) / spec.hs_target_m) : 0.0;
+    out.tp_error_pct = (spec.tp_target_s > 0.0) ? std::abs(100.0 * (r.tp_s - spec.tp_target_s) / spec.tp_target_s) : 0.0;
+    out.rbw = r.rbw;
+    out.peakedness_ochi_q = r.peakedness_ochi_q;
+    out.spectrum_type = to_spectrum_type(r.spectrum_type);
+
+    constexpr double HS_GATE_PCT = 5.0;
+    constexpr double TP_GATE_PCT = 8.0;
+    out.pass = r.valid && out.hs_error_pct <= HS_GATE_PCT && out.tp_error_pct <= TP_GATE_PCT;
+
+    return out;
+}
+
+}  // namespace
+
+int main() {
+    const std::vector<CaseSpec> cases = {
+        {"narrow_peak_swell_like", 1.50, 10.0, 0.015},
+        {"broad_peak_windsea_like", 1.50, 6.0, 0.050},
+    };
+
+    const auto freqs_hz = build_frequency_grid();
+
+    std::ofstream csv("sea_metrics_from_spectrum_report.csv");
+    if (!csv.is_open()) {
+        std::cerr << "Failed to open sea_metrics_from_spectrum_report.csv for writing\n";
+        return EXIT_FAILURE;
+    }
+
+    csv << "case_name,hs_target_m,hs_est_m,hs_error_pct,tp_target_s,tp_est_s,tp_error_pct,rbw,peakedness_ochi_q,spectrum_type,pass\n";
+    csv << std::fixed << std::setprecision(6);
+
+    std::cout << "SeaMetricsFromSpectrum synthetic-spectrum test report\n";
+
+    bool all_ok = true;
+    std::vector<CaseResult> results;
+    results.reserve(cases.size());
+
+    for (const auto& c : cases) {
+        CaseResult r = run_case(c, freqs_hz);
+        all_ok = all_ok && r.pass;
+        results.push_back(r);
+
+        csv << r.name << ','
+            << r.hs_target_m << ',' << r.hs_est_m << ',' << r.hs_error_pct << ','
+            << r.tp_target_s << ',' << r.tp_est_s << ',' << r.tp_error_pct << ','
+            << r.rbw << ',' << r.peakedness_ochi_q << ','
+            << r.spectrum_type << ',' << (r.pass ? 1 : 0) << "\n";
+
+        std::cout << "  - " << r.name
+                  << ": Hs(est=" << r.hs_est_m << " m, err=" << r.hs_error_pct << "%), "
+                  << "Tp(est=" << r.tp_est_s << " s, err=" << r.tp_error_pct << "%), "
+                  << "RBW=" << r.rbw << ", q=" << r.peakedness_ochi_q << ", type=" << r.spectrum_type
+                  << " -> " << (r.pass ? "PASS" : "FAIL") << "\n";
+    }
+
+    if (results.size() == 2) {
+        const bool narrow_is_narrower = results[0].rbw < results[1].rbw;
+        std::cout << "  - cross-check: narrow RBW < broad RBW -> "
+                  << (narrow_is_narrower ? "PASS" : "FAIL") << "\n";
+        all_ok = all_ok && narrow_is_narrower;
+    }
+
+    std::cout << "CSV written: sea_metrics_from_spectrum_report.csv\n";
+    return all_ok ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
### Motivation
- Provide unit-level coverage for `SeaMetricsFromSpectrum` using deterministic synthetic spectra to ensure key metrics (`Hs`, `Tp`, RBW, peakedness, spectrum type) behave as expected. 
- Produce machine-readable test output (CSV) and a LaTeX table fragment so spectral validation can be included in documentation in the same pattern used for plots.

### Description
- Added a new spectrum test executable `tests/spectrum/sea-metrics-from-spectrum-test.cpp` which defines two synthetic cases (`narrow_peak_swell_like`, `broad_peak_windsea_like`), runs `SeaMetricsFromSpectrum::updateFromSpectrum`, validates `Hs/Tp` against gates, emits a CSV `sea_metrics_from_spectrum_report.csv`, and prints a human-readable summary. 
- Added `plots/spectrum/sea-metrics-report.py` which reads the CSV and writes a LaTeX table fragment `doc/spectrum/sea_metrics_from_spectrum_table_fragment.tex` and a main LaTeX file `doc/spectrum/sea_metrics_from_spectrum_table.tex` that includes the fragment. 
- Hooked the new test into `tests/spectrum/Makefile` (added target and build rule) and into `tests/spectrum/run_tests.sh` so it runs with other spectrum tests and the report generator is invoked automatically. 
- Kept changes scoped to spectrum tests and reporting only and used only standard-library Python CSV handling to avoid extra dependencies.

### Testing
- Ran `make all` from the repository root and the build completed successfully with the new target included. (success)
- From `tests/spectrum` ran `./sea-metrics-from-spectrum-test` which produced `sea_metrics_from_spectrum_report.csv` and printed both cases as `PASS` and the RBW cross-check as `PASS` (success).
- Ran the report generator `python3 ../../plots/spectrum/sea-metrics-report.py --csv sea_metrics_from_spectrum_report.csv --out-fragment ../../doc/spectrum/sea_metrics_from_spectrum_table_fragment.tex --out-main ../../doc/spectrum/sea_metrics_from_spectrum_table.tex` which wrote the LaTeX fragment and main files (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd4144d24483288c0fd7c4754195d1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated validation tests for sea metrics extraction from spectral data with pass/fail assessment.

* **Documentation**
  * Added automated test report generation with formatted output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->