### PR TITLE
Fix Mahony compass heading freeze on Bosch API path

### DIFF
--- a/sensors/compass_ahrs/atomS3R_compass_mahony/atomS3R_compass_mahony.ino
+++ b/sensors/compass_ahrs/atomS3R_compass_mahony/atomS3R_compass_mahony.ino
@@ -52,7 +52,11 @@ class MahonyBackend : public IAttitudeBackend {
     if (an > 1e-6f) a_att *= (ImuCalCfg::g_std / an);
 
     float pd = 0.0f, rd = 0.0f, yd = 0.0f;
-    if (s.mag_ok && s.mag_fresh) {
+    // With Bosch FIFO/AUX path the magnetometer update flag can be sparse
+    // or temporarily stop toggling. Using only mag_fresh makes yaw rely on
+    // gyro integration for long periods and the compass can appear "stuck".
+    // Feed the latest healthy calibrated magnetometer whenever it is valid.
+    if (s.mag_ok) {
       mahony_AHRS_update_mag(&mahony_, s.w_cal.x(), s.w_cal.y(), s.w_cal.z(), a_att.x(), a_att.y(), a_att.z(), s.m_unit.x(),
                              s.m_unit.y(), s.m_unit.z(), &pd, &rd, &yd, s.dt);
     } else {


### PR DESCRIPTION
### Motivation
- The Bosch FIFO/AUX magnetometer path can leave the `mag_fresh` flag false for long intervals, which causes the Mahony yaw estimate to run on gyro integration alone and the compass heading to drift or appear stuck.

### Description
- Change magnetometer fusion trigger in `sensors/compass_ahrs/atomS3R_compass_mahony/atomS3R_compass_mahony.ino` to use `s.mag_ok` (any healthy mag sample) instead of requiring `s.mag_fresh`, and add a short explanatory comment.

### Testing
- Ran `make all` in the repository root and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d59dcf3c9c832881af6ee5a0a3ecd4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced magnetometer integration in compass heading calculations. The system now continuously incorporates the latest calibrated magnetometer data for yaw correction, instead of waiting for fresh samples only, with automatic fallback to gyro and accelerometer when magnetometer readings are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->