### PR TITLE
Throttle Bosch FIFO sketch serial output and add read diagnostics

### DIFF
--- a/sensors/imu_fifo/atomS3R_fifo_bosch/atomS3R_fifo_bosch.ino
+++ b/sensors/imu_fifo/atomS3R_fifo_bosch/atomS3R_fifo_bosch.ino
@@ -10,6 +10,8 @@ using namespace atoms3r_ical;
 
 constexpr float kImuOdrHz = kDefaultImuOdrHz;
 constexpr uint32_t kLoopPeriodUs = loopPeriodUsFromHz(kImuOdrHz);
+constexpr uint32_t kLogPeriodUs = 50000u;       // 20 Hz serial output keeps logs readable at 115200 baud.
+constexpr uint32_t kNoSampleLogPeriodUs = 500000u; // 2 Hz diagnostic when FIFO produces no sample.
 
 BoschBmi270_ImuCal imu;
 
@@ -60,13 +62,30 @@ void setup()
 void loop()
 {
   const uint32_t loopStartUs = micros();
+  static uint32_t lastLogUs = 0u;
+  static uint32_t lastNoSampleLogUs = 0u;
+  static uint32_t consecutiveReadFailures = 0u;
 
   ImuSample sample{};
   if (!imu.read(sample))
   {
+    ++consecutiveReadFailures;
+    const uint32_t nowUs = micros();
+    if (static_cast<uint32_t>(nowUs - lastNoSampleLogUs) >= kNoSampleLogPeriodUs)
+    {
+      lastNoSampleLogUs = nowUs;
+      Serial.printf("Waiting for FIFO sample (failures=%lu): imu=%s fifo=%s len=%u req=%u got=%u\n",
+                    static_cast<unsigned long>(consecutiveReadFailures),
+                    imu.lastErrorString(),
+                    imu.fifo().lastErrorString(),
+                    static_cast<unsigned int>(imu.fifo().lastFifoLen()),
+                    static_cast<unsigned int>(imu.fifo().lastFifoReq()),
+                    static_cast<unsigned int>(imu.fifo().lastFifoGot()));
+    }
     waitForNextLoopTick(loopStartUs, kLoopPeriodUs);
     return;
   }
+  consecutiveReadFailures = 0u;
 
   ImuLogRow row{};
   row.fifoLen = static_cast<int32_t>(imu.fifo().lastFifoLen());
@@ -92,6 +111,11 @@ void loop()
   row.magE = sample.m.y();
   row.magD = sample.m.z();
 
-  printImuLogRow(row);
+  const uint32_t nowUs = micros();
+  if (static_cast<uint32_t>(nowUs - lastLogUs) >= kLogPeriodUs)
+  {
+    lastLogUs = nowUs;
+    printImuLogRow(row);
+  }
   waitForNextLoopTick(loopStartUs, kLoopPeriodUs);
 }

--- a/sensors/imu_fifo/atomS3R_fifo_bosch/atomS3R_fifo_bosch.ino
+++ b/sensors/imu_fifo/atomS3R_fifo_bosch/atomS3R_fifo_bosch.ino
@@ -10,8 +10,6 @@ using namespace atoms3r_ical;
 
 constexpr float kImuOdrHz = kDefaultImuOdrHz;
 constexpr uint32_t kLoopPeriodUs = loopPeriodUsFromHz(kImuOdrHz);
-constexpr uint32_t kLogPeriodUs = 50000u;       // 20 Hz serial output keeps logs readable at 115200 baud.
-constexpr uint32_t kNoSampleLogPeriodUs = 500000u; // 2 Hz diagnostic when FIFO produces no sample.
 
 BoschBmi270_ImuCal imu;
 
