### PR TITLE
Align PII observer firmware tuning with simulator profile

### DIFF
--- a/sensors/full_marine_ins/atomS3R_ins_pii_ovserver/atomS3R_ins_pii_ovserver.ino
+++ b/sensors/full_marine_ins/atomS3R_ins_pii_ovserver/atomS3R_ins_pii_ovserver.ino
@@ -294,7 +294,56 @@ class FusionApp {
     Fusion::Config cfg{};
     cfg.gravity_mps2 = g_std;
     cfg.use_mag = true;
-    cfg.adapt_mahony_gains = true;
+
+    // Keep runtime behavior aligned with the simulator adapter defaults used in
+    // tests/pii_observer/pii_observer-adaptive.cpp, otherwise Z/heave shape can
+    // diverge noticeably from the expected wave profile.
+    cfg.core.observer.r          = 0.150f;
+    cfg.core.observer.tau_a      = 0.68f;
+    cfg.core.observer.tau_d      = 49.0f;
+    cfg.core.observer.kb         = 2.5e-5f;
+    cfg.core.observer.lambda_b   = 3.0e-3f;
+    cfg.core.observer.bias_limit = 0.12f;
+    cfg.core.observer.a_f_limit  = 50.0f;
+    cfg.core.observer.v_limit    = 50.0f;
+    cfg.core.observer.p_limit    = 20.0f;
+    cfg.core.observer.S_limit    = 200.0f;
+    cfg.core.observer.d_limit    = 20.0f;
+
+    cfg.core.adaptation.enabled          = true;
+    cfg.core.adaptation.min_confidence   = 0.22f;
+    cfg.core.adaptation.f_disp_ref_hz    = 0.12f;
+    cfg.core.adaptation.sigma_a_ref      = 0.95f;
+    cfg.core.adaptation.input_smooth_tau = 4.5f;
+    cfg.core.adaptation.param_smooth_tau = 7.5f;
+    cfg.core.adaptation.r_freq_exp       = 0.28f;
+    cfg.core.adaptation.r_sigma_exp      = 0.02f;
+    cfg.core.adaptation.tau_a_freq_exp   = -0.40f;
+    cfg.core.adaptation.tau_a_sigma_exp  = -0.03f;
+    cfg.core.adaptation.tau_d_freq_exp   = -0.03f;
+    cfg.core.adaptation.tau_d_sigma_exp  = -0.01f;
+    cfg.core.adaptation.kb_freq_exp      = 0.02f;
+    cfg.core.adaptation.kb_sigma_exp     = 0.08f;
+    cfg.core.adaptation.r_min            = 0.145f;
+    cfg.core.adaptation.r_max            = 0.225f;
+    cfg.core.adaptation.tau_a_min        = 0.50f;
+    cfg.core.adaptation.tau_a_max        = 0.90f;
+    cfg.core.adaptation.tau_d_min        = 44.0f;
+    cfg.core.adaptation.tau_d_max        = 58.0f;
+    cfg.core.adaptation.kb_min           = 5e-6f;
+    cfg.core.adaptation.kb_max           = 6e-5f;
+
+    cfg.core.auto_schedule_from_accel_freq = true;
+    cfg.core.auto_schedule_period_s = 0.50f;
+    cfg.core.force_enable_adaptation_when_auto_schedule = true;
+    cfg.core.fallback_confidence_floor = 0.52f;
+    cfg.core.fallback_confidence_when_locked = 0.82f;
+    cfg.core.coarse_schedule_blend = 0.48f;
+    cfg.core.coarse_schedule_confidence_floor = 0.62f;
+
+    cfg.mahony_twoKp = 1.40f;
+    cfg.mahony_twoKi = 0.060f;
+    cfg.adapt_mahony_gains = false;
 
     fusion_.configure(cfg);
     fusion_.reset();


### PR DESCRIPTION
### Motivation
- Onboard PII observer heave (Z) waveform did not match the simulator reference because runtime used generic/default tuning rather than the simulator-tested parameters.
- The change aims to keep firmware runtime behavior aligned with the simulator adapter used in tests so estimated heave follows the expected wave shape without changing public APIs.

### Description
- Updated `resetFusion_()` in `sensors/full_marine_ins/atomS3R_ins_pii_ovserver/atomS3R_ins_pii_ovserver.ino` to populate `cfg.core.observer` tuning values and the `cfg.core.adaptation` schedule parameters to match the simulator adapter defaults.
- Set Mahony gains (`cfg.mahony_twoKp`, `cfg.mahony_twoKi`) and disabled `cfg.adapt_mahony_gains` to match the simulator configuration.
- Added an inline comment documenting the intent to align firmware tuning with `tests/pii_observer/pii_observer-adaptive.cpp` defaults and kept the change limited to initialization/config only.

### Testing
- Ran `make all` from the repository root, which completed successfully and built the test binaries including the `pii_observer` test.
- No build failures were observed after the change and the firmware source compiles as before.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd23955f848328a70a16faad1a9ee3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined inertial navigation system sensor fusion configuration with updated gain parameters and expanded controls for observer behavior, adaptation scheduling, and fallback handling to enhance system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->