### PR TITLE
Fix MAG calibration capture to tolerate transient NaN samples

### DIFF
--- a/src/AtomS3R/AtomS3R_ImuCalWizard.h
+++ b/src/AtomS3R/AtomS3R_ImuCalWizard.h
@@ -673,9 +673,10 @@ private:
       ImuSample s;
       if (!readSample_(s)) { delay(2); continue; }
       if (!finite3_(s.m)) {
-        Serial.println("[MAG] invalid sample (NaN/Inf) -> failing MAG capture");
-        out_why = "MAG returned NaN/Inf";
-        return false;
+        // During startup/recovery the mag path may briefly report NaN/Inf.
+        // Treat this as "no usable sample yet" rather than a hard failure.
+        delay(2);
+        continue;
       }
 
       const uint32_t now = millis();


### PR DESCRIPTION
### Motivation
- The MAG capture routine aborted immediately when a single magnetometer sample was non-finite (`NaN`/`Inf`), which can occur briefly during sensor startup or recovery even though normal operation provides valid readings.

### Description
- In `src/AtomS3R/AtomS3R_ImuCalWizard.h` the MAG loop now treats non-finite `s.m` samples as temporary/unusable by skipping them (`continue`) instead of failing the capture, preserving the existing stuck/timeout logic to decide eventual failure.

### Testing
- Ran `make all` from the repository root and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d48dad1d7c8328a47ea8205316a48c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IMU calibration robustness by implementing a retry mechanism for magnetometer sensor readings, allowing the system to recover from transient invalid readings instead of failing immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->