### PR TITLE
Fix missing SeaMetrics full metrics section in LaTeX reports

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,7 @@ jobs:
           chmod +x *.sh
           ./run_tests.sh
           cp *.csv ../../plots/${{ matrix.dir }}
+          cp sea_metrics_from_spectrum_full_metrics_*.txt ../../plots/${{ matrix.dir }} || true
 
       - name: Generate PGF plots (${{ matrix.dir }})
         shell: bash

--- a/doc/spectrum/spectrum-sea_metrics-classic.tex
+++ b/doc/spectrum/spectrum-sea_metrics-classic.tex
@@ -2,6 +2,7 @@
 \usepackage{fullpage}
 \usepackage{booktabs}
 \usepackage{float}
+\usepackage{longtable}
 \title{SeaMetricsFromSpectrum Report (Classic/Goertzel Estimator)}
 \author{Auto-generated}
 \date{\today}

--- a/doc/spectrum/spectrum-sea_metrics-wavelets.tex
+++ b/doc/spectrum/spectrum-sea_metrics-wavelets.tex
@@ -2,6 +2,7 @@
 \usepackage{fullpage}
 \usepackage{booktabs}
 \usepackage{float}
+\usepackage{longtable}
 \title{SeaMetricsFromSpectrum Report (Wavelets Estimator)}
 \author{Auto-generated}
 \date{\today}


### PR DESCRIPTION
### Motivation
- The LaTeX report generator supports including a full name/value dump produced by `write_report_summary(...)`, but the full-metrics text files were not being propagated into the plotting directory in CI so the fragment omitted that section.
- The generated fragment uses the `longtable` environment, so the wrapper documents must load `longtable` to compile when the full dump is present.

### Description
- Updated CI workflow to copy `sea_metrics_from_spectrum_full_metrics_*.txt` from `tests/${{ matrix.dir }}` into `plots/${{ matrix.dir }}` after test execution so the plotting scripts can find the optional full-metrics file (`.github/workflows/build.yml`).
- Added `\usepackage{longtable}` to `doc/spectrum/spectrum-sea_metrics-classic.tex` so generated fragments with the "Full metrics dump" longtable compile.
- Added `\usepackage{longtable}` to `doc/spectrum/spectrum-sea_metrics-wavelets.tex` for the same reason.

### Testing
- Ran `python3 plots/spectrum/spectrum-sea_metrics.py --help` to verify the reporting script invocation still works, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce9980502c83288fc212ee283dfbfe)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Documentation infrastructure updated with improved table formatting support for technical documentation generation across all document types
  * CI/CD pipeline enhanced to capture and include additional performance and test metric files in build artifacts, complementing existing metric reports and expanding available data for analysis

<!-- end of auto-generated comment: release notes by coderabbit.ai -->