### PR TITLE
Move displacement detrending into SeaStateFusion_OU_II and make it optional

### DIFF
--- a/sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino
+++ b/sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino
@@ -60,7 +60,6 @@ constexpr float FREQ_GUESS = 0.3f;
 #define ZERO_CROSSINGS_STEEPNESS_TIME 0.21f
 
 #include "kalman_ou_ii/SeaStateFusionFilter_OU_II.h"
-#include "detrend/AdaptiveWaveDetrender3D.h"
 
 #ifndef MAG_DELAY_SEC
   #define MAG_DELAY_SEC 8.0f
@@ -266,10 +265,6 @@ private:
   float wave_envelope_m_ = 0.0f;
   float wave_hz_         = FREQ_GUESS;
 
-  AdaptiveWaveDetrender3D z_detrender_{};
-  AdaptiveWaveDetrender3D::Output z_det_out_{};
-  Vector3f pos_raw_up_m_ = Vector3f::Zero();
-
   float heave_raw_m_        = 0.0f;   // raw heave from fusion position.z() (up-positive)
   float heave_baseline_m_   = 0.0f;   // slow baseline actually subtracted
   float heave_wave_raw_m_   = 0.0f;   // raw residual = heave_raw - baseline
@@ -444,6 +439,7 @@ private:
     fcfg.mag_ref_timeout_sec = 2.0f;
     fcfg.mag_odr_guess_hz    = MAG_TUNE_REF_HZ;
     fcfg.use_custom_mag_tuner_cfg = false;
+    fcfg.enable_displacement_detrend = true;
 
     fusion_.begin(fcfg);
 
@@ -481,47 +477,6 @@ private:
     stale_frame_count_ = 0;
     have_last_sample_us_ = false;
     last_sample_us_      = 0;
-
-    AdaptiveWaveDetrender3D::Config zcfg;
-    zcfg.init_wave_freq_hz = FREQ_GUESS;   // startup guess
-    zcfg.min_wave_freq_hz  = 0.02f;        // long swell
-    zcfg.max_wave_freq_hz  = 1.20f;        // short chop
-
-    // Slow baseline tracker
-    zcfg.baseline_cutoff_fraction = 0.25f;
-    zcfg.min_baseline_cutoff_hz   = 0.003f;
-    zcfg.max_baseline_cutoff_hz   = 0.25f;
-
-    // Frequency learning from slope
-    zcfg.freq_smooth_tau_s = 12.0f;
-    zcfg.slope_lpf_tau_s   = 0.20f;
-    zcfg.slope_rms_tau_s   = 8.0f;
-    zcfg.freq_learn_axis   = 2;  // learn from heave(Z)
-
-    // Because input is heave in meters, this threshold is in m/s
-    zcfg.threshold_rms_fraction  = 0.15f;
-    zcfg.min_slope_threshold_abs = 0.002f;
-    zcfg.max_slope_threshold_abs = 1.0e9f;
-
-    zcfg.startup_hold_s     = 2.0f;
-    zcfg.freq_timeout_cycles = 3.0f;
-
-    // Extra cleanup on the residual only
-    zcfg.enable_wave_cleanup   = true;
-    zcfg.cleanup_cutoff_fraction = 1.0f;
-    zcfg.min_cleanup_cutoff_hz = 0.003f;
-    zcfg.max_cleanup_cutoff_hz = 0.50f;
-    zcfg.cleanup_stages        = 2;   // try 2 if LF wobble still leaks through
-
-    zcfg.min_dt_s = 1.0e-4f;
-    zcfg.max_dt_s = 0.25f;            // generous guard for missed samples
-    zcfg.output_abs_limit = 0.0f;     // disabled
-
-    z_detrender_.setConfig(zcfg);
-    z_detrender_.reset(0.0f, 0.0f, 0.0f);
-
-    z_det_out_ = AdaptiveWaveDetrender3D::Output{};
-    pos_raw_up_m_.setZero();
     heave_raw_m_        = 0.0f;
     heave_baseline_m_   = 0.0f;
     heave_wave_raw_m_   = 0.0f;
@@ -668,30 +623,17 @@ private:
     if (!rot_inited_) { rot_inited_ = true; rot_dpm_filt_ = rot_dpm_meas; }
     else              { rot_dpm_filt_ += alpha_r * (rot_dpm_meas - rot_dpm_filt_); }
 
-    const Vector3f pos_ned_m = fusion_.raw().mekf().get_position();
-    pos_raw_up_m_ = Vector3f(pos_ned_m.x(), pos_ned_m.y(), -pos_ned_m.z());
+    const Vector3f displacement_raw_up_m = fusion_.displacementUpMeters();
+    const auto& displacement_det_out = fusion_.displacementDetrend();
 
