### PR TITLE
Improve spectrum case labels in LaTeX report

### DIFF
--- a/plots/spectrum/spectrum-sea_metrics.py
+++ b/plots/spectrum/spectrum-sea_metrics.py
@@ -124,18 +124,22 @@ def describe_case(case_name: str) -> str:
         mode = "Wavelets estimator"
         stem = stem[len("spectrum_wavelets_"):]
 
-    match = re.match(
-        r"(?P<wave>[a-z0-9]+)_H(?P<h>[0-9.]+)_L(?P<l>[0-9.]+)_A(?P<a>[0-9.]+)_P(?P<p>[0-9.]+)$",
-        stem,
-    )
-    if not match:
+    if "_" not in stem:
         return case_name
 
-    wave_type = match.group("wave").upper()
-    height = float(match.group("h"))
-    length = float(match.group("l"))
-    azimuth = float(match.group("a"))
-    phase = float(match.group("p"))
+    wave_type, _, encoded = stem.partition("_")
+    token_pattern = re.compile(r"([A-Z])([-+]?[0-9]*\.?[0-9]+)")
+    values = {key: value for key, value in token_pattern.findall(encoded)}
+
+    required = {"H", "L", "A", "P"}
+    if not required.issubset(values):
+        return case_name
+
+    height = float(values["H"])
+    length = float(values["L"])
+    azimuth = float(values["A"])
+    phase = float(values["P"])
+    wave_type = wave_type.upper()
     details = f"{wave_type}: H={height:.2f} m, L={length:.2f} m, az={azimuth:.1f}°, phase={phase:.1f}°"
     return f"{mode} — {details}" if mode else details
 


### PR DESCRIPTION
### Motivation
- Make the `Case` column in autogenerated LaTeX reports human-readable by decoding encoded spectrum filenames instead of showing raw `.csv` names.
- Support filenames that include extra encoded suffix tokens (e.g., `N`, `B`, `S`) and signed numeric tokens like negative azimuths so descriptions render correctly.

### Description
- Replace an end-anchored regex parsing path in `describe_case` with token extraction using `re.compile(r"([A-Z])([-+]?[0-9]*\.?[0-9]+)")` to find `H`, `L`, `A`, `P` tokens in `plots/spectrum/spectrum-sea_metrics.py`.
- Require the presence of the `H`, `L`, `A`, and `P` tokens and fall back to the original case name when they are missing, preserving previous fallback behavior.
- Convert extracted token values to floats and build a readable string like `Classic estimator — JONSWAP: H=1.50 m, L=50.71 m, az=-30.0°, phase=120.0°` for use in the LaTeX table.

### Testing
- Imported the modified module and ran `describe_case(...)` on representative filenames (including examples with negative azimuth and trailing tokens) and verified the returned human-readable descriptions matched expectations.
- No other automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cecfeed1788328bfece113c2fa17a5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing logic for spectrum case name identification, making it more robust and flexible in handling various input formats while maintaining consistent output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->