### PR TITLE
Add NO_BOSCH_API magnetometer fallback to atomS3R_ins_kalman_ou2

### DIFF
--- a/sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino
+++ b/sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino
@@ -16,6 +16,7 @@
 #endif
 
 #define ARDUINO_PLOTTER 1
+#define NO_BOSCH_API
 
 #include <M5Unified.h>
 #include <cmath>
@@ -31,7 +32,7 @@
 #include <ArduinoOceanImu.h>
 
 #include "Bosch/BoschBmi270_ImuCal.h"
-#if !defined(ATOMS3R_HAVE_BOSCH_SENSORAPI) || !(ATOMS3R_HAVE_BOSCH_SENSORAPI)
+#if (!defined(NO_BOSCH_API)) && (!defined(ATOMS3R_HAVE_BOSCH_SENSORAPI) || !(ATOMS3R_HAVE_BOSCH_SENSORAPI))
   #error "Bosch BMI270 SensorAPI is not available in this build. Install the library that provides Arduino_BMI270_BMM150.h."
 #endif
 
@@ -475,6 +476,30 @@ private:
       pending_mag_update_ = true;
     }
 
+    have_mag_sample_     = true;
+    last_mag_success_ms_ = now_ms;
+#elif defined(NO_BOSCH_API)
+    const uint32_t now_ms = millis();
+    constexpr uint32_t kCompassMagSpacingMs = 35u;
+
+    if (last_mag_poll_ms_ != 0 &&
+        static_cast<uint32_t>(now_ms - last_mag_poll_ms_) < kCompassMagSpacingMs) {
+      return;
+    }
+    last_mag_poll_ms_ = now_ms;
+
+    const auto data = M5.Imu.getImuData();
+    const Vector3f m_s(
+      data.mag.value.x,
+      data.mag.value.y,
+      data.mag.value.z);
+    const Vector3f m_body = map_sensor_vec_to_body_ned_(m_s);
+    const bool sample_usable = ::finite3_(m_body) &&
+                               (m_body.x() != 0.0f || m_body.y() != 0.0f || m_body.z() != 0.0f);
+    if (!sample_usable) return;
+
+    mag_raw_uT_ = m_body;
+    pending_mag_update_ = true;
     have_mag_sample_     = true;
     last_mag_success_ms_ = now_ms;
 #else


### PR DESCRIPTION
### Motivation
- Make the INS sketch behave like the compass sketches when `NO_BOSCH_API` is used so builds without the Bosch SensorAPI still work.
- Ensure magnetometer update cadence and freshness handling in the INS path match the compass `.ino` behavior to avoid yaw locking when Bosch AUX hints are sparse.

### Description
- Define `NO_BOSCH_API` in `sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino` to mirror the compass sketches by default via `#define NO_BOSCH_API`.
- Relax the compile-time check around the Bosch SensorAPI error to skip the `#error` when `NO_BOSCH_API` is defined by changing the `#if` to `#if (!defined(NO_BOSCH_API)) && (!defined(ATOMS3R_HAVE_BOSCH_SENSORAPI) || !(ATOMS3R_HAVE_BOSCH_SENSORAPI))`.
- Add a `NO_BOSCH_API` branch in `pollRuntimeMag_()` that reads magnetometer data from `M5.Imu.getImuData()`, maps samples to BODY-NED using `map_sensor_vec_to_body_ned_()`, validates finite/non-zero samples, and marks updates (`mag_raw_uT_`, `pending_mag_update_`, `have_mag_sample_`, `last_mag_success_ms_`) on a 35 ms cadence to match the compass apps.

### Testing
- Ran `make all` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6588580e48328b4672e5f00259ff4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable build option enabling alternative magnetometer data acquisition paths, providing flexibility in sensor interface selection.
  * Enhanced magnetometer polling with improved timing management and data validation checks to ensure reliable magnetic field measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->