-    heave_m_         = pos_raw_up_m_.z();  // positive-up
+    heave_m_         = displacement_raw_up_m.z();  // positive-up
     wave_envelope_m_ =  fusion_.raw().getDisplacementScale();
     wave_hz_         =  fusion_.raw().getFreqHz();
 
     heave_raw_m_ = heave_m_;
-
-    const bool ext_freq_valid =
-        fusion_.isLive() &&
-        std::isfinite(wave_hz_) &&
-        (wave_hz_ >= z_detrender_.config().min_wave_freq_hz) &&
-        (wave_hz_ <= z_detrender_.config().max_wave_freq_hz);
-
-    // Option A: blend in SeaStateFusion_OU_III frequency estimate
-    z_det_out_ = z_detrender_.update(pos_raw_up_m_, dt_, wave_hz_, ext_freq_valid);
-
-    // Option B: let the detrender learn frequency entirely by itself
-    // z_det_out_ = z_detrender_.update(pos_raw_up_m_, dt_);
-
-    heave_baseline_m_   = z_det_out_.baseline_slow.z();
-    heave_wave_raw_m_   = z_det_out_.wave_raw.z();
-    heave_wave_clean_m_ = z_det_out_.wave_clean.z();
+    heave_baseline_m_   = displacement_det_out.baseline_slow.z();
+    heave_wave_raw_m_   = displacement_det_out.wave_raw.z();
+    heave_wave_clean_m_ = displacement_det_out.wave_clean.z();
   }
 
   void drawHomeStatic_() {

--- a/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
+++ b/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
@@ -60,6 +60,7 @@
 #include "ahrs/FrameConversions.h"
 #include "wave_dir/KalmanWaveDirection.h"
 #include "wave_dir/WaveDirectionDetector.h"
+#include "detrend/AdaptiveWaveDetrender3D.h"
 
 // Shared constants
 
@@ -1027,6 +1028,11 @@ public:
         // MagAutoTuner config override (optional)
         bool use_custom_mag_tuner_cfg = false;
         MagAutoTuner::Config mag_tuner_cfg{};
+
+        // Optional displacement detrending on fused displacement in UP frame.
+        bool enable_displacement_detrend = false;
+        bool use_custom_displacement_detrend_cfg = false;
+        AdaptiveWaveDetrender3D::Config displacement_detrend_cfg{};
     };
 
     void begin(const Config& cfg) {
@@ -1076,6 +1082,41 @@ public:
 
         // IMPORTANT: allow warmup to restore nominal accel measurement noise
         impl_.setNominalRaccStd(cfg.sigma_a);
+
+        displacement_up_m_.setZero();
+        displacement_det_out_ = AdaptiveWaveDetrender3D::Output{};
+        if (cfg_.enable_displacement_detrend) {
+            if (cfg_.use_custom_displacement_detrend_cfg) {
+                displacement_detrender_.setConfig(cfg_.displacement_detrend_cfg);
+            } else {
+                AdaptiveWaveDetrender3D::Config dcfg;
+                dcfg.init_wave_freq_hz = FREQ_GUESS;
+                dcfg.min_wave_freq_hz  = 0.02f;
+                dcfg.max_wave_freq_hz  = 1.20f;
+                dcfg.baseline_cutoff_fraction = 0.25f;
+                dcfg.min_baseline_cutoff_hz   = 0.003f;
+                dcfg.max_baseline_cutoff_hz   = 0.25f;
+                dcfg.freq_smooth_tau_s = 12.0f;
+                dcfg.slope_lpf_tau_s   = 0.20f;
+                dcfg.slope_rms_tau_s   = 8.0f;
+                dcfg.freq_learn_axis   = 2;
+                dcfg.threshold_rms_fraction  = 0.15f;
+                dcfg.min_slope_threshold_abs = 0.002f;
+                dcfg.max_slope_threshold_abs = 1.0e9f;
+                dcfg.startup_hold_s      = 2.0f;
+                dcfg.freq_timeout_cycles = 3.0f;
+                dcfg.enable_wave_cleanup    = true;
+                dcfg.cleanup_cutoff_fraction = 1.0f;
+                dcfg.min_cleanup_cutoff_hz  = 0.003f;
+                dcfg.max_cleanup_cutoff_hz  = 0.50f;
+                dcfg.cleanup_stages         = 2;
+                dcfg.min_dt_s = 1.0e-4f;
+                dcfg.max_dt_s = 0.25f;
+                dcfg.output_abs_limit = 0.0f;
+                displacement_detrender_.setConfig(dcfg);
+            }
+            displacement_detrender_.reset(0.0f, 0.0f, 0.0f);
+        }
     }
 
     // One IMU sample
