### PR TITLE
Fix sea-metrics report LaTeX fragment handling with .tex-part

### DIFF
--- a/doc/spectrum/sea_metrics_from_spectrum_table.tex
+++ b/doc/spectrum/sea_metrics_from_spectrum_table.tex
@@ -7,5 +7,5 @@
 \date{\today}
 \begin{document}
 \maketitle
-\input{sea_metrics_from_spectrum_table_fragment.tex}
+\input{sea_metrics_from_spectrum_table_fragment.tex-part}
 \end{document}

--- a/doc/spectrum/sea_metrics_from_spectrum_table_fragment.tex-part
+++ b/doc/spectrum/sea_metrics_from_spectrum_table_fragment.tex-part
@@ -1,0 +1,13 @@
+\begin{table}[H]
+\centering
+\caption{SeaMetricsFromSpectrum validation using two synthetic spectra derived from spectrum-estimator scenarios.}
+\label{tab:sea_metrics_from_spectrum}
+\begin{tabular}{lrrrrrcl}
+\toprule
+Case & $H_{s,target}$ & $H_{s,est}$ & $H_s$ err [\%] & $T_{p,target}$ & $T_{p,est}$ & Type & Gate \\
+\midrule
+narrow\_peak\_swell\_like & 1.500 & 1.501 & 0.04 & 10.000 & 10.028 & Mixed & \textbf{PASS} \\
+broad\_peak\_windsea\_like & 1.500 & 1.498 & 0.13 & 6.000 & 6.006 & Mixed & \textbf{PASS} \\
+\bottomrule
+\end{tabular}
+\end{table}

--- a/plots/spectrum/sea-metrics-report.py
+++ b/plots/spectrum/sea-metrics-report.py
@@ -43,20 +43,10 @@ def build_table(rows) -> str:
 
 
 def build_fragment(rows) -> str:
-    table_tex = build_table(rows).strip()
-    return "\n".join([
-        r"\documentclass[11pt,letterpaper]{article}",
-        r"\usepackage{booktabs}",
-        r"\usepackage{float}",
-        r"\begin{document}",
-        table_tex,
-        r"\end{document}",
-        "",
-    ])
+    return build_table(rows)
 
 
 def build_main(rows) -> str:
-    table_tex = build_table(rows).strip()
     return "\n".join([
         r"\documentclass[11pt,letterpaper]{article}",
         r"\usepackage{fullpage}",
@@ -67,7 +57,7 @@ def build_main(rows) -> str:
         r"\date{\today}",
         r"\begin{document}",
         r"\maketitle",
-        table_tex,
+        r"\input{sea_metrics_from_spectrum_table_fragment.tex-part}",
         r"\end{document}",
         "",
     ])
@@ -76,7 +66,7 @@ def build_main(rows) -> str:
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--csv", default="sea_metrics_from_spectrum_report.csv")
-    parser.add_argument("--out-fragment", default="../../doc/spectrum/sea_metrics_from_spectrum_table_fragment.tex")
+    parser.add_argument("--out-fragment", default="../../doc/spectrum/sea_metrics_from_spectrum_table_fragment.tex-part")
     parser.add_argument("--out-main", default="../../doc/spectrum/sea_metrics_from_spectrum_table.tex")
     args = parser.parse_args()
 

--- a/tests/spectrum/run_tests.sh
+++ b/tests/spectrum/run_tests.sh
@@ -4,4 +4,4 @@
 ./spectrum-wavelets-estimator-sim
 
 ./sea-metrics-from-spectrum-test
-python3 ../../plots/spectrum/sea-metrics-report.py --csv sea_metrics_from_spectrum_report.csv --out-fragment ../../doc/spectrum/sea_metrics_from_spectrum_table_fragment.tex --out-main ../../doc/spectrum/sea_metrics_from_spectrum_table.tex
+python3 ../../plots/spectrum/sea-metrics-report.py --csv sea_metrics_from_spectrum_report.csv --out-fragment ../../doc/spectrum/sea_metrics_from_spectrum_table_fragment.tex-part --out-main ../../doc/spectrum/sea_metrics_from_spectrum_table.tex


### PR DESCRIPTION
### Motivation
- The sea-state metrics report generator produced a standalone LaTeX document for the fragment, which prevented it from being included as a content-only fragment following the repository `.tex-part` convention.

### Description
- Changed `plots/spectrum/sea-metrics-report.py` so `build_fragment` returns only the table content (via `build_table`) instead of a full LaTeX document wrapper.
- Updated `plots/spectrum/sea-metrics-report.py` to use a `.tex-part` default for `--out-fragment` and modified `build_main` to `\input{sea_metrics_from_spectrum_table_fragment.tex-part}`.
- Updated `tests/spectrum/run_tests.sh` to request the `.tex-part` fragment path when invoking the report script.
- Regenerated `doc/spectrum/sea_metrics_from_spectrum_table.tex` to include the `.tex-part` fragment and added the generated `doc/spectrum/sea_metrics_from_spectrum_table_fragment.tex-part` file.

### Testing
- Ran `make all` and the build completed successfully.
- Ran `bash tests/spectrum/run_tests.sh` and it completed successfully, producing `sea_metrics_from_spectrum_report.csv`, `doc/spectrum/sea_metrics_from_spectrum_table_fragment.tex-part`, and `doc/spectrum/sea_metrics_from_spectrum_table.tex`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cda8f91ab883288438a4b5e3db0b1d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a validation results table to the spectrum documentation, displaying SeaMetrics accuracy metrics across two synthetic spectrum test scenarios with PASS status.

* **Chores**
  * Refactored documentation build process to use external file fragments instead of inline content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->