### PR TITLE
Fix AtomS3R BMM150 AUX init ordering

### DIFF
--- a/src/Bosch/BoschBmm150Aux.h
+++ b/src/Bosch/BoschBmm150Aux.h
@@ -232,6 +232,13 @@ public:
       return false;
     }
 
+    if (!powerOn_()) {
+      ++init_fail_total_;
+      last_error_ = Error::BMM_POWER_ON_FAILED;
+      bestEffortRollback_();
+      return false;
+    }
+
     uint8_t chip_id = 0;
     if (!readChipIdRaw_(chip_id)) {
       ++init_fail_total_;
@@ -242,13 +249,6 @@ public:
     if (chip_id != kExpectedChipId) {
       ++init_fail_total_;
       last_error_ = Error::CHIP_ID_MISMATCH;
-      bestEffortRollback_();
-      return false;
-    }
-
-    if (!powerOn_()) {
-      ++init_fail_total_;
-      last_error_ = Error::BMM_POWER_ON_FAILED;
       bestEffortRollback_();
       return false;
     }


### PR DESCRIPTION
### Motivation
- Chip-ID probing of the BMM150 can fail if the magnetometer remains powered-off; the AUX bring-up should power the BMM150 before attempting a chip-id read to match known-working AtomS3R init ordering.

### Description
- Move the `powerOn_()` call ahead of the chip-id probe in `BoschBmm150Aux::begin()` by updating `src/Bosch/BoschBmm150Aux.h`, while keeping existing rollback and error-path behavior unchanged.

### Testing
- Ran `make all` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4766b013083289d13a6d5ae6c383a)