### PR TITLE
Qualify finite3_ calls to resolve overload ambiguity in AtomS3R OU2 sketch

### DIFF
--- a/sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino
+++ b/sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino
@@ -457,12 +457,12 @@ private:
 
     Vector3f m_s;
     const bool read_ok = runtime_imu_.mag().readMag_uT(m_s);
-    const bool sample_usable = finite3_(m_s) && (m_s.norm() > 1.0f);
+    const bool sample_usable = ::finite3_(m_s) && (m_s.norm() > 1.0f);
     if (!read_ok && !sample_usable) return;
 
     const Vector3f m_body(m_s.y(), m_s.x(), -m_s.z());
 
-    const bool have_prev = finite3_(mag_raw_uT_);
+    const bool have_prev = ::finite3_(mag_raw_uT_);
     const float dm       = have_prev ? (m_body - mag_raw_uT_).norm() : INFINITY;
 
     if (!have_prev || dm >= MAG_MIN_DELTA_uT) {


### PR DESCRIPTION
### Motivation
- Resolve a compile error caused by an overload ambiguity between a local `finite3_` helper and `atoms3r_ical::finite3_` when compiling the AtomS3R OU2 sketch. 

### Description
- Qualify two call sites in `sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino` to call the global helper as `::finite3_(...)` (checks for `m_s` and `mag_raw_uT_`).

### Testing
- Ran `make all` which completed successfully with no build errors.
- Ran `make clean` to verify the workspace cleaned without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d046644cc4832881429268447be813)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced magnetometer sensor data validation reliability by improving function resolution logic, ensuring accurate sample usability determination and magnitude delta computation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->