### PR TITLE
Fix BMM150 AUX microtesla conversion scaling

### DIFF
--- a/src/Bosch/BoschBmm150Aux.h
+++ b/src/Bosch/BoschBmm150Aux.h
@@ -570,15 +570,12 @@ private:
 
   template <typename T>
   static float compValueToMicroTesla_(T v) {
-    // Bosch BMM150 SensorAPI behavior:
-    // - floating-point mode: bmm150_mag_data.{x,y,z} are already microtesla.
-    // - fixed-point mode: values are int16 with 4 fractional bits (LSB/16 = uT).
-    // Detect by type (not macro) to stay correct across library variants.
-    if constexpr (std::is_floating_point<T>::value) {
-      return static_cast<float>(v);
-    } else {
-      return static_cast<float>(v) * (1.0f / 16.0f);
-    }
+    // Bosch BMM150 SensorAPI behavior (Bosch + Arduino + SparkFun forks):
+    // - floating-point mode: bmm150_mag_data.{x,y,z} are in microtesla.
+    // - fixed-point mode: bmm150_mag_data.{x,y,z} are int16 microtesla values
+    //   (compensation already applies internal /16 scaling before return).
+    // Therefore both paths should be interpreted directly as uT.
+    return static_cast<float>(v);
   }
 
   static float pickAxis_(int8_t code, const Vector3f& v) {


### PR DESCRIPTION
### Motivation
- The BMM150 AUX path returned magnetometer values about 16x too small because integer compensated outputs were incorrectly divided by 16 before being treated as microtesla, breaking the mag readings used by the Bosch FIFO sketch.

### Description
- Changed `src/Bosch/BoschBmm150Aux.h` to treat both floating and integer `bmm150_mag_data` compensation outputs as already being in microtesla (removed the extra `/16` scaling) and updated the inline comment to match Bosch/Arduino/SparkFun SensorAPI behavior.

### Testing
- Ran `make all` at the repository root and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3ef1513f08328855aa74d5f7c4cb5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved magnetometer calibration value calculations for accurate sensor readings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->