### PR TITLE
Fix standalone build guard in sea metrics LaTeX fragment

### DIFF
--- a/doc/spectrum/sea_metrics_from_spectrum_table_fragment.tex
+++ b/doc/spectrum/sea_metrics_from_spectrum_table_fragment.tex
@@ -1,5 +1,4 @@
-\ifdefined\SEAMETRICSFRAGMENT
-\else
+\expandafter\ifx\csname SEAMETRICSFRAGMENT\endcsname\relax
 \documentclass[11pt,letterpaper]{article}
 \usepackage{booktabs}
 \usepackage{float}
@@ -20,7 +19,6 @@ broad\_peak\_windsea\_like & 1.500 & 1.498 & 0.13 & 6.000 & 6.006 & Mixed & \tex
 \end{tabular}
 \end{table}
 
-\ifdefined\SEAMETRICSFRAGMENT
-\else
+\expandafter\ifx\csname SEAMETRICSFRAGMENT\endcsname\relax
 \end{document}
 \fi


### PR DESCRIPTION
### Motivation
- The LaTeX fragment `doc/spectrum/sea_metrics_from_spectrum_table_fragment.tex` used `\ifdefined\SEAMETRICSFRAGMENT` which can fail when the fragment is compiled standalone, so the guard needed a more robust existence check for `SEAMETRICSFRAGMENT`.

### Description
- Replace the fragile `\ifdefined\SEAMETRICSFRAGMENT` checks with a robust `\expandafter\ifx\csname SEAMETRICSFRAGMENT\endcsname\relax` guard at both the top and bottom of `doc/spectrum/sea_metrics_from_spectrum_table_fragment.tex` so the fragment emits `\documentclass`/`\begin{document}` and `\end{document}` only when compiled standalone.
- No behavioral change when the fragment is included from `sea_metrics_from_spectrum_table.tex`.

### Testing
- Ran `make all`, which completed successfully and built the test binaries (no source-level failures).
- Attempted to run `latexmk`/`lualatex` on the fragment for direct TeX validation, but the environment is missing TeX tools (`latexmk` and `lualatex` not found), so standalone PDF compilation could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd5a00ae588328a029a5d6a5a3794c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved conditional documentation handling to use an alternative control-flow mechanism while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->