### PR TITLE
Fix NO_BOSCH_API magnetometer field access in atomS3R INS sketch

### DIFF
--- a/sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino
+++ b/sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino
@@ -490,9 +490,9 @@ private:
 
     const auto data = M5.Imu.getImuData();
     const Vector3f m_s(
-      data.mag.value.x,
-      data.mag.value.y,
-      data.mag.value.z);
+      data.mag.value[0],
+      data.mag.value[1],
+      data.mag.value[2]);
     const Vector3f m_body = map_sensor_vec_to_body_ned_(m_s);
     const bool sample_usable = ::finite3_(m_body) &&
                                (m_body.x() != 0.0f || m_body.y() != 0.0f || m_body.z() != 0.0f);


### PR DESCRIPTION
### Motivation
- Resolve a compile-time error caused by treating `data.mag.value` as a struct with `.x/.y/.z` when it is actually a `float[3]`, so magnetometer reads must use array indices.

### Description
- In `sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino` (in `FusionApp::pollRuntimeMag_()` under `NO_BOSCH_API`) replaced `data.mag.value.x/.y/.z` with `data.mag.value[0/1/2]` to match the actual IMU data layout.

### Testing
- Ran `make all` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6706f3c9c832881d79a883a9933d5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal magnetometer data access methodology to maintain consistent functionality.

*Note: This is a maintenance update with no impact on user-facing features or behavior.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->