### PR TITLE
Remove obsolete IMU FIFO references

### DIFF
--- a/TLDR.md
+++ b/TLDR.md
@@ -9,7 +9,7 @@ In simple terms:
 - Includes double-integration drift-correction pseudo-measurements.
 - Kalman parameters must be and are adapted to match actual sea states.
 - Adaptation uses acceleration-frequency tracking for time-scale tuning, and direct acceleration-variance estimation for amplitude-scale tuning.
-- IMU sample timestamps are using accurate FIFO timestamps. Correct sample timestamps are very important due to samples being double integrated over time steps.
+- IMU sample timestamps are tracked accurately. Correct sample timestamps are very important due to samples being double integrated over time steps.
 - Performs initial learning of gravity relation to magnetic field needed because sensor might be turned on when already in waves motion
 - Optional wave shape de-trending to correct post-estimated displacememt drifts due to unmodelled biases
 - Compared to oscillatory models this one doesn't produce fake "ringing" motions

--- a/sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino
+++ b/sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino
@@ -212,7 +212,6 @@ public:
 
     ImuSample sample{};
     const bool got_sample = readImuMapped(M5.Imu, sample);
-    last_fifo_batch_count_ = got_sample ? 1u : 0u;
     stale_frame_count_           = 0;
 
     if (got_sample) {
@@ -283,8 +282,6 @@ private:
 
   uint16_t stale_frame_count_ = 0;
   uint32_t last_skipped_total_ = 0;
-  uint16_t last_fifo_batch_count_ = 0;
-
   bool     have_last_sample_us_ = false;
   uint32_t last_sample_us_      = 0;
 
@@ -783,8 +780,7 @@ private:
       static_cast<double>(heave_wave_clean_m_ * 100.0f));
 #else
     Serial.printf(
-      "FIFO batch=%u | dt_imu_ms=%.2f | mag_valid=%u | dt_mag_ms=%s%.2f (target~%.2f) | acc_ned[m/s^2] N=%.3f E=%.3f D=%.3f | gyro_ned[rad/s] N=%.3f E=%.3f D=%.3f | mag_ned[uT] N=%.2f E=%.2f D=%.2f\n",
-      static_cast<unsigned>(last_fifo_batch_count_),
+      "dt_imu_ms=%.2f | mag_valid=%u | dt_mag_ms=%s%.2f (target~%.2f) | acc_ned[m/s^2] N=%.3f E=%.3f D=%.3f | gyro_ned[rad/s] N=%.3f E=%.3f D=%.3f | mag_ned[uT] N=%.2f E=%.2f D=%.2f\n",
       static_cast<double>(dt_ * 1000.0f),
       mag_ok_ ? 1U : 0U,
       mag_fresh_ ? "+" : "~",

--- a/sensors/imu_basic/atomS3R_imu_m5_basic/atomS3R_imu_m5_basic.ino
+++ b/sensors/imu_basic/atomS3R_imu_m5_basic/atomS3R_imu_m5_basic.ino
@@ -105,10 +105,6 @@ void loop()
   }
 
   ImuLogRow row{};
-  row.fifoLen = -1;
-  row.fifoReq = -1;
-  row.fifoGot = -1;
-
   row.dtImuMs = (imuTickCount > 1u) ? kImuDtMs : -1.0f;
   row.magValid = (lastMagSampleUs != 0u);
   row.magUpdated = magCadenceTick;

--- a/src/AtomS3R/AtomS3R_ImuCommon.h
+++ b/src/AtomS3R/AtomS3R_ImuCommon.h
@@ -32,11 +32,6 @@ inline float usToMs(uint64_t us)
 
 struct ImuLogRow
 {
-  // FIFO / batch stats
-  int32_t fifoLen = -1;
-  int32_t fifoReq = -1;
-  int32_t fifoGot = -1;
-
   // Timing
   float dtImuMs = -1.0f;
   bool magValid = false;
@@ -105,15 +100,12 @@ struct ImuLoopLogState
 inline void printImuLogRow(const ImuLogRow& row)
 {
   Serial.printf(
-    "FIFO len=%ld req=%ld got=%ld | dt_imu_ms=%.2f | "
+    "dt_imu_ms=%.2f | "
     "mag_valid=%u mag_updated=%u | mag_age_ms=%.2f | mag_step_ms=%.2f | last_mag_dt_ms=%.2f | "
     "acc_ned[m/s^2] N=%.3f E=%.3f D=%.3f | "
     "gyro_ned[dps] N=%.3f E=%.3f D=%.3f | "
     "mag_ned[uT] N=%.2f E=%.2f D=%.2f | "
     "mag_cal_ned[uT] N=%.2f E=%.2f D=%.2f\n",
-    static_cast<long>(row.fifoLen),
-    static_cast<long>(row.fifoReq),
-    static_cast<long>(row.fifoGot),
     row.dtImuMs,
     row.magValid ? 1U : 0U,
     row.magUpdated ? 1U : 0U,


### PR DESCRIPTION
### Motivation
- FIFO support was removed from the IMU codebase but various places still referenced FIFO/batch fields and log text, causing stale code and misleading logs.

### Description
- Removed FIFO fields (`fifoLen`, `fifoReq`, `fifoGot`) from `ImuLogRow` and simplified `printImuLogRow` to stop printing FIFO stats (modified `src/AtomS3R/AtomS3R_ImuCommon.h`).
- Removed obsolete FIFO placeholder assignments from the basic IMU sketch (modified `sensors/imu_basic/atomS3R_imu_m5_basic/atomS3R_imu_m5_basic.ino`).
- Removed FIFO batch tracking state and removed FIFO text from the debug `Serial.printf` in the full marine INS sketch (modified `sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino`).
- Updated `TLDR.md` wording to remove FIFO-specific phrasing while preserving the note about accurate IMU timestamps.

### Testing
- Ran a repository search `rg -n "fifo|FIFO|Fifo"` to verify there are no remaining FIFO references and it returned no matches.
- Ran `make all` and the build completed successfully (all unit/test binaries compiled without errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d692c2add48328afc188adc1ce2f50)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified IMU timestamp documentation to describe accurate sample tracking throughout the system and emphasize the critical importance of precise timing measurements for calculating motion parameters.

* **Chores**
  * Removed internal batch tracking statistics from IMU sensor debug output and logging structures, resulting in cleaner and more concise sensor data telemetry reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->