### PR TITLE
Fix CompassAppBase build by scoping NO_BOSCH_API around ImuCalWizard include

### DIFF
--- a/src/AtomS3R/AtomS3R_CompassAppBase.h
+++ b/src/AtomS3R/AtomS3R_CompassAppBase.h
@@ -10,7 +10,16 @@
 #include <new>
 
 #include "AtomS3R/AtomS3R_ImuCal.h"
+
+#ifndef NO_BOSCH_API
+#define NO_BOSCH_API
+#define ATOMS3R_COMPASSAPPBASE_LOCAL_NO_BOSCH_API 1
+#endif
 #include "AtomS3R/AtomS3R_ImuCalWizard.h"
+#if defined(ATOMS3R_COMPASSAPPBASE_LOCAL_NO_BOSCH_API)
+#undef ATOMS3R_COMPASSAPPBASE_LOCAL_NO_BOSCH_API
+#undef NO_BOSCH_API
+#endif
 #include "AtomS3R/AtomS3R_CompassUI.h"
 #include "nmea/NmeaCompass.h"
 


### PR DESCRIPTION
### Motivation
- `CompassAppBase` used the 2-argument `ImuCalWizard` constructor (non-Bosch runtime) but `ImuCalWizard` defaulted to the Bosch path requiring a third `BoschBmi270_ImuCal&` argument, causing a compile error in the compass build.

### Description
- Wrap the include of `AtomS3R_ImuCalWizard.h` in `AtomS3R_CompassAppBase.h` with a locally-scoped `NO_BOSCH_API` define so the header exposes the non-Bosch (2-argument) `ImuCalWizard` constructor, and immediately `#undef` the macro after the include to avoid leaking the definition; the only modified file is `src/AtomS3R/AtomS3R_CompassAppBase.h`.

### Testing
- Ran `make all` from the repository root and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3fd51ac8c8328ae0eec56b2dea1e8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build configuration flexibility for sensor calibration features through improved compile-time dependency isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->