### PR TITLE
Preserve yaw on accel re-lock; add boat quaternion setter and improve mag init/delay handling

### DIFF
--- a/src/kalman_ou_ii/Kalman3D_Wave_OU_II.h
+++ b/src/kalman_ou_ii/Kalman3D_Wave_OU_II.h
@@ -238,6 +238,7 @@ class Kalman3D_Wave_OU_II {
     // Initialization / measurement API
     void initialize_from_acc_mag(Vector3 const& acc, Vector3 const& mag);
     void initialize_from_acc(Vector3 const& acc);
+    void initialize_from_acc_preserve_yaw(Vector3 const& acc);
     static Eigen::Quaternion<T> quaternion_from_acc(Vector3 const& acc);
 
     // Set the world-frame magnetic reference vector used by the mag measurement model.
@@ -285,6 +286,24 @@ class Kalman3D_Wave_OU_II {
 
         // Composition: B→W = (B'→W) ∘ (B→B') = q_WB' * q_B'B
         return q_WBprime * q_BprimeB;
+    }
+
+    void set_quaternion_boat(const Eigen::Quaternion<T>& q_bw) {
+        Eigen::Quaternion<T> q = q_bw;
+        const T nq = q.norm();
+        if (!(nq > T(1e-8))) return;
+        q.normalize();
+
+        const T half = -wind_heel_rad_ * T(0.5);
+        const T c = std::cos(half);
+        const T s = std::sin(half);
+        const Eigen::Quaternion<T> q_BprimeB(c, s, 0, 0);
+        const Eigen::Quaternion<T> q_BBprime = q_BprimeB.conjugate();
+
+        const Eigen::Quaternion<T> q_WBprime = q * q_BBprime;
+        qref = q_WBprime.conjugate();
+        qref.normalize();
+        xext.template segment<3>(0).setZero();
     }
 
     [[nodiscard]] Vector3 gyroscope_bias() const {
@@ -1412,6 +1431,50 @@ void Kalman3D_Wave_OU_II<T, with_gyro_bias, with_accel_bias>::initialize_from_ac
     // Use accelerometer to align z axis, yaw remains arbitrary
     qref = quaternion_from_acc(acc_n);
     qref.normalize();
+}
+
+template<typename T, bool with_gyro_bias, bool with_accel_bias>
+void Kalman3D_Wave_OU_II<T, with_gyro_bias, with_accel_bias>::initialize_from_acc_preserve_yaw(
+    Vector3 const& acc_body)
+{
+    const Eigen::Quaternion<T> q_old_bw = quaternion_boat();
+
+    const T ox = q_old_bw.x();
+    const T oy = q_old_bw.y();
+    const T oz = q_old_bw.z();
+    const T ow = q_old_bw.w();
+    const T siny_cosp = T(2) * (ow * oz + ox * oy);
+    const T cosy_cosp = T(1) - T(2) * (oy * oy + oz * oz);
+    const T yaw_old = std::atan2(siny_cosp, cosy_cosp);
+
+    // Re-lock tilt from accelerometer first.
+    initialize_from_acc(acc_body);
+
+    Eigen::Quaternion<T> q_tilt_bw = quaternion_boat();
+    const T nq_tilt = q_tilt_bw.norm();
+    if (!(nq_tilt > T(1e-8))) return;
+    q_tilt_bw.normalize();
+
+    const T tx = q_tilt_bw.x();
+    const T ty = q_tilt_bw.y();
+    const T tz = q_tilt_bw.z();
+    const T tw = q_tilt_bw.w();
+
+    const T sinp_raw = T(2) * (tw * ty - tz * tx);
+    const T sinp = std::max(T(-1), std::min(T(1), sinp_raw));
+    const T pitch = std::asin(sinp);
+
+    const T sinr_cosp = T(2) * (tw * tx + ty * tz);
+    const T cosr_cosp = T(1) - T(2) * (tx * tx + ty * ty);
+    const T roll = std::atan2(sinr_cosp, cosr_cosp);
+
+    const Eigen::Quaternion<T> q_yaw(Eigen::AngleAxis<T>(yaw_old, Vector3::UnitZ()));
+    const Eigen::Quaternion<T> q_pitch(Eigen::AngleAxis<T>(pitch, Vector3::UnitY()));
+    const Eigen::Quaternion<T> q_roll(Eigen::AngleAxis<T>(roll, Vector3::UnitX()));
+
+    Eigen::Quaternion<T> q_new_bw = q_yaw * q_pitch * q_roll;
+    q_new_bw.normalize();
+    set_quaternion_boat(q_new_bw);
 }
 
 template <typename T, bool with_gyro_bias, bool with_accel_bias>

--- a/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
+++ b/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
@@ -220,12 +220,12 @@ public:
             }
 
             if (tilt_over_limit_sec_ >= TILT_RESET_HOLD_SEC && tilt_reset_cooldown_sec_ <= 0.0f) {
-                // Re-lock attitude to gravity.
-                mekf_->initialize_from_acc(acc);
-
-                // Only force full Cold re-entry while not yet fully live. In Live, keep
-                // linear states running to avoid long "frozen heave" plateaus.
-                if (startup_stage_ != StartupStage::Live) {
+                if (startup_stage_ == StartupStage::Live) {
+                    // In Live, re-lock only tilt while preserving yaw/north frame.
+                    mekf_->initialize_from_acc_preserve_yaw(acc);
+                } else {
+                    // During startup stages, accel-only re-lock is acceptable.
+                    mekf_->initialize_from_acc(acc);
                     enterCold_();
                     resetTrackingState_();
                 }
@@ -1252,10 +1252,6 @@ public:
             }
         }
 
