### PR TITLE
Fix AtomS3R BMM150 AUX axis polarity mapping

### DIFF
--- a/src/Bosch/BoschBmi270_ImuCal.h
+++ b/src/Bosch/BoschBmi270_ImuCal.h
@@ -555,6 +555,13 @@ private:
     mcfg.verify_first_read        = cfg_.mag_verify_first_read;
     mcfg.gate_reads_by_wall_time  = true;
     mcfg.return_last_on_fast_poll = false;
+    // AtomS3R board-level fixed magnetometer mounting:
+    // M5Unified applies X/Z inversion for BMM150 on AtomS3R series.
+    // Keep this low-level map aligned so Bosch AUX path matches the
+    // reference M5/SparkFun orientation before NED conversion.
+    mcfg.axis_map[0] = -1;
+    mcfg.axis_map[1] = +2;
+    mcfg.axis_map[2] = -3;
 
     const uint8_t preferred = cfg_.mag_bmm150_addr;
     const uint8_t alternate = (preferred == 0x10u) ? 0x12u : 0x10u;


### PR DESCRIPTION
### Motivation
- Fix incorrect magnetometer orientation reported by the Bosch AUX path on AtomS3R boards by applying the board-level BMM150 axis polarity so readings match reference M5/SparkFun behavior before NED conversion.

### Description
- Set the BMM150 AUX axis map to `{-1, +2, -3}` during Bosch AUX initialization in `beginMagWithAddrFallback_` (`src/Bosch/BoschBmi270_ImuCal.h`) so the Bosch AUX reader applies the AtomS3R X/Z inversion at setup time and the change is local and API-compatible.

### Testing
- Ran `make all` and the build completed successfully (tests/build passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3a82f4bc08328966b0f43bcd035ee)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal magnetometer axis configuration for IMU calibration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->