@@ -1103,6 +1144,26 @@ public:
 
         // Normal IMU fusion
         impl_.updateTime(dt, gyro_body_ned, acc_body_ned, tempC);
+
+        const Eigen::Vector3f pos_ned_m = impl_.mekf().get_position();
+        displacement_up_m_ = Eigen::Vector3f(pos_ned_m.x(), pos_ned_m.y(), -pos_ned_m.z());
+        if (cfg_.enable_displacement_detrend) {
+            const float wave_hz = impl_.getFreqHz();
+            const bool ext_freq_valid =
+                isLive() &&
+                std::isfinite(wave_hz) &&
+                (wave_hz >= displacement_detrender_.config().min_wave_freq_hz) &&
+                (wave_hz <= displacement_detrender_.config().max_wave_freq_hz);
+
+            displacement_det_out_ = displacement_detrender_.update(
+                displacement_up_m_, dt, wave_hz, ext_freq_valid);
+        } else {
+            displacement_det_out_ = AdaptiveWaveDetrender3D::Output{};
+            displacement_det_out_.input = displacement_up_m_;
+            displacement_det_out_.baseline_slow = Eigen::Vector3f::Zero();
+            displacement_det_out_.wave_raw = displacement_up_m_;
+            displacement_det_out_.wave_clean = displacement_up_m_;
+        }
 
         // If internal filter fell back to Cold (tilt reset), force mag ref re-learn
         const auto cur_stage = impl_.getStartupStage();
@@ -1246,6 +1307,8 @@ public:
     float freqHz() const { return impl_.getFreqHz(); }
     float waveDirectionDeg() const { return impl_.getWaveDirectionDeg(); }
     Eigen::Vector3f eulerNauticalDeg() const { return impl_.getEulerNautical(); }
+    const Eigen::Vector3f& displacementUpMeters() const { return displacement_up_m_; }
+    const AdaptiveWaveDetrender3D::Output& displacementDetrend() const { return displacement_det_out_; }
 
     SeaStateFusionFilter_OU_II<trackerT>& raw() { return impl_; }
 
@@ -1326,4 +1389,7 @@ private:
     int fallback_mean_count_ = 0;
 
     MagAutoTuner mag_auto_;
+    AdaptiveWaveDetrender3D displacement_detrender_{};
+    AdaptiveWaveDetrender3D::Output displacement_det_out_{};
+    Eigen::Vector3f displacement_up_m_ = Eigen::Vector3f::Zero();
 };


### PR DESCRIPTION
### Motivation
- Move detrending out of the sketch into the SeaState fusion wrapper so the filter can manage displacement detrend consistently and make the feature optional at the fusion layer. 
- Rename the concept from `z_detrend` to `displacement` to reflect that this operates on fused UP-frame displacement (x,y,z up) rather than only a Z-specific symbol.

### Description
- Added `#include "detrend/AdaptiveWaveDetrender3D.h"` to `SeaStateFusionFilter_OU_II.h` and introduced optional displacement-detrend config fields in `SeaStateFusion_OU_II::Config`: `enable_displacement_detrend`, `use_custom_displacement_detrend_cfg`, and `displacement_detrend_cfg`.
- Initialized a `AdaptiveWaveDetrender3D displacement_detrender_` and default detrend parameters inside `SeaStateFusion_OU_II::begin()` when enabled, and added storage members `displacement_det_out_` and `displacement_up_m_`.
- In `SeaStateFusion_OU_II::update()` compute fused displacement in UP frame from the internal `mekf()` position and run the detrending step when enabled; when disabled return passthrough outputs (wave_raw/wave_clean == raw displacement).
- Exposed wrapper getters `displacementUpMeters()` and `displacementDetrend()` so callers can read raw and detrended displacement outputs.
- Updated the INS sketch `sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino` to remove its local `AdaptiveWaveDetrender3D` usage, enable wrapper-level detrending via `fcfg.enable_displacement_detrend = true`, and consume the new wrapper getters; renamed `z_*` usages to displacement/heave naming.

### Testing
- Ran `make all` in the repository and the build completed successfully (no errors).
- Ran `make clean` to remove generated test binaries successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6df51c9408328831dc3103746cc4e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration options and methods to access displacement detrending data from the sensor fusion system.

* **Refactor**
  * Consolidated wave and heave detection to use the fusion object's built-in displacement detrending capability, improving consistency and reducing duplicate processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->