### PR TITLE
Improve sea metrics full-table readability and value formatting

### DIFF
--- a/plots/spectrum/spectrum-sea_metrics.py
+++ b/plots/spectrum/spectrum-sea_metrics.py
@@ -184,20 +184,21 @@ def build_full_metrics_block(full_metrics_rows, last_case_description: str | Non
 
     lines = [
         title,
-        r"\begin{longtable}{p{0.20\linewidth}p{0.22\linewidth}p{0.42\linewidth}p{0.12\linewidth}}",
+        r"\begin{longtable}{p{0.23\linewidth}p{0.25\linewidth}p{0.35\linewidth}p{0.13\linewidth}}",
+        r"\normalsize",
         r"\toprule",
-        r"Metric key & Human-readable name & Meaning & Value \\",
+        r"Metric key & Metrics Name & Meaning & Value \\",
         r"\midrule",
         r"\endfirsthead",
         r"\toprule",
-        r"Metric key & Human-readable name & Meaning & Value \\",
+        r"Metric key & Metrics Name & Meaning & Value \\",
         r"\midrule",
         r"\endhead",
     ]
 
     for row in full_metrics_rows:
         metric = row["metric"]
-        value = row["value"]
+        value = format_metric_value(row["value"])
         display_name, meaning = METRIC_METADATA.get(
             metric,
             ("(unmapped metric)", "Metric emitted by report but not yet described in this script."),
@@ -209,6 +210,14 @@ def build_full_metrics_block(full_metrics_rows, last_case_description: str | Non
 
     lines.extend([r"\bottomrule", r"\end{longtable}", ""])
     return "\n".join(lines)
+
+
+def format_metric_value(raw_value: str) -> str:
+    try:
+        value = float(raw_value)
+    except ValueError:
+        return raw_value
+    return f"{value:.6g}"
 
 
 def parse_name_value_lines(path: Path):


### PR DESCRIPTION
### Motivation
- Improve TeX report readability of the Full metrics longtable by preventing font shrinking and rebalancing column widths. 
- Reduce overly verbose numeric output in the `Value` column and rename the second column to a shorter header for clarity.

### Description
- Adjusted the `longtable` column spec in `plots/spectrum/spectrum-sea_metrics.py` from `{p{0.20\linewidth}p{0.22\linewidth}p{0.42\linewidth}p{0.12\linewidth}}` to `{p{0.23\linewidth}p{0.25\linewidth}p{0.35\linewidth}p{0.13\linewidth}}` to widen `Metric key` and the second column while narrowing `Meaning`.
- Inserted `\normalsize` before the table to keep table text readable instead of reduced font size.
- Renamed the second column header from `Human-readable name` to `Metrics Name` in both the first head and repeated head.
- Added `format_metric_value()` and used it when emitting the `Value` cell to format numeric entries with 6 significant digits (`.6g`) while leaving non-numeric values unchanged.

### Testing
- Ran `make all` from the repository root and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cea7bda6ec8328bb15136b3eb903e9)