### PR TITLE
Fix spectrum table fragment LaTeX generation for standalone builds

### DIFF
--- a/plots/spectrum/sea-metrics-report.py
+++ b/plots/spectrum/sea-metrics-report.py
@@ -12,7 +12,7 @@ def pass_cell(v: str) -> str:
     return r"\textbf{PASS}" if str(v).strip() in ("1", "true", "True") else r"\textbf{FAIL}"
 
 
-def build_fragment(rows) -> str:
+def build_table(rows) -> str:
     lines = [
         r"\begin{table}[H]",
         r"\centering",
@@ -42,7 +42,21 @@ def build_fragment(rows) -> str:
     return "\n".join(lines) + "\n"
 
 
-def build_main(fragment_path: Path) -> str:
+def build_fragment(rows) -> str:
+    table_tex = build_table(rows).strip()
+    return "\n".join([
+        r"\documentclass[11pt,letterpaper]{article}",
+        r"\usepackage{booktabs}",
+        r"\usepackage{float}",
+        r"\begin{document}",
+        table_tex,
+        r"\end{document}",
+        "",
+    ])
+
+
+def build_main(rows) -> str:
+    table_tex = build_table(rows).strip()
     return "\n".join([
         r"\documentclass[11pt,letterpaper]{article}",
         r"\usepackage{fullpage}",
@@ -53,7 +67,7 @@ def build_main(fragment_path: Path) -> str:
         r"\date{\today}",
         r"\begin{document}",
         r"\maketitle",
-        rf"\input{{{fragment_path.name}}}",
+        table_tex,
         r"\end{document}",
         "",
     ])
@@ -76,7 +90,7 @@ def main() -> None:
     fragment_path.parent.mkdir(parents=True, exist_ok=True)
     main_path.parent.mkdir(parents=True, exist_ok=True)
     fragment_path.write_text(build_fragment(rows), encoding="utf-8")
-    main_path.write_text(build_main(fragment_path), encoding="utf-8")
+    main_path.write_text(build_main(rows), encoding="utf-8")
 
     print(f"Loaded CSV rows: {len(rows)} from {csv_path}")
     print(f"Wrote LaTeX fragment: {fragment_path}")


### PR DESCRIPTION
### Motivation
- The CI LaTeX step treats every `*.tex` in `doc/spectrum` as a root file, and the generated `sea_metrics_from_spectrum_table_fragment.tex` previously began with `\begin{table}` which fails standalone compilation with `Environment table undefined.`
- Make the generated fragment a complete LaTeX document so it can be compiled directly by workflows that treat every `.tex` as a root file.

### Description
- Added a reusable `build_table(rows)` helper that renders the table body once and is used by both outputs.
- Changed `build_fragment` to emit a complete LaTeX document (preamble, `\begin{document}`, table, `\end{document}`) so the fragment compiles standalone. 
- Changed `build_main` to embed the same table content directly instead of `\input`-ing the fragment, and updated the writer to call `build_main(rows)`.

### Testing
- Ran the report generator with a sample CSV using `python3 plots/spectrum/sea-metrics-report.py --csv /tmp/sea_metrics_sample.csv --out-fragment doc/spectrum/sea_metrics_from_spectrum_table_fragment.tex --out-main doc/spectrum/sea_metrics_from_spectrum_table.tex` and it successfully wrote both files. 
- Attempted to compile the generated `.tex` files with `latexmk` in the local environment, but the command failed because `latexmk` is not installed in this environment. 
- No other automated test failures were observed from running the generator; CI LaTeX compilation should now succeed because the fragment is a standalone document.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd9788d4188328b4cf010a87c2c595)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal restructuring of LaTeX document generation logic for improved code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->