### PR TITLE
Use fused EKF heading for compass output

### DIFF
--- a/sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino
+++ b/sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino
@@ -636,8 +636,9 @@ private:
       }
     }
 
-    // For compass UX prefer direct tilt-compensated magnetic heading when valid.
-    heading_deg_ = heading_mag_ok_ ? heading_mag_deg_ : heading_est_deg;
+    // Use fused filter yaw as primary heading output.
+    // Keep tilt-compensated magnetic heading for diagnostics only.
+    heading_deg_ = heading_est_deg;
 
     if (still) {
       const float alpha_b = 1.0f - expf(-dt_ / ROT_BIAS_TAU_S);


### PR DESCRIPTION
### Motivation
- The filter now produces a fused yaw estimate but the UI still preferred the raw tilt‑compensated magnetic heading when available, which meant the displayed compass did not reflect the EKF fused heading.

### Description
- Change `heading_deg_` assignment in `sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino` to use the filter estimate (`heading_est_deg`) as the primary compass output instead of `heading_mag_deg_`.
- Leave the computed `heading_mag_deg_` and its validity (`heading_mag_ok_`) intact for diagnostics and remove the stale comment that preferred raw mag for the compass UX.

### Testing
- Ran `make all` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7e8b76c648328a62ca6c8cc78ba27)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Heading output now consistently uses the fused filter-derived calculation instead of switching between magnetic and filter-based methods based on validity status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->