### PR TITLE
Unify magnetometer mapping to BODY-NED and normalize BMM150 output scaling

### DIFF
--- a/src/AtomS3R/AtomS3R_ImuCal.h
+++ b/src/AtomS3R/AtomS3R_ImuCal.h
@@ -103,6 +103,13 @@ struct ImuCalCfg {
 };
 
 // Axis mapping (AtomS3R)
+//
+// Internal convention in this library is BODY-NED (x=north, y=east, z=down).
+// End-user "nautical Z-up" is therefore z_up = -z_down.
+//
+// With the board lying still, screen facing up:
+//   - accelerometer body Z (down) is expected near -g specific force
+//   - user-facing Z-up value is the opposite sign.
 // acc_body = ( ay, ax, -az ) * g
 // gyr_body = ( gy, gx, -gz ) * deg2rad
 // mag_body = ( my, mx, -mz ) * (1/10)

--- a/src/Bosch/BoschBmi270_ImuCal.h
+++ b/src/Bosch/BoschBmi270_ImuCal.h
@@ -313,6 +313,12 @@ private:
     return Vector3f::Constant(std::numeric_limits<float>::quiet_NaN());
   }
 
+  // Convert board/sensor-frame mag to this library BODY-NED convention.
+  // Keep identical to AtomS3R_ImuCal.h mapping: (my, mx, -mz).
+  static Vector3f mapMagToBodyNed_(const Vector3f& m_sensor_uT) {
+    return Vector3f(m_sensor_uT.y(), m_sensor_uT.x(), -m_sensor_uT.z());
+  }
+
   static bool finite3_(const Vector3f& v) {
     return std::isfinite(v.x()) && std::isfinite(v.y()) && std::isfinite(v.z());
   }
@@ -448,7 +454,7 @@ private:
     ++mag_poll_total_;
 
     if (ok && finite3_(m_s)) {
-      last_mag_uT_ = Vector3f(m_s.y(), m_s.x(), -m_s.z());
+      last_mag_uT_ = mapMagToBodyNed_(m_s);
 
       have_last_good_mag_ = true;
       have_valid_mag_ = true;
@@ -558,7 +564,12 @@ private:
     // AtomS3R board-level fixed magnetometer mounting:
     // M5Unified applies X/Z inversion for BMM150 on AtomS3R series.
     // Keep this low-level map aligned so Bosch AUX path matches the
-    // reference M5/SparkFun orientation before NED conversion.
+    // reference M5/SparkFun orientation before BODY-NED conversion.
+    //
+    // Net Bosch mapping:
+    //   AUX axis_map: (-x, +y, -z)
+    //   BODY-NED map: (my, mx, -mz)
+    // => body mag = (y, -x, +z) in original BMM150 sensor axes.
     mcfg.axis_map[0] = -1;
     mcfg.axis_map[1] = +2;
     mcfg.axis_map[2] = -3;

--- a/src/Bosch/BoschBmm150Aux.h
+++ b/src/Bosch/BoschBmm150Aux.h
@@ -570,12 +570,15 @@ private:
 
   template <typename T>
   static float compValueToMicroTesla_(T v) {
-    // Bosch BMM150 SensorAPI behavior (Bosch + Arduino + SparkFun forks):
-    // - floating-point mode: bmm150_mag_data.{x,y,z} are in microtesla.
-    // - fixed-point mode: bmm150_mag_data.{x,y,z} are int16 microtesla values
-    //   (compensation already applies internal /16 scaling before return).
-    // Therefore both paths should be interpreted directly as uT.
+    // Bosch BMM150 SensorAPI behavior:
+    // - floating-point mode: output is in microtesla.
+    // - fixed-point mode: output is in 16 LSB per microtesla.
+    // Normalize both build modes to microtesla here.
+#if defined(BMM150_USE_FLOATING_POINT) && (BMM150_USE_FLOATING_POINT)
     return static_cast<float>(v);
+#else
+    return static_cast<float>(v) / 16.0f;
+#endif
   }
 
   static float pickAxis_(int8_t code, const Vector3f& v) {


### PR DESCRIPTION
### Motivation

- Clarify and standardize sensor-to-library axis conventions so all IMU sensors produce vectors in the library's internal BODY-NED frame.
- Ensure BMM150 auxiliary magnetic data is normalized correctly across builds that use floating-point and fixed-point SensorAPI modes.

### Description

- Documented the library internal convention (BODY-NED) and added explanatory comments in `AtomS3R_ImuCal.h` so accelerometer, gyro and magnetometer mappings are explicit and note `z_up = -z_down` semantics.
- Introduced `mapMagToBodyNed_` in `BoschBmi270_ImuCal.h` and replaced the inline manual mapping with a call to that function to keep magnetometer mapping consistent with `AtomS3R_ImuCal.h`.
- Clarified `BoschBmm150Aux` axis mapping comments to describe how BMM150 AUX axis_map relates to the BODY-NED mapping and documented the effective mapping applied to the sensor axes.
- Normalized BMM150 values in `BoschBmm150Aux::compValueToMicroTesla_` with a compile-time switch so floating-point builds return values directly and fixed-point builds divide by 16 to convert to microtesla using `BMM150_USE_FLOATING_POINT`.

### Testing

- Built the project for the supported embedded target using the normal build system (`make`) and the build completed successfully.
- Ran the project's automated unit tests (`make test`) and sensor-related tests for IMU calibration and BMM150 handling, and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d408165ed88328bcc53791da84f8e5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced IMU calibration documentation with clearer axis convention details and sign behavior explanations.

* **Bug Fixes**
  * Fixed magnetometer value conversion to ensure correct unit normalization across sensor configurations.

* **Refactor**
  * Improved sensor axis mapping code organization for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->