### PR TITLE
Fix LaTeX spectrum table fragment input file name

### DIFF
--- a/doc/spectrum/sea_metrics_from_spectrum_table_fragment.tex
+++ b/doc/spectrum/sea_metrics_from_spectrum_table_fragment.tex
@@ -2,5 +2,5 @@
 \usepackage{booktabs}
 \usepackage{float}
 \begin{document}
-\input{sea_metrics_from_spectrum_table_content.tex}
+\input{sea_metrics_from_spectrum_table_fragment.tex-part}
 \end{document}


### PR DESCRIPTION
### Motivation
- Fix LaTeX fragment compilation failure by using the generated fragment filename instead of a non-generated content file so the document build can find the table input.

### Description
- Updated `doc/spectrum/sea_metrics_from_spectrum_table_fragment.tex` to replace `\input{sea_metrics_from_spectrum_table_content.tex}` with `\input{sea_metrics_from_spectrum_table_fragment.tex-part}`.

### Testing
- Ran `make all` from the repository root which completed successfully.
- Attempted `cd doc/spectrum && latexmk -lualatex -shell-escape sea_metrics_from_spectrum_table_fragment.tex` but it failed in this environment because `latexmk` is not installed (`/bin/bash: latexmk: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdad5bb2e88328853575e6b554ae3b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation build references for spectrum metrics content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->