### PR TITLE
Fix LaTeX undefined \degree command in wave_sim-fenton doc

### DIFF
--- a/doc/wave_sim/wave_sim-fenton.tex
+++ b/doc/wave_sim/wave_sim-fenton.tex
@@ -185,7 +185,7 @@ $Ur = HL^2/d^3$ is large; for moderate Ursell numbers neither
 the Stokes nor the cnoidal approximation is reliable, and a fully
 numerical approach is required.
 
-The theoretical limiting wave---the steep crest wave with a $120\degree$
+The theoretical limiting wave---the steep crest wave with a $120^\circ$
 interior angle at the free surface---was studied by Stokes and later
 by Michell \cite{Michell1893}, who computed the limiting steepness in
 deep water as $(H/L)_{\max} \approx 0.1418$.
@@ -618,7 +618,7 @@ real axis to the nearest singularity of the analytically continued
 free surface \cite{Fenton1988,Schwartz1974}.
 
 In practice, convergence degrades as the limiting steepness is
-approached, because the $120\degree$ corner at the crest introduces a
+approached, because the $120^\circ$ corner at the crest introduces a
 non-analytic singularity.
 Near the Stokes limit, convergence is only algebraic in $N$, and a
 much larger truncation order is required to maintain a given accuracy
@@ -984,7 +984,7 @@ wave theory in shallow water, and Williams' near-limiting-wave data
 confirms that the implementation is accurate to better than $0.01\%$
 over the practical wave parameter range.
 Near the Stokes limiting steepness the convergence becomes algebraic
-in $N$, consistent with the known $120\degree$-corner singularity at
+in $N$, consistent with the known $120^\circ$-corner singularity at
 the wave crest; $N=32$ or larger is recommended for steepnesses above
 $95\%$ of the limiting value.
 


### PR DESCRIPTION
### Motivation
- The document `doc/wave_sim/wave_sim-fenton.tex` used the undefined LaTeX macro `\degree`, which produced an `Undefined control sequence` error when compiling in environments that do not provide that macro.  

### Description
- Replaced three occurrences of `\degree` with the math-safe `^\circ` in `doc/wave_sim/wave_sim-fenton.tex` to ensure the document compiles without requiring a package that defines `\degree`.  

### Testing
- Confirmed via text search that no `\degree` occurrences remain in the file.  
- Attempted to run `pdflatex` in `doc/wave_sim`, but the command is unavailable in this environment (`pdflatex: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d16472b2308328bec57168c4cb6e5a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved documentation formatting for consistency with standard conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->