### PR TITLE
Add missing IMU calibration include in SparkFun FIFO sketch

### DIFF
--- a/sensors/imu_fifo/atomS3R_fifo_sparkfun/atomS3R_fifo_sparkfun.ino
+++ b/sensors/imu_fifo/atomS3R_fifo_sparkfun/atomS3R_fifo_sparkfun.ino
@@ -1,6 +1,7 @@
 #include <Wire.h>
 #include <ArduinoOceanImu.h>
 
+#include "AtomS3R/AtomS3R_ImuCal.h"
 #include "AtomS3R/AtomS3R_ImuCommon.h"
 #include "SparkFun/ImuReader.h"
 #include "SparkFun/MagReader.h"


### PR DESCRIPTION
### Motivation
- The SparkFun AtomS3R FIFO Arduino sketch referenced IMU calibration types and Eigen aliases but did not include their header, which led to compile errors like unknown types `ImuCalStoreNvs`, `ImuCalBlobV2`, `RuntimeCals`, `Matrix3f`, and `Vector3f`.

### Description
- Add `#include "AtomS3R/AtomS3R_ImuCal.h"` to `sensors/imu_fifo/atomS3R_fifo_sparkfun/atomS3R_fifo_sparkfun.ino` to restore the missing declarations.

### Testing
- Ran `make all` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d57a6e355883288cbbe78859499c1e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal IMU calibration dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->