### PR TITLE
Implement staged Bayesian startup (tilt → mag-collect → heading commit → mag-grace) for OU‑III fusion

### DIFF
--- a/src/kalman_ou_iii/Kalman3D_Wave_OU_III.h
+++ b/src/kalman_ou_iii/Kalman3D_Wave_OU_III.h
@@ -263,6 +263,7 @@ class Kalman3D_Wave_OU_III {
     // Measurement updates preserved (operate on extended state internally)
     void measurement_update_acc_only(Vector3 const& acc, T tempC = tempC_ref);
     void measurement_update_mag_only(Vector3 const& mag);
+    void measurement_update_heading_only(T yaw_meas_rad, T yaw_std_rad);
 
     // Extended-only API:
     // Apply zero pseudo-measurement on S (integral drift correction)
@@ -505,6 +506,10 @@ class Kalman3D_Wave_OU_III {
     void set_Rmag(const Vector3& sigma_mag) {
         Rmag = sigma_mag.array().square().matrix().asDiagonal();
     }
+    void set_acc_tilt_only_mode(bool en) { accel_tilt_only_mode_ = en; }
+    void set_mag_yaw_only_mode(bool en)  { mag_yaw_only_mode_ = en; }
+    bool acc_tilt_only_mode() const { return accel_tilt_only_mode_; }
+    bool mag_yaw_only_mode() const { return mag_yaw_only_mode_; }
 
     void set_initial_linear_uncertainty(T sigma_v0, T sigma_p0, T sigma_S0) {
         Pext.template block<3,3>(OFF_V, OFF_V) = Matrix3::Identity() * (sigma_v0 * sigma_v0);   // v (3)
@@ -699,6 +704,8 @@ class Kalman3D_Wave_OU_III {
 
     MeasDiag3 last_acc_diag_;
     MeasDiag3 last_mag_diag_;
+    bool accel_tilt_only_mode_ = false;
+    bool mag_yaw_only_mode_ = false;
 
     EIGEN_STRONG_INLINE void symmetrize_Pext_() {
         for (int i = 0; i < NX; ++i) {
@@ -1894,7 +1901,7 @@ void Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::measurement_updat
     }
 
     const Vector3 f_meas = acc_meas;
-    const Vector3 r = f_meas - f_pred;
+    Vector3 r = f_meas - f_pred;
 
     last_acc_diag_.r = r;
 
@@ -1914,9 +1921,28 @@ void Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::measurement_updat
         J_aw.setZero(); // no aw Jacobian when linear is OFF
     }
 
+    const Vector3 ghat_b = (R_wb() * g_world).normalized();
+    Matrix3 proj_tilt = Matrix3::Identity();
+    if (accel_tilt_only_mode_ && ghat_b.allFinite()) {
+        proj_tilt.noalias() -= ghat_b * ghat_b.transpose();
+        r = proj_tilt * r;
+        J_att = proj_tilt * J_att;
+        J_aw  = proj_tilt * J_aw;
+        J_bg  = proj_tilt * J_bg;
+    }
+
+    Matrix3 J_ba = Matrix3::Identity();
+    if (accel_tilt_only_mode_ && ghat_b.allFinite()) {
+        J_ba = proj_tilt;
+    }
+
     // Innovation covariance S = C P Cᵀ + Racc (3×3)
     Matrix3& S_mat = S_scratch_;
     S_mat = Racc;
+    if (accel_tilt_only_mode_ && ghat_b.allFinite()) {
+        const T par_var = std::max<T>(Racc.diagonal().maxCoeff() * T(150.0), T(25.0));
+        S_mat = proj_tilt * Racc * proj_tilt.transpose() + par_var * (ghat_b * ghat_b.transpose());
+    }
     {
         constexpr int OFF_TH = 0;
         const int off_aw = OFF_AW;
@@ -1944,31 +1970,29 @@ void Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::measurement_updat
 		    if (use_ba) {
 		        const Matrix3 P_th_ba = Pext.template block<3,3>(OFF_TH, off_ba);
 
-		        // J_ba = I
-		        S_mat.noalias() += J_att * P_th_ba;
-		        S_mat.noalias() += P_th_ba.transpose() * J_att.transpose();
-		        S_mat.noalias() += P_ba_ba;
+		        S_mat.noalias() += J_att * P_th_ba * J_ba.transpose();
+		        S_mat.noalias() += J_ba * P_th_ba.transpose() * J_att.transpose();
+		        S_mat.noalias() += J_ba * P_ba_ba * J_ba.transpose();
 
 		        if (linear_block_enabled_) {
 		            const Matrix3 P_aw_ba = Pext.template block<3,3>(off_aw, off_ba);
-		            S_mat.noalias() += J_aw * P_aw_ba;
-		            S_mat.noalias() += P_aw_ba.transpose() * J_aw.transpose();
+		            S_mat.noalias() += J_aw * P_aw_ba * J_ba.transpose();
+		            S_mat.noalias() += J_ba * P_aw_ba.transpose() * J_aw.transpose();
 		        }
 		    } else {
 		        // BA frozen: marginalize its uncertainty (and any existing cross-cov) into S.
 		        // (If code already zeroed P_th_ba/P_aw_ba when disabling BA updates, these are 0 anyway.)
 		        const Matrix3 P_th_ba = Pext.template block<3,3>(OFF_TH, off_ba);
 
-		        // J_ba = I
-		        S_mat.noalias() += J_att * P_th_ba;
-		        S_mat.noalias() += P_th_ba.transpose() * J_att.transpose();
+		        S_mat.noalias() += J_att * P_th_ba * J_ba.transpose();
+		        S_mat.noalias() += J_ba * P_th_ba.transpose() * J_att.transpose();
 
 		        if (linear_block_enabled_) {
 		            const Matrix3 P_aw_ba = Pext.template block<3,3>(off_aw, off_ba);
-		            S_mat.noalias() += J_aw * P_aw_ba;
-		            S_mat.noalias() += P_aw_ba.transpose() * J_aw.transpose();
+		            S_mat.noalias() += J_aw * P_aw_ba * J_ba.transpose();
+		            S_mat.noalias() += J_ba * P_aw_ba.transpose() * J_aw.transpose();
 		        }
-		        S_mat.noalias() += P_ba_ba;
+		        S_mat.noalias() += J_ba * P_ba_ba * J_ba.transpose();
 		    }
 		}
         if constexpr (with_gyro_bias) {
@@ -1990,8 +2014,8 @@ void Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::measurement_updat
                 if constexpr (with_accel_bias) {
                     if (use_ba) {
                         const Matrix3 P_bg_ba = Pext.template block<3,3>(OFF_BG, OFF_BA);
-                        S_mat.noalias() += J_bg * P_bg_ba; // J_ba = I
-                        S_mat.noalias() += P_bg_ba.transpose() * J_bg.transpose();
+                        S_mat.noalias() += J_bg * P_bg_ba * J_ba.transpose();
+                        S_mat.noalias() += J_ba * P_bg_ba.transpose() * J_bg.transpose();
                     }
                 }
             }
@@ -2012,7 +2036,7 @@ void Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::measurement_updat
         if constexpr (with_accel_bias) {
             if (use_ba) {
                 const auto P_all_ba = Pext.template block<NX,3>(0, OFF_BA);
-                PCt.noalias() += P_all_ba; // J_ba = I
+                PCt.noalias() += P_all_ba * J_ba.transpose();
             }
         }
         if constexpr (with_gyro_bias) {
@@ -2082,15 +2106,32 @@ void Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::measurement_updat
     const Vector3 v2hat = R_wb() * v2ref;
 
     const Vector3 zhat = v2hat;
-    const Vector3 r = mag_meas - zhat;
+    Vector3 r = mag_meas - zhat;
     last_mag_diag_.r = r;
 
     // Jacobian uses the no-bias predicted vector
-    const Matrix3 J_att = -skew_symmetric_matrix(v2hat);
+    Matrix3 J_att = -skew_symmetric_matrix(v2hat);
+
+    if (mag_yaw_only_mode_) {
+        const Vector3 ghat_b = (R_wb() * Vector3(0,0,+gravity_magnitude_)).normalized();
+        if (ghat_b.allFinite()) {
+            Matrix3 Ptilt = Matrix3::Identity() - ghat_b * ghat_b.transpose();
+            r = Ptilt * r;
+            J_att = Ptilt * J_att;
+        }
+    }
 
     // Innovation covariance S = C P Cᵀ + R
     Matrix3& S_mat = S_scratch_;
     S_mat = Rmag;
+    if (mag_yaw_only_mode_) {
+        const Vector3 ghat_b = (R_wb() * Vector3(0,0,+gravity_magnitude_)).normalized();
+        if (ghat_b.allFinite()) {
+            const Matrix3 Ptilt = Matrix3::Identity() - ghat_b * ghat_b.transpose();
+            const T par_var = std::max<T>(Rmag.diagonal().maxCoeff() * T(150.0), T(10.0));
+            S_mat = Ptilt * Rmag * Ptilt.transpose() + par_var * (ghat_b * ghat_b.transpose());
+        }
+    }
 
     const Matrix3 P_th_th = Pext.template block<3,3>(0,0);
     S_mat.noalias() += J_att * P_th_th * J_att.transpose();
@@ -2177,6 +2218,75 @@ Matrix<T, 3, 3> Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::skew_s
          vec(2), 0, -vec(0),
         -vec(1), vec(0), 0;
     return M;
+}
+
+template<typename T>
+static inline T wrap_pi_(T a) {
+    while (a > T(M_PI)) a -= T(2.0 * M_PI);
+    while (a < T(-M_PI)) a += T(2.0 * M_PI);
+    return a;
+}
+
+template<typename T, bool with_gyro_bias, bool with_accel_bias>
+void Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::measurement_update_heading_only(
+    T yaw_meas_rad, T yaw_std_rad)
+{
+    if (!(yaw_std_rad > T(0)) || !std::isfinite(yaw_meas_rad)) return;
+
+    const auto yaw_from_qbw = [](const Eigen::Quaternion<T>& qbw) -> T {
+        const T x = qbw.x(), y = qbw.y(), z = qbw.z(), w = qbw.w();
+        const T s_yaw = T(2) * (w * z + x * y);
+        const T c_yaw = T(1) - T(2) * (y * y + z * z);
+        return std::atan2(s_yaw, c_yaw);
+    };
+
+    Eigen::Quaternion<T> q_bw = quaternion_boat();
+    q_bw.normalize();
+    const T yaw_hat = yaw_from_qbw(q_bw);
+    const T r = wrap_pi_(yaw_meas_rad - yaw_hat);
+
+    Eigen::Matrix<T,1,NX> H;
+    H.setZero();
+
+    constexpr T eps = T(1e-4);
+    for (int i = 0; i < 3; ++i) {
+        Vector3 d = Vector3::Zero();
+        d(i) = eps;
+        Eigen::Quaternion<T> qref_p = quat_from_delta_theta(d) * qref;
+        qref_p.normalize();
+        Eigen::Quaternion<T> qwb_p = qref_p.conjugate();
+
+        const T half = -wind_heel_rad_ * T(0.5);
+        const T c = std::cos(half);
+        const T s = std::sin(half);
+        const Eigen::Quaternion<T> q_BprimeB(c, s, 0, 0);
+        const Eigen::Quaternion<T> qbw_p = qwb_p * q_BprimeB;
+
+        const T dyaw = wrap_pi_(yaw_from_qbw(qbw_p) - yaw_hat);
+        H(i) = dyaw / eps;
+    }
+
+    Eigen::Matrix<T,NX,1> PHt = Pext * H.transpose();
+    if (!linear_block_enabled_) {
+        PHt.template segment<12>(OFF_V).setZero();
+    }
+    if constexpr (with_accel_bias) {
+        if (!acc_bias_updates_enabled_) {
+            PHt.template segment<3>(OFF_BA).setZero();
+        }
+    }
+
+    T S = (H * PHt)(0,0) + yaw_std_rad * yaw_std_rad;
+    if (!(S > T(1e-12)) || !std::isfinite(S)) return;
+
+    Eigen::Matrix<T,NX,1> K = PHt / S;
+    xext.noalias() += K * r;
+
+    MatrixNX I = MatrixNX::Identity();
+    MatrixNX A = I - K * H;
+    Pext = A * Pext * A.transpose() + (yaw_std_rad * yaw_std_rad) * (K * K.transpose());
+    symmetrize_Pext_();
+    applyQuaternionCorrectionFromErrorState();
 }
 
 template<typename T, bool with_gyro_bias, bool with_accel_bias>

--- a/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
+++ b/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
@@ -1277,6 +1277,8 @@ public:
         impl_.setOnlineTuneWarmupSec(cfg.online_tune_warmup_sec);
 
         impl_.initialize(cfg.sigma_a, cfg.sigma_g, cfg.sigma_m);
+        impl_.mekf().set_acc_tilt_only_mode(true);
+        impl_.mekf().set_mag_yaw_only_mode(true);
         last_impl_startup_stage_ = impl_.getStartupStage();
 
         // IMPORTANT: allow warmup to restore nominal accel measurement noise
@@ -1299,6 +1301,7 @@ public:
             impl_.initialize_from_acc(acc_body_ned);
             stage_ = Stage::Warming;
             stage_t_ = 0.0f;
+            mag_stage_ = MagStage::TiltWarm;
         } else {
             stage_t_ += dt;
         }
@@ -1315,11 +1318,15 @@ public:
         // If internal filter fell back to Cold (tilt reset), force mag ref re-learn
 const auto cur_stage = impl_.getStartupStage();
 
-if (cur_stage != last_impl_startup_stage_) {
+    if (cur_stage != last_impl_startup_stage_) {
     if (cur_stage == SeaStateFusionFilter_OU_III<trackerT>::StartupStage::Cold) {
         // Entered Cold (startup or non-Live tilt reset): reset mag-init ONCE
         mag_ref_set_ = false;
         mag_auto_.reset();
+        mag_stage_ = MagStage::TiltWarm;
+        mag_grace_updates_ = 0;
+        impl_.mekf().set_acc_tilt_only_mode(true);
+        impl_.mekf().set_mag_yaw_only_mode(true);
 
         last_mag_time_sec_ = NAN;
         dt_mag_sec_ = NAN;
@@ -1336,6 +1343,9 @@ if (cur_stage != last_impl_startup_stage_) {
 
         if (stage_ == Stage::Warming && impl_.isAdaptiveLive()) {
             stage_ = Stage::Live;
+            if (mag_stage_ == MagStage::TiltWarm) {
+                mag_stage_ = MagStage::MagCollect;
+            }
         }
     }
 
@@ -1381,6 +1391,10 @@ if (cur_stage != last_impl_startup_stage_) {
         // Respect mag delay for actual mag fusion, but keep learning active
         // from startup so the first post-delay reference is better conditioned.
         if (t_ < cfg_.mag_delay_sec) return;
+
+        if (mag_stage_ == MagStage::TiltWarm && impl_.isAdaptiveLive()) {
+            mag_stage_ = MagStage::MagCollect;
+        }
 
         if (!mag_ref_set_) {
             if (cfg_.use_fixed_mag_world_ref) {
@@ -1445,8 +1459,33 @@ if (cur_stage != last_impl_startup_stage_) {
                 }
             }
         }
-        if (mag_ref_set_) {
+        if (mag_ref_set_ && mag_stage_ == MagStage::MagCollect && have_last_imu_) {
+            const Eigen::Quaternionf q_tilt = tiltOnlyQuatFromAccel_(last_acc_body_ned_);
+            float dtm = dt_mag_sec_;
+            if (!std::isfinite(dtm) || dtm <= 0.0f) {
+                dtm = 1.0f / std::max(1.0f, cfg_.mag_odr_guess_hz);
+            }
+            (void)mag_auto_.addHeadingSample(dtm, q_tilt, mag_body_ned, last_acc_body_ned_, last_gyro_body_ned_);
+
+            float psi_mean = 0.0f, psi_var = 0.0f, n_eff = 1.0f;
+            if (mag_auto_.getHeadingStats(psi_mean, psi_var, n_eff)) {
+                const float yaw_std = std::sqrt(std::max(1e-4f, 0.02f * 0.02f + psi_var / std::max(1.0f, n_eff)));
+                impl_.mekf().measurement_update_heading_only(psi_mean, yaw_std);
+                impl_.mekf().set_acc_tilt_only_mode(false);
+                mag_stage_ = MagStage::MagGrace;
+                mag_grace_updates_ = 0;
+            }
+        }
+
+        if (mag_ref_set_ && mag_stage_ != MagStage::MagCollect) {
           impl_.updateMag(mag_body_ned);
+          if (mag_stage_ == MagStage::MagGrace) {
+              mag_grace_updates_++;
+              if (mag_grace_updates_ >= 100) {
+                  impl_.mekf().set_mag_yaw_only_mode(false);
+                  mag_stage_ = MagStage::Live;
+              }
+          }
         }
     }
 
@@ -1460,6 +1499,7 @@ if (cur_stage != last_impl_startup_stage_) {
 
 private:
     enum class Stage { Uninitialized, Warming, Live };
+    enum class MagStage { TiltWarm, MagCollect, MagGrace, Live };
 
     // Tilt-only (yaw-free) quaternion body->world from accel.
     // We assume “rest accel” direction represents gravity (up to sign convention),
@@ -1512,6 +1552,8 @@ private:
     Stage stage_ = Stage::Uninitialized;
     float t_ = 0.0f;
     float stage_t_ = 0.0f;
+    MagStage mag_stage_ = MagStage::TiltWarm;
+    int mag_grace_updates_ = 0;
     typename SeaStateFusionFilter_OU_III<trackerT>::StartupStage last_impl_startup_stage_ =
              SeaStateFusionFilter_OU_III<trackerT>::StartupStage::Cold;
 

--- a/src/tuner/MagAutoTuner.h
+++ b/src/tuner/MagAutoTuner.h
@@ -59,6 +59,14 @@ public:
     int   min_good_samples  = 40;    // e.g. 0.4s @ 100 Hz mag
     int   max_total_samples = 400;   // safety cap
     float min_good_time_sec = 0.45f;
+
+    // Staged heading initialization (circular stats)
+    float heading_gyro_norm_max = 20.0f * float(M_PI) / 180.0f;
+    float heading_accel_dev_g_max = 0.18f;
+    int   min_heading_samples = 24;
+    float min_heading_concentration = 0.82f;
+    float heading_weight_accel = 0.25f;
+    float heading_weight_gyro = 0.03f;
   };
 
   MagAutoTuner() : cfg_(Config{}) { reset(); }
@@ -80,6 +88,9 @@ public:
     acc_dir_ema_valid_ = false;
 
     ready_ = false;
+    heading_ready_ = false;
+    heading_C_ = heading_S_ = heading_W_ = heading_W2_ = 0.0f;
+    heading_count_ = 0;
   }
 
   // Call only when you actually have a NEW mag sample.
@@ -168,6 +179,56 @@ public:
     return mag_unit_mean.allFinite();
   }
 
+  bool addHeadingSample(float dt,
+                        const Eigen::Quaternionf& q_tilt_bw,
+                        const Eigen::Vector3f& mag_body_ned,
+                        const Eigen::Vector3f& acc_body_ned,
+                        const Eigen::Vector3f& gyro_body_ned)
+  {
+    if (!(dt > 0.0f) || !std::isfinite(dt)) return false;
+    if (!q_tilt_bw.coeffs().allFinite() || !mag_body_ned.allFinite() ||
+        !acc_body_ned.allFinite() || !gyro_body_ned.allFinite()) return false;
+
+    const float gn = std::max(1e-6f, cfg_.g);
+    const float accel_dev_g = std::fabs(acc_body_ned.norm() - cfg_.g) / gn;
+    const float gyro_n = gyro_body_ned.norm();
+    if (accel_dev_g > cfg_.heading_accel_dev_g_max) return heading_ready_;
+    if (gyro_n > cfg_.heading_gyro_norm_max) return heading_ready_;
+
+    Eigen::Vector3f mt = q_tilt_bw * mag_body_ned;
+    const float horiz = std::hypot(mt.x(), mt.y());
+    if (!(horiz > 1e-6f) || !std::isfinite(horiz)) return heading_ready_;
+
+    const float psi = std::atan2(mt.y(), mt.x());
+    const float w = 1.0f / (1.0f
+        + cfg_.heading_weight_accel * accel_dev_g * accel_dev_g
+        + cfg_.heading_weight_gyro * gyro_n * gyro_n);
+
+    if (!(w > 0.0f) || !std::isfinite(w)) return heading_ready_;
+
+    heading_C_ += w * std::cos(psi);
+    heading_S_ += w * std::sin(psi);
+    heading_W_ += w;
+    heading_W2_ += w * w;
+    heading_count_++;
+
+    if (heading_count_ >= cfg_.min_heading_samples && heading_W_ > 1e-6f) {
+      const float R = std::sqrt(heading_C_ * heading_C_ + heading_S_ * heading_S_) / heading_W_;
+      heading_ready_ = (R >= cfg_.min_heading_concentration);
+    }
+    return heading_ready_;
+  }
+
+  bool getHeadingStats(float& heading_mean_rad, float& heading_var_rad2, float& neff) const {
+    if (!heading_ready_ || heading_W_ <= 1e-6f) return false;
+    heading_mean_rad = std::atan2(heading_S_, heading_C_);
+    const float R = std::sqrt(heading_C_ * heading_C_ + heading_S_ * heading_S_) / heading_W_;
+    const float Rc = std::min(std::max(R, 1e-6f), 0.999999f);
+    heading_var_rad2 = -2.0f * std::log(Rc);
+    neff = (heading_W2_ > 1e-9f) ? (heading_W_ * heading_W_ / heading_W2_) : 1.0f;
+    return std::isfinite(heading_mean_rad) && std::isfinite(heading_var_rad2) && std::isfinite(neff);
+  }
+
 private:
   bool isGoodAccel_(const Eigen::Vector3f& a) {
     const float g = cfg_.g;
@@ -233,6 +294,7 @@ private:
   int   good_count_ = 0;
   int   total_count_ = 0;
   bool  ready_ = false;
+  bool  heading_ready_ = false;
 
   Eigen::Vector3f acc_sum_     = Eigen::Vector3f::Zero();
   Eigen::Vector3f mag_raw_sum_ = Eigen::Vector3f::Zero();
@@ -243,6 +305,12 @@ private:
   // Heel-safe accel direction EMA
   Eigen::Vector3f acc_dir_ema_ = Eigen::Vector3f::Zero();
   bool acc_dir_ema_valid_ = false;
+
+  float heading_C_ = 0.0f;
+  float heading_S_ = 0.0f;
+  float heading_W_ = 0.0f;
+  float heading_W2_ = 0.0f;
+  int   heading_count_ = 0;
 };
 
 static inline MagAutoTuner::Config makeDefaultMagInitCfg(float mag_odr_hz) {


### PR DESCRIPTION
### Motivation
- Startup must be a staged Bayesian alignment so tilt (gravity) is learned first and yaw is only conditioned when trustworthy magnetic evidence exists. 
- Prevent accelerometer updates from spuriously reducing yaw uncertainty and avoid premature gyro/accel-bias conditioning during rough-wave startup.
- Provide a robust, weighted circular-heading collector so the filter can commit heading in a single covariance-consistent EKF step.

### Description
- Added tilt-only and yaw-only measurement modes to the core filter: new setters `set_acc_tilt_only_mode` and `set_mag_yaw_only_mode` and flags in `Kalman3D_Wave_OU_III`.  Tilt-only accelerometer updates now project the accel innovation and Jacobians into the gravity-orthogonal (tilt) subspace and inflate the gravity-axis variance to keep yaw unobserved.  (`src/kalman_ou_iii/Kalman3D_Wave_OU_III.h`)
- Added a Bayesian heading pseudo-measurement update `measurement_update_heading_only(yaw, std)` that forms a scalar yaw observation, computes a Kalman gain, applies the Joseph form covariance update and then injects the quaternion correction consistently.  This performs the mathematically correct one-shot yaw commit from batch heading evidence. (`src/kalman_ou_iii/Kalman3D_Wave_OU_III.h`)
- Added a yaw-only magnetometer projection for the mag-grace phase so vector mag updates do not immediately over-constrain tilt or other axes. (`src/kalman_ou_iii/Kalman3D_Wave_OU_III.h`)
- Extended `MagAutoTuner` with heading-collection logic: `addHeadingSample`, circular accumulator (`C/S/W`), `getHeadingStats`, and new config knobs (min samples, concentration, accel/gyro gating, weighting). This yields a robust `bar psi` and variance for the commit step. (`src/tuner/MagAutoTuner.h`)
- Orchestrated a small startup state machine in the wrapper `SeaStateFusion_OU_III` / `SeaStateFusionFilter_OU_III` to run stages: start tilt-only + yaw-only, move to `MagCollect` to accumulate heading samples, issue the heading pseudo-measurement when concentration criteria are met, enter `MagGrace` (yaw-only mag fusion) and then transition to full mag-vector fusion and normal adaptive tuning. (`src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h`)
- Maintained covariance hygiene: updates use the Joseph-style covariance update in the heading commit, symmetrize/clamp paths remain, and accel-bias learning remains frozen until Live per existing warmup policy.

### Testing
- Built the project with `make all`; the build completed successfully.
- Ran the OU‑III simulation `./tests/kalman_ou_iii/kalman_ou_iii-sim --no-noise` and the run started successfully (startup and mag stages exercised); no test failures observed.
- No quality-gate settings were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de657b210c8328baaf11e1de80befb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added staged magnetometer heading initialization with enhanced validation during startup sequence.
  * Introduced adaptive sensor fusion modes to improve attitude stability during sensor warmup phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->