### PR TITLE
Fail MAG capture immediately on invalid magnetometer samples

### DIFF
--- a/src/AtomS3R/AtomS3R_ImuCalWizard.h
+++ b/src/AtomS3R/AtomS3R_ImuCalWizard.h
@@ -672,7 +672,11 @@ private:
 
       ImuSample s;
       if (!readSample_(s)) { delay(2); continue; }
-      if (!finite3_(s.m)) { delay(2); continue; }
+      if (!finite3_(s.m)) {
+        Serial.println("[MAG] invalid sample (NaN/Inf) -> failing MAG capture");
+        out_why = "MAG returned NaN/Inf";
+        return false;
+      }
 
       const uint32_t now = millis();
 


### PR DESCRIPTION
### Motivation
- The MAG capture loop previously ignored non-finite magnetometer readings (`NaN`/`Inf`) and continued the full rotation/time gating (e.g. ~45s), forcing long waits when the sensor or path was broken; the wizard should surface the failure immediately.

### Description
- Add a non-finite check in `captureMag_` so that when `s.m` is not finite the code logs `"[MAG] invalid sample (NaN/Inf) -> failing MAG capture"`, sets `out_why = "MAG returned NaN/Inf"`, and returns `false` immediately, with no public API, filename, or build target changes.

### Testing
- Ran `make all` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d48bc43950832891eefb50dd64b964)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during magnetometer calibration to explicitly fail when invalid sensor readings are detected, rather than silently skipping them. Users will now receive a diagnostic message when issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->