### PR TITLE
Remove Bosch IMU path support from AtomS3R calibration and compass flows

### DIFF
--- a/sensors/compass_ahrs/atomS3R_compass_mahony/atomS3R_compass_mahony.ino
+++ b/sensors/compass_ahrs/atomS3R_compass_mahony/atomS3R_compass_mahony.ino
@@ -7,8 +7,6 @@
 #include <Arduino.h>
 #include <M5Unified.h>
 
-#define NO_BOSCH_API
-
 #include <ArduinoOceanImu.h>
 
 // 1 = graphical compass by default, 0 = text UI by default
@@ -52,9 +50,6 @@ class MahonyBackend : public IAttitudeBackend {
     if (an > 1e-6f) a_att *= (ImuCalCfg::g_std / an);
 
     float pd = 0.0f, rd = 0.0f, yd = 0.0f;
-    // With Bosch FIFO/AUX path the magnetometer update flag can be sparse
-    // or temporarily stop toggling. Using only mag_fresh makes yaw rely on
-    // gyro integration for long periods and the compass can appear "stuck".
     // Feed the latest healthy calibrated magnetometer whenever it is valid.
     if (s.mag_ok) {
       mahony_AHRS_update_mag(&mahony_, s.w_cal.x(), s.w_cal.y(), s.w_cal.z(), a_att.x(), a_att.y(), a_att.z(), s.m_unit.x(),

--- a/sensors/compass_ahrs/atomS3R_compass_qmekf/atomS3R_compass_qmekf.ino
+++ b/sensors/compass_ahrs/atomS3R_compass_qmekf/atomS3R_compass_qmekf.ino
@@ -7,8 +7,6 @@
 #include <Arduino.h>
 #include <M5Unified.h>
 
-#define NO_BOSCH_API
-
 #include <ArduinoOceanImu.h>
 
 // 1 = graphical compass by default, 0 = text UI by default

--- a/sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino
+++ b/sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino
@@ -16,7 +16,6 @@
 #endif
 
 #define ARDUINO_PLOTTER 1
-#define NO_BOSCH_API
 
 #include <M5Unified.h>
 #include <cmath>

--- a/src/AtomS3R/AtomS3R_CompassAppBase.h
+++ b/src/AtomS3R/AtomS3R_CompassAppBase.h
@@ -264,11 +264,7 @@ class CompassAppBase {
  public:
   CompassAppBase(std::unique_ptr<IAttitudeBackend> backend, MagGateConfig mag_cfg, const char* boot_name)
       : backend_(std::move(backend))
-#if ATOMS3R_WIZARD_USE_BOSCH
-      , wizard_(ui_, store_, bosch_),
-#else
       , wizard_(ui_, store_),
-#endif
       mag_gate_(mag_cfg), boot_name_(boot_name) {}
 
   void begin() {
@@ -292,18 +288,11 @@ class CompassAppBase {
       if (!compass_ui_ready_) use_graphics_ = false;
     }
 
-#if ATOMS3R_WIZARD_USE_BOSCH
-    if (!beginBoschImu_()) {
-      ui_.fail("IMU", "Bosch init fail");
-      while (true) delay(100);
-    }
-#else
     if (!M5.Imu.isEnabled()) {
       Serial.println("[BOOT] IMU not found / not enabled");
       ui_.fail("IMU", "Not found");
       while (true) delay(100);
     }
-#endif
 
     reloadBlobAndRuntime_();
 
@@ -374,17 +363,10 @@ class CompassAppBase {
     }
 
     ImuSample s;
-#if ATOMS3R_WIZARD_USE_BOSCH
-    if (bosch_.read(s)) {
-      const bool mag_fresh = bosch_.magUpdatedThisRead();
-      updateOutputs_(s, &mag_fresh);
-    }
-#else
     const uint32_t sample_us = micros();
     const uint32_t update_mask = M5.Imu.update();
     if (readImuMapped(M5.Imu, update_mask, sample_us, s))
       updateOutputs_(s);
-#endif
 
     updateUI_();
     streamSerial_();
@@ -440,7 +422,7 @@ class CompassAppBase {
     last_update_us_ = 0;
   }
 
-CalibratedSample makeCalibratedSample_(const ImuSample& s, const bool* mag_fresh_hint = nullptr) {
+CalibratedSample makeCalibratedSample_(const ImuSample& s) {
   CalibratedSample out{};
   out.a_raw_norm = s.a.norm();
 
@@ -461,56 +443,15 @@ CalibratedSample makeCalibratedSample_(const ImuSample& s, const bool* mag_fresh
 
   if (out.mag_ok && out.mag_norm_uT > 1e-6f) out.m_unit = out.m_cal / out.mag_norm_uT;
 
-  if (mag_fresh_hint) {
-    // Bosch path provides an explicit "updated on this read" hint.
-    // Keep that fast-path, but also fall back to the same time-gate used by
-    // the non-Bosch path so behavior stays aligned if the hint becomes sparse.
-    const bool hinted_fresh = out.mag_ok && (*mag_fresh_hint);
-    const bool gated_fresh = mag_gate_.update(out.m_cal, out.mag_ok, millis());
-    out.mag_fresh = hinted_fresh || gated_fresh;
-  } else {
-    out.mag_fresh = mag_gate_.update(out.m_cal, out.mag_ok, millis());
-  }
+  out.mag_fresh = mag_gate_.update(out.m_cal, out.mag_ok, millis());
   
   return out;
 }
 
-  void updateOutputs_(const ImuSample& s, const bool* mag_fresh_hint = nullptr) {
-    sample_ = makeCalibratedSample_(s, mag_fresh_hint);
+  void updateOutputs_(const ImuSample& s) {
+    sample_ = makeCalibratedSample_(s);
     backend_->step(sample_, outputs_.att);
     outputs_.rot_dpm = rot_.update(sample_.dt, sample_.a_cal, sample_.w_cal, outputs_.att);
-  }
-
-  bool beginBoschImu_() {
-#if ATOMS3R_WIZARD_USE_BOSCH
-    BoschBmi270_ImuCal::Config cfg;
-    cfg.bmi270_addr                = 0x68;
-    cfg.ag_hz                      = LOOP_HZ;
-    cfg.enable_mag_aux             = true;
-    cfg.mag_bmm150_addr            = 0x10;
-    cfg.mag_aux_odr_hz             = 25.0f;
-    cfg.mag_startup_settle_ms      = 200;
-    cfg.mag_verify_first_read      = true;
-    cfg.mag_stale_min_us           = 75000u;
-    cfg.mag_stale_factor           = 3u;
-    cfg.enable_mag_recovery        = true;
-    cfg.mag_recover_after_failures = 6u;
-    cfg.mag_recover_cooldown_us    = 1000000u;
-    cfg.tempC_default              = 35.0f;
-    cfg.i2c_hz                     = 400000u;
-
-    if (!bosch_.begin(M5.In_I2C, cfg)) {
-      Serial.printf("[BOOT] Bosch IMU init failed: %s\n", bosch_.lastErrorString());
-      Serial.printf("[BOOT] FIFO detail: %s\n", bosch_.fifo().lastErrorString());
-      Serial.printf("[BOOT] FIFO init path: %s\n", bosch_.fifo().initPathString());
-      Serial.printf("[BOOT] FIFO Bosch init rslt: %d\n", (int)bosch_.fifo().lastBoschInitResult());
-      Serial.printf("[BOOT] BMI addr tried: 0x%02X\n", cfg.bmi270_addr);
-      return false;
-    }
-    return true;
-#else
-    return false;
-#endif
   }
 
   void drawHomeStatic_() {
@@ -603,10 +544,6 @@ CalibratedSample makeCalibratedSample_(const ImuSample& s, const bool* mag_fresh
   std::unique_ptr<IAttitudeBackend> backend_;
   MagGate mag_gate_;
   RotEstimator rot_;
-
-#if ATOMS3R_WIZARD_USE_BOSCH
-  BoschBmi270_ImuCal bosch_{};
-#endif
 
   bool have_blob_ = false;
   ImuCalBlobV2 blob_{};

--- a/src/AtomS3R/AtomS3R_ImuCal.h
+++ b/src/AtomS3R/AtomS3R_ImuCal.h
@@ -135,8 +135,7 @@ static inline Vector3f map_mag_to_body_uT_(const m5::imu_3d_t& m_raw) {
 struct ImuCalBlobV2 {
   static constexpr uint32_t IMU_CAL_MAGIC   = 0x434C554D; // 'MULC'
   static constexpr uint16_t IMU_CAL_VERSION = 2;
-  static constexpr uint8_t  IMU_CAL_MODE_BOSCH_API = 1;
-  static constexpr uint8_t  IMU_CAL_MODE_NO_BOSCH_API = 2;
+  static constexpr uint8_t  IMU_CAL_MODE_M5_IMU_API = 1;
 
   uint32_t magic = IMU_CAL_MAGIC;
   uint16_t version = IMU_CAL_VERSION;
@@ -202,12 +201,7 @@ static inline bool validateBlob(const ImuCalBlobV2& b) {
   if (b.magic != ImuCalBlobV2::IMU_CAL_MAGIC) return false;
   if (b.version != ImuCalBlobV2::IMU_CAL_VERSION) return false;
   if (b.size_bytes != sizeof(ImuCalBlobV2)) return false;
-  const uint8_t expected_mode =
-#if defined(NO_BOSCH_API)
-      ImuCalBlobV2::IMU_CAL_MODE_NO_BOSCH_API;
-#else
-      ImuCalBlobV2::IMU_CAL_MODE_BOSCH_API;
-#endif
+  const uint8_t expected_mode = ImuCalBlobV2::IMU_CAL_MODE_M5_IMU_API;
   if (b.build_mode != expected_mode) return false;
   const uint32_t want = b.crc;
   return (computeBlobCrc(b) == want);
@@ -217,18 +211,12 @@ static inline bool validateBlob(const ImuCalBlobV2& b) {
 class ImuCalStoreNvs {
 public:
   // Namespace kept stable so different sketches share saved cals.
-  // Keys are mode-specific to avoid Bosch/non-Bosch collisions.
   static constexpr const char* kNamespace = "imu_cal";
   static constexpr const char* kKeyLegacy = "blob";
-  static constexpr const char* kKeyBosch  = "blob_bosch";
-  static constexpr const char* kKeyNoBosch = "blob_nob";
+  static constexpr const char* kKeyM5ImuApi = "blob_m5";
 
   static constexpr const char* modeKey() {
-#if defined(NO_BOSCH_API)
-    return kKeyNoBosch;
-#else
-    return kKeyBosch;
-#endif
+    return kKeyM5ImuApi;
   }
 
   bool loadByKey_(Preferences& prefs, const char* key, ImuCalBlobV2& out) {
@@ -257,12 +245,7 @@ public:
     tmp.magic = ImuCalBlobV2::IMU_CAL_MAGIC;
     tmp.version = ImuCalBlobV2::IMU_CAL_VERSION;
     tmp.size_bytes = sizeof(ImuCalBlobV2);
-    tmp.build_mode =
-#if defined(NO_BOSCH_API)
-      ImuCalBlobV2::IMU_CAL_MODE_NO_BOSCH_API;
-#else
-      ImuCalBlobV2::IMU_CAL_MODE_BOSCH_API;
-#endif
+    tmp.build_mode = ImuCalBlobV2::IMU_CAL_MODE_M5_IMU_API;
     tmp.crc = 0;
     tmp.crc = computeBlobCrc(tmp);
 
@@ -364,8 +347,7 @@ static inline void printMatHeader(Print& out, const char* name, const char* mean
 // Print helpers (startup serial)
 static inline void printBlobSummary(Print& out, const ImuCalBlobV2& b) {
   const char* mode = "unknown";
-  if (b.build_mode == ImuCalBlobV2::IMU_CAL_MODE_BOSCH_API) mode = "bosch_api";
-  else if (b.build_mode == ImuCalBlobV2::IMU_CAL_MODE_NO_BOSCH_API) mode = "no_bosch_api";
+  if (b.build_mode == ImuCalBlobV2::IMU_CAL_MODE_M5_IMU_API) mode = "m5_imu_api";
   out.printf("  build_mode: %s\n", mode);
   out.printf("  ok: A=%d G=%d M=%d\n", (int)b.accel_ok, (int)b.gyro_ok, (int)b.mag_ok);
 }

--- a/src/AtomS3R/AtomS3R_ImuCalWizard.h
+++ b/src/AtomS3R/AtomS3R_ImuCalWizard.h
@@ -5,9 +5,7 @@
 
   AtomS3R IMU calibration wizard UI (Accel + Gyro + Mag) using imu_cal::* calibrators.
 
-  Build switch:
-    - Define NO_BOSCH_API to force readImuMapped
-    - Default (NO_BOSCH_API not defined): use BoschBmi270_ImuCal as the IMU sample source
+  Uses M5Unified IMU API as the IMU sample source.
 */
 
 #include <Arduino.h>
@@ -25,14 +23,6 @@
 #include "AtomS3R/AtomS3R_ImuCal.h"         // ImuSample, axis mapping conventions, blob/store/runtime helpers
 #include "AtomS3R/AtomS3R_M5Ui.h"           // UI + Input + clamp01_
 #include "imu_calibrate/CalibrateIMU.h"     // imu_cal::* + FitFail
-
-// Bosch path (default unless NO_BOSCH_API is defined)
-#if !defined(NO_BOSCH_API)
-  #include "Bosch/BoschBmi270_ImuCal.h"
-  #define ATOMS3R_WIZARD_USE_BOSCH 1
-#else
-  #define ATOMS3R_WIZARD_USE_BOSCH 0
-#endif
 
 namespace atoms3r_ical {
 
@@ -143,13 +133,8 @@ struct Pose {
 
 class ImuCalWizard {
 public:
-#if ATOMS3R_WIZARD_USE_BOSCH
-  ImuCalWizard(M5Ui& ui, ImuCalStoreNvs& store, BoschBmi270_ImuCal& imu)
-  : ui_(ui), store_(store), imu_(&imu) {}
-#else
   ImuCalWizard(M5Ui& ui, ImuCalStoreNvs& store)
   : ui_(ui), store_(store) {}
-#endif
 
   // Runs full wizard and saves to NVS. Returns true only if saved successfully.
   // out_saved is filled with the saved blob (readback-validated).
@@ -201,7 +186,7 @@ public:
       }
       if (!runFitTask_(FitKind::GYRO, "GYRO", true)) return false;
 
-      // If mag is unavailable (Bosch path failed / absent), skip MAG stage cleanly.
+      // If mag is unavailable, skip MAG stage cleanly.
       if (!magAvailable_()) {
         Serial.println("[MAG] unavailable -> skipping mag calibration");
         mag_out_.ok = false;
@@ -466,12 +451,8 @@ private:
   }
 
   bool magAvailable_() {
-#if ATOMS3R_WIZARD_USE_BOSCH
-    if (!imu_) return false;
-    return imu_->hasMag();
-#else
-    // Legacy (non-Bosch) path: actively probe MAG so we can skip calibration
-    // cleanly when magnetometer data is unavailable/stuck.
+    // Actively probe MAG so we can skip calibration cleanly when
+    // magnetometer data is unavailable/stuck.
     Vector3f m = Vector3f::Zero();
     bool have_prev = false;
     Vector3f prev = Vector3f::Zero();
@@ -499,31 +480,18 @@ private:
       delay(4);
     }
     return false;
-#endif
   }
 
   // Capture steps
   bool readSample_(ImuSample& s) {
-#if ATOMS3R_WIZARD_USE_BOSCH
-    if (!imu_) return false;
-    return imu_->read(s);
-#else
     return readImuMapped(M5.Imu, s);
-#endif
   }
 
   bool readMagSample_(Vector3f& m_out) {
-#if ATOMS3R_WIZARD_USE_BOSCH
-    ImuSample s{};
-    if (!readSample_(s) || !finite3_(s.m)) return false;
-    m_out = s.m;
-    return true;
-#else
     (void)M5.Imu.update();
     const auto data = M5.Imu.getImuData();
     m_out = map_mag_to_body_uT_(data.mag);
     return finite3_(m_out);
-#endif
   }
 
   void configureCalibrators_() {
@@ -868,10 +836,6 @@ private:
 private:
   M5Ui& ui_;
   ImuCalStoreNvs& store_;
-
-#if ATOMS3R_WIZARD_USE_BOSCH
-  BoschBmi270_ImuCal* imu_ = nullptr;
-#endif
 
 public:
   // Stored inside wizard => not on stack

--- a/src/AtomS3R/ImuCalWizardRunner.h
+++ b/src/AtomS3R/ImuCalWizardRunner.h
@@ -5,51 +5,12 @@
 #include "AtomS3R/AtomS3R_ImuCal.h"
 #include "AtomS3R/AtomS3R_ImuCalWizard.h"
 #include "AtomS3R/AtomS3R_M5Ui.h"
-#include "Bosch/BoschBmi270_ImuCal.h"
 
 namespace atoms3r_ical {
 
-static constexpr uint8_t RUNNER_BMI270_ADDR = 0x68;
-static constexpr float   RUNNER_AG_HZ       = 200.0f;
-
 inline bool runImuCalWizard(M5Ui& ui, ImuCalStoreNvs& store, ImuCalBlobV2& out_saved) {
-#if ATOMS3R_WIZARD_USE_BOSCH
-  BoschBmi270_ImuCal imu;
-
-  BoschBmi270_ImuCal::Config cfg;
-  cfg.bmi270_addr                = RUNNER_BMI270_ADDR;
-  cfg.ag_hz                      = RUNNER_AG_HZ;
-  cfg.enable_mag_aux             = true;
-  cfg.mag_bmm150_addr            = 0x10;
-  cfg.mag_aux_odr_hz             = 25.0f;
-  cfg.mag_startup_settle_ms      = 200;
-  cfg.mag_verify_first_read      = true;
-  cfg.mag_stale_min_us           = 75000u;
-  cfg.mag_stale_factor           = 3u;
-  cfg.enable_mag_recovery        = true;
-  cfg.mag_recover_after_failures = 6u;
-  cfg.mag_recover_cooldown_us    = 1000000u;
-  cfg.tempC_default              = 35.0f;
-  cfg.i2c_hz                     = 400000u;
-
-  if (!imu.begin(M5.In_I2C, cfg)) {
-    Serial.printf("[WIZ] IMU init failed: %s\n", imu.lastErrorString());
-    Serial.printf("[WIZ] FIFO detail: %s\n", imu.fifo().lastErrorString());
-    Serial.printf("[WIZ] FIFO init path: %s\n", imu.fifo().initPathString());
-    Serial.printf("[WIZ] FIFO Bosch init rslt: %d\n", (int)imu.fifo().lastBoschInitResult());
-    Serial.printf("[WIZ] BMI addr tried: 0x%02X\n", cfg.bmi270_addr);
-    return false;
-  }
-
-  ImuCalWizard wizard(ui, store, imu);
-  const bool ok = wizard.runAndSave(out_saved);
-
-  (void)imu.end();
-  return ok;
-#else
   ImuCalWizard wizard(ui, store);
   return wizard.runAndSave(out_saved);
-#endif
 }
 
 } // namespace atoms3r_ical


### PR DESCRIPTION
### Motivation
- Consolidate IMU handling to the M5Unified IMU path and remove the Bosch-specific code path and build-time branching to simplify calibration, storage, and runtime sampling behavior.

### Description
- Replace Bosch-specific blob modes with a single `IMU_CAL_MODE_M5_IMU_API` and change NVS key to `blob_m5` so saved calibration blobs are always tagged for the M5 IMU API; updates are in `src/AtomS3R/AtomS3R_ImuCal.h`.
- Simplify the calibration wizard to always use the M5Unified IMU sampling path by removing Bosch includes/constructors and conditional branches; changes are in `src/AtomS3R/AtomS3R_ImuCalWizard.h` and `src/AtomS3R/ImuCalWizardRunner.h`.
- Simplify `CompassAppBase` to always read from `M5.Imu` and remove Bosch init/read/mag-hint handling and Bosch member variables; updates are in `src/AtomS3R/AtomS3R_CompassAppBase.h`.
- Remove leftover `NO_BOSCH_API` defines and Bosch-specific comments from example sketches so they align with the single supported IMU path; affected sketches are under `sensors/`.

### Testing
- Ran the project build/validation with `make all`, which completed successfully (all compiled test targets built without errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6831581ac832881ac424af66dfec7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Refactor**
* Removed Bosch API configuration options from sensor sketches and the calibration system.
* Consolidated IMU initialization to a single implementation approach.
* Simplified calibration mode constants and storage key management.
* Removed Bosch-specific constructor overloads from the calibration wizard.
* Streamlined IMU sample reading and magnetometer availability detection to use the consolidated path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->