### PR TITLE
Handle non-Bosch builds in ImuCalWizardRunner

### DIFF
--- a/src/AtomS3R/ImuCalWizardRunner.h
+++ b/src/AtomS3R/ImuCalWizardRunner.h
@@ -13,6 +13,7 @@ static constexpr uint8_t RUNNER_BMI270_ADDR = 0x68;
 static constexpr float   RUNNER_AG_HZ       = 200.0f;
 
 inline bool runImuCalWizard(M5Ui& ui, ImuCalStoreNvs& store, ImuCalBlobV2& out_saved) {
+#if ATOMS3R_WIZARD_USE_BOSCH
   BoschBmi270_ImuCal imu;
 
   BoschBmi270_ImuCal::Config cfg;
@@ -45,6 +46,10 @@ inline bool runImuCalWizard(M5Ui& ui, ImuCalStoreNvs& store, ImuCalBlobV2& out_s
 
   (void)imu.end();
   return ok;
+#else
+  ImuCalWizard wizard(ui, store);
+  return wizard.runAndSave(out_saved);
+#endif
 }
 
 } // namespace atoms3r_ical


### PR DESCRIPTION
### Motivation
- Fix a compile error when the wizard is built without Bosch API support (`NO_BOSCH_API` / `ATOMS3R_WIZARD_USE_BOSCH == 0`) caused by the runner always passing a Bosch IMU to the `ImuCalWizard` constructor. 

### Description
- Guarded the Bosch-specific initialization and wizard construction with `#if ATOMS3R_WIZARD_USE_BOSCH` in `src/AtomS3R/ImuCalWizardRunner.h`. 
- Added a non-Bosch fallback that constructs `ImuCalWizard(ui, store)` and calls `runAndSave` when Bosch support is disabled. 
- Preserved the existing Bosch `imu.begin(...)` configuration and behavior unchanged for the Bosch-enabled path. 

### Testing
- Ran `make all` from the repository root and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d440fbb7608328b381987b938278f7)