### PR TITLE
Prevent cross-use of IMU calibration between Bosch and NO_BOSCH_API builds

### DIFF
--- a/sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino
+++ b/sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino
@@ -255,7 +255,7 @@ private:
 
   ImuCalStoreNvs store_{};
   bool           have_blob_ = false;
-  ImuCalBlobV1   blob_{};
+  ImuCalBlobV2   blob_{};
   RuntimeCals    runtime_{};
 
   BoschBmi270_ImuCal runtime_imu_{};
@@ -404,7 +404,7 @@ private:
       (void)runtime_imu_.end();
     }
 
-    ImuCalBlobV1 saved{};
+    ImuCalBlobV2 saved{};
     const bool did_save = runImuCalWizard(ui_, store_, saved);
 
     if (did_save) {

--- a/src/AtomS3R/AtomS3R_CompassAppBase.h
+++ b/src/AtomS3R/AtomS3R_CompassAppBase.h
@@ -309,7 +309,7 @@ class CompassAppBase {
 
     if (!have_blob_) {
       Serial.println("[BOOT] No saved calibration. Starting wizard...");
-      ImuCalBlobV1 saved{};
+      ImuCalBlobV2 saved{};
       if (wizard_.runAndSave(saved)) {
         Serial.println("[BOOT] Wizard saved calibration. Loaded:");
         printBlobSummary(Serial, saved);
@@ -415,7 +415,7 @@ class CompassAppBase {
   void handleRunWizard_() {
     Serial.println("[HOME] single tap => RUN WIZARD");
 
-    ImuCalBlobV1 saved{};
+    ImuCalBlobV2 saved{};
     if (!wizard_.runAndSave(saved)) {
       ui_.notSavedNotice();
       return;
@@ -603,7 +603,7 @@ CalibratedSample makeCalibratedSample_(const ImuSample& s, const bool* mag_fresh
 #endif
 
   bool have_blob_ = false;
-  ImuCalBlobV1 blob_{};
+  ImuCalBlobV2 blob_{};
 
   bool use_graphics_ = (COMPASS_UI_DEFAULT_GRAPHICS != 0);
   bool compass_ui_ready_ = false;

--- a/src/AtomS3R/AtomS3R_ImuCal.h
+++ b/src/AtomS3R/AtomS3R_ImuCal.h
@@ -132,11 +132,14 @@ static inline Vector3f map_mag_to_body_uT_(const m5::imu_3d_t& m_raw) {
 // Blob + CRC utilities
 struct ImuCalBlobV1 {
   static constexpr uint32_t IMU_CAL_MAGIC   = 0x434C554D; // 'MULC'
-  static constexpr uint16_t IMU_CAL_VERSION = 1;
+  static constexpr uint16_t IMU_CAL_VERSION = 2;
+  static constexpr uint8_t  IMU_CAL_MODE_BOSCH_API = 1;
+  static constexpr uint8_t  IMU_CAL_MODE_NO_BOSCH_API = 2;
 
   uint32_t magic = IMU_CAL_MAGIC;
   uint16_t version = IMU_CAL_VERSION;
   uint16_t size_bytes = sizeof(ImuCalBlobV1);
+  uint8_t  build_mode = 0;
 
   uint8_t  accel_ok = 0;
   float    accel_g = ImuCalCfg::g_std;
@@ -197,6 +200,13 @@ static inline bool validateBlob(const ImuCalBlobV1& b) {
   if (b.magic != ImuCalBlobV1::IMU_CAL_MAGIC) return false;
   if (b.version != ImuCalBlobV1::IMU_CAL_VERSION) return false;
   if (b.size_bytes != sizeof(ImuCalBlobV1)) return false;
+  const uint8_t expected_mode =
+#if defined(NO_BOSCH_API)
+      ImuCalBlobV1::IMU_CAL_MODE_NO_BOSCH_API;
+#else
+      ImuCalBlobV1::IMU_CAL_MODE_BOSCH_API;
+#endif
+  if (b.build_mode != expected_mode) return false;
   const uint32_t want = b.crc;
   return (computeBlobCrc(b) == want);
 }
@@ -230,6 +240,12 @@ public:
     tmp.magic = ImuCalBlobV1::IMU_CAL_MAGIC;
     tmp.version = ImuCalBlobV1::IMU_CAL_VERSION;
     tmp.size_bytes = sizeof(ImuCalBlobV1);
+    tmp.build_mode =
+#if defined(NO_BOSCH_API)
+      ImuCalBlobV1::IMU_CAL_MODE_NO_BOSCH_API;
+#else
+      ImuCalBlobV1::IMU_CAL_MODE_BOSCH_API;
+#endif
     tmp.crc = 0;
     tmp.crc = computeBlobCrc(tmp);
 
@@ -326,6 +342,10 @@ static inline void printMatHeader(Print& out, const char* name, const char* mean
 
 // Print helpers (startup serial)
 static inline void printBlobSummary(Print& out, const ImuCalBlobV1& b) {
+  const char* mode = "unknown";
+  if (b.build_mode == ImuCalBlobV1::IMU_CAL_MODE_BOSCH_API) mode = "bosch_api";
+  else if (b.build_mode == ImuCalBlobV1::IMU_CAL_MODE_NO_BOSCH_API) mode = "no_bosch_api";
+  out.printf("  build_mode: %s\n", mode);
   out.printf("  ok: A=%d G=%d M=%d\n", (int)b.accel_ok, (int)b.gyro_ok, (int)b.mag_ok);
 }
 

--- a/src/AtomS3R/AtomS3R_ImuCal.h
+++ b/src/AtomS3R/AtomS3R_ImuCal.h
@@ -17,7 +17,7 @@
     #include "AtomS3R/AtomS3R_ImuCal.h"
 
     atoms3r_ical::ImuCalStoreNvs store;
-    atoms3r_ical::ImuCalBlobV1   blob;
+    atoms3r_ical::ImuCalBlobV2   blob;
     atoms3r_ical::RuntimeCals    cals;
 
     void setup() {
@@ -130,7 +130,7 @@ static inline Vector3f map_mag_to_body_uT_(const m5::imu_3d_t& m_raw) {
 }
 
 // Blob + CRC utilities
-struct ImuCalBlobV1 {
+struct ImuCalBlobV2 {
   static constexpr uint32_t IMU_CAL_MAGIC   = 0x434C554D; // 'MULC'
   static constexpr uint16_t IMU_CAL_VERSION = 2;
   static constexpr uint8_t  IMU_CAL_MODE_BOSCH_API = 1;
@@ -138,7 +138,7 @@ struct ImuCalBlobV1 {
 
   uint32_t magic = IMU_CAL_MAGIC;
   uint16_t version = IMU_CAL_VERSION;
-  uint16_t size_bytes = sizeof(ImuCalBlobV1);
+  uint16_t size_bytes = sizeof(ImuCalBlobV2);
   uint8_t  build_mode = 0;
 
   uint8_t  accel_ok = 0;
@@ -162,7 +162,7 @@ struct ImuCalBlobV1 {
 
   uint32_t crc = 0;
 };
-static constexpr size_t IMU_CAL_CRC_LEN = offsetof(ImuCalBlobV1, crc);
+static constexpr size_t IMU_CAL_CRC_LEN = offsetof(ImuCalBlobV2, crc);
 
 static inline uint32_t crc32_ieee_(const uint8_t* data, size_t n) {
   uint32_t crc = 0xFFFFFFFFu;
@@ -190,21 +190,21 @@ static inline void mat_to_rowmajor9_(const Matrix3f& M, float a[9]) {
   a[6]=M(2,0); a[7]=M(2,1); a[8]=M(2,2);
 }
 
-static inline uint32_t computeBlobCrc(const ImuCalBlobV1& in) {
-  ImuCalBlobV1 tmp = in;
+static inline uint32_t computeBlobCrc(const ImuCalBlobV2& in) {
+  ImuCalBlobV2 tmp = in;
   tmp.crc = 0;
   return crc32_ieee_((const uint8_t*)&tmp, IMU_CAL_CRC_LEN);
 }
 
-static inline bool validateBlob(const ImuCalBlobV1& b) {
-  if (b.magic != ImuCalBlobV1::IMU_CAL_MAGIC) return false;
-  if (b.version != ImuCalBlobV1::IMU_CAL_VERSION) return false;
-  if (b.size_bytes != sizeof(ImuCalBlobV1)) return false;
+static inline bool validateBlob(const ImuCalBlobV2& b) {
+  if (b.magic != ImuCalBlobV2::IMU_CAL_MAGIC) return false;
+  if (b.version != ImuCalBlobV2::IMU_CAL_VERSION) return false;
+  if (b.size_bytes != sizeof(ImuCalBlobV2)) return false;
   const uint8_t expected_mode =
 #if defined(NO_BOSCH_API)
-      ImuCalBlobV1::IMU_CAL_MODE_NO_BOSCH_API;
+      ImuCalBlobV2::IMU_CAL_MODE_NO_BOSCH_API;
 #else
-      ImuCalBlobV1::IMU_CAL_MODE_BOSCH_API;
+      ImuCalBlobV2::IMU_CAL_MODE_BOSCH_API;
 #endif
   if (b.build_mode != expected_mode) return false;
   const uint32_t want = b.crc;
@@ -219,13 +219,13 @@ public:
   static constexpr const char* kNamespace = "imu_cal";
   static constexpr const char* kKey       = "blob";
 
-  bool load(ImuCalBlobV1& out) {
+  bool load(ImuCalBlobV2& out) {
     Preferences prefs;
     prefs.begin(kNamespace, true);
     size_t n = prefs.getBytesLength(kKey);
-    if (n != sizeof(ImuCalBlobV1)) { prefs.end(); return false; }
+    if (n != sizeof(ImuCalBlobV2)) { prefs.end(); return false; }
 
-    ImuCalBlobV1 tmp;
+    ImuCalBlobV2 tmp;
     size_t got = prefs.getBytes(kKey, &tmp, sizeof(tmp));
     prefs.end();
     if (got != sizeof(tmp)) return false;
@@ -235,16 +235,16 @@ public:
     return true;
   }
 
-  bool save(const ImuCalBlobV1& in) {
-    ImuCalBlobV1 tmp = in;
-    tmp.magic = ImuCalBlobV1::IMU_CAL_MAGIC;
-    tmp.version = ImuCalBlobV1::IMU_CAL_VERSION;
-    tmp.size_bytes = sizeof(ImuCalBlobV1);
+  bool save(const ImuCalBlobV2& in) {
+    ImuCalBlobV2 tmp = in;
+    tmp.magic = ImuCalBlobV2::IMU_CAL_MAGIC;
+    tmp.version = ImuCalBlobV2::IMU_CAL_VERSION;
+    tmp.size_bytes = sizeof(ImuCalBlobV2);
     tmp.build_mode =
 #if defined(NO_BOSCH_API)
-      ImuCalBlobV1::IMU_CAL_MODE_NO_BOSCH_API;
+      ImuCalBlobV2::IMU_CAL_MODE_NO_BOSCH_API;
 #else
-      ImuCalBlobV1::IMU_CAL_MODE_BOSCH_API;
+      ImuCalBlobV2::IMU_CAL_MODE_BOSCH_API;
 #endif
     tmp.crc = 0;
     tmp.crc = computeBlobCrc(tmp);
@@ -270,7 +270,7 @@ struct RuntimeCals {
   imu_cal::GyroCalibration<float>  gyr{};
   imu_cal::MagCalibration<float>   mag{};
 
-  void rebuildFromBlob(const ImuCalBlobV1& b) {
+  void rebuildFromBlob(const ImuCalBlobV2& b) {
     acc.ok = (b.accel_ok != 0);
     acc.g  = b.accel_g;
     acc.S  = mat_from_rowmajor9_(b.accel_S);
@@ -341,15 +341,15 @@ static inline void printMatHeader(Print& out, const char* name, const char* mean
 }
 
 // Print helpers (startup serial)
-static inline void printBlobSummary(Print& out, const ImuCalBlobV1& b) {
+static inline void printBlobSummary(Print& out, const ImuCalBlobV2& b) {
   const char* mode = "unknown";
-  if (b.build_mode == ImuCalBlobV1::IMU_CAL_MODE_BOSCH_API) mode = "bosch_api";
-  else if (b.build_mode == ImuCalBlobV1::IMU_CAL_MODE_NO_BOSCH_API) mode = "no_bosch_api";
+  if (b.build_mode == ImuCalBlobV2::IMU_CAL_MODE_BOSCH_API) mode = "bosch_api";
+  else if (b.build_mode == ImuCalBlobV2::IMU_CAL_MODE_NO_BOSCH_API) mode = "no_bosch_api";
   out.printf("  build_mode: %s\n", mode);
   out.printf("  ok: A=%d G=%d M=%d\n", (int)b.accel_ok, (int)b.gyro_ok, (int)b.mag_ok);
 }
 
-static inline void printBlobDetail(Print& out, const ImuCalBlobV1& b) {
+static inline void printBlobDetail(Print& out, const ImuCalBlobV2& b) {
   // ACCEL
   out.printf("  accel: g=%.6f T0=%.2f rms_mag=%.4f\n", (double)b.accel_g, (double)b.accel_T0, (double)b.accel_rms_mag);
   out.printf("    b0=[%.5f %.5f %.5f]\n", (double)b.accel_b0[0], (double)b.accel_b0[1], (double)b.accel_b0[2]);

--- a/src/AtomS3R/AtomS3R_ImuCalWizard.h
+++ b/src/AtomS3R/AtomS3R_ImuCalWizard.h
@@ -153,7 +153,7 @@ public:
 
   // Runs full wizard and saves to NVS. Returns true only if saved successfully.
   // out_saved is filled with the saved blob (readback-validated).
-  bool runAndSave(ImuCalBlobV1& out_saved) {
+  bool runAndSave(ImuCalBlobV2& out_saved) {
     Serial.println("[WIZ] start");
 
     for (;;) {
@@ -206,7 +206,7 @@ public:
         Serial.println("[MAG] unavailable -> skipping mag calibration");
         mag_out_.ok = false;
         // Build + save blob (accel+gyro only)
-        ImuCalBlobV1 blob{};
+        ImuCalBlobV2 blob{};
         fillBlob_(blob);
         blob.mag_ok = 0;
 
@@ -215,7 +215,7 @@ public:
         ui_.line("Writing...");
         const bool wrote = store_.save(blob);
 
-        ImuCalBlobV1 rb{};
+        ImuCalBlobV2 rb{};
         const bool okrb = store_.load(rb);
 
         Serial.printf("[SAVE] wrote=%d readback=%d\n", (int)wrote, (int)okrb);
@@ -278,7 +278,7 @@ public:
       }
 
       // Build blob from fitted calibrations
-      ImuCalBlobV1 blob{};
+      ImuCalBlobV2 blob{};
       fillBlob_(blob);
 
       ui_.setReadRotation();
@@ -287,7 +287,7 @@ public:
       const bool wrote = store_.save(blob);
 
       // Readback validation (also ensures CRC correctness)
-      ImuCalBlobV1 rb{};
+      ImuCalBlobV2 rb{};
       const bool okrb = store_.load(rb);
 
       Serial.printf("[SAVE] wrote=%d readback=%d\n", (int)wrote, (int)okrb);
@@ -794,11 +794,11 @@ private:
     return false;
   }
 
-  void fillBlob_(ImuCalBlobV1& blob) {
+  void fillBlob_(ImuCalBlobV2& blob) {
     memset(&blob, 0, sizeof(blob));
-    blob.magic = ImuCalBlobV1::IMU_CAL_MAGIC;
-    blob.version = ImuCalBlobV1::IMU_CAL_VERSION;
-    blob.size_bytes = sizeof(ImuCalBlobV1);
+    blob.magic = ImuCalBlobV2::IMU_CAL_MAGIC;
+    blob.version = ImuCalBlobV2::IMU_CAL_VERSION;
+    blob.size_bytes = sizeof(ImuCalBlobV2);
 
     blob.accel_ok = acc_out_.ok ? 1 : 0;
     blob.accel_g  = acc_out_.g;

--- a/src/AtomS3R/ImuCalWizardRunner.h
+++ b/src/AtomS3R/ImuCalWizardRunner.h
@@ -12,7 +12,7 @@ namespace atoms3r_ical {
 static constexpr uint8_t RUNNER_BMI270_ADDR = 0x68;
 static constexpr float   RUNNER_AG_HZ       = 200.0f;
 
-inline bool runImuCalWizard(M5Ui& ui, ImuCalStoreNvs& store, ImuCalBlobV1& out_saved) {
+inline bool runImuCalWizard(M5Ui& ui, ImuCalStoreNvs& store, ImuCalBlobV2& out_saved) {
   BoschBmi270_ImuCal imu;
 
   BoschBmi270_ImuCal::Config cfg;


### PR DESCRIPTION
### Motivation

- Prevent a calibration produced by firmware compiled with one IMU acquisition path (`NO_BOSCH_API` vs Bosch API) from being silently reused by firmware built with the opposite path, which can cause incorrect IMU/magnetometer behavior.

### Description

- Bumped persisted calibration blob version (`ImuCalBlobV1::IMU_CAL_VERSION`) to `2` and added a `build_mode` byte plus `IMU_CAL_MODE_BOSCH_API` and `IMU_CAL_MODE_NO_BOSCH_API` constants.
- Stamp `build_mode` in `ImuCalStoreNvs::save` based on whether `NO_BOSCH_API` is defined at compile time so saved blobs record the producing build mode.
- Enforce compatibility in `validateBlob` by rejecting blobs whose stored `build_mode` does not match the currently compiled mode, making cross-use explicit-incompatible.
- Print the saved blob's `build_mode` in `printBlobSummary` to aid boot-time diagnostics.

### Testing

- Built the project with `make all` and the build completed successfully with the updated header and tests compiled without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d435cd77b48328b0f6f14b056103df)