### PR TITLE
Add Makefile target to fetch and unpack simulation data and update README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean
+.PHONY: all clean fetch-sim-data
 
 TEST_DIRS := \
 	tests/ahrs \
@@ -11,6 +11,11 @@ TEST_DIRS := \
 	tests/spectrum \
 	tests/wave_sim
 
+SIM_DATA_VERSION ?= v1.0.9
+SIM_DATA_REPO ?= bareboat-necessities/oceanography-waves-lib
+SIM_DATA_ZIP ?= sim-data-files.zip
+SIM_DATA_URL ?= https://github.com/$(SIM_DATA_REPO)/releases/download/$(SIM_DATA_VERSION)/$(SIM_DATA_ZIP)
+
 all:
 	@set -e; \
 	for d in $(TEST_DIRS); do \
@@ -21,4 +26,15 @@ clean:
 	@set -e; \
 	for d in $(TEST_DIRS); do \
 		$(MAKE) -C $$d clean >/dev/null 2>&1 || true; \
+	done
+
+fetch-sim-data:
+	@set -e; \
+	echo "Downloading $(SIM_DATA_URL)"; \
+	curl -fL "$(SIM_DATA_URL)" -o "$(SIM_DATA_ZIP)"; \
+	for d in $(TEST_DIRS); do \
+		plot_dir="plots/$${d#tests/}"; \
+		mkdir -p "$$plot_dir"; \
+		unzip -o "$(SIM_DATA_ZIP)" -d "$$plot_dir" >/dev/null; \
+		echo "Unpacked $(SIM_DATA_ZIP) -> $$plot_dir"; \
 	done

--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ Some validation and simulation workflows depend on data released in:
 
 In CI/docs, this is often referenced as `sim-data-files.zip` from that project’s releases.
 
+You can fetch and unpack this data for local runs with:
+
+```bash
+make fetch-sim-data
+```
+
 ## Build
 
 Run builds from the specific test folder you want to validate:


### PR DESCRIPTION
### Motivation

- Provide a simple, reproducible way to obtain the external simulation data used by tests and docs. 
- Centralize configurable release parameters so the data source and version can be overridden in CI or locally.

### Description

- Add `SIM_DATA_VERSION`, `SIM_DATA_REPO`, `SIM_DATA_ZIP`, and `SIM_DATA_URL` variables to the `Makefile` with sensible defaults. 
- Introduce a new `.PHONY` target `fetch-sim-data` that downloads the release archive and unpacks it into per-test `plots/` subdirectories using `curl` and `unzip`. 
- Update the top-level `.PHONY` declaration to include `fetch-sim-data`. 
- Update `README.md` with usage instructions showing `make fetch-sim-data` for local retrieval.

### Testing

- No automated tests were changed or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d01dd9a2b08328b433a218dc9d438a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New `make fetch-sim-data` command downloads and extracts simulation data to test directories.

* **Documentation**
  * Added instructions for fetching and unpacking simulation data locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->