### PR TITLE
Fix standalone build for sea metrics table fragment

### DIFF
--- a/doc/spectrum/sea_metrics_from_spectrum_table.tex
+++ b/doc/spectrum/sea_metrics_from_spectrum_table.tex
@@ -7,6 +7,5 @@
 \date{\today}
 \begin{document}
 \maketitle
-\newcommand{\SEAMETRICSFRAGMENT}{}
-\input{sea_metrics_from_spectrum_table_fragment.tex}
+\input{sea_metrics_from_spectrum_table_content.tex}
 \end{document}

--- a/doc/spectrum/sea_metrics_from_spectrum_table_content.tex
+++ b/doc/spectrum/sea_metrics_from_spectrum_table_content.tex
@@ -1,0 +1,13 @@
+\begin{table}[H]
+\centering
+\caption{SeaMetricsFromSpectrum validation using two synthetic spectra derived from spectrum-estimator scenarios.}
+\label{tab:sea_metrics_from_spectrum}
+\begin{tabular}{lrrrrrcl}
+\toprule
+Case & $H_{s,target}$ & $H_{s,est}$ & $H_s$ err [\%] & $T_{p,target}$ & $T_{p,est}$ & Type & Gate \\
+\midrule
+narrow\_peak\_swell\_like & 1.500 & 1.501 & 0.04 & 10.000 & 10.028 & Mixed & \textbf{PASS} \\
+broad\_peak\_windsea\_like & 1.500 & 1.498 & 0.13 & 6.000 & 6.006 & Mixed & \textbf{PASS} \\
+\bottomrule
+\end{tabular}
+\end{table}

--- a/doc/spectrum/sea_metrics_from_spectrum_table_fragment.tex
+++ b/doc/spectrum/sea_metrics_from_spectrum_table_fragment.tex
@@ -1,24 +1,6 @@
-\expandafter\ifx\csname SEAMETRICSFRAGMENT\endcsname\relax
 \documentclass[11pt,letterpaper]{article}
 \usepackage{booktabs}
 \usepackage{float}
 \begin{document}
-\fi
-
-\begin{table}[H]
-\centering
-\caption{SeaMetricsFromSpectrum validation using two synthetic spectra derived from spectrum-estimator scenarios.}
-\label{tab:sea_metrics_from_spectrum}
-\begin{tabular}{lrrrrrcl}
-\toprule
-Case & $H_{s,target}$ & $H_{s,est}$ & $H_s$ err [\%] & $T_{p,target}$ & $T_{p,est}$ & Type & Gate \\
-\midrule
-narrow\_peak\_swell\_like & 1.500 & 1.501 & 0.04 & 10.000 & 10.028 & Mixed & \textbf{PASS} \\
-broad\_peak\_windsea\_like & 1.500 & 1.498 & 0.13 & 6.000 & 6.006 & Mixed & \textbf{PASS} \\
-\bottomrule
-\end{tabular}
-\end{table}
-
-\expandafter\ifx\csname SEAMETRICSFRAGMENT\endcsname\relax
+\input{sea_metrics_from_spectrum_table_content.tex}
 \end{document}
-\fi


### PR DESCRIPTION
### Motivation
- The LaTeX fragment `doc/spectrum/sea_metrics_from_spectrum_table_fragment.tex` failed to compile with `lualatex` reporting "Environment table undefined", caused by the conditional preamble guard being skipped in some execution paths. 
- The intent is to make the fragment compile standalone and keep the table content single-sourced to avoid divergence between fragment and full report.

### Description
- Added `doc/spectrum/sea_metrics_from_spectrum_table_content.tex` which contains the shared table body. 
- Updated `doc/spectrum/sea_metrics_from_spectrum_table_fragment.tex` to be a true standalone document that `\input{sea_metrics_from_spectrum_table_content.tex}` and removed the conditional preamble guard. 
- Updated `doc/spectrum/sea_metrics_from_spectrum_table.tex` to `\input` the same shared content so both full report and fragment render from one source of truth.

### Testing
- Ran `make all` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd664c5504832887b075be3fe1daee)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated documentation with a validation results table for SeaMetricsFromSpectrum, displaying test outcomes for synthetic spectrum scenarios including significant wave height, peak period measurements, error percentages, and validation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->