### PR TITLE
Guard magnetometer calibration output against NaNs

### DIFF
--- a/src/AtomS3R/AtomS3R_ImuCal.h
+++ b/src/AtomS3R/AtomS3R_ImuCal.h
@@ -296,7 +296,11 @@ struct RuntimeCals {
 
   Vector3f applyAccel(const Vector3f& a_raw, float tempC) const { return acc.ok ? acc.apply(a_raw, tempC) : a_raw; }
   Vector3f applyGyro (const Vector3f& w_raw, float tempC) const { return gyr.ok ? gyr.apply(w_raw, tempC) : w_raw; }
-  Vector3f applyMag  (const Vector3f& m_raw) const { return mag.ok ? mag.apply(m_raw) : m_raw; }
+  Vector3f applyMag  (const Vector3f& m_raw) const {
+    if (!mag.ok) return m_raw;
+    const Vector3f m_cal = mag.apply(m_raw);
+    return m_cal.allFinite() ? m_cal : m_raw;
+  }
 };
 
 // Pretty 3x3 print from row-major float[9].


### PR DESCRIPTION
### Motivation
- Prevent calibrated magnetometer vectors with non-finite components from propagating `NaN` values into downstream heading and attitude logic when a bad calibration is loaded or produced.

### Description
- Add a defensive check in `RuntimeCals::applyMag` (in `src/AtomS3R/AtomS3R_ImuCal.h`) to use `mag.apply(...)` only if the resulting `m_cal.allFinite()`; otherwise return the raw mapped magnetometer vector instead of the calibrated one.

### Testing
- Ran `make all`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d47bb1f7e8832883488a220475635f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced magnetometer calibration with improved validation and fallback to raw sensor readings when calibrated values are invalid, ensuring more robust sensor data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->