### PR TITLE
Fix Bosch BMM150 AUX µT scaling in fixed-point builds

### DIFF
--- a/src/Bosch/BoschBmm150Aux.h
+++ b/src/Bosch/BoschBmm150Aux.h
@@ -838,11 +838,12 @@ private:
     float z = 0.0f;
 
   #if defined(BMM150_USE_FIXED_POINT)
-    // Bosch fixed-point mode stores magnetometer outputs with 4 fractional bits.
-    // Convert to physical microtesla units expected by the rest of this pipeline.
-    x = static_cast<float>(mag.x) * (1.0f / 16.0f);
-    y = static_cast<float>(mag.y) * (1.0f / 16.0f);
-    z = static_cast<float>(mag.z) * (1.0f / 16.0f);
+    // bmm150_aux_mag_data() already returns compensated values in microtesla
+    // for both fixed-point and floating-point builds of Bosch SensorAPI.
+    // Do not divide by 16 here or we will under-report field strength.
+    x = static_cast<float>(mag.x);
+    y = static_cast<float>(mag.y);
+    z = static_cast<float>(mag.z);
   #else
     x = static_cast<float>(mag.x);
     y = static_cast<float>(mag.y);


### PR DESCRIPTION
### Motivation
- Compensated BMM150 samples read via the Bosch SensorAPI were being divided a second time in the fixed-point code path, producing magnetometer values ~16× too small instead of microtesla.

### Description
- Updated `src/Bosch/BoschBmm150Aux.h` to remove the erroneous `/16` conversion in the `BMM150_USE_FIXED_POINT` branch so `bmm150_aux_mag_data()` output is used directly as µT, and added a clarifying comment explaining that the Bosch SensorAPI already returns compensated microtesla values.

### Testing
- Ran `make all` and the build completed successfully with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3db0a6e50832882ec52a3c9854101)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect magnetometer data scaling in fixed-point computation mode, ensuring accurate sensor readings are returned to applications using this configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->