### PR TITLE
Fix spectrum estimate PGF filenames for LaTeX inputs

### DIFF
--- a/plots/spectrum/spectrum-estimates-plots.py
+++ b/plots/spectrum/spectrum-estimates-plots.py
@@ -170,7 +170,8 @@ def plot_mode(mode):
         fig.suptitle(f"{wave.upper()} — {level.capitalize()} sea ($H_s={height:.2f}$ m)", fontsize=11, y=0.97)
         fig.tight_layout(rect=[0, 0, 1, 0.96])
 
-        out_spectrum = f"{out_prefix}_{wave}_{level}_spectrum.pgf"
+        wave_slug = wave.lower()
+        out_spectrum = f"{out_prefix}_{wave_slug}_{level}_spectrum.pgf"
         fig.savefig(out_spectrum, bbox_inches="tight")
         plt.close(fig)
 
@@ -211,7 +212,7 @@ def plot_mode(mode):
         ax_hs.set_title(f"{wave.upper()} — {level.capitalize()} sea")
         ax_hs.grid(True, axis="y", alpha=0.3)
         fig_hs.tight_layout()
-        out_hs = f"{out_prefix}_{wave}_{level}_hs.pgf"
+        out_hs = f"{out_prefix}_{wave_slug}_{level}_hs.pgf"
         fig_hs.savefig(out_hs, bbox_inches="tight")
         plt.close(fig_hs)
 
@@ -226,7 +227,7 @@ def plot_mode(mode):
         ax_tp.set_title(f"{wave.upper()} — {level.capitalize()} sea")
         ax_tp.grid(True, axis="y", alpha=0.3)
         fig_tp.tight_layout()
-        out_tp = f"{out_prefix}_{wave}_{level}_tp.pgf"
+        out_tp = f"{out_prefix}_{wave_slug}_{level}_tp.pgf"
         fig_tp.savefig(out_tp, bbox_inches="tight")
         plt.close(fig_tp)
 


### PR DESCRIPTION
### Motivation
- LaTeX documents in `doc/spectrum` reference lowercase PGF filenames (e.g. `spectrum_estimates_pmstokes_low_spectrum.pgf`) while mixed-case wave tokens in CSV metadata caused the plot generator to emit mismatched filenames and break the LaTeX build.

### Description
- Lowercase the wave name segment when constructing output filenames in `plots/spectrum/spectrum-estimates-plots.py` by introducing `wave_slug = wave.lower()` and using it for the `_spectrum.pgf`, `_hs.pgf`, and `_tp.pgf` outputs.

### Testing
- Ran `make all` which completed successfully (tests compiled for all subdirectories).
- Ran `python3 -m py_compile plots/spectrum/spectrum-estimates-plots.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce03b60e5883288a59585106a6dba7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected spectrum-related plot output filenames to consistently use lowercase wave identifiers, ensuring uniform file naming conventions across all spectrum estimation outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->