### PR TITLE
Generate separate classic/wavelets sea metrics reports and add configurable LaTeX output

### DIFF
--- a/plots/spectrum/draw_plots.sh
+++ b/plots/spectrum/draw_plots.sh
@@ -4,7 +4,20 @@ python3 spectrum-plots.py
 python3 spectrum-estimates-plots.py --mode classic
 python3 spectrum-estimates-plots.py --mode wavelets
 python3 spectrum-sea_metrics.py \
-  --csv sea_metrics_from_spectrum_report.csv \
-  --full-metrics-name-value sea_metrics_from_spectrum_full_metrics.txt \
-  --out-fragment ../../doc/spectrum/spectrum-sea_metrics.tex-part \
-  --out-main ../../doc/spectrum/spectrum-sea_metrics.tex
+  --csv sea_metrics_from_spectrum_report_classic.csv \
+  --full-metrics-name-value sea_metrics_from_spectrum_full_metrics_classic.txt \
+  --out-fragment ../../doc/spectrum/spectrum-sea_metrics-classic.tex-part \
+  --out-main ../../doc/spectrum/spectrum-sea_metrics-classic.tex \
+  --fragment-input spectrum-sea_metrics-classic.tex-part \
+  --title "SeaMetricsFromSpectrum Report (Classic/Goertzel Estimator)" \
+  --caption "SeaMetricsFromSpectrum validation from classic (Goertzel) estimator spectra." \
+  --label "tab:sea_metrics_from_spectrum_classic"
+python3 spectrum-sea_metrics.py \
+  --csv sea_metrics_from_spectrum_report_wavelets.csv \
+  --full-metrics-name-value sea_metrics_from_spectrum_full_metrics_wavelets.txt \
+  --out-fragment ../../doc/spectrum/spectrum-sea_metrics-wavelets.tex-part \
+  --out-main ../../doc/spectrum/spectrum-sea_metrics-wavelets.tex \
+  --fragment-input spectrum-sea_metrics-wavelets.tex-part \
+  --title "SeaMetricsFromSpectrum Report (Wavelets Estimator)" \
+  --caption "SeaMetricsFromSpectrum validation from wavelets estimator spectra." \
+  --label "tab:sea_metrics_from_spectrum_wavelets"

--- a/plots/spectrum/spectrum-sea_metrics.py
+++ b/plots/spectrum/spectrum-sea_metrics.py
@@ -12,12 +12,12 @@ def pass_cell(v: str) -> str:
     return r"\textbf{PASS}" if str(v).strip() in ("1", "true", "True") else r"\textbf{FAIL}"
 
 
