### PR TITLE
Add optional Bosch BMI270 IMU backend and propagate mag-fresh hint

### DIFF
--- a/src/AtomS3R/AtomS3R_CompassAppBase.h
+++ b/src/AtomS3R/AtomS3R_CompassAppBase.h
@@ -262,7 +262,13 @@ class IAttitudeBackend {
 class CompassAppBase {
  public:
   CompassAppBase(std::unique_ptr<IAttitudeBackend> backend, MagGateConfig mag_cfg, const char* boot_name)
-      : backend_(std::move(backend)), wizard_(ui_, store_), mag_gate_(mag_cfg), boot_name_(boot_name) {}
+      : backend_(std::move(backend))
+#if ATOMS3R_WIZARD_USE_BOSCH
+      , wizard_(ui_, store_, bosch_),
+#else
+      , wizard_(ui_, store_),
+#endif
+      mag_gate_(mag_cfg), boot_name_(boot_name) {}
 
   void begin() {
     Serial.begin(115200);
@@ -285,11 +291,18 @@ class CompassAppBase {
       if (!compass_ui_ready_) use_graphics_ = false;
     }
 
+#if ATOMS3R_WIZARD_USE_BOSCH
+    if (!beginBoschImu_()) {
+      ui_.fail("IMU", "Bosch init fail");
+      while (true) delay(100);
+    }
+#else
     if (!M5.Imu.isEnabled()) {
       Serial.println("[BOOT] IMU not found / not enabled");
       ui_.fail("IMU", "Not found");
       while (true) delay(100);
     }
+#endif
 
     reloadBlobAndRuntime_();
 
@@ -359,11 +372,18 @@ class CompassAppBase {
       drawHomeStatic_();
     }
 
+    ImuSample s;
+#if ATOMS3R_WIZARD_USE_BOSCH
+    if (bosch_.read(s)) {
+      const bool mag_fresh = bosch_.magUpdatedThisRead();
+      updateOutputs_(s, &mag_fresh);
+    }
+#else
     const uint32_t sample_us = micros();
     const uint32_t update_mask = M5.Imu.update();
-
-    ImuSample s;
-    if (readImuMapped(M5.Imu, update_mask, sample_us, s)) updateOutputs_(s);
+    if (readImuMapped(M5.Imu, update_mask, sample_us, s))
+      updateOutputs_(s);
+#endif
 
     updateUI_();
     streamSerial_();
@@ -419,7 +439,7 @@ class CompassAppBase {
     last_update_us_ = 0;
   }
 
-CalibratedSample makeCalibratedSample_(const ImuSample& s) {
+CalibratedSample makeCalibratedSample_(const ImuSample& s, const bool* mag_fresh_hint = nullptr) {
   CalibratedSample out{};
   out.a_raw_norm = s.a.norm();
 
@@ -440,14 +460,50 @@ CalibratedSample makeCalibratedSample_(const ImuSample& s) {
 
   if (out.mag_ok && out.mag_norm_uT > 1e-6f) out.m_unit = out.m_cal / out.mag_norm_uT;
 
-  out.mag_fresh = mag_gate_.update(out.m_cal, out.mag_ok, millis());
+  if (mag_fresh_hint) {
+    out.mag_fresh = out.mag_ok && (*mag_fresh_hint);
+  } else {
+    out.mag_fresh = mag_gate_.update(out.m_cal, out.mag_ok, millis());
+  }
   return out;
 }
 
-  void updateOutputs_(const ImuSample& s) {
-    sample_ = makeCalibratedSample_(s);
+  void updateOutputs_(const ImuSample& s, const bool* mag_fresh_hint = nullptr) {
+    sample_ = makeCalibratedSample_(s, mag_fresh_hint);
     backend_->step(sample_, outputs_.att);
     outputs_.rot_dpm = rot_.update(sample_.dt, sample_.a_cal, sample_.w_cal, outputs_.att);
+  }
+
+  bool beginBoschImu_() {
+#if ATOMS3R_WIZARD_USE_BOSCH
+    BoschBmi270_ImuCal::Config cfg;
+    cfg.bmi270_addr                = 0x68;
+    cfg.ag_hz                      = LOOP_HZ;
+    cfg.enable_mag_aux             = true;
+    cfg.mag_bmm150_addr            = 0x10;
+    cfg.mag_aux_odr_hz             = 25.0f;
+    cfg.mag_startup_settle_ms      = 3;
+    cfg.mag_verify_first_read      = true;
+    cfg.mag_stale_min_us           = 75000u;
+    cfg.mag_stale_factor           = 3u;
+    cfg.enable_mag_recovery        = true;
+    cfg.mag_recover_after_failures = 6u;
+    cfg.mag_recover_cooldown_us    = 1000000u;
+    cfg.tempC_default              = 35.0f;
+    cfg.i2c_hz                     = 400000u;
+
+    if (!bosch_.begin(M5.In_I2C, cfg)) {
+      Serial.printf("[BOOT] Bosch IMU init failed: %s\n", bosch_.lastErrorString());
+      Serial.printf("[BOOT] FIFO detail: %s\n", bosch_.fifo().lastErrorString());
+      Serial.printf("[BOOT] FIFO init path: %s\n", bosch_.fifo().initPathString());
+      Serial.printf("[BOOT] FIFO Bosch init rslt: %d\n", (int)bosch_.fifo().lastBoschInitResult());
+      Serial.printf("[BOOT] BMI addr tried: 0x%02X\n", cfg.bmi270_addr);
+      return false;
+    }
+    return true;
+#else
+    return false;
+#endif
   }
 
   void drawHomeStatic_() {
@@ -540,6 +596,10 @@ CalibratedSample makeCalibratedSample_(const ImuSample& s) {
   std::unique_ptr<IAttitudeBackend> backend_;
   MagGate mag_gate_;
   RotEstimator rot_;
+
+#if ATOMS3R_WIZARD_USE_BOSCH
+  BoschBmi270_ImuCal bosch_{};
+#endif
 
   bool have_blob_ = false;
   ImuCalBlobV1 blob_{};


### PR DESCRIPTION
### Motivation
- Add optional support for a Bosch BMI270 IMU backend and let the calibration wizard and runtime prefer Bosch-provided magnetometer freshness when available.

### Description
- Make `CompassAppBase` construct the `wizard_` with `bosch_` under `ATOMS3R_WIZARD_USE_BOSCH` and add a `BoschBmi270_ImuCal bosch_` member.
- Add `beginBoschImu_()` to configure and initialize the Bosch IMU with detailed failure logging.
- Replace the M5 Unified IMU init/read path with conditional code that uses `bosch_.begin`/`bosch_.read` and `bosch_.magUpdatedThisRead()` when the Bosch option is enabled.
- Thread an optional `mag_fresh_hint` through `updateOutputs_` and `makeCalibratedSample_` so external IMU drivers can provide magnetometer freshness instead of relying solely on `MagGate::update`.

### Testing
- Built the firmware with `ATOMS3R_WIZARD_USE_BOSCH` disabled and the build completed successfully.
- Built the firmware with `ATOMS3R_WIZARD_USE_BOSCH` enabled and the build completed successfully.
- Ran the project compile/static checks which passed with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3f3e789c883288a9e6acdcce39524)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Bosch IMU sensor support for enhanced inertial measurement capabilities
  * Improved magnetometer data freshness detection and propagation
  * Enhanced IMU initialization with detailed error reporting during boot

<!-- end of auto-generated comment: release notes by coderabbit.ai -->