### PR TITLE
Print analysis fmax once in spectrum estimator sim outputs

### DIFF
--- a/tests/spectrum/spectrum-estimator-sim.cpp
+++ b/tests/spectrum/spectrum-estimator-sim.cpp
@@ -16,6 +16,11 @@ int main() {
     using Estimator = WaveSpectrumEstimator<Nfreq, Nblock>;
 
     std::cout << "Spectrum estimator simulation (IMU -> estimator vs ref spectrum files)\n";
+    {
+        const double fs_hz = 1.0 / static_cast<double>(dt);
+        Estimator estimator_info(fs_hz, 30, true);
+        std::cout << "Estimator analysis fmax: " << estimator_info.getAnalysisFmaxHz() << " Hz\n";
+    }
 
     bool all_quality_ok = true;
     for (const auto& fname : SpectrumEstimatorSimShared::discover_wave_data_files()) {

--- a/tests/spectrum/spectrum-wavelets-estimator-sim.cpp
+++ b/tests/spectrum/spectrum-wavelets-estimator-sim.cpp
@@ -16,6 +16,11 @@ int main() {
     using Estimator = WaveSpectrumEstimator_Wavelets<Nfreq, Nblock>;
 
     std::cout << "Wavelet spectrum estimator simulation (IMU -> estimator vs ref spectrum files)\n";
+    {
+        const double fs_hz = 1.0 / static_cast<double>(dt);
+        Estimator estimator_info(fs_hz, 30, true);
+        std::cout << "Estimator analysis fmax: " << estimator_info.getAnalysisFmaxHz() << " Hz\n";
+    }
 
     bool all_quality_ok = true;
     for (const auto& fname : SpectrumEstimatorSimShared::discover_wave_data_files()) {


### PR DESCRIPTION
### Motivation
- Make the estimator analysis maximum frequency (`getAnalysisFmaxHz()`) visible once in spectrum simulator test output so CI and devs can confirm the analyzer band limit without flooding logs.

### Description
- Add a one-time startup instantiation of a temporary `Estimator` and print `estimator.getAnalysisFmaxHz()` in `tests/spectrum/spectrum-estimator-sim.cpp` and `tests/spectrum/spectrum-wavelets-estimator-sim.cpp` using `fs_hz = 1.0 / dt` and the same constructor parameters as the running tests.

### Testing
- Ran `make all` successfully and executed `./tests/spectrum/spectrum-estimator-sim | head -n 6` and `./tests/spectrum/spectrum-wavelets-estimator-sim | head -n 6`, both printed the `Estimator analysis fmax:` line and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cec7423d308328955ced8b884641a1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added diagnostic output to spectrum estimator test simulations to verify analysis frequency calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->