### PR TITLE
Stop forcing `NO_BOSCH_API` in AtomS3R_CompassAppBase.h

### DIFF
--- a/src/AtomS3R/AtomS3R_CompassAppBase.h
+++ b/src/AtomS3R/AtomS3R_CompassAppBase.h
@@ -11,15 +11,7 @@
 
 #include "AtomS3R/AtomS3R_ImuCal.h"
 
-#ifndef NO_BOSCH_API
-#define NO_BOSCH_API
-#define ATOMS3R_COMPASSAPPBASE_LOCAL_NO_BOSCH_API 1
-#endif
 #include "AtomS3R/AtomS3R_ImuCalWizard.h"
-#if defined(ATOMS3R_COMPASSAPPBASE_LOCAL_NO_BOSCH_API)
-#undef ATOMS3R_COMPASSAPPBASE_LOCAL_NO_BOSCH_API
-#undef NO_BOSCH_API
-#endif
 #include "AtomS3R/AtomS3R_CompassUI.h"
 #include "nmea/NmeaCompass.h"
 


### PR DESCRIPTION
### Motivation
- Allow build configurations to control Bosch API availability instead of forcibly defining `NO_BOSCH_API` inside the header, avoiding unintended side effects and enabling Bosch sensor support.

### Description
- Removed local `#define NO_BOSCH_API` / `#define ATOMS3R_COMPASSAPPBASE_LOCAL_NO_BOSCH_API` and the corresponding `#undef` guards around the `AtomS3R_ImuCalWizard` include in `src/AtomS3R/AtomS3R_CompassAppBase.h`.

### Testing
- Project successfully compiled for the target with `NO_BOSCH_API` undefined and also with `NO_BOSCH_API` defined by the build system, indicating no regression in either configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d40043a40083289ade241710428f95)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal build configuration management by removing a local preprocessor override. Build settings will now directly govern related code compilation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->