### PR TITLE
Make spectrum table fragment compile standalone and embeddable

### DIFF
--- a/doc/spectrum/sea_metrics_from_spectrum_table.tex
+++ b/doc/spectrum/sea_metrics_from_spectrum_table.tex
@@ -7,5 +7,6 @@
 \date{\today}
 \begin{document}
 \maketitle
+\newcommand{\SEAMETRICSFRAGMENT}{}
 \input{sea_metrics_from_spectrum_table_fragment.tex}
 \end{document}

--- a/doc/spectrum/sea_metrics_from_spectrum_table_fragment.tex
+++ b/doc/spectrum/sea_metrics_from_spectrum_table_fragment.tex
@@ -1,3 +1,11 @@
+\ifdefined\SEAMETRICSFRAGMENT
+\else
+\documentclass[11pt,letterpaper]{article}
+\usepackage{booktabs}
+\usepackage{float}
+\begin{document}
+\fi
+
 \begin{table}[H]
 \centering
 \caption{SeaMetricsFromSpectrum validation using two synthetic spectra derived from spectrum-estimator scenarios.}
@@ -11,3 +19,8 @@ broad\_peak\_windsea\_like & 1.500 & 1.498 & 0.13 & 6.000 & 6.006 & Mixed & \tex
 \bottomrule
 \end{tabular}
 \end{table}
+
+\ifdefined\SEAMETRICSFRAGMENT
+\else
+\end{document}
+\fi


### PR DESCRIPTION
### Motivation
- Allow `doc/spectrum/sea_metrics_from_spectrum_table_fragment.tex` to be compiled directly for local testing while preserving its ability to be `\input`-included in the full report.

### Description
- Wrap the fragment with a conditional preamble/document block keyed on `\SEAMETRICSFRAGMENT` so it becomes self-contained when compiled directly.
- Define `\SEAMETRICSFRAGMENT` in `doc/spectrum/sea_metrics_from_spectrum_table.tex` before `\input` so the fragment omits the standalone boilerplate when included.

### Testing
- Attempted to run `cd doc/spectrum && latexmk -lualatex sea_metrics_from_spectrum_table_fragment.tex` and `cd doc/spectrum && latexmk -lualatex sea_metrics_from_spectrum_table.tex`, but `latexmk` is not installed in the environment (`command not found`), so compilation could not be verified here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd5393d41c8328b7df46fa9dbdf685)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Improved documentation modular structure to support both standalone and embedded rendering modes for technical content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->