### PR TITLE
Fix sea metrics LaTeX fragment generation for longtable compatibility

### DIFF
--- a/plots/spectrum/spectrum-sea_metrics.py
+++ b/plots/spectrum/spectrum-sea_metrics.py
@@ -185,14 +185,13 @@ def build_full_metrics_block(full_metrics_rows, last_case_description: str | Non
     lines = [
         title,
         r"\begin{longtable}{p{0.23\linewidth}p{0.25\linewidth}p{0.35\linewidth}p{0.13\linewidth}}",
-        r"\normalsize",
-        r"\toprule",
+        r"\hline",
         r"Metric key & Metrics Name & Meaning & Value \\",
-        r"\midrule",
+        r"\hline",
         r"\endfirsthead",
-        r"\toprule",
+        r"\hline",
         r"Metric key & Metrics Name & Meaning & Value \\",
-        r"\midrule",
+        r"\hline",
         r"\endhead",
     ]
 
@@ -208,7 +207,7 @@ def build_full_metrics_block(full_metrics_rows, last_case_description: str | Non
             r"\\"
         )
 
-    lines.extend([r"\bottomrule", r"\end{longtable}", ""])
+    lines.extend([r"\hline", r"\end{longtable}", ""])
     return "\n".join(lines)
 
 


### PR DESCRIPTION
### Motivation
- The LaTeX build failed with `! Misplaced \noalign.` when including generated `longtable` fragments that used `\toprule/\midrule/\bottomrule`, so the fragment generator needs to emit table rules compatible with `longtable` to avoid TeX errors.

### Description
- In `plots/spectrum/spectrum-sea_metrics.py` the `longtable` full-metrics block now uses `\hline` instead of `\toprule/\midrule/\bottomrule` and the in-table `\normalsize` line was removed, keeping the rest of the fragment output unchanged.

### Testing
- Ran `python3 -m py_compile plots/spectrum/spectrum-sea_metrics.py` which succeeded, and executed the fragment generator on synthetic CSV/name-value inputs which produced the fragment file successfully; attempted `lualatex` validation but it failed because `lualatex` is not available in this environment (`command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cebcc010208328a0ab7c741108560b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated table formatting for spectrum sea metrics visualization to enhance visual presentation and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->