-        // Respect mag delay for actual mag fusion, but keep learning active
-        // from startup so the first post-delay reference is better conditioned.
-        if (t_ < cfg_.mag_delay_sec) return;
-
         if (!mag_ref_set_) {
             if (cfg_.use_fixed_mag_world_ref) {
                 impl_.mekf().set_mag_world_ref(cfg_.mag_world_ref);
@@ -1308,22 +1304,13 @@ public:
                 }
 
                 if (!mag_ref_set_ && have_ref_candidate) {
-                    Eigen::Quaternionf q_bw_mag = Eigen::Quaternionf::Identity();
-                    Eigen::Vector3f mag_world_ref_uT = Eigen::Vector3f::Zero();
-                    if (quatFromAccelMagBodyToWorldNed_(acc_for_ref, mag_body_for_ref,
-                                                        q_bw_mag, &mag_world_ref_uT))
-                    {
-                        // Lock yaw convention explicitly from accel+mag together.
-                        // This aligns attitude and learned world magnetic reference
-                        // to a single body->world NED compass frame at initialization.
-                        impl_.mekf().initialize_from_acc_mag(acc_for_ref, mag_body_for_ref);
-                        impl_.mekf().set_mag_world_ref(mag_world_ref_uT);
-                        mag_ref_set_ = true;
-                    }
+                    northLockFromAccelMag_(acc_for_ref, mag_body_for_ref);
                 }
             }
         }
-        if (mag_ref_set_) {
+
+        // Delay only ongoing mag EKF correction, not initial north-lock.
+        if (mag_ref_set_ && t_ >= cfg_.mag_delay_sec) {
           impl_.updateMag(mag_body_ned);
         }
     }
@@ -1341,45 +1328,20 @@ public:
 private:
     enum class Stage { Uninitialized, Warming, Live };
 
