### PR TITLE
Stop regenerating spectrum sea metrics wrapper TeX files

### DIFF
--- a/doc/spectrum/spectrum-sea_metrics-classic.tex
+++ b/doc/spectrum/spectrum-sea_metrics-classic.tex
@@ -1,0 +1,11 @@
+\documentclass[11pt,letterpaper]{article}
+\usepackage{fullpage}
+\usepackage{booktabs}
+\usepackage{float}
+\title{SeaMetricsFromSpectrum Report (Classic/Goertzel Estimator)}
+\author{Auto-generated}
+\date{\today}
+\begin{document}
+\maketitle
+\input{spectrum-sea_metrics-classic.tex-part}
+\end{document}

--- a/doc/spectrum/spectrum-sea_metrics-wavelets.tex
+++ b/doc/spectrum/spectrum-sea_metrics-wavelets.tex
@@ -1,0 +1,11 @@
+\documentclass[11pt,letterpaper]{article}
+\usepackage{fullpage}
+\usepackage{booktabs}
+\usepackage{float}
+\title{SeaMetricsFromSpectrum Report (Wavelets Estimator)}
+\author{Auto-generated}
+\date{\today}
+\begin{document}
+\maketitle
+\input{spectrum-sea_metrics-wavelets.tex-part}
+\end{document}

--- a/plots/spectrum/draw_plots.sh
+++ b/plots/spectrum/draw_plots.sh
@@ -7,7 +7,7 @@ python3 spectrum-sea_metrics.py \
   --csv sea_metrics_from_spectrum_report_classic.csv \
   --full-metrics-name-value sea_metrics_from_spectrum_full_metrics_classic.txt \
   --out-fragment ../../doc/spectrum/spectrum-sea_metrics-classic.tex-part \
-  --out-main ../../doc/spectrum/spectrum-sea_metrics-classic.tex \
+  --skip-main \
   --fragment-input spectrum-sea_metrics-classic.tex-part \
   --title "SeaMetricsFromSpectrum Report (Classic/Goertzel Estimator)" \
   --caption "SeaMetricsFromSpectrum validation from classic (Goertzel) estimator spectra." \
@@ -16,7 +16,7 @@ python3 spectrum-sea_metrics.py \
   --csv sea_metrics_from_spectrum_report_wavelets.csv \
   --full-metrics-name-value sea_metrics_from_spectrum_full_metrics_wavelets.txt \
   --out-fragment ../../doc/spectrum/spectrum-sea_metrics-wavelets.tex-part \
-  --out-main ../../doc/spectrum/spectrum-sea_metrics-wavelets.tex \
+  --skip-main \
   --fragment-input spectrum-sea_metrics-wavelets.tex-part \
   --title "SeaMetricsFromSpectrum Report (Wavelets Estimator)" \
   --caption "SeaMetricsFromSpectrum validation from wavelets estimator spectra." \

--- a/plots/spectrum/spectrum-sea_metrics.py
+++ b/plots/spectrum/spectrum-sea_metrics.py
@@ -95,6 +95,7 @@ def main() -> None:
     parser.add_argument("--full-metrics-name-value", default="sea_metrics_from_spectrum_full_metrics.txt")
     parser.add_argument("--out-fragment", default="../../doc/spectrum/spectrum-sea_metrics.tex-part")
     parser.add_argument("--out-main", default="../../doc/spectrum/spectrum-sea_metrics.tex")
+    parser.add_argument("--skip-main", action="store_true")
     parser.add_argument("--fragment-input", default="spectrum-sea_metrics.tex-part")
     parser.add_argument("--title", default="SeaMetricsFromSpectrum Test Report")
     parser.add_argument("--caption", default="SeaMetricsFromSpectrum validation from estimator spectra.")
@@ -114,9 +115,10 @@ def main() -> None:
         full_metrics_rows = parse_name_value_lines(full_metrics_path)
 
     fragment_path.parent.mkdir(parents=True, exist_ok=True)
-    main_path.parent.mkdir(parents=True, exist_ok=True)
     fragment_path.write_text(build_fragment(rows, args.caption, args.label, full_metrics_rows), encoding="utf-8")
-    main_path.write_text(build_main(args.fragment_input, args.title), encoding="utf-8")
+    if not args.skip_main:
+        main_path.parent.mkdir(parents=True, exist_ok=True)
+        main_path.write_text(build_main(args.fragment_input, args.title), encoding="utf-8")
 
     print(f"Loaded CSV rows: {len(rows)} from {csv_path}")
     if full_metrics_rows:
@@ -124,7 +126,10 @@ def main() -> None:
     else:
         print(f"Full metrics name=value file not found (optional): {full_metrics_path}")
     print(f"Wrote LaTeX fragment: {fragment_path}")
-    print(f"Wrote LaTeX main: {main_path}")
+    if args.skip_main:
+        print("Skipped writing LaTeX main wrapper (--skip-main).")
+    else:
+        print(f"Wrote LaTeX main: {main_path}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Prevent automated plot generation from overwriting committed wrapper LaTeX documents and ensure the wrapper files simply `\input{...-tex-part}` fragments.
- Keep generated output limited to fragment files so documentation wrappers remain stable and human-managed.

### Description
- Added a `--skip-main` flag to `plots/spectrum/spectrum-sea_metrics.py` to suppress writing the wrapper `.tex` file and only write the `.tex-part` fragment when requested.
- Updated `plots/spectrum/draw_plots.sh` to pass `--skip-main` for both classic and wavelets runs so they only refresh `*.tex-part` fragments.
- Committed static wrapper documents `doc/spectrum/spectrum-sea_metrics-classic.tex` and `doc/spectrum/spectrum-sea_metrics-wavelets.tex` that permanently `\input` their respective `*.tex-part` fragments.
- Updated script logging to report when the main wrapper is skipped versus written.

### Testing
- Ran `make all` which completed successfully with no build errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdda1aa43483288f76d5c4a1a1304c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added new LaTeX report templates for SeaMetrics spectrum analysis using Classic/Goertzel and Wavelets estimators.

* **Chores**
  * Updated build system to support conditional generation of LaTeX documentation fragments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->