### PR TITLE
Improve readability of SeaMetrics synthetic case reporting

### DIFF
--- a/plots/spectrum/spectrum-sea_metrics.py
+++ b/plots/spectrum/spectrum-sea_metrics.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import csv
+import re
 from pathlib import Path
 
 
@@ -113,6 +114,32 @@ def pass_cell(v: str) -> str:
     return r"\textbf{PASS}" if str(v).strip() in ("1", "true", "True") else r"\textbf{FAIL}"
 
 
+def describe_case(case_name: str) -> str:
+    stem = Path(case_name).stem
+    mode = ""
+    if stem.startswith("spectrum_estimator_"):
+        mode = "Classic estimator"
+        stem = stem[len("spectrum_estimator_"):]
+    elif stem.startswith("spectrum_wavelets_"):
+        mode = "Wavelets estimator"
+        stem = stem[len("spectrum_wavelets_"):]
+
+    match = re.match(
+        r"(?P<wave>[a-z0-9]+)_H(?P<h>[0-9.]+)_L(?P<l>[0-9.]+)_A(?P<a>[0-9.]+)_P(?P<p>[0-9.]+)$",
+        stem,
+    )
+    if not match:
+        return case_name
+
+    wave_type = match.group("wave").upper()
+    height = float(match.group("h"))
+    length = float(match.group("l"))
+    azimuth = float(match.group("a"))
+    phase = float(match.group("p"))
+    details = f"{wave_type}: H={height:.2f} m, L={length:.2f} m, az={azimuth:.1f}°, phase={phase:.1f}°"
+    return f"{mode} — {details}" if mode else details
+
+
 def build_table(rows, caption: str, label: str) -> str:
     lines = [
         r"\begin{table}[H]",
@@ -127,7 +154,7 @@ def build_table(rows, caption: str, label: str) -> str:
 
     for row in rows:
         line = (
-            f"{tex_escape(row['case_name'])} & "
+            f"{tex_escape(describe_case(row['case_name']))} & "
             f"{float(row['hs_target_m']):.3f} & "
             f"{float(row['hs_est_m']):.3f} & "
             f"{float(row['hs_error_pct']):.2f} & "
@@ -143,12 +170,20 @@ def build_table(rows, caption: str, label: str) -> str:
     return "\n".join(lines) + "\n"
 
 
-def build_full_metrics_block(full_metrics_rows) -> str:
+def build_full_metrics_block(full_metrics_rows, last_case_description: str | None = None) -> str:
     if not full_metrics_rows:
         return ""
 
+    title = r"\subsection*{Full metrics dump}"
+    if last_case_description:
+        title = (
+            r"\subsection*{Full metrics dump (last synthetic spectrum case: "
+            + tex_escape(last_case_description)
+            + ")}"
+        )
+
     lines = [
-        r"\subsection*{Full metrics dump (last synthetic spectrum case)}",
+        title,
         r"\begin{longtable}{p{0.20\linewidth}p{0.22\linewidth}p{0.42\linewidth}p{0.12\linewidth}}",
         r"\toprule",
         r"Metric key & Human-readable name & Meaning & Value \\",
@@ -188,7 +223,11 @@ def parse_name_value_lines(path: Path):
 
 
 def build_fragment(rows, caption: str, label: str, full_metrics_rows=None) -> str:
-    return build_table(rows, caption, label) + build_full_metrics_block(full_metrics_rows or [])
+    last_case_description = describe_case(rows[-1]["case_name"]) if rows else None
+    return build_table(rows, caption, label) + build_full_metrics_block(
+        full_metrics_rows or [],
+        last_case_description,
+    )
 
 
 def main() -> None:


### PR DESCRIPTION
### Motivation
- The SeaMetrics report showed raw synthetic spectrum filenames and a generic “last synthetic spectrum case” heading which is not human-friendly; the change makes the case identification readable in tables and headings.

### Description
- Added `describe_case()` in `plots/spectrum/spectrum-sea_metrics.py` to parse common synthetic filename patterns (handles `spectrum_estimator_` and `spectrum_wavelets_` prefixes) and produce a concise human-readable description. 
- Replaced the table first-column rendering to use `describe_case(row['case_name'])` instead of the raw filename so Table 1 shows readable case descriptions. 
- Updated `build_full_metrics_block()` to accept a `last_case_description` and include the exact last-case description in the subsection heading, and wired `build_fragment()` to derive that description from the last CSV row. 
- Small addition: imported `re` and kept all changes local to `plots/spectrum/spectrum-sea_metrics.py` with no public API, filename, or build-target changes.

### Testing
- Ran `python3 -m py_compile plots/spectrum/spectrum-sea_metrics.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cea52f74ac83289686eae85f82c355)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Spectrum case names in metrics tables now display with human-readable descriptions.
  * Full metrics dump section titles now include descriptive synthetic spectrum case information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->