### PR TITLE
Unify sensor-frame → body-NED mapping (central helper)

### DIFF
--- a/sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino
+++ b/sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino
@@ -465,7 +465,7 @@ private:
     const bool sample_usable = ::finite3_(m_s) && (m_s.norm() > 1.0f);
     if (!read_ok && !sample_usable) return;
 
-    const Vector3f m_body(m_s.y(), m_s.x(), -m_s.z());
+    const Vector3f m_body = map_sensor_vec_to_body_ned_(m_s);
 
     const bool have_prev = ::finite3_(mag_raw_uT_);
     const float dm       = have_prev ? (m_body - mag_raw_uT_).norm() : INFINITY;

--- a/src/AtomS3R/AtomS3R_ImuCal.h
+++ b/src/AtomS3R/AtomS3R_ImuCal.h
@@ -113,20 +113,22 @@ struct ImuCalCfg {
 // acc_body = ( ay, ax, -az ) * g
 // gyr_body = ( gy, gx, -gz ) * deg2rad
 // mag_body = ( my, mx, -mz ) * (1/10)
+static inline Vector3f map_sensor_xyz_to_body_ned_(float sx, float sy, float sz, float scale = 1.0f) {
+  return Vector3f(sy * scale, sx * scale, -sz * scale);
+}
+
+static inline Vector3f map_sensor_vec_to_body_ned_(const Vector3f& v_sensor, float scale = 1.0f) {
+  return map_sensor_xyz_to_body_ned_(v_sensor.x(), v_sensor.y(), v_sensor.z(), scale);
+}
+
 static inline Vector3f map_acc_to_body_ned_(const m5::imu_3d_t& a_g) {
-  return Vector3f(a_g.y * ImuCalCfg::g_std,
-                  a_g.x * ImuCalCfg::g_std,
-                 -a_g.z * ImuCalCfg::g_std);
+  return map_sensor_xyz_to_body_ned_(a_g.x, a_g.y, a_g.z, ImuCalCfg::g_std);
 }
 static inline Vector3f map_gyr_to_body_ned_(const m5::imu_3d_t& w_deg_s) {
-  return Vector3f(w_deg_s.y * ImuCalCfg::DEG2RAD,
-                  w_deg_s.x * ImuCalCfg::DEG2RAD,
-                 -w_deg_s.z * ImuCalCfg::DEG2RAD);
+  return map_sensor_xyz_to_body_ned_(w_deg_s.x, w_deg_s.y, w_deg_s.z, ImuCalCfg::DEG2RAD);
 }
 static inline Vector3f map_mag_to_body_uT_(const m5::imu_3d_t& m_raw) {
-  return Vector3f(m_raw.y / 10.0f,
-                  m_raw.x / 10.0f,
-                 -m_raw.z / 10.0f);
+  return map_sensor_xyz_to_body_ned_(m_raw.x, m_raw.y, m_raw.z, 0.1f);
 }
 
 // Blob + CRC utilities

--- a/src/Bosch/BoschBmi270_ImuCal.h
+++ b/src/Bosch/BoschBmi270_ImuCal.h
@@ -238,8 +238,8 @@ public:
     const Vector3f a_s(ag.ax, ag.ay, ag.az);
     const Vector3f w_s(ag.gx, ag.gy, ag.gz);
 
-    const Vector3f a_b(a_s.y(), a_s.x(), -a_s.z());
-    const Vector3f w_b(w_s.y(), w_s.x(), -w_s.z());
+    const Vector3f a_b = map_sensor_vec_to_body_ned_(a_s);
+    const Vector3f w_b = map_sensor_vec_to_body_ned_(w_s);
 
     mag_updated_this_read_ = false;
     maybePollMag_(sample_us64);
@@ -313,7 +313,7 @@ private:
   }
 
   static Vector3f mapMagToBodyNed_(const Vector3f& m_sensor_uT) {
-    return Vector3f(m_sensor_uT.y(), m_sensor_uT.x(), -m_sensor_uT.z());
+    return map_sensor_vec_to_body_ned_(m_sensor_uT);
   }
 
   static bool finite3_(const Vector3f& v) {


### PR DESCRIPTION
### Motivation
- Remove scattered, repeated axis-remap expressions and enforce a single canonical sensor→body-NED conversion so magnetometer/accel/gyro frames stay consistent across Bosch and non‑Bosch paths.
- Restore the working frame convention from the reference implementation by centralizing the `(y,x,-z)` remap and reducing risk of sign/frame drift between call sites.

### Description
- Added shared helpers in `src/AtomS3R/AtomS3R_ImuCal.h`: `map_sensor_xyz_to_body_ned_` and `map_sensor_vec_to_body_ned_` and updated the public mappers to call them (`map_acc_to_body_ned_`, `map_gyr_to_body_ned_`, `map_mag_to_body_uT_`).
- Replaced inline ad-hoc remaps with the shared helpers in `src/Bosch/BoschBmi270_ImuCal.h` (accel/gyro and `mapMagToBodyNed_`) so the Bosch FIFO path uses the same conversion.
- Replaced a manual remap in `sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino` to use the shared helper for BMM150 reads, ensuring the runtime mag polling path matches the canonical mapping.

### Testing
- Ran the project build with `make all` and it completed successfully with compiled test binaries (no failing commands or compile errors reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d55741f7a48328956880415beee321)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized sensor coordinate mapping logic across accelerometer, gyroscope, and magnetometer sensors using shared helper functions for improved code consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->