### PR TITLE
Fix spectrum estimate plot filename parsing for seeded outputs

### DIFF
--- a/plots/spectrum/spectrum-estimates-plots.py
+++ b/plots/spectrum/spectrum-estimates-plots.py
@@ -28,7 +28,7 @@ plt.rcParams.update({
 height_groups = {"low": 0.27, "medium": 1.50, "high": 8.50}
 
 classic_pattern = re.compile(
-    r"spectrum_"
+    r"^spectrum_"
     r"(?P<tracker>[^_]+)_"
     r"(?P<wave>[A-Za-z0-9]+)_"
     r"H(?P<height>[-0-9\.]+)"
@@ -37,11 +37,13 @@ classic_pattern = re.compile(
     r"(?:_P(?P<phase>[-0-9\.]+))?"
     r"_N(?P<noise>[-0-9\.]+)"
     r"_B(?P<bias>[-0-9\.]+)"
-    r"\.csv"
+    r"(?:_S(?P<seed>[-0-9]+))?"
+    r"\.csv$"
 )
 
 wavelets_pattern = re.compile(
-    r"spectrum_wavelets_"
+    r"^spectrum_wavelets_"
+    r"(?:(?P<tracker>[^_]+)_)?"
     r"(?P<wave>[A-Za-z0-9]+)_"
     r"H(?P<height>[-0-9\.]+)"
     r"(?:_L(?P<length>[-0-9\.]+))?"
@@ -49,7 +51,8 @@ wavelets_pattern = re.compile(
     r"(?:_P(?P<phase>[-0-9\.]+))?"
     r"_N(?P<noise>[-0-9\.]+)"
     r"_B(?P<bias>[-0-9\.]+)"
-    r"\.csv"
+    r"(?:_S(?P<seed>[-0-9]+))?"
+    r"\.csv$"
 )
 
 
@@ -70,7 +73,10 @@ def collect_groups(mode):
     if mode == "classic":
         files = sorted(glob.glob("spectrum_*.csv"))
         for f in files:
-            m = classic_pattern.search(os.path.basename(f))
+            basename = os.path.basename(f)
+            if basename.startswith("spectrum_wavelets_"):
+                continue
+            m = classic_pattern.search(basename)
             if not m:
                 continue
             tracker = m.group("tracker")


### PR DESCRIPTION
### Motivation
- The spectrum plotting code failed to recognize newer simulator output names that include an optional `_S<seed>` suffix and also mis-parsed some `spectrum_wavelets_*` names, preventing generation of PGF plot assets referenced by the LaTeX docs.
- Anchoring filename regexes and explicitly handling the wavelets naming variants ensures the correct CSV inputs are discovered for each plotting mode.

### Description
- Updated `plots/spectrum/spectrum-estimates-plots.py` to accept an optional `_S<seed>` suffix in both classic and wavelets filename regexes by adding `(?:_S(?P<seed>[-0-9]+))?` and anchoring patterns with `^`/`$`.
- Added support for an optional tracker token in the `spectrum_wavelets_` pattern so names like `spectrum_wavelets_estimator_...` are recognized via `(?:(?P<tracker>[^_]+)_)?`.
- Prevented cross-matching by skipping `spectrum_wavelets_` files when collecting `classic` mode groups and by matching against the basename before applying the anchored regex.

### Testing
- Ran `make all` which completed successfully and built all test targets (compilers invoked with vendored-or-system Eigen include fallback as in test Makefiles). 
- Attempted the plotting pipeline `plots/spectrum/draw_plots.sh` but it failed in this environment due to missing Python dependencies (`pandas`, `matplotlib`) and missing generated CSV artifacts, so PGF outputs were not produced here. 
- Attempted to run `latexmk -lualatex` on `doc/spectrum` but the environment does not have `latexmk` installed, so PDF generation could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce07c88444832885363f04cd4d5aae)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed spectrum data file classification to prevent incorrect categorization between analysis types.

## New Features
* Added support for optional seed parameters in spectrum analysis files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->