### PR TITLE
Fix magnetometer ambiguity and add mag NIS gate

### DIFF
--- a/sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino
+++ b/sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino
@@ -622,9 +622,8 @@ private:
     if (rollPitchHeadingFromQuatBw_(q_bw, roll_est_deg, pitch_est_deg, heading_est_deg)) {
       roll_deg_ = roll_est_deg;
       pitch_deg_ = pitch_est_deg;
-      heading_deg_ = heading_est_deg;
     } else {
-      heading_deg_ = headingFromQuatBodyToWorldNed_(q_bw);
+      heading_est_deg = headingFromQuatBodyToWorldNed_(q_bw);
     }
 
     heading_mag_ok_ = false;
@@ -636,6 +635,9 @@ private:
         heading_mag_deg_ = hdg_mag;
       }
     }
+
+    // For compass UX prefer direct tilt-compensated magnetic heading when valid.
+    heading_deg_ = heading_mag_ok_ ? heading_mag_deg_ : heading_est_deg;
 
     if (still) {
       const float alpha_b = 1.0f - expf(-dt_ / ROT_BIAS_TAU_S);

--- a/src/kalman_ou_ii/Kalman3D_Wave_OU_II.h
+++ b/src/kalman_ou_ii/Kalman3D_Wave_OU_II.h
@@ -2035,12 +2035,7 @@ void Kalman3D_Wave_OU_II<T, with_gyro_bias, with_accel_bias>::measurement_update
     if (!(mag_norm > T(1e-6))) return;
 
     // Predicted no-bias field for Jacobian
-    Vector3 v2hat = R_wb() * v2ref;
-
-    // Optional dot-product sign fix (helps if ref polarity is off or "horizontal only" is used)
-    if (v2hat.dot(mag_meas) < T(0)) {
-        v2hat = -v2hat;
-    }
+    const Vector3 v2hat = R_wb() * v2ref;
 
     const Vector3 zhat = v2hat;
     const Vector3 r = mag_meas - zhat;
@@ -2079,7 +2074,13 @@ void Kalman3D_Wave_OU_II<T, with_gyro_bias, with_accel_bias>::measurement_update
         return;
     }
     last_mag_diag_.S = S_mat;
-    last_mag_diag_.nis = nis3_from_ldlt_(ldlt, r);
+    const T nis = nis3_from_ldlt_(ldlt, r);
+    last_mag_diag_.nis = nis;
+    // 3D NIS gate (~99.7% chi-square region for 3 DoF).
+    if (!std::isfinite(nis) || nis > T(14.2)) {
+        last_mag_diag_.accepted = false;
+        return;
+    }
     MatrixNX3& K = K_scratch_;
     K.noalias() = PCt * ldlt.solve(Matrix3::Identity());
 

--- a/src/kalman_ou_iii/Kalman3D_Wave_OU_III.h
+++ b/src/kalman_ou_iii/Kalman3D_Wave_OU_III.h
@@ -1903,12 +1903,7 @@ void Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::measurement_updat
     if (!(mag_norm > T(1e-6))) return;
 
     // Predicted no-bias field for Jacobian
-    Vector3 v2hat = R_wb() * v2ref;
-
-    // Optional dot-product sign fix (helps if ref polarity is off or "horizontal only" is used)
-    if (v2hat.dot(mag_meas) < T(0)) {
-        v2hat = -v2hat;
-    }
+    const Vector3 v2hat = R_wb() * v2ref;
 
     const Vector3 zhat = v2hat;
     const Vector3 r = mag_meas - zhat;
@@ -1947,7 +1942,13 @@ void Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::measurement_updat
         return;
     }
     last_mag_diag_.S = S_mat;
-    last_mag_diag_.nis = nis3_from_ldlt_(ldlt, r);
+    const T nis = nis3_from_ldlt_(ldlt, r);
+    last_mag_diag_.nis = nis;
+    // 3D NIS gate (~99.7% chi-square region for 3 DoF).
+    if (!std::isfinite(nis) || nis > T(14.2)) {
+        last_mag_diag_.accepted = false;
+        return;
+    }
     MatrixNX3& K = K_scratch_;
     K.noalias() = PCt * ldlt.solve(Matrix3::Identity());
 


### PR DESCRIPTION
### Motivation
- Remove a harmful two-valued magnetometer measurement model that allowed `B` / `-B` ambiguity during mag updates and caused 180° heading flips and wandering. 
- Reduce yaw perturbations from transient bad mag samples by rejecting outlier magnetometer updates before applying state correction.

### Description
- Removed the sign-flip hack in `measurement_update_mag_only()` so the predicted magnetometer is the single-valued `R_wb() * v2ref` (made `v2hat` const) in `src/kalman_ou_ii/Kalman3D_Wave_OU_II.h` and mirrored the same fix in `src/kalman_ou_iii/Kalman3D_Wave_OU_III.h`.
- Added a 3D NIS rejection gate using `nis3_from_ldlt_(...)` and a threshold of `14.2` (≈99.7% chi-square region for 3 DoF) to early-reject mag updates when the innovation is an outlier in both OU_II and OU_III implementations.
- Kept and record `last_mag_diag_.S` and `last_mag_diag_.nis` diagnostics and mark `last_mag_diag_.accepted` accordingly when a mag update is rejected.
- Adjusted app-layer heading selection in `sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino` so the UI prefers the direct tilt-compensated magnetic heading (`magneticHeadingFromDownAndMagBody_`) when valid and otherwise falls back to the filter yaw.

### Testing
- Ran the repository validation `make all` which built the test binaries and examples successfully, with no compile errors.
- Confirmed the modified files compiled as part of `make all` and the `make` output showed successful linking of the test executables.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7e321f39c8328a2386cb7eeb1f097)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved heading computation by prioritizing magnetic heading estimates when valid, with fallback to alternative estimates when unavailable.
  * Enhanced sensor measurement validation by implementing stricter criteria to reject unreliable magnetometer data during fusion updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->