@@ -62,20 +60,17 @@ void setup()
 void loop()
 {
   const uint32_t loopStartUs = micros();
-  static uint32_t lastLogUs = 0u;
-  static uint32_t lastNoSampleLogUs = 0u;
-  static uint32_t consecutiveReadFailures = 0u;
+  static ImuLoopLogState logState{};
 
   ImuSample sample{};
   if (!imu.read(sample))
   {
-    ++consecutiveReadFailures;
+    logState.markReadFailure();
     const uint32_t nowUs = micros();
-    if (static_cast<uint32_t>(nowUs - lastNoSampleLogUs) >= kNoSampleLogPeriodUs)
+    if (logState.shouldLogNoSample(nowUs))
     {
-      lastNoSampleLogUs = nowUs;
       Serial.printf("Waiting for FIFO sample (failures=%lu): imu=%s fifo=%s len=%u req=%u got=%u\n",
-                    static_cast<unsigned long>(consecutiveReadFailures),
+                    static_cast<unsigned long>(logState.consecutiveReadFailures),
                     imu.lastErrorString(),
                     imu.fifo().lastErrorString(),
                     static_cast<unsigned int>(imu.fifo().lastFifoLen()),
@@ -85,7 +80,7 @@ void loop()
     waitForNextLoopTick(loopStartUs, kLoopPeriodUs);
     return;
   }
-  consecutiveReadFailures = 0u;
+  logState.markReadSuccess();
 
   ImuLogRow row{};
   row.fifoLen = static_cast<int32_t>(imu.fifo().lastFifoLen());
@@ -112,9 +107,8 @@ void loop()
   row.magD = sample.m.z();
 
   const uint32_t nowUs = micros();
-  if (static_cast<uint32_t>(nowUs - lastLogUs) >= kLogPeriodUs)
+  if (logState.shouldLogSample(nowUs))
   {
-    lastLogUs = nowUs;
     printImuLogRow(row);
   }
   waitForNextLoopTick(loopStartUs, kLoopPeriodUs);

--- a/sensors/imu_fifo/atomS3R_fifo_sparkfun/atomS3R_fifo_sparkfun.ino
+++ b/sensors/imu_fifo/atomS3R_fifo_sparkfun/atomS3R_fifo_sparkfun.ino
@@ -52,13 +52,22 @@ void setup()
 void loop()
 {
   const uint32_t loopStartUs = micros();
+  static ImuLoopLogState logState{};
 
   const ImuReader::Sample imuSample = imuReader.readLatestSample();
   if (!imuSample.valid)
   {
+    logState.markReadFailure();
+    const uint32_t nowUs = micros();
+    if (logState.shouldLogNoSample(nowUs))
+    {
+      Serial.printf("Waiting for FIFO sample (failures=%lu)\n",
+                    static_cast<unsigned long>(logState.consecutiveReadFailures));
+    }
     waitForNextLoopTick(loopStartUs, kLoopPeriodUs);
     return;
   }
+  logState.markReadSuccess();
 
   const MagReader::Sample magSample =
     magAvailable ? magReader.readLatestSample(imuReader.sensor(), imuSample.timestampMs)
@@ -106,6 +115,10 @@ void loop()
   row.magE = magEastUt;
   row.magD = magDownUt;
 
-  printImuLogRow(row);
+  const uint32_t nowUs = micros();
+  if (logState.shouldLogSample(nowUs))
+  {
+    printImuLogRow(row);
+  }
   waitForNextLoopTick(loopStartUs, kLoopPeriodUs);
 }

--- a/src/AtomS3R/AtomS3R_ImuCommon.h
+++ b/src/AtomS3R/AtomS3R_ImuCommon.h
@@ -6,6 +6,8 @@
 namespace atoms3r_ical {
 
 constexpr float kDefaultImuOdrHz = 200.0f;
+constexpr uint32_t kDefaultImuLogPeriodUs = 50000u;          // 20 Hz
+constexpr uint32_t kDefaultNoSampleLogPeriodUs = 500000u;    // 2 Hz
 
 constexpr uint32_t loopPeriodUsFromHz(float hz)
 {
@@ -55,6 +57,45 @@ struct ImuLogRow
   float magN = 0.0f;
   float magE = 0.0f;
   float magD = 0.0f;
+};
+
+struct ImuLoopLogState
+{
+  uint32_t lastLogUs = 0u;
+  uint32_t lastNoSampleLogUs = 0u;
+  uint32_t consecutiveReadFailures = 0u;
+
+  void markReadFailure()
+  {
+    ++consecutiveReadFailures;
+  }
+
+  void markReadSuccess()
+  {
+    consecutiveReadFailures = 0u;
+  }
+
+  bool shouldLogNoSample(uint32_t nowUs, uint32_t periodUs = kDefaultNoSampleLogPeriodUs)
+  {
+    if (static_cast<uint32_t>(nowUs - lastNoSampleLogUs) < periodUs)
+    {
+      return false;
+    }
+
+    lastNoSampleLogUs = nowUs;
+    return true;
+  }
+
+  bool shouldLogSample(uint32_t nowUs, uint32_t periodUs = kDefaultImuLogPeriodUs)
+  {
+    if (static_cast<uint32_t>(nowUs - lastLogUs) < periodUs)
+    {
+      return false;
+    }
+
+    lastLogUs = nowUs;
+    return true;
+  }
 };
 
 inline void printImuLogRow(const ImuLogRow& row)


### PR DESCRIPTION
### Motivation
- The Bosch FIFO Arduino sketch was printing every sample (up to 200 Hz) which can overwhelm the serial link and make IMU readings invisible on the host side.
- When `imu.read()` produced no sample the sketch returned silently making it hard to diagnose FIFO/read problems during bring-up.

### Description
- Added rate limiting constants `kLogPeriodUs` (20 Hz) and `kNoSampleLogPeriodUs` (2 Hz) to reduce normal IMU log frequency and keep serial output readable at 115200 baud. 
- Added static loop-state variables `lastLogUs`, `lastNoSampleLogUs`, and `consecutiveReadFailures` to track and throttle output and diagnostics. 
- Throttled calls to `printImuLogRow` so rows are printed at most at `kLogPeriodUs` and added periodic diagnostics when `imu.read()` fails that print `imu.lastErrorString()`, `imu.fifo().lastErrorString()`, and FIFO stats (`lastFifoLen()`, `lastFifoReq()`, `lastFifoGot()`).
- Preserved all existing IMU initialization, sample mapping and timing behavior; only output/diagnostic logic was changed in `sensors/imu_fifo/atomS3R_fifo_bosch/atomS3R_fifo_bosch.ino`.

### Testing
- Ran `make all` which completed successfully on the local build environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2e9c5726083288c1daff006a0f7fd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes & Improvements**
  * Enhanced IMU sensor logging with intelligent rate limiting to reduce log verbosity while maintaining diagnostic visibility
  * Added failure tracking for FIFO read operations with diagnostic messages when samples are unavailable
  * Configured adjustable logging intervals for both normal samples and failure diagnostics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->