### PR TITLE
Avoid stack allocation of ImuCalWizard in runner to prevent calibration crashes

### DIFF
--- a/src/AtomS3R/ImuCalWizardRunner.h
+++ b/src/AtomS3R/ImuCalWizardRunner.h
@@ -2,6 +2,8 @@
 
 #include <Wire.h>
 
+#include <memory>
+
 #include "AtomS3R/AtomS3R_ImuCal.h"
 #include "AtomS3R/AtomS3R_ImuCalWizard.h"
 #include "AtomS3R/AtomS3R_M5Ui.h"
@@ -9,8 +11,12 @@
 namespace atoms3r_ical {
 
 inline bool runImuCalWizard(M5Ui& ui, ImuCalStoreNvs& store, ImuCalBlobV2& out_saved) {
-  ImuCalWizard wizard(ui, store);
-  return wizard.runAndSave(out_saved);
+  // Keep the large wizard object off the caller task stack.
+  // This avoids stack pressure in sketches that invoke calibration from loop()
+  // with smaller stack budgets than CompassAppBase.
+  std::unique_ptr<ImuCalWizard> wizard(new ImuCalWizard(ui, store));
+  if (!wizard) return false;
+  return wizard->runAndSave(out_saved);
 }
 
 } // namespace atoms3r_ical


### PR DESCRIPTION
### Motivation
- `runImuCalWizard` previously constructed a large `ImuCalWizard` on the caller task stack which can exhaust small loop/task stacks and cause crashes during magnetometer calibration in `atomS3R_ins_kalman_ou2.ino`.
- Compass sketches keep the wizard as a member and do not hit this failure mode, so moving the wizard off-stack makes the runner robust for sketches launched from `loop()`.

### Description
- Added `#include <memory>` and changed `runImuCalWizard` in `src/AtomS3R/ImuCalWizardRunner.h` to allocate the `ImuCalWizard` on the heap via `std::unique_ptr<ImuCalWizard>` instead of a stack-local object.
- Added a brief comment documenting that the change keeps the large wizard object off the caller task stack to avoid stack pressure, and return `false` if allocation fails.

### Testing
- Ran `make all` from the repository root as the primary validation and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d70e53d1508328820c91b6c235ed56)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling and robustness in IMU calibration wizard initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->