### PR TITLE
Fix fetch-sim-data to populate test directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,10 @@ fetch-sim-data:
 	curl -fL "$(SIM_DATA_URL)" -o "$(SIM_DATA_ZIP)"; \
 	for d in $(TEST_DIRS); do \
 		plot_dir="plots/$${d#tests/}"; \
+		test_dir="$$d"; \
 		mkdir -p "$$plot_dir"; \
 		unzip -o "$(SIM_DATA_ZIP)" -d "$$plot_dir" >/dev/null; \
 		echo "Unpacked $(SIM_DATA_ZIP) -> $$plot_dir"; \
+		unzip -o "$(SIM_DATA_ZIP)" -d "$$test_dir" >/dev/null; \
+		echo "Unpacked $(SIM_DATA_ZIP) -> $$test_dir"; \
 	done


### PR DESCRIPTION
### Motivation
- Some test runners execute from `tests/*` and expect wave CSV fixtures in the local working directory, but `fetch-sim-data` only unpacked files under `plots/*`, causing missing-file failures (e.g. `tests/detrend/detrend-wave-test`).

### Description
- Update the top-level `Makefile` `fetch-sim-data` target to also `unzip -o "$(SIM_DATA_ZIP)" -d "tests/<suite>"` for each test suite in `TEST_DIRS`, in addition to the existing unpack into `plots/<suite>`.

### Testing
- Ran `make all`, `make fetch-sim-data`, and `cd tests/detrend && ./run_tests.sh`, and the commands completed successfully (tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d087642b6c8328b8cc60209d7d6f20)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build process to improve simulation data distribution during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->