### PR TITLE
Use percent-of-reference RMS for spectrum amplitude quality gate

### DIFF
--- a/tests/spectrum/SpectrumEstimatorSimShared.h
+++ b/tests/spectrum/SpectrumEstimatorSimShared.h
@@ -310,6 +310,7 @@ inline bool process_wave_file(const std::string& data_file,
     double cum_est = 0.0;
     double cum_ref = 0.0;
     double sum_sq_amp_error = 0.0;
+    double sum_sq_amp_ref = 0.0;
     double sum_weight = 0.0;
 
     for (int i = 0; i < Nfreq; ++i) {
@@ -336,6 +337,7 @@ inline bool process_wave_file(const std::string& data_file,
 
         // Weight RMS by bin width so denser grids do not distort the metric.
         sum_sq_amp_error += a_eta_err * a_eta_err * delta_f;
+        sum_sq_amp_ref += a_eta_ref * a_eta_ref * delta_f;
         sum_weight += delta_f;
 
         ofs << f_est << "," << s_est << "," << s_ref << "," << ratio << ","
@@ -347,17 +349,18 @@ inline bool process_wave_file(const std::string& data_file,
 
     const double amp_err_rms_m =
         (sum_weight > 0.0) ? std::sqrt(sum_sq_amp_error / sum_weight) : 0.0;
+    const double amp_ref_rms_m =
+        (sum_weight > 0.0) ? std::sqrt(sum_sq_amp_ref / sum_weight) : 0.0;
 
-    const double hs_ref_m = static_cast<double>(wp.height);
-    const double amp_err_rms_pct_hs =
-        (hs_ref_m > 0.0) ? (100.0 * amp_err_rms_m / hs_ref_m) : 0.0;
+    const double amp_err_rms_pct_value =
+        (amp_ref_rms_m > 0.0) ? (100.0 * amp_err_rms_m / amp_ref_rms_m) : 0.0;
 
-    constexpr double AMP_ERR_RMS_LIMIT_PCT_HS = 800.0;
-    const bool quality_ok = amp_err_rms_pct_hs <= AMP_ERR_RMS_LIMIT_PCT_HS;
+    constexpr double AMP_ERR_RMS_LIMIT_PCT_VALUE = 800.0;
+    const bool quality_ok = amp_err_rms_pct_value <= AMP_ERR_RMS_LIMIT_PCT_VALUE;
 
     std::cout << "Spectrum amplitude error RMS=" << amp_err_rms_m
-              << " m (" << amp_err_rms_pct_hs << "%Hs, gate "
-              << AMP_ERR_RMS_LIMIT_PCT_HS << "%Hs) -> "
+              << " m (" << amp_err_rms_pct_value << "% of reference RMS, gate "
+              << AMP_ERR_RMS_LIMIT_PCT_VALUE << "% of reference RMS) -> "
               << (quality_ok ? "PASS" : "FAIL") << "\n";
 
     std::cout << "Finished " << data_file << " with " << block_count


### PR DESCRIPTION
### Motivation
- The spectrum amplitude quality gate previously normalized the RMS error by significant wave height (`Hs`) which is the wrong unit for the amplitude-RMS metric and can mislead the spectrum estimator tests. 
- The intent is to report amplitude RMS error as a relative percent of the reference amplitude RMS value so the gate reflects the estimator amplitude fidelity, not a fraction of `Hs`.

### Description
- Updated `tests/spectrum/SpectrumEstimatorSimShared.h` to add a weighted reference-amplitude accumulator `sum_sq_amp_ref` and compute `amp_ref_rms_m` from it. 
- Changed the normalization to compute `amp_err_rms_pct_value = 100.0 * amp_err_rms_m / amp_ref_rms_m` instead of dividing by `Hs`. 
- Renamed the gate constant to `AMP_ERR_RMS_LIMIT_PCT_VALUE` and adjusted the `quality_ok` logic to use the new percent-of-reference value. 
- Updated the diagnostic output text to show "% of reference RMS" and the corresponding gate wording.

### Testing
- Ran `make all` which completed successfully and built the test binaries.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce9c9a36dc832895102777bb06ac82)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated amplitude error measurement methodology in spectrum estimation testing to use reference signal normalization, improving consistency in quality assessment calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->