### PR TITLE
Robust IMU read and mag polling for atomS3R_ins_kalman_ou2

### DIFF
--- a/sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino
+++ b/sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino
@@ -206,14 +206,18 @@ public:
     }
 #endif
 
-    pollRuntimeMag_();
-
     ImuSample sample{};
-    const bool got_sample = readImuMapped(M5.Imu, sample);
-    stale_frame_count_           = 0;
+    const bool got_sample = readImuSampleRobust_(sample);
 
     if (got_sample) {
+      stale_frame_count_ = 0;
+      pollRuntimeMag_();
       updateFilter_(sample);
+    } else {
+      if (stale_frame_count_ < 0xFFFFu) stale_frame_count_++;
+      if ((stale_frame_count_ % 50u) == 0u) {
+        Serial.printf("[IMU] waiting: stale=%u\n", static_cast<unsigned>(stale_frame_count_));
+      }
     }
 
     updateUI_();
@@ -371,6 +375,28 @@ private:
     last_skipped_total_ = 0;
     have_last_sample_us_ = false;
     last_sample_us_      = 0;
+  }
+
+  bool readImuSampleRobust_(ImuSample& out) {
+    const uint32_t sample_us = micros();
+    const uint32_t update_mask = M5.Imu.update();
+    if (readImuMapped(M5.Imu, update_mask, sample_us, out)) return true;
+
+    // Fallback path: some M5Unified builds do not raise accel/gyro bits reliably.
+    // Keep producing samples if raw vectors are finite.
+    const auto data = M5.Imu.getImuData();
+    out.sample_us = sample_us;
+    out.mask = update_mask;
+    out.tempC = NAN;
+    (void)M5.Imu.getTemp(&out.tempC);
+    out.a = map_acc_to_body_ned_(data.accel);
+    out.w = map_gyr_to_body_ned_(data.gyro);
+    out.m = map_mag_to_body_uT_(data.mag);
+
+    const bool a_ok = finite3_(out.a);
+    const bool w_ok = finite3_(out.w);
+    const bool has_signal = (out.a.norm() > 1e-4f) || (out.w.norm() > 1e-5f);
+    return a_ok && w_ok && has_signal;
   }
 
   void pollRuntimeMag_() {


### PR DESCRIPTION
### Motivation
- Some M5Unified firmware/builds provide valid IMU payloads but do not reliably set accel/gyro update bits, which caused the estimator to drop frames and freeze attitude/heave outputs.
- Magnetometer polling was running every loop regardless of IMU sample availability, leaving mag reads misaligned with fresh IMU data.

### Description
- Added a fallback reader `readImuSampleRobust_(...)` that first calls `readImuMapped(...)` and then falls back to direct mapped raw vectors via `M5.Imu.getImuData()` when update-mask bits are not asserted.
- Moved `pollRuntimeMag_()` to run only after a successful IMU sample so magnetometer reads are aligned with fresh IMU samples.
- Stale-frame handling now increments `stale_frame_count_` when samples are missing and periodically logs a `Serial` message instead of resetting the counter each loop.
- Changes are implemented in `sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino` and preserve existing calibration and mapping paths (`map_acc_to_body_ned_`, `map_gyr_to_body_ned_`, `map_mag_to_body_uT_`).

### Testing
- Ran `make all` and the build completed successfully.
- Ran `make clean` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f8203aac8328971f633611d4e6c5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved sensor data acquisition robustness with automatic fallback handling when primary data sources are unavailable.
  * Added periodic diagnostic alerts to notify users when sensor data becomes stale, including tracking of unavailable samples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->