### PR TITLE
Run detrend-wave3d regression in detrend test pipeline

### DIFF
--- a/tests/detrend/run_tests.sh
+++ b/tests/detrend/run_tests.sh
@@ -3,3 +3,5 @@
 ./detrend-basic-test
 
 ./detrend-wave-test
+
+./detrend-wave3d-test


### PR DESCRIPTION
### Motivation
- The plot generation step expects `adaptive_wave_detrender3d_sim_output.csv` and `adaptive_wave_detrender3d_sim_summary.csv` to exist, but the detrend test driver did not run the 3D regression that produces them, causing plotting to fail in CI.

### Description
- Append a call to `./detrend-wave3d-test` in `tests/detrend/run_tests.sh` so the 3D detrender produces its CSV outputs before plotting.
- Modified file: `tests/detrend/run_tests.sh` (added one line to invoke `./detrend-wave3d-test`).

### Testing
- Ran `make all`, which completed successfully in this environment. 
- Ran `cd tests/detrend && ./run_tests.sh` which failed locally because required simulation CSV inputs are not present, with the error `Unable to open wave samples CSV: wave_data_pmstokes_H0.270_L14.047_A30.00_P60.00.csv`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d14056d67c8328b0e818f0b7ac3bc4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new test execution step to the test runner suite, enhancing test coverage for the detrend functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->