### PR TITLE
Add Arduino/PlatformIO library manifests for AtomS3R (library.json, library.properties)

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,41 @@
+{
+  "name": "ocean-imu",
+  "version": "0.1.0",
+  "description": "Marine IMU, AHRS, and wave-processing algorithms with AtomS3R integrations for M5Stack AtomS3R.",
+  "keywords": [
+    "imu",
+    "ahrs",
+    "kalman",
+    "m5stack",
+    "atoms3r",
+    "marine",
+    "wave"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bareboat-necessities/ocean-imu.git"
+  },
+  "authors": [
+    {
+      "name": "Bareboat Necessities"
+    }
+  ],
+  "license": "MIT",
+  "frameworks": [
+    "arduino"
+  ],
+  "platforms": [
+    "espressif32"
+  ],
+  "dependencies": [
+    {
+      "name": "M5Unified"
+    },
+    {
+      "name": "Eigen"
+    }
+  ],
+  "build": {
+    "srcFilter": "+<src/>"
+  }
+}

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,11 @@
+name=ocean-imu
+version=0.1.0
+author=Bareboat Necessities
+maintainer=Bareboat Necessities <github@bareboat-necessities.github.io>
+sentence=Marine IMU, AHRS, and wave-processing algorithms with AtomS3R helpers.
+paragraph=Reusable C++ modules for IMU calibration, attitude estimation, and marine wave analytics, including AtomS3R-oriented integrations for M5Stack devices.
+category=Sensors
+url=https://github.com/bareboat-necessities/ocean-imu
+architectures=esp32
+depends=M5Unified, Eigen
+includes=AtomS3R/ImuCalWizardRunner.h,AtomS3R/AtomS3R_CompassAppBase.h,ahrs/KalmanQMEKF.h


### PR DESCRIPTION
### Motivation
- Provide Arduino/PlatformIO packaging metadata so this repository can be consumed as an Arduino/PlatformIO library for M5Stack AtomS3R-based projects without changing code or public APIs.

### Description
- Add `library.properties` to support Arduino IDE/CLI consumption with `architectures=esp32`, declared `depends=M5Unified, Eigen`, and an `includes=` hint for AtomS3R headers.
- Add `library.json` to support PlatformIO with `frameworks: ["arduino"]`, `platforms: ["espressif32"]`, declared `dependencies` (`M5Unified`, `Eigen`) and a `build.srcFilter` that exposes the `src/` tree.
- No source code, public APIs, filenames, or build targets were changed and no `component.mk` (ESP-IDF component metadata) was added because the two manifest files satisfy Arduino/PlatformIO packaging.

### Testing
- Ran `make all` at the repository root which completed successfully (tests and example builds produced their binaries).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2b4dcc79c8328b616991229faef0c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added library configuration and metadata files for Arduino IDE and PlatformIO integration with declared dependencies on M5Unified and Eigen libraries targeting ESP32 platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->