### PR TITLE
Align kalman_ou_iii simulator attitude extraction with common filter chain

### DIFF
--- a/tests/kalman_ou_iii/kalman_ou_iii-sim.cpp
+++ b/tests/kalman_ou_iii/kalman_ou_iii-sim.cpp
@@ -16,6 +16,7 @@
 #include "util/W3dSimCommon.h"
 #include "kalman_ou_iii/SeaStateFusionFilter_OU_III.h"
 
+using Eigen::Quaternionf;
 using Eigen::Vector3f;
 
 bool add_noise = true;
@@ -71,7 +72,15 @@ public:
         s.disp_est_zu = ned_to_zu(filter.mekf().get_position());
         s.vel_est_zu = ned_to_zu(filter.mekf().get_velocity());
         s.acc_est_zu = ned_to_zu(filter.mekf().get_world_accel());
-        s.euler_nautical_deg = filter.getEulerNautical();
+        const Quaternionf q_bw_ned = filter.mekf().quaternion_boat().normalized();
+
+        float roll_deg  = 0.0f;
+        float pitch_deg = 0.0f;
+        float yaw_deg   = 0.0f;
+
+        quat_to_euler_nautical(q_bw_ned, roll_deg, pitch_deg, yaw_deg);
+        yaw_deg = wrapDeg(yaw_deg + MagSim_WMM::default_declination_deg);
+        s.euler_nautical_deg = Vector3f(roll_deg, pitch_deg, yaw_deg);
         s.acc_bias_est_ned = filter.mekf().get_acc_bias();
         s.gyro_bias_est_ned = filter.mekf().gyroscope_bias();
         s.mag_bias_est_ned_uT = get_mag_bias_est_uT(filter.mekf());


### PR DESCRIPTION
### Motivation
- Remove an inconsistency in how the OU-III test reports attitude compared to other simulators by using the same quaternion→nautical Euler conversion path. 
- Ensure reported yaw is referenced to true-north consistently with the rest of the IMU/gyro/mag simulation chain. 
- Keep changes minimal and targeted to the test adapter so public APIs and filter implementations are unchanged. 

### Description
- Updated `tests/kalman_ou_iii/kalman_ou_iii-sim.cpp` to compute Euler nautical angles from the MEKF quaternion via `quat_to_euler_nautical` instead of calling the previous reporting path. 
- Applied magnetic declination correction using `MagSim_WMM::default_declination_deg` before reporting yaw so OU-III yaw output matches the mag-referenced convention used elsewhere. 
- Added explicit `Eigen::Quaternionf` usage in the test adapter for clearer type consistency. 

### Testing
- Ran `make all` which completed successfully. 
- Executed the OU-III simulator with the downloaded wave data using `cd tests/kalman_ou_iii && ./kalman_ou_iii-sim`, which ran and produced CSV outputs but the run still triggers the RMS quality gate error: `ERROR: 3D RMS above limit (171.754% > 55%). Failing.` 
- Verified that the change improves yaw reporting consistency versus the previous path but did not by itself bring the dataset under the existing displacement RMS thresholds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8e137d648328a0184eb143839c93)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined Kalman filter test computations for improved accuracy of orientation angle measurements in filter simulation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->