### PR TITLE
Normalize BMM150 magnetometer outputs to µT via type-detecting helper

### DIFF
--- a/src/Bosch/BoschBmm150Aux.h
+++ b/src/Bosch/BoschBmm150Aux.h
@@ -568,6 +568,19 @@ private:
     return allZero3_(v.x(), v.y(), v.z());
   }
 
+  template <typename T>
+  static float compValueToMicroTesla_(T v) {
+    // Bosch BMM150 SensorAPI behavior:
+    // - floating-point mode: bmm150_mag_data.{x,y,z} are already microtesla.
+    // - fixed-point mode: values are int16 with 4 fractional bits (LSB/16 = uT).
+    // Detect by type (not macro) to stay correct across library variants.
+    if constexpr (std::is_floating_point<T>::value) {
+      return static_cast<float>(v);
+    } else {
+      return static_cast<float>(v) * (1.0f / 16.0f);
+    }
+  }
+
   static float pickAxis_(int8_t code, const Vector3f& v) {
     switch (code) {
       case +1: return  v.x();
@@ -833,21 +846,9 @@ private:
       last_error_ = Error::COMP_INVALID;
       return false;
     }
-    float x = 0.0f;
-    float y = 0.0f;
-    float z = 0.0f;
-
-  #if defined(BMM150_USE_FIXED_POINT)
-    // Bosch fixed-point mode stores magnetometer outputs with 4 fractional bits.
-    // Convert to physical microtesla units expected by the rest of this pipeline.
-    x = static_cast<float>(mag.x) * (1.0f / 16.0f);
-    y = static_cast<float>(mag.y) * (1.0f / 16.0f);
-    z = static_cast<float>(mag.z) * (1.0f / 16.0f);
-  #else
-    x = static_cast<float>(mag.x);
-    y = static_cast<float>(mag.y);
-    z = static_cast<float>(mag.z);
-  #endif
+    const float x = compValueToMicroTesla_(mag.x);
+    const float y = compValueToMicroTesla_(mag.y);
+    const float z = compValueToMicroTesla_(mag.z);
 
     if (!finite3_(x, y, z)) {
       last_error_ = Error::NONFINITE_MAG;


### PR DESCRIPTION
### Motivation
- Ensure magnetometer outputs from the Bosch BMM150 are interpreted with correct units regardless of whether the library supplies floating-point or fixed-point values.
- Replace preprocessor-driven unit conversion with a type-aware conversion to remain correct across different library variants.

### Description
- Add a template helper `compValueToMicroTesla_` that converts sensor values to microtesla by detecting whether `T` is a floating-point type and applying the fixed-point scale (`1/16`) only for integer types.
- Replace the previous `#if defined(BMM150_USE_FIXED_POINT)` conditional conversion in `compensateRawTo_uT_` with calls to `compValueToMicroTesla_` for `mag.x`, `mag.y`, and `mag.z`.
- Keep Bosch SensorAPI behavior and overflow handling unchanged by continuing to use `bmm150_aux_mag_data` and existing validation checks.

### Testing
- Project was rebuilt to validate compilation after the change and the build completed successfully.
- Existing driver unit tests for the BMM150 code were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3deb7738883288f47dcd6d3d7153b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined Bosch BMM150 magnetometer compensation to use a more consistent approach for converting sensor values, improving reliability across different input types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->