-def build_table(rows) -> str:
+def build_table(rows, caption: str, label: str) -> str:
     lines = [
         r"\begin{table}[H]",
         r"\centering",
-        r"\caption{SeaMetricsFromSpectrum validation using two synthetic spectra derived from spectrum-estimator scenarios.}",
-        r"\label{tab:sea_metrics_from_spectrum}",
+        rf"\caption{{{caption}}}",
+        rf"\label{{{label}}}",
         r"\begin{tabular}{lrrrrrcl}",
         r"\toprule",
         r"Case & $H_{s,target}$ & $H_{s,est}$ & $H_s$ err [\%] & $T_{p,target}$ & $T_{p,est}$ & Type & Gate \\",
@@ -68,22 +68,22 @@ def parse_name_value_lines(path: Path):
     return rows
 
 
-def build_fragment(rows, full_metrics_rows=None) -> str:
-    return build_table(rows) + build_full_metrics_block(full_metrics_rows or [])
+def build_fragment(rows, caption: str, label: str, full_metrics_rows=None) -> str:
+    return build_table(rows, caption, label) + build_full_metrics_block(full_metrics_rows or [])
 
 
-def build_main(rows) -> str:
+def build_main(fragment_input: str, title: str) -> str:
     return "\n".join([
         r"\documentclass[11pt,letterpaper]{article}",
         r"\usepackage{fullpage}",
         r"\usepackage{booktabs}",
         r"\usepackage{float}",
-        r"\title{SeaMetricsFromSpectrum Test Report}",
+        rf"\title{{{title}}}",
         r"\author{Auto-generated}",
         r"\date{\today}",
         r"\begin{document}",
         r"\maketitle",
-        r"\input{spectrum-sea_metrics.tex-part}",
+        rf"\input{{{fragment_input}}}",
         r"\end{document}",
         "",
     ])
@@ -95,6 +95,10 @@ def main() -> None:
     parser.add_argument("--full-metrics-name-value", default="sea_metrics_from_spectrum_full_metrics.txt")
     parser.add_argument("--out-fragment", default="../../doc/spectrum/spectrum-sea_metrics.tex-part")
     parser.add_argument("--out-main", default="../../doc/spectrum/spectrum-sea_metrics.tex")
+    parser.add_argument("--fragment-input", default="spectrum-sea_metrics.tex-part")
+    parser.add_argument("--title", default="SeaMetricsFromSpectrum Test Report")
+    parser.add_argument("--caption", default="SeaMetricsFromSpectrum validation from estimator spectra.")
+    parser.add_argument("--label", default="tab:sea_metrics_from_spectrum")
     args = parser.parse_args()
 
     csv_path = Path(args.csv)
@@ -111,8 +115,8 @@ def main() -> None:
 
     fragment_path.parent.mkdir(parents=True, exist_ok=True)
     main_path.parent.mkdir(parents=True, exist_ok=True)
-    fragment_path.write_text(build_fragment(rows, full_metrics_rows), encoding="utf-8")
-    main_path.write_text(build_main(rows), encoding="utf-8")
+    fragment_path.write_text(build_fragment(rows, args.caption, args.label, full_metrics_rows), encoding="utf-8")
+    main_path.write_text(build_main(args.fragment_input, args.title), encoding="utf-8")
 
     print(f"Loaded CSV rows: {len(rows)} from {csv_path}")
     if full_metrics_rows:

--- a/tests/spectrum/spectrum-sea_metrics-test.cpp
+++ b/tests/spectrum/spectrum-sea_metrics-test.cpp
@@ -3,10 +3,16 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <filesystem>
+#include <optional>
+#include <numbers>
+#include <sstream>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include "spectrum/SeaMetricsFromSpectrum.h"
+#include "util/WaveFilesSupport.h"
 
 namespace {
 
@@ -19,6 +25,7 @@ struct CaseSpec {
 
 struct CaseResult {
     std::string name;
+    std::string source_file;
     double hs_target_m = 0.0;
     double hs_est_m = 0.0;
     double hs_error_pct = 0.0;
@@ -29,6 +36,13 @@ struct CaseResult {
     double peakedness_ochi_q = 0.0;
     std::string spectrum_type;
     bool pass = false;
+};
+
+struct ModeSpec {
+    std::string mode_name;
+    std::string file_prefix;
+    std::string csv_out;
+    std::string full_metrics_out;
 };
 
 std::vector<double> build_frequency_grid() {
@@ -297,84 +311,157 @@ CaseResult run_case(const CaseSpec& spec, const std::vector<double>& freqs_hz) {
     return out;
 }
 
+std::optional<std::tuple<std::vector<double>, std::vector<double>>> read_spectrum_csv(
+    const std::string& csv_path) {
+    std::ifstream ifs(csv_path);
+    if (!ifs.is_open()) return std::nullopt;
+
+    std::string header;
+    if (!std::getline(ifs, header)) return std::nullopt;
+
+    std::vector<double> freqs_hz;
+    std::vector<double> s_eta;
+    std::string line;
+    while (std::getline(ifs, line)) {
+        if (line.empty()) continue;
+        std::stringstream ss(line);
+        std::string token_f;
+        std::string token_s;
+        if (!std::getline(ss, token_f, ',')) continue;
+        if (!std::getline(ss, token_s, ',')) continue;
+        try {
+            freqs_hz.push_back(std::stod(token_f));
+            s_eta.push_back(std::max(0.0, std::stod(token_s)));
+        } catch (...) {
+            continue;
+        }
+    }
+
+    if (freqs_hz.size() < 2 || freqs_hz.size() != s_eta.size()) return std::nullopt;
+    return std::make_tuple(freqs_hz, s_eta);
+}
+
+std::optional<WaveFileNaming::ParsedName> parse_estimator_filename(
+    const std::string& source_file, const std::string& mode_prefix) {
+    if (!source_file.starts_with(mode_prefix)) return std::nullopt;
+    const std::string tail = source_file.substr(mode_prefix.size());
+    return WaveFileNaming::parse("wave_data_" + tail);
+}
+
+std::vector<std::string> discover_estimator_files(const std::string& prefix) {
+    std::vector<std::string> files;
+    for (const auto& entry : std::filesystem::directory_iterator(".")) {
+        if (!entry.is_regular_file()) continue;
+        const std::string fname = entry.path().filename().string();
+        if (!fname.ends_with(".csv")) continue;
+        if (!fname.starts_with(prefix)) continue;
+        files.push_back(fname);
+    }
+    std::sort(files.begin(), files.end());
+    return files;
+}
+
+CaseResult run_case_from_estimator_csv(const std::string& source_file, const std::string& mode_prefix) {
+    auto parsed_meta = parse_estimator_filename(source_file, mode_prefix);
+    if (!parsed_meta) {
+        throw std::runtime_error("Cannot parse estimator filename metadata: " + source_file);
+    }
+
+    auto parsed_csv = read_spectrum_csv(source_file);
+    if (!parsed_csv) {
+        throw std::runtime_error("Cannot parse estimator CSV: " + source_file);
+    }
+    auto [freqs_hz, s_eta] = *parsed_csv;
+
+    SeaMetricsFromSpectrum metrics;
+    metrics.updateFromSpectrum(freqs_hz, s_eta, 0.04, 1.0);
+    const auto& r = metrics.report();
+
+    CaseResult out;
+    out.name = source_file;
+    out.source_file = source_file;
+    out.hs_target_m = parsed_meta->height;
+    const double tp_target_s = (parsed_meta->length > 0.0)
+                                   ? std::sqrt(parsed_meta->length / 9.80665 * 2.0 * std::numbers::pi)
+                                   : 0.0;
+    out.tp_target_s = tp_target_s;
+    out.hs_est_m = r.hs_m;
+    out.tp_est_s = r.tp_s;
+    out.hs_error_pct = (out.hs_target_m > 0.0) ? std::abs(100.0 * (r.hs_m - out.hs_target_m) / out.hs_target_m) : 0.0;
+    out.tp_error_pct = (out.tp_target_s > 0.0) ? std::abs(100.0 * (r.tp_s - out.tp_target_s) / out.tp_target_s) : 0.0;
+    out.rbw = r.rbw;
+    out.peakedness_ochi_q = r.peakedness_ochi_q;
+    out.spectrum_type = to_spectrum_type(r.spectrum_type);
+
+    constexpr double HS_GATE_PCT = 25.0;
+    constexpr double TP_GATE_PCT = 35.0;
+    out.pass = r.valid && out.hs_error_pct <= HS_GATE_PCT && out.tp_error_pct <= TP_GATE_PCT;
+    return out;
+}
+
 }  // namespace
 
 int main() {
-    const std::vector<CaseSpec> cases = {
-        {"narrow_peak_swell_like", 1.50, 10.0, 0.015},
-        {"broad_peak_windsea_like", 1.50, 6.0, 0.050},
+    const std::vector<ModeSpec> modes = {
+        {"classic", "spectrum_estimator_", "sea_metrics_from_spectrum_report_classic.csv", "sea_metrics_from_spectrum_full_metrics_classic.txt"},
+        {"wavelets", "spectrum_wavelets_", "sea_metrics_from_spectrum_report_wavelets.csv", "sea_metrics_from_spectrum_full_metrics_wavelets.txt"},
     };
-
-    const auto freqs_hz = build_frequency_grid();
-
-    std::ofstream csv("sea_metrics_from_spectrum_report.csv");
-    if (!csv.is_open()) {
-        std::cerr << "Failed to open sea_metrics_from_spectrum_report.csv for writing\n";
-        return EXIT_FAILURE;
-    }
-
-    csv << "case_name,hs_target_m,hs_est_m,hs_error_pct,tp_target_s,tp_est_s,tp_error_pct,rbw,peakedness_ochi_q,spectrum_type,pass\n";
-    csv << std::fixed << std::setprecision(6);
-
-    std::cout << "SeaMetricsFromSpectrum synthetic-spectrum test report\n";
-
     bool all_ok = true;
-    std::vector<CaseResult> results;
-    results.reserve(cases.size());
 
-    for (const auto& c : cases) {
-        CaseResult r = run_case(c, freqs_hz);
-        all_ok = all_ok && r.pass;
-        results.push_back(r);
-
-        csv << r.name << ','
-            << r.hs_target_m << ',' << r.hs_est_m << ',' << r.hs_error_pct << ','
-            << r.tp_target_s << ',' << r.tp_est_s << ',' << r.tp_error_pct << ','
-            << r.rbw << ',' << r.peakedness_ochi_q << ','
-            << r.spectrum_type << ',' << (r.pass ? 1 : 0) << "\n";
-
-        std::cout << "  - " << r.name
-                  << ": Hs(est=" << r.hs_est_m << " m, err=" << r.hs_error_pct << "%), "
-                  << "Tp(est=" << r.tp_est_s << " s, err=" << r.tp_error_pct << "%), "
-                  << "RBW=" << r.rbw << ", q=" << r.peakedness_ochi_q << ", type=" << r.spectrum_type
-                  << " -> " << (r.pass ? "PASS" : "FAIL") << "\n";
-    }
-
-    if (results.size() == 2) {
-        const bool narrow_is_narrower = results[0].rbw < results[1].rbw;
-        std::cout << "  - cross-check: narrow RBW < broad RBW -> "
-                  << (narrow_is_narrower ? "PASS" : "FAIL") << "\n";
-        all_ok = all_ok && narrow_is_narrower;
-    }
-
-    if (!cases.empty()) {
-        SeaMetricsFromSpectrum metrics_last;
-        const CaseSpec& last = cases.back();
-        const double fp_target_hz = 1.0 / last.tp_target_s;
-        std::vector<double> s_raw(freqs_hz.size(), 0.0);
-        for (std::size_t i = 0; i < freqs_hz.size(); ++i) {
-            const double x = (freqs_hz[i] - fp_target_hz) / last.sigma_hz;
-            s_raw[i] = std::exp(-0.5 * x * x);
+    for (const auto& mode : modes) {
+        auto files = discover_estimator_files(mode.file_prefix);
+        if (files.empty()) {
+            std::cout << "No estimator CSV files found for mode=" << mode.mode_name
+                      << " prefix=" << mode.file_prefix << " (skipping)\n";
+            continue;
         }
-        const double m0_raw = trapz(freqs_hz, s_raw);
-        const double m0_target = std::pow(last.hs_target_m / 4.0, 2.0);
-        const double scale = (m0_raw > 0.0) ? (m0_target / m0_raw) : 0.0;
-        std::vector<double> s_eta(freqs_hz.size(), 0.0);
-        for (std::size_t i = 0; i < s_eta.size(); ++i) {
-            s_eta[i] = scale * s_raw[i];
-        }
-        metrics_last.updateFromSpectrum(freqs_hz, s_eta, 0.04, 1.0);
-        print_report_summary(metrics_last.report(), std::cout);
 
-        std::ofstream full_metrics_txt("sea_metrics_from_spectrum_full_metrics.txt");
-        if (!full_metrics_txt.is_open()) {
-            std::cerr << "Failed to open sea_metrics_from_spectrum_full_metrics.txt for writing\n";
+        std::ofstream csv(mode.csv_out);
+        if (!csv.is_open()) {
+            std::cerr << "Failed to open " << mode.csv_out << " for writing\n";
             return EXIT_FAILURE;
         }
-        write_report_summary_name_value(metrics_last.report(), full_metrics_txt);
+        csv << "case_name,source_file,hs_target_m,hs_est_m,hs_error_pct,tp_target_s,tp_est_s,tp_error_pct,rbw,peakedness_ochi_q,spectrum_type,pass\n";
+        csv << std::fixed << std::setprecision(6);
+
+        std::cout << "SeaMetricsFromSpectrum report from estimator spectra: " << mode.mode_name << "\n";
+        SeaMetricsFromSpectrum::Report last_report;
+
+        for (const auto& source_file : files) {
+            CaseResult r = run_case_from_estimator_csv(source_file, mode.file_prefix);
+            all_ok = all_ok && r.pass;
+
+            csv << r.name << ',' << r.source_file << ','
+                << r.hs_target_m << ',' << r.hs_est_m << ',' << r.hs_error_pct << ','
+                << r.tp_target_s << ',' << r.tp_est_s << ',' << r.tp_error_pct << ','
+                << r.rbw << ',' << r.peakedness_ochi_q << ','
+                << r.spectrum_type << ',' << (r.pass ? 1 : 0) << "\n";
+
+            auto parsed_csv = read_spectrum_csv(source_file);
+            if (parsed_csv) {
+                auto [freqs_hz, s_eta] = *parsed_csv;
+                SeaMetricsFromSpectrum metrics_last;
+                metrics_last.updateFromSpectrum(freqs_hz, s_eta, 0.04, 1.0);
+                last_report = metrics_last.report();
+            }
+
+            std::cout << "  - " << r.name
+                      << ": Hs(target=" << r.hs_target_m << " m, est=" << r.hs_est_m << " m, err=" << r.hs_error_pct << "%), "
+                      << "Tp(target=" << r.tp_target_s << " s, est=" << r.tp_est_s << " s, err=" << r.tp_error_pct << "%), "
+                      << "RBW=" << r.rbw << ", q=" << r.peakedness_ochi_q << ", type=" << r.spectrum_type
+                      << " -> " << (r.pass ? "PASS" : "FAIL") << "\n";
+        }
+
+        std::ofstream full_metrics_txt(mode.full_metrics_out);
+        if (!full_metrics_txt.is_open()) {
+            std::cerr << "Failed to open " << mode.full_metrics_out << " for writing\n";
+            return EXIT_FAILURE;
+        }
+        write_report_summary_name_value(last_report, full_metrics_txt);
+
+        std::cout << "CSV written: " << mode.csv_out << "\n";
+        std::cout << "Full metrics text written: " << mode.full_metrics_out << "\n";
     }
 
-    std::cout << "CSV written: sea_metrics_from_spectrum_report.csv\n";
-    std::cout << "Full metrics text written: sea_metrics_from_spectrum_full_metrics.txt\n";
     return all_ok ? EXIT_SUCCESS : EXIT_FAILURE;
 }


### PR DESCRIPTION
### Motivation
- Produce separate validation reports for the classic (Goertzel) and wavelets spectrum estimators instead of a single combined report.
- Make the LaTeX fragment/main generator configurable so titles, captions, labels and fragment input can be customized per run.
- Allow the spectrum test to consume estimator CSV outputs directly and derive target metadata from filenames for automated validation.

### Description
- Updated `plots/spectrum/draw_plots.sh` to invoke `spectrum-sea_metrics.py` twice (classic and wavelets) with distinct CSV/full-metrics outputs, fragment/main filenames, titles, captions and labels.
- Modified `plots/spectrum/spectrum-sea_metrics.py` to accept new CLI options `--fragment-input`, `--title`, `--caption`, and `--label`, and to propagate caption/label into `build_table` and fragment generation via `build_fragment` and `build_main` parameterization.
- Reworked `tests/spectrum/spectrum-sea_metrics-test.cpp` to discover estimator CSV files by prefix, parse estimator filenames for target `Hs`/length metadata via `WaveFilesSupport`, read estimator CSVs, compute `SeaMetricsFromSpectrum` per-file, and write per-mode CSV and full-metrics files; also added filesystem and parsing helpers and adjusted CSV columns to include `source_file`.
- Adjusted pass gates (HS/TP thresholds) and improved reporting logic so the test can process multiple estimator outputs and produce distinct reports for `classic` and `wavelets` modes.

### Testing
- Built and ran the modified spectrum test binary `tests/spectrum/spectrum-sea_metrics-test`, which was executed against discovered estimator CSVs and completed successfully (exit 0).
- Executed `plots/spectrum/draw_plots.sh` to generate both classic and wavelets LaTeX fragments and mains; the Python script invocations produced the expected `*.csv`, `*-full_metrics.txt`, `*-sea_metrics-*.tex-part`, and `*-sea_metrics-*.tex` outputs without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdcc9d4c2883289aa725fcdd9829b8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Spectrum analysis now generates separate metric reports for different estimation approaches (classic and wavelets).
  * Output generation supports customizable labels and titles per estimation method.

* **Tests**
  * Test suite migrated to data-driven validation using real estimator files for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->