### PR TITLE
Add 3D detrending regression test, 3D plot generator, and chart doc

### DIFF
--- a/doc/detrend/detrend-3d-charts.tex
+++ b/doc/detrend/detrend-3d-charts.tex
@@ -1,0 +1,50 @@
+\documentclass[11pt,letterpaper]{article}
+\usepackage{amsmath}
+\usepackage{amssymb}
+\usepackage{fullpage}
+\usepackage{mathrsfs}
+\usepackage{graphicx}
+\usepackage{cite}
+\usepackage{pgf}
+\usepackage{pgfplots}
+\usepgfplotslibrary{groupplots}
+\pgfplotsset{compat=1.18}
+\usepackage{bm}
+\usepackage{float}
+\usepackage{microtype}
+\usepackage{array,booktabs,makecell,adjustbox}
+
+\providecommand{\mathdefault}[1]{#1}
+
+\title{Wave Simulation Charts (3D Detrending)}
+\author{Mikhail Grushinskiy}
+\date{2026}
+
+\begin{document}
+    \maketitle
+
+\begin{figure}[H]\centering
+\resizebox{\textwidth}{!}{\input{detrend-wave3d-plots-h0_270.pgf}}
+\caption{AdaptiveWaveDetrender3D sample-driven simulation, low sea state ($H_s=0.27$ m).}
+\label{fig:adaptive_wave_detrender3d_sim_h0270}
+\end{figure}
+
+\begin{figure}[H]\centering
+\resizebox{\textwidth}{!}{\input{detrend-wave3d-plots-h1_500.pgf}}
+\caption{AdaptiveWaveDetrender3D sample-driven simulation, medium sea state ($H_s=1.5$ m).}
+\label{fig:adaptive_wave_detrender3d_sim_h1500}
+\end{figure}
+
+\begin{figure}[H]\centering
+\resizebox{\textwidth}{!}{\input{detrend-wave3d-plots-h4_000.pgf}}
+\caption{AdaptiveWaveDetrender3D sample-driven simulation, large sea state ($H_s=4.0$ m).}
+\label{fig:adaptive_wave_detrender3d_sim_h4000}
+\end{figure}
+
+\begin{figure}[H]\centering
+\resizebox{\textwidth}{!}{\input{detrend-wave3d-plots-h8_500.pgf}}
+\caption{AdaptiveWaveDetrender3D sample-driven simulation, extreme sea state ($H_s=8.5$ m).}
+\label{fig:adaptive_wave_detrender3d_sim_h8500}
+\end{figure}
+
+\end{document}

--- a/plots/detrend/detrend-wave3d-plots.py
+++ b/plots/detrend/detrend-wave3d-plots.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import csv
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+TEST_DIR = SCRIPT_DIR.parent / ".." / "tests" / "detrend"
+OUT_DIR = SCRIPT_DIR
+SAMPLES_CSV = TEST_DIR / "adaptive_wave_detrender3d_sim_output.csv"
+SUMMARY_CSV = TEST_DIR / "adaptive_wave_detrender3d_sim_summary.csv"
+TIME_WINDOW_S = 80.0
+SAMPLE_RATE_HZ = 200
+DOWNSAMPLE = 10
+HEIGHT_ORDER = [0.27, 1.5, 4.0, 8.5]
+FILE_BY_HEIGHT = {
+    0.27: "detrend-wave3d-plots-h0_270.pgf",
+    1.5: "detrend-wave3d-plots-h1_500.pgf",
+    4.0: "detrend-wave3d-plots-h4_000.pgf",
+    8.5: "detrend-wave3d-plots-h8_500.pgf",
+}
+
+
+def load_rows(path: Path):
+    with path.open(newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def coordinate_block(rows, key):
+    lines = []
+    for row in rows:
+        lines.append(f"({float(row['time_s']):.3f},{float(row[key]):.6f})")
+    return "\n".join(lines)
+
+
+def axis_block(rows, axis_name: str):
+    key = axis_name.lower()
+    return f"""\\nextgroupplot[
+  grid=both,
+  grid style={{line width=.1pt, draw=gray!25}},
+  major grid style={{line width=.2pt, draw=gray!45}},
+  xlabel={{Time [s]}},
+  ylabel={{{axis_name} [m]}},
+  xmin={float(rows[0]['time_s']):.3f},
+  xmax={float(rows[-1]['time_s']):.3f},
+  legend style={{at={{(0.5,1.02)}}, anchor=south, legend columns=3, draw=none, /tikz/every even column/.append style={{column sep=0.4cm}}}},
+]
+\\addplot[smooth, line width=0.8pt, color=black!60] coordinates {{
+{coordinate_block(rows, f'drifted_{key}_m')}
+}};
+\\addlegendentry{{Drifted {axis_name}}}
+
+\\addplot[smooth, line width=0.9pt, color=red!75!black] coordinates {{
+{coordinate_block(rows, f'detrended_{key}_m')}
+}};
+\\addlegendentry{{AdaptiveWaveDetrender3D {axis_name}}}
+
+\\addplot[smooth, dashed, line width=0.9pt, color=blue!70!black] coordinates {{
+{coordinate_block(rows, f'reference_{key}_m')}
+}};
+\\addlegendentry{{Reference {axis_name}}}
+"""
+
+
+def write_plot(path: Path, rows, case):
+    title = (
+        rf"$H_s={float(case['height_m']):.2f}\,\mathrm{{m}}$, "
+        rf"$T_p={float(case['period_s']):.1f}\,\mathrm{{s}}$, "
+        rf"$RMS_z={float(case['detrended_rms_z_m']):.3f}\,\mathrm{{m}}$ "
+        rf"(gate {float(case['gate_rms_z_m']):.3f} m)"
+    )
+    content = f"""\\begin{{tikzpicture}}
+\\begin{{groupplot}}[
+  group style={{group size=1 by 3, vertical sep=1.1cm}},
+  width=14.5cm,
+  height=4.0cm,
+  title={{{title}}},
+]
+{axis_block(rows, 'X')}
+{axis_block(rows, 'Y')}
+{axis_block(rows, 'Z')}
+\\end{{groupplot}}
+\\end{{tikzpicture}}
+"""
+    path.write_text(content)
+
+
+def main() -> None:
+    samples = load_rows(SAMPLES_CSV)
+    summary = load_rows(SUMMARY_CSV)
+
+    for height_m in HEIGHT_ORDER:
+        case = next(row for row in summary if abs(float(row['height_m']) - height_m) < 1.0e-9)
+        scenario = case['scenario']
+        case_rows = [row for row in samples if row['scenario'] == scenario]
+        case_rows = case_rows[-int(TIME_WINDOW_S * SAMPLE_RATE_HZ):]
+        case_rows = case_rows[::DOWNSAMPLE]
+        out_path = OUT_DIR / FILE_BY_HEIGHT[height_m]
+        write_plot(out_path, case_rows, case)
+        print(f"saved {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plots/detrend/draw_plots.sh
+++ b/plots/detrend/draw_plots.sh
@@ -2,3 +2,4 @@
 
 python3 ./detrend-basic-plots.py
 python3 ./detrend-wave-plots.py
+python3 ./detrend-wave3d-plots.py

--- a/tests/detrend/Makefile
+++ b/tests/detrend/Makefile
@@ -17,7 +17,7 @@ endif
 LDFLAGS  =
 
 # Targets
-TARGETS = detrend-basic-test detrend-wave-test
+TARGETS = detrend-basic-test detrend-wave-test detrend-wave3d-test
 
 all: $(TARGETS)
 

--- a/tests/detrend/detrend-wave3d-test.cpp
+++ b/tests/detrend/detrend-wave3d-test.cpp
@@ -1,0 +1,349 @@
+#include <algorithm>
+#include <cmath>
+#include <cctype>
+#include <cstdlib>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#define EIGEN_NON_ARDUINO
+#include "detrend/AdaptiveWaveDetrender3D.h"
+
+namespace {
+
+constexpr double kPi = 3.14159265358979323846;
+constexpr double kWarmupMinS = 60.0;
+constexpr double kRmsGateFractionOfHeight = 0.16;
+
+struct Scenario {
+  const char* tag;
+  double height_m;
+  double period_s;
+  const char* wave_samples_csv;
+};
+
+struct WaveRow {
+  double time_s = 0.0;
+  double disp_z_m = 0.0;
+};
+
+struct Vec3d {
+  double x = 0.0;
+  double y = 0.0;
+  double z = 0.0;
+};
+
+struct RMSAccumulator3D {
+  Vec3d sum_sq{};
+  std::size_t count = 0U;
+
+  void add(const Vec3d& v) {
+    sum_sq.x += v.x * v.x;
+    sum_sq.y += v.y * v.y;
+    sum_sq.z += v.z * v.z;
+    ++count;
+  }
+
+  Vec3d rms() const {
+    if (count == 0U) {
+      return Vec3d{};
+    }
+    const double inv_n = 1.0 / static_cast<double>(count);
+    return Vec3d{std::sqrt(sum_sq.x * inv_n), std::sqrt(sum_sq.y * inv_n), std::sqrt(sum_sq.z * inv_n)};
+  }
+};
+
+const std::vector<Scenario> kScenarios = {
+    {"low", 0.27, 3.0, "wave_data_pmstokes_H0.270_L14.047_A30.00_P60.00.csv"},
+    {"medium", 1.5, 5.7, "wave_data_pmstokes_H1.500_L50.710_A-30.00_P120.00.csv"},
+    {"large", 4.0, 8.5, "wave_data_pmstokes_H4.000_L112.766_A30.00_P30.00.csv"},
+    {"extreme", 8.5, 11.4, "wave_data_pmstokes_H8.500_L202.839_A-30.00_P72.00.csv"},
+};
+
+std::string trim(const std::string& value) {
+  std::size_t start = 0;
+  while (start < value.size() && std::isspace(static_cast<unsigned char>(value[start])) != 0) {
+    ++start;
+  }
+
+  std::size_t end = value.size();
+  while (end > start && std::isspace(static_cast<unsigned char>(value[end - 1])) != 0) {
+    --end;
+  }
+
+  return value.substr(start, end - start);
+}
+
+std::vector<std::string> split_csv_line(const std::string& line) {
+  std::vector<std::string> fields;
+  std::stringstream ss(line);
+  std::string field;
+  while (std::getline(ss, field, ',')) {
+    fields.push_back(trim(field));
+  }
+  return fields;
+}
+
+double parse_double_field(const std::string& value, const char* name) {
+  try {
+    return std::stod(value);
+  } catch (const std::exception&) {
+    throw std::runtime_error(std::string("Unable to parse ") + name + " value: " + value);
+  }
+}
+
+std::vector<WaveRow> load_wave_rows(const std::string& path) {
+  std::ifstream ifs(path);
+  if (!ifs.is_open()) {
+    throw std::runtime_error("Unable to open wave samples CSV: " + path);
+  }
+
+  std::string line;
+  if (!std::getline(ifs, line)) {
+    throw std::runtime_error("Wave samples CSV is empty: " + path);
+  }
+
+  const std::vector<std::string> header = split_csv_line(line);
+  std::size_t time_idx = std::numeric_limits<std::size_t>::max();
+  std::size_t disp_z_idx = std::numeric_limits<std::size_t>::max();
+  for (std::size_t i = 0; i < header.size(); ++i) {
+    if (header[i] == "time") {
+      time_idx = i;
+    } else if (header[i] == "disp_z") {
+      disp_z_idx = i;
+    }
+  }
+
+  if (time_idx == std::numeric_limits<std::size_t>::max() || disp_z_idx == std::numeric_limits<std::size_t>::max()) {
+    throw std::runtime_error("Wave CSV missing required columns 'time' and 'disp_z': " + path);
+  }
+
+  std::vector<WaveRow> rows;
+  while (std::getline(ifs, line)) {
+    if (trim(line).empty()) {
+      continue;
+    }
+
+    const std::vector<std::string> fields = split_csv_line(line);
+    if (fields.size() <= std::max(time_idx, disp_z_idx)) {
+      throw std::runtime_error("Malformed row in wave CSV: " + path);
+    }
+
+    WaveRow row;
+    row.time_s = parse_double_field(fields[time_idx], "time");
+    row.disp_z_m = parse_double_field(fields[disp_z_idx], "disp_z");
+    rows.push_back(row);
+  }
+
+  if (rows.empty()) {
+    throw std::runtime_error("No wave samples found in CSV: " + path);
+  }
+
+  return rows;
+}
+
+Vec3d reference_signal(const Scenario& scenario, double wave_freq_hz, double time_s, double ref_z_m) {
+  const double omega = 2.0 * kPi * wave_freq_hz;
+  Vec3d ref;
+  ref.z = ref_z_m;
+  ref.x = (0.35 * scenario.height_m) * std::sin((omega * time_s) + 0.40) +
+          (0.08 * scenario.height_m) * std::sin((0.50 * omega * time_s) - 0.70);
+  ref.y = (0.28 * scenario.height_m) * std::cos((omega * time_s) - 0.30) +
+          (0.06 * scenario.height_m) * std::sin((0.65 * omega * time_s) + 0.20);
+  return ref;
+}
+
+Vec3d drift_signal(const Scenario& scenario, double wave_freq_hz, double time_s, double duration_s) {
+  const double primary_freq_hz = std::max(0.0035, wave_freq_hz * 0.085);
+  const double secondary_freq_hz = std::max(0.0020, primary_freq_hz * 0.41);
+  const double normalized_time = (time_s / duration_s) - 0.5;
+
+  Vec3d drift;
+  drift.x = (0.16 * scenario.height_m) * std::sin((2.0 * kPi * primary_freq_hz * time_s) + 0.10) +
+            (0.05 * scenario.height_m) * std::sin((2.0 * kPi * secondary_freq_hz * time_s) - 0.40) +
+            (0.08 * scenario.height_m) * normalized_time;
+  drift.y = (0.13 * scenario.height_m) * std::sin((2.0 * kPi * primary_freq_hz * time_s) - 0.80) +
+            (0.06 * scenario.height_m) * std::sin((2.0 * kPi * secondary_freq_hz * time_s) + 0.35) +
+            (0.07 * scenario.height_m) * normalized_time;
+  drift.z = (0.38 * scenario.height_m) * std::sin((2.0 * kPi * primary_freq_hz * time_s) + 0.35) +
+            (0.14 * scenario.height_m) * std::sin((2.0 * kPi * secondary_freq_hz * time_s) - 0.80) +
+            (0.20 * scenario.height_m) * normalized_time;
+  return drift;
+}
+
+std::string resolve_output_path(int argc, char* argv[], int arg_index, const char* fallback) {
+  return (argc > arg_index) ? argv[arg_index] : std::string(fallback);
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+  try {
+    const std::string samples_path = resolve_output_path(argc, argv, 1, "adaptive_wave_detrender3d_sim_output.csv");
+    const std::string summary_path = resolve_output_path(argc, argv, 2, "adaptive_wave_detrender3d_sim_summary.csv");
+
+    std::ofstream samples_ofs(samples_path);
+    if (!samples_ofs.is_open()) {
+      throw std::runtime_error("Unable to open output CSV: " + samples_path);
+    }
+
+    std::ofstream summary_ofs(summary_path);
+    if (!summary_ofs.is_open()) {
+      throw std::runtime_error("Unable to open summary CSV: " + summary_path);
+    }
+
+    samples_ofs << "scenario,height_m,period_s,wave_freq_hz,time_s,"
+                   "reference_x_m,drift_x_m,drifted_x_m,detrended_x_m,baseline_x_m,error_x_m,"
+                   "reference_y_m,drift_y_m,drifted_y_m,detrended_y_m,baseline_y_m,error_y_m,"
+                   "reference_z_m,drift_z_m,drifted_z_m,detrended_z_m,baseline_z_m,error_z_m\n";
+    samples_ofs << std::fixed << std::setprecision(9);
+
+    summary_ofs << "scenario,height_m,period_s,wave_freq_hz,warmup_s,"
+                   "drift_rms_x_m,detrended_rms_x_m,gate_rms_x_m,improvement_ratio_x,"
+                   "drift_rms_y_m,detrended_rms_y_m,gate_rms_y_m,improvement_ratio_y,"
+                   "drift_rms_z_m,detrended_rms_z_m,gate_rms_z_m,improvement_ratio_z\n";
+    summary_ofs << std::fixed << std::setprecision(9);
+
+    bool all_ok = true;
+
+    for (const Scenario& scenario : kScenarios) {
+      const std::vector<WaveRow> wave_rows = load_wave_rows(scenario.wave_samples_csv);
+      const double wave_freq_hz = 1.0 / scenario.period_s;
+      const double warmup_s = std::max(kWarmupMinS, 6.0 * scenario.period_s);
+      const double gate_rms_m = kRmsGateFractionOfHeight * scenario.height_m;
+      const double duration_s = wave_rows.back().time_s;
+
+      AdaptiveWaveDetrender3D detrender;
+      RMSAccumulator3D drift_rms;
+      RMSAccumulator3D detrended_rms;
+
+      bool initialized = false;
+      double prev_time_s = 0.0;
+
+      for (const WaveRow& row : wave_rows) {
+        if (initialized && !(row.time_s > prev_time_s)) {
+          continue;
+        }
+
+        const Vec3d reference = reference_signal(scenario, wave_freq_hz, row.time_s, row.disp_z_m);
+        const Vec3d drift = drift_signal(scenario, wave_freq_hz, row.time_s, duration_s);
+        const Vec3d drifted{reference.x + drift.x, reference.y + drift.y, reference.z + drift.z};
+
+        AdaptiveWaveDetrender3D::Output output;
+        if (!initialized) {
+          detrender.reset(static_cast<float>(drifted.x),
+                         static_cast<float>(drifted.y),
+                         static_cast<float>(drifted.z));
+          output = detrender.lastOutput();
+          initialized = true;
+        } else {
+          const double dt_s = row.time_s - prev_time_s;
+          output = detrender.update(static_cast<float>(drifted.x),
+                                    static_cast<float>(drifted.y),
+                                    static_cast<float>(drifted.z),
+                                    static_cast<float>(dt_s),
+                                    static_cast<float>(wave_freq_hz),
+                                    true);
+        }
+
+        const Vec3d detrended{static_cast<double>(output.wave_clean.x()),
+                              static_cast<double>(output.wave_clean.y()),
+                              static_cast<double>(output.wave_clean.z())};
+        const Vec3d baseline{static_cast<double>(output.baseline_slow.x()),
+                             static_cast<double>(output.baseline_slow.y()),
+                             static_cast<double>(output.baseline_slow.z())};
+        const Vec3d error{detrended.x - reference.x,
+                          detrended.y - reference.y,
+                          detrended.z - reference.z};
+
+        if (row.time_s >= warmup_s) {
+          drift_rms.add(drift);
+          detrended_rms.add(error);
+        }
+
+        samples_ofs << scenario.tag << ','
+                    << scenario.height_m << ','
+                    << scenario.period_s << ','
+                    << wave_freq_hz << ','
+                    << row.time_s << ','
+                    << reference.x << ','
+                    << drift.x << ','
+                    << drifted.x << ','
+                    << detrended.x << ','
+                    << baseline.x << ','
+                    << error.x << ','
+                    << reference.y << ','
+                    << drift.y << ','
+                    << drifted.y << ','
+                    << detrended.y << ','
+                    << baseline.y << ','
+                    << error.y << ','
+                    << reference.z << ','
+                    << drift.z << ','
+                    << drifted.z << ','
+                    << detrended.z << ','
+                    << baseline.z << ','
+                    << error.z << '\n';
+
+        prev_time_s = row.time_s;
+      }
+
+      const Vec3d drift_rms_v = drift_rms.rms();
+      const Vec3d detrended_rms_v = detrended_rms.rms();
+
+      const double improvement_x = (detrended_rms_v.x > 0.0)
+          ? (drift_rms_v.x / detrended_rms_v.x)
+          : std::numeric_limits<double>::infinity();
+      const double improvement_y = (detrended_rms_v.y > 0.0)
+          ? (drift_rms_v.y / detrended_rms_v.y)
+          : std::numeric_limits<double>::infinity();
+      const double improvement_z = (detrended_rms_v.z > 0.0)
+          ? (drift_rms_v.z / detrended_rms_v.z)
+          : std::numeric_limits<double>::infinity();
+
+      summary_ofs << scenario.tag << ','
+                  << scenario.height_m << ','
+                  << scenario.period_s << ','
+                  << wave_freq_hz << ','
+                  << warmup_s << ','
+                  << drift_rms_v.x << ','
+                  << detrended_rms_v.x << ','
+                  << gate_rms_m << ','
+                  << improvement_x << ','
+                  << drift_rms_v.y << ','
+                  << detrended_rms_v.y << ','
+                  << gate_rms_m << ','
+                  << improvement_y << ','
+                  << drift_rms_v.z << ','
+                  << detrended_rms_v.z << ','
+                  << gate_rms_m << ','
+                  << improvement_z << '\n';
+
+      std::cout << scenario.tag
+                << ": RMS x (drift/detrended/gate) = " << drift_rms_v.x << '/' << detrended_rms_v.x << '/' << gate_rms_m
+                << ", y = " << drift_rms_v.y << '/' << detrended_rms_v.y << '/' << gate_rms_m
+                << ", z = " << drift_rms_v.z << '/' << detrended_rms_v.z << '/' << gate_rms_m << '\n';
+
+      const bool ok_x = (detrended_rms_v.x <= gate_rms_m) && (detrended_rms_v.x < drift_rms_v.x);
+      const bool ok_y = (detrended_rms_v.y <= gate_rms_m) && (detrended_rms_v.y < drift_rms_v.y);
+      const bool ok_z = (detrended_rms_v.z <= gate_rms_m) && (detrended_rms_v.z < drift_rms_v.z);
+      if (!(ok_x && ok_y && ok_z)) {
+        all_ok = false;
+        std::cerr << "Quality gate failed for scenario '" << scenario.tag << "'\n";
+      }
+    }
+
+    std::cout << "Wrote simulation samples to " << samples_path << '\n';
+    std::cout << "Wrote simulation summary to " << summary_path << '\n';
+
+    return all_ok ? EXIT_SUCCESS : EXIT_FAILURE;
+  } catch (const std::exception& ex) {
+    std::cerr << "detrend-wave3d-test failed: " << ex.what() << '\n';
+    return EXIT_FAILURE;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a regression test and plotting support for the 3D detrending variant to validate `AdaptiveWaveDetrender3D` on synthetic 3-axis records.
- Reuse the existing 2D/1D detrend test patterns to produce comparable CSV outputs and PGF plots for X/Y/Z components.
- Add a document file to include the generated 3D plots in the project charts.

### Description
- Added `tests/detrend/detrend-wave3d-test.cpp` which mirrors the existing wave simulation test but uses `AdaptiveWaveDetrender3D`, emits per-axis sample CSV (`adaptive_wave_detrender3d_sim_output.csv`) and summary CSV, and applies per-axis RMS quality gates; the test defines `EIGEN_NON_ARDUINO` so host builds use system Eigen includes.
- Added `plots/detrend/detrend-wave3d-plots.py` modeled on `detrend-wave-plots.py` to generate grouped X/Y/Z PGF plots for each sea state.
- Added `doc/detrend/detrend-3d-charts.tex` to include the generated `detrend-wave3d-plots-*.pgf` figures for all four sea states.
- Updated `tests/detrend/Makefile` to build the new `detrend-wave3d-test` target and updated `plots/detrend/draw_plots.sh` to run the new plotting script.

### Testing
- Ran `make all` initially which failed while compiling the new test due to the `ArduinoEigenDense.h` include path branch being selected; the failure was `fatal error: ArduinoEigenDense.h: No such file or directory`.
- Fixed the build by adding `#define EIGEN_NON_ARDUINO` at the top of `tests/detrend/detrend-wave3d-test.cpp` so the system Eigen headers are used.
- Ran `make all` again and the build completed successfully (tests and targets compiled).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d139733cb083288d18bceb3d0acfab)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 3D wave simulation charts visualization for detrending analysis across multiple sea states.
  * Implemented 3D wave detrending capability with output charts showing drift correction.

* **Tests**
  * Added comprehensive test coverage for 3D wave detrending with quality validation across multiple scenarios.

* **Documentation**
  * New documentation for 3D wave simulation charts with detrending visualization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->