-    static bool quatFromAccelMagBodyToWorldNed_(const Eigen::Vector3f& acc_body_ned,
-                                                const Eigen::Vector3f& mag_body_ned,
-                                                Eigen::Quaternionf& q_bw_out,
-                                                Eigen::Vector3f* mag_world_out_uT = nullptr) {
-        if (!acc_body_ned.allFinite() || !mag_body_ned.allFinite()) return false;
+    void northLockFromAccelMag_(const Eigen::Vector3f& acc_body,
+                                const Eigen::Vector3f& mag_body) {
+        impl_.mekf().initialize_from_acc_mag(acc_body, mag_body);
 
-        const float an = acc_body_ned.norm();
-        const float mn = mag_body_ned.norm();
-        if (!(an > 1e-6f) || !(mn > 1e-6f)) return false;
+        Eigen::Quaternionf q0 = impl_.mekf().quaternion_boat();
+        const float nq = q0.norm();
+        if (!(nq > 1e-6f) || !std::isfinite(nq)) return;
+        q0.normalize();
 
-        // In this stack, at-rest specific force is ~ -g along body down.
-        Eigen::Vector3f down_b = (-acc_body_ned / an);
+        const Eigen::Vector3f mag_world_ref_uT = q0 * mag_body;
+        if (!mag_world_ref_uT.allFinite() || !(mag_world_ref_uT.norm() > 1e-3f)) return;
 
-        // Build local N/E/D basis in body coordinates.
-        Eigen::Vector3f east_b = down_b.cross(mag_body_ned);
-        const float en = east_b.norm();
-        if (!(en > 1e-6f) || !east_b.allFinite()) return false;
-        east_b /= en;
-
-        Eigen::Vector3f north_b = east_b.cross(down_b);
-        const float nn = north_b.norm();
-        if (!(nn > 1e-6f) || !north_b.allFinite()) return false;
-        north_b /= nn;
-        down_b.normalize();
-
-        Eigen::Matrix3f R_wb;
-        R_wb.col(0) = north_b; // world north in body coords
-        R_wb.col(1) = east_b;  // world east  in body coords
-        R_wb.col(2) = down_b;  // world down  in body coords
-
-        const Eigen::Matrix3f R_bw = R_wb.transpose();
-        Eigen::Quaternionf q_bw(R_bw);
-        q_bw.normalize();
-        q_bw_out = q_bw;
-
-        if (mag_world_out_uT) {
-            *mag_world_out_uT = q_bw * mag_body_ned;
-        }
-        return true;
+        impl_.mekf().set_mag_world_ref(mag_world_ref_uT);
+        mag_ref_set_ = true;
     }
 
 private:


### PR DESCRIPTION
### Motivation

- Prevent large heading jumps when re-locking attitude from accelerometer during Live operation by preserving yaw.
- Provide an API to set the boat-frame quaternion while accounting for heel offset and to re-lock tilt without disturbing heading.
- Make magnetic reference initialization more robust and ensure the magnetic EKF delay only defers ongoing corrections and not the initial north-lock.

### Description

- Added `initialize_from_acc_preserve_yaw` to realign tilt from accelerometer while preserving the current yaw frame using `set_quaternion_boat` internally.  
- Added `set_quaternion_boat` to set a boat-frame quaternion while removing the configured heel and updating internal attitude state.  
- Changed tilt-reset behavior in `SeaStateFusionFilter_OU_II` so that when `startup_stage_ == StartupStage::Live` the filter calls `initialize_from_acc_preserve_yaw(acc)` instead of a full cold re-entry, and retains the previous cold-entry path for non-live startup stages.  
- Reworked magnetic initialization: replaced the old `quatFromAccelMagBodyToWorldNed_` helper with `northLockFromAccelMag_` which performs an accel+mag north-lock via `initialize_from_acc_mag` and then derives and sets a robust `mag_world_ref` from the resulting boat quaternion; made mag EKF corrections subject to `cfg_.mag_delay_sec` but not the initial north-lock.  

### Testing

- Project build was executed and completed successfully (`cmake`/build).  
- Existing automated unit and integration tests covering attitude/magnetometer initialization and filter behaviour were run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7d9993b888328899c776d143b565b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Heading is now preserved during accelerometer-based attitude recalibration, improving yaw stability
  * Magnetometer initialization timing optimized for earlier north-lock convergence and better heading accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->