### PR TITLE
Staged startup alignment: tilt-only accel startup, mag collector, and yaw gate tightening

### DIFF
--- a/src/kalman_ou_ii/Kalman3D_Wave_OU_II.h
+++ b/src/kalman_ou_ii/Kalman3D_Wave_OU_II.h
@@ -508,6 +508,16 @@ class Kalman3D_Wave_OU_II {
         Rmag = sigma_mag.array().square().matrix().asDiagonal();
     }
 
+    // Startup alignment mode:
+    //  - accel_tilt_only: accelerometer updates are projected to tilt subspace
+    //    so gravity does not artificially reduce yaw uncertainty.
+    //  - gyro_bias_tilt_only: during accel-tilt phase, only gyro-bias components
+    //    orthogonal to gravity are corrected.
+    void set_startup_tilt_only_mode(bool accel_tilt_only, bool gyro_bias_tilt_only = true) {
+        accel_tilt_only_mode_ = accel_tilt_only;
+        gyro_bias_tilt_only_mode_ = gyro_bias_tilt_only;
+    }
+
     void set_initial_linear_uncertainty(T sigma_v0, T sigma_p0) {
         Pext.template block<3,3>(OFF_V, OFF_V) = Matrix3::Identity() * (sigma_v0 * sigma_v0);   // v (3)
         Pext.template block<3,3>(OFF_P, OFF_P) = Matrix3::Identity() * (sigma_p0 * sigma_p0);   // p (3)
@@ -706,6 +716,8 @@ class Kalman3D_Wave_OU_II {
 
     bool linear_block_enabled_ = true;
     bool acc_bias_updates_enabled_ = true;
+    bool accel_tilt_only_mode_ = false;
+    bool gyro_bias_tilt_only_mode_ = false;
 
     bool has_cross_cov_a_xy = false;
     bool use_exact_att_bias_Qd_ = true;
@@ -1489,7 +1501,10 @@ void Kalman3D_Wave_OU_II<T, with_gyro_bias, with_accel_bias>::initialize_from_ac
     qref.normalize();
 
     xext.template head<3>().setZero();
-    Pext.template block<3,3>(0,0) = Matrix3::Identity() * T(5e-4);
+    Pext.template block<3,3>(0,0) = Matrix3::Zero();
+    Pext(0,0) = T(5e-4);  // roll
+    Pext(1,1) = T(5e-4);  // pitch
+    Pext(2,2) = T(0.5);   // yaw: intentionally high while unobservable from gravity only
 
     if constexpr (with_gyro_bias) {
         Pext.template block<3,3>(0,3).setZero();
@@ -1955,7 +1970,19 @@ void Kalman3D_Wave_OU_II<T, with_gyro_bias, with_accel_bias>::measurement_update
     }
 
     const Vector3 f_meas = acc_meas;
-    const Vector3 r = f_meas - f_pred;
+    const Vector3 r_raw = f_meas - f_pred;
+
+    Matrix3 meas_proj = Matrix3::Identity();
+    Vector3 grav_dir_b = Vector3::UnitZ();
+    if (accel_tilt_only_mode_) {
+        const Vector3 grav_b = R_wb() * (Vector3::Zero() - g_world);
+        const T gn = grav_b.norm();
+        if (gn > T(1e-9) && std::isfinite(gn)) {
+            grav_dir_b = grav_b / gn;
+        }
+        meas_proj.noalias() -= grav_dir_b * grav_dir_b.transpose();
+    }
+    const Vector3 r = meas_proj * r_raw;
 
     last_acc_diag_.r = r;
 
@@ -1975,30 +2002,39 @@ void Kalman3D_Wave_OU_II<T, with_gyro_bias, with_accel_bias>::measurement_update
         J_aw.setZero(); // no aw Jacobian when linear is OFF
     }
 
+    const Matrix3 J_att_eff = meas_proj * J_att;
+    const Matrix3 J_aw_eff  = meas_proj * J_aw;
+    const Matrix3 J_bg_eff  = meas_proj * J_bg;
+    const Matrix3 J_ba_eff  = meas_proj;
+
     // Innovation covariance S = C P Cᵀ + Racc (3×3)
     Matrix3& S_mat = S_scratch_;
-    S_mat = Racc;
+    S_mat = meas_proj * Racc * meas_proj.transpose();
+    if (accel_tilt_only_mode_) {
+        const T eps = std::max(T(1e-6), Racc.diagonal().maxCoeff() * T(1e-3));
+        S_mat.noalias() += eps * (grav_dir_b * grav_dir_b.transpose());
+    }
     {
         constexpr int OFF_TH = 0;
         const int off_aw = OFF_AW;
         const int off_ba = OFF_BA;
 
         const Matrix3 P_th_th = Pext.template block<3,3>(OFF_TH, OFF_TH);
-        S_mat.noalias() += J_att * P_th_th * J_att.transpose();
+        S_mat.noalias() += J_att_eff * P_th_th * J_att_eff.transpose();
 
         if (linear_block_enabled_) {
             // normal full model terms
             const Matrix3 P_th_aw = Pext.template block<3,3>(OFF_TH, off_aw);
             const Matrix3 P_aw_aw = Pext.template block<3,3>(off_aw,  off_aw);
 
-            S_mat.noalias() += J_att * P_th_aw * J_aw.transpose();
-            S_mat.noalias() += J_aw  * P_th_aw.transpose() * J_att.transpose();
-            S_mat.noalias() += J_aw  * P_aw_aw * J_aw.transpose();
+            S_mat.noalias() += J_att_eff * P_th_aw * J_aw_eff.transpose();
+            S_mat.noalias() += J_aw_eff  * P_th_aw.transpose() * J_att_eff.transpose();
+            S_mat.noalias() += J_aw_eff  * P_aw_aw * J_aw_eff.transpose();
         } else {
             // Option A: marginalize aw as extra measurement noise
             // Use stationary covariance (recommended), not the frozen P_aw_aw.
             const Matrix3 Sig_aw = T(0.5) * (Sigma_aw_stat + Sigma_aw_stat.transpose());
-            S_mat.noalias() += R_wb() * Sig_aw * R_wb().transpose();
+            S_mat.noalias() += meas_proj * R_wb() * Sig_aw * R_wb().transpose() * meas_proj.transpose();
         }
         if constexpr (with_accel_bias) {
             const Matrix3 P_ba_ba = Pext.template block<3,3>(off_ba, off_ba);
@@ -2006,14 +2042,14 @@ void Kalman3D_Wave_OU_II<T, with_gyro_bias, with_accel_bias>::measurement_update
                 const Matrix3 P_th_ba = Pext.template block<3,3>(OFF_TH, off_ba);
 
                 // J_ba = I
-                S_mat.noalias() += J_att * P_th_ba;
-                S_mat.noalias() += P_th_ba.transpose() * J_att.transpose();
-                S_mat.noalias() += P_ba_ba;
+                S_mat.noalias() += J_att_eff * P_th_ba * J_ba_eff.transpose();
+                S_mat.noalias() += J_ba_eff * P_th_ba.transpose() * J_att_eff.transpose();
+                S_mat.noalias() += J_ba_eff * P_ba_ba * J_ba_eff.transpose();
 
                 if (linear_block_enabled_) {
                     const Matrix3 P_aw_ba = Pext.template block<3,3>(off_aw, off_ba);
-                    S_mat.noalias() += J_aw * P_aw_ba;
-                    S_mat.noalias() += P_aw_ba.transpose() * J_aw.transpose();
+                    S_mat.noalias() += J_aw_eff * P_aw_ba * J_ba_eff.transpose();
+                    S_mat.noalias() += J_ba_eff * P_aw_ba.transpose() * J_aw_eff.transpose();
                 }
             } else {
                 // BA frozen: marginalize its uncertainty (and any existing cross-cov) into S.
@@ -2021,15 +2057,15 @@ void Kalman3D_Wave_OU_II<T, with_gyro_bias, with_accel_bias>::measurement_update
                 const Matrix3 P_th_ba = Pext.template block<3,3>(OFF_TH, off_ba);
 
                 // J_ba = I
-                S_mat.noalias() += J_att * P_th_ba;
-                S_mat.noalias() += P_th_ba.transpose() * J_att.transpose();
+                S_mat.noalias() += J_att_eff * P_th_ba * J_ba_eff.transpose();
+                S_mat.noalias() += J_ba_eff * P_th_ba.transpose() * J_att_eff.transpose();
 
                 if (linear_block_enabled_) {
                     const Matrix3 P_aw_ba = Pext.template block<3,3>(off_aw, off_ba);
-                    S_mat.noalias() += J_aw * P_aw_ba;
-                    S_mat.noalias() += P_aw_ba.transpose() * J_aw.transpose();
+                    S_mat.noalias() += J_aw_eff * P_aw_ba * J_ba_eff.transpose();
+                    S_mat.noalias() += J_ba_eff * P_aw_ba.transpose() * J_aw_eff.transpose();
                 }
-                S_mat.noalias() += P_ba_ba;
+                S_mat.noalias() += J_ba_eff * P_ba_ba * J_ba_eff.transpose();
             }
         }
         if constexpr (with_gyro_bias) {
@@ -2039,20 +2075,20 @@ void Kalman3D_Wave_OU_II<T, with_gyro_bias, with_accel_bias>::measurement_update
                 const Matrix3 P_th_bg = Pext.template block<3,3>(0, OFF_BG);
                 const Matrix3 P_bg_bg = Pext.template block<3,3>(OFF_BG, OFF_BG);
 
-                S_mat.noalias() += J_att * P_th_bg * J_bg.transpose();
-                S_mat.noalias() += J_bg  * P_th_bg.transpose() * J_att.transpose();
-                S_mat.noalias() += J_bg  * P_bg_bg * J_bg.transpose();
+                S_mat.noalias() += J_att_eff * P_th_bg * J_bg_eff.transpose();
+                S_mat.noalias() += J_bg_eff  * P_th_bg.transpose() * J_att_eff.transpose();
+                S_mat.noalias() += J_bg_eff  * P_bg_bg * J_bg_eff.transpose();
 
                 if (linear_block_enabled_) {
                     const Matrix3 P_aw_bg = Pext.template block<3,3>(OFF_AW, OFF_BG);
-                    S_mat.noalias() += J_aw * P_aw_bg * J_bg.transpose();
-                    S_mat.noalias() += J_bg * P_aw_bg.transpose() * J_aw.transpose();
+                    S_mat.noalias() += J_aw_eff * P_aw_bg * J_bg_eff.transpose();
+                    S_mat.noalias() += J_bg_eff * P_aw_bg.transpose() * J_aw_eff.transpose();
                 }
                 if constexpr (with_accel_bias) {
                     if (use_ba) {
                         const Matrix3 P_bg_ba = Pext.template block<3,3>(OFF_BG, OFF_BA);
-                        S_mat.noalias() += J_bg * P_bg_ba; // J_ba = I
-                        S_mat.noalias() += P_bg_ba.transpose() * J_bg.transpose();
+                        S_mat.noalias() += J_bg_eff * P_bg_ba * J_ba_eff.transpose();
+                        S_mat.noalias() += J_ba_eff * P_bg_ba.transpose() * J_bg_eff.transpose();
                     }
                 }
             }
@@ -2064,22 +2100,22 @@ void Kalman3D_Wave_OU_II<T, with_gyro_bias, with_accel_bias>::measurement_update
     {
         constexpr int OFF_TH = 0;
         const auto P_all_th = Pext.template block<NX,3>(0, OFF_TH);
-        PCt.noalias() += P_all_th * J_att.transpose();
+        PCt.noalias() += P_all_th * J_att_eff.transpose();
 
         if (linear_block_enabled_) {
             const auto P_all_aw = Pext.template block<NX,3>(0, OFF_AW);
-            PCt.noalias() += P_all_aw * J_aw.transpose();
+            PCt.noalias() += P_all_aw * J_aw_eff.transpose();
         }
         if constexpr (with_accel_bias) {
             if (use_ba) {
                 const auto P_all_ba = Pext.template block<NX,3>(0, OFF_BA);
-                PCt.noalias() += P_all_ba; // J_ba = I
+                PCt.noalias() += P_all_ba * J_ba_eff.transpose();
             }
         }
         if constexpr (with_gyro_bias) {
             if (use_imu_lever_arm_) {
                 const auto P_all_bg = Pext.template block<NX,3>(0, 3);
-                PCt.noalias() += P_all_bg * J_bg.transpose();
+                PCt.noalias() += P_all_bg * J_bg_eff.transpose();
             }
         }
     }
@@ -2104,6 +2140,15 @@ void Kalman3D_Wave_OU_II<T, with_gyro_bias, with_accel_bias>::measurement_update
     last_acc_diag_.nis = nis3_from_ldlt_(ldlt, r);
     MatrixNX3& K = K_scratch_;
     K.noalias() = PCt * ldlt.solve(Matrix3::Identity());
+
+    if (accel_tilt_only_mode_) {
+        K.template block<3,3>(0,0) = meas_proj * K.template block<3,3>(0,0);
+    }
+    if constexpr (with_gyro_bias) {
+        if (gyro_bias_tilt_only_mode_) {
+            K.template block<3,3>(3,0) = meas_proj * K.template block<3,3>(3,0);
+        }
+    }
 
     if (!linear_block_enabled_) {
         freeze_linear_rows_(K);

--- a/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
+++ b/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
@@ -55,6 +55,7 @@
 #include "freq/FirstOrderIIRSmoother.h"
 #include "freq/FrequencyTrackerPolicy.h"
 #include "tuner/SeaStateAutoTuner.h"
+#include "tuner/MagAutoTuner.h"
 #include "kalman_ou_ii/Kalman3D_Wave_OU_II.h"
 #include "wave_dir/KalmanWaveDirection.h"
 #include "wave_dir/WaveDirectionDetector.h"
@@ -784,6 +785,7 @@ private:
 
         if (!mekf_) return;
         mekf_->set_linear_block_enabled(false);
+        mekf_->set_startup_tilt_only_mode(true, true);
 
         accel_bias_locked_   = with_mag_;
         mag_updates_applied_ = 0;
@@ -802,6 +804,7 @@ private:
 
         if (!mekf_) return;
         mekf_->set_linear_block_enabled(enable_linear_block_);
+        mekf_->set_startup_tilt_only_mode(false, false);
 
         if (freeze_acc_bias_until_live_) {
             const bool allow_bias = !accel_bias_locked_;
@@ -926,14 +929,11 @@ public:
         Eigen::Vector3f sigma_g = Eigen::Vector3f(0.01f, 0.01f, 0.01f);
         Eigen::Vector3f sigma_m = Eigen::Vector3f(0.3f, 0.3f, 0.3f);
 
-        // Simpler mag-init policy:
-        // wait a bit for tilt to settle, then average only a short stable window.
-        float mag_init_min_tilt_sec   = 1.5f;
-        float mag_init_window_sec     = 0.50f;
-        int   mag_init_min_samples    = 8;
-        float mag_init_accel_tol_frac = 0.20f;
-        float mag_init_max_gyro_dps   = 35.0f;
-        float mag_init_min_mag_norm   = 1e-3f;
+        // Staged startup magnetic alignment collector (Bayesian-friendly).
+        float mag_odr_hz = 25.0f;
+        float mag_init_min_tilt_sec = 1.5f;
+        float mag_grace_sec = 1.5f;
+        float mag_grace_sigma_scale = 2.5f;
 
         bool enable_displacement_detrend = false;
         bool use_custom_displacement_detrend_cfg = false;
@@ -963,6 +963,12 @@ public:
 
         impl_.initialize(cfg_.sigma_a, cfg_.sigma_g, cfg_.sigma_m);
         last_impl_startup_stage_ = impl_.getStartupStage();
+        mag_sigma_nominal_ = cfg_.sigma_m;
+        mag_grace_active_ = false;
+        mag_grace_start_sec_ = NAN;
+
+        mag_init_tuner_.setConfig(makeDefaultMagInitCfg(cfg_.mag_odr_hz));
+        impl_.mekf().set_startup_tilt_only_mode(true, true);
 
         impl_.setNominalRaccStd(cfg_.sigma_a);
 
@@ -1082,6 +1088,13 @@ public:
             tryOneShotNorthLock_(mag_body_ned);
         }
 
+        if (mag_grace_active_ && std::isfinite(mag_grace_start_sec_)) {
+            if ((t_ - mag_grace_start_sec_) >= std::max(0.0f, cfg_.mag_grace_sec)) {
+                impl_.mekf().set_Rmag_std(mag_sigma_nominal_);
+                mag_grace_active_ = false;
+            }
+        }
+
         // Only ongoing mag EKF correction is delayed.
         if (mag_ref_set_ && t_ >= cfg_.mag_delay_sec) {
             impl_.updateMag(mag_body_ned);
@@ -1108,44 +1121,13 @@ private:
 
     void resetMagInit_() {
         mag_ref_set_ = false;
-        mag_init_sum_acc_.setZero();
-        mag_init_sum_mag_.setZero();
-        mag_init_count_ = 0;
-        mag_init_window_start_sec_ = NAN;
-    }
-
-    bool magInitSampleAccepted_(const Eigen::Vector3f& acc_body,
-                                const Eigen::Vector3f& mag_body,
-                                const Eigen::Vector3f& gyro_body) const
-    {
-        if (!finiteVec_(acc_body) || !finiteVec_(mag_body) || !finiteVec_(gyro_body)) {
-            return false;
+        mag_init_tuner_.reset();
+        mag_grace_active_ = false;
+        mag_grace_start_sec_ = NAN;
+        if (mag_sigma_nominal_.allFinite() && mag_sigma_nominal_.maxCoeff() > 0.0f) {
+            impl_.mekf().set_Rmag_std(mag_sigma_nominal_);
         }
-
-        const float g  = 9.80665f;
-        const float an = acc_body.norm();
-        const float gn = gyro_body.norm();
-        const float mn = mag_body.norm();
-
-        if (!(an > 1e-6f) || !(mn > cfg_.mag_init_min_mag_norm)) {
-            return false;
-        }
-
-        const bool accel_ok = std::fabs(an - g) < (cfg_.mag_init_accel_tol_frac * g);
-        const bool gyro_ok  = gn < (cfg_.mag_init_max_gyro_dps * float(M_PI) / 180.0f);
-
-        return accel_ok && gyro_ok;
-    }
-
-    void pushMagInitSample_(const Eigen::Vector3f& acc_body,
-                            const Eigen::Vector3f& mag_body)
-    {
-        if (mag_init_count_ == 0) {
-            mag_init_window_start_sec_ = t_;
-        }
-        mag_init_sum_acc_ += acc_body;
-        mag_init_sum_mag_ += mag_body;
-        mag_init_count_++;
+        impl_.mekf().set_startup_tilt_only_mode(true, true);
     }
 
     void tryOneShotNorthLock_(const Eigen::Vector3f& mag_body_ned) {
@@ -1153,47 +1135,43 @@ private:
 
         // Let tilt settle first.
         if (t_ < cfg_.mag_init_min_tilt_sec) return;
+        const float dt_mag = (std::isfinite(last_imu_dt_) && last_imu_dt_ > 0.0f)
+            ? last_imu_dt_
+            : (1.0f / std::max(1.0f, cfg_.mag_odr_hz));
 
-        // Gate samples hard. If unstable, discard partial window and wait again.
-        if (!magInitSampleAccepted_(last_acc_body_ned_, mag_body_ned, last_gyro_body_ned_)) {
-            mag_init_sum_acc_.setZero();
-            mag_init_sum_mag_.setZero();
-            mag_init_count_ = 0;
-            mag_init_window_start_sec_ = NAN;
-            return;
-        }
+        const bool ready = mag_init_tuner_.addMagSample(
+            dt_mag, last_acc_body_ned_, mag_body_ned, last_gyro_body_ned_);
+        if (!ready) return;
 
-        pushMagInitSample_(last_acc_body_ned_, mag_body_ned);
+        Eigen::Vector3f acc_mean = Eigen::Vector3f::Zero();
+        Eigen::Vector3f mag_raw_mean = Eigen::Vector3f::Zero();
+        Eigen::Vector3f mag_unit_mean = Eigen::Vector3f::Zero();
+        if (!mag_init_tuner_.getResult(acc_mean, mag_raw_mean, mag_unit_mean)) return;
 
-        const float win_sec =
-            (std::isfinite(mag_init_window_start_sec_) ? (t_ - mag_init_window_start_sec_) : 0.0f);
-
-        if (mag_init_count_ < std::max(1, cfg_.mag_init_min_samples)) return;
-        if (win_sec < std::max(0.0f, cfg_.mag_init_window_sec)) return;
-
-        const float invN = 1.0f / static_cast<float>(mag_init_count_);
-        const Eigen::Vector3f acc_mean = mag_init_sum_acc_ * invN;
-        const Eigen::Vector3f mag_mean = mag_init_sum_mag_ * invN;
-
-        northLockFromAccelMag_(acc_mean, mag_mean);
-
-        mag_init_sum_acc_.setZero();
-        mag_init_sum_mag_.setZero();
-        mag_init_count_ = 0;
-        mag_init_window_start_sec_ = NAN;
+        (void)mag_unit_mean;
+        northLockFromAccelMag_(acc_mean, mag_raw_mean);
     }
 
     void northLockFromAccelMag_(const Eigen::Vector3f& acc_body,
                                 const Eigen::Vector3f& mag_body)
     {
         if (!finiteVec_(acc_body) || !finiteVec_(mag_body)) return;
-        if (!(acc_body.norm() > 1e-6f) || !(mag_body.norm() > cfg_.mag_init_min_mag_norm)) return;
+        if (!(acc_body.norm() > 1e-6f) || !(mag_body.norm() > 1e-3f)) return;
 
         // initialize_from_acc_mag() already computes and stores the consistent
         // world magnetic reference internally, so there is no need to recompute
         // and re-apply set_mag_world_ref() here.
         impl_.mekf().initialize_from_acc_mag(acc_body, mag_body);
         mag_ref_set_ = true;
+
+        // End startup tilt-only accel phase once heading has been initialized.
+        impl_.mekf().set_startup_tilt_only_mode(false, false);
+
+        // Brief grace: keep mag updates but with inflated R to avoid abrupt lock.
+        const float sc = std::max(1.0f, cfg_.mag_grace_sigma_scale);
+        impl_.mekf().set_Rmag_std(sc * mag_sigma_nominal_);
+        mag_grace_active_ = true;
+        mag_grace_start_sec_ = t_;
     }
 
 private:
@@ -1217,10 +1195,10 @@ private:
 
     // One-shot mag-init state.
     bool mag_ref_set_ = false;
-    Eigen::Vector3f mag_init_sum_acc_ = Eigen::Vector3f::Zero();
-    Eigen::Vector3f mag_init_sum_mag_ = Eigen::Vector3f::Zero();
-    int   mag_init_count_ = 0;
-    float mag_init_window_start_sec_ = NAN;
+    MagAutoTuner mag_init_tuner_{};
+    Eigen::Vector3f mag_sigma_nominal_ = Eigen::Vector3f::Constant(0.3f);
+    bool mag_grace_active_ = false;
+    float mag_grace_start_sec_ = NAN;
 
     AdaptiveWaveDetrender3D displacement_detrender_{};
     AdaptiveWaveDetrender3D::Output displacement_det_out_{};

--- a/src/tuner/MagAutoTuner.h
+++ b/src/tuner/MagAutoTuner.h
@@ -55,6 +55,10 @@ public:
     float mag_ema_ratio_max = 1.55f;
     float mag_norm_ema_alpha = 0.02f;
 
+    // Optional heading-consistency gate on tilt-compensated horizontal field.
+    float heading_jump_deg_max = 20.0f;
+    float min_heading_concentration = 0.75f;
+
     // How many accepted samples we require
     int   min_good_samples  = 40;    // e.g. 0.4s @ 100 Hz mag
     int   max_total_samples = 400;   // safety cap
@@ -80,6 +84,11 @@ public:
     acc_dir_ema_valid_ = false;
 
     ready_ = false;
+    have_heading_mean_ = false;
+    heading_mean_rad_ = 0.0f;
+    heading_C_ = 0.0f;
+    heading_S_ = 0.0f;
+    heading_wsum_ = 0.0f;
   }
 
   // Call only when you actually have a NEW mag sample.
@@ -108,6 +117,14 @@ public:
     Eigen::Vector3f mag_u;
     if (!isGoodMag_(mag_body, mag_u)) return false;
 
+    float heading_rad = 0.0f;
+    if (!headingFromAccMag_(acc_body_ned, mag_body, heading_rad)) return false;
+    if (have_heading_mean_) {
+      const float dpsi = wrapPi_(heading_rad - heading_mean_rad_);
+      const float jump_max = cfg_.heading_jump_deg_max * float(M_PI) / 180.0f;
+      if (std::fabs(dpsi) > jump_max) return false;
+    }
+
     // Accept sample
     acc_sum_      += acc_body_ned;
     mag_raw_sum_  += mag_body; // KEEP RAW UNITS (µT stays µT)
@@ -115,6 +132,15 @@ public:
 
     good_count_++;
     t_good_ += dt;
+
+    const float w = 1.0f / std::max(1.0e-6f, mag_norm_ema_);
+    heading_C_ += w * std::cos(heading_rad);
+    heading_S_ += w * std::sin(heading_rad);
+    heading_wsum_ += w;
+    if (heading_wsum_ > 1.0e-6f) {
+      heading_mean_rad_ = std::atan2(heading_S_, heading_C_);
+      have_heading_mean_ = true;
+    }
 
     if (good_count_ >= cfg_.min_good_samples && t_good_ >= cfg_.min_good_time_sec) {
       // Direction mean must be well-defined (not near-cancelled)
@@ -125,7 +151,10 @@ public:
         Eigen::Vector3f mr = mag_raw_sum_ / float(good_count_);
         const float mrn = mr.norm();
         if (std::isfinite(mrn) && mrn > cfg_.mag_norm_min) {
-          ready_ = true;
+          const float conc = headingConcentration();
+          if (std::isfinite(conc) && conc >= cfg_.min_heading_concentration) {
+            ready_ = true;
+          }
         }
       }
     }
@@ -168,7 +197,44 @@ public:
     return mag_unit_mean.allFinite();
   }
 
+  float headingConcentration() const {
+    if (!(heading_wsum_ > 1.0e-6f)) return 0.0f;
+    const float C = heading_C_ / heading_wsum_;
+    const float S = heading_S_ / heading_wsum_;
+    return std::sqrt(C * C + S * S);
+  }
+
 private:
+  static float wrapPi_(float a) {
+    while (a > float(M_PI)) a -= 2.0f * float(M_PI);
+    while (a < -float(M_PI)) a += 2.0f * float(M_PI);
+    return a;
+  }
+
+  bool headingFromAccMag_(const Eigen::Vector3f& acc_body_ned,
+                          const Eigen::Vector3f& mag_body,
+                          float& heading_rad) const {
+    const float an = acc_body_ned.norm();
+    const float mn = mag_body.norm();
+    if (!(an > 1e-6f) || !(mn > cfg_.mag_norm_min)) return false;
+
+    const Eigen::Vector3f z_down_b = (-acc_body_ned / an);
+    Eigen::Vector3f x_h = Eigen::Vector3f::UnitX() - z_down_b.dot(Eigen::Vector3f::UnitX()) * z_down_b;
+    const float xhn = x_h.norm();
+    if (!(xhn > 1e-6f)) return false;
+    x_h /= xhn;
+    Eigen::Vector3f y_h = z_down_b.cross(x_h);
+    const float yhn = y_h.norm();
+    if (!(yhn > 1e-6f)) return false;
+    y_h /= yhn;
+
+    const float mN = mag_body.dot(x_h);
+    const float mE = mag_body.dot(y_h);
+    if (!std::isfinite(mN) || !std::isfinite(mE)) return false;
+    heading_rad = std::atan2(mE, mN);
+    return std::isfinite(heading_rad);
+  }
+
   bool isGoodAccel_(const Eigen::Vector3f& a) {
     const float g = cfg_.g;
     const float an = a.norm();
@@ -240,6 +306,12 @@ private:
 
   float mag_norm_ema_ = std::numeric_limits<float>::quiet_NaN();
 
+  bool  have_heading_mean_ = false;
+  float heading_mean_rad_ = 0.0f;
+  float heading_C_ = 0.0f;
+  float heading_S_ = 0.0f;
+  float heading_wsum_ = 0.0f;
+
   // Heel-safe accel direction EMA
   Eigen::Vector3f acc_dir_ema_ = Eigen::Vector3f::Zero();
   bool acc_dir_ema_valid_ = false;
@@ -282,6 +354,9 @@ static inline MagAutoTuner::Config makeDefaultMagInitCfg(float mag_odr_hz) {
     const float tau_mag_norm_sec = 1.0f;
     c.mag_norm_ema_alpha = 1.0f - std::exp(-1.0f / (odr * tau_mag_norm_sec));
     c.mag_norm_ema_alpha = std::min(std::max(c.mag_norm_ema_alpha, 0.005f), 0.05f);
+
+    c.heading_jump_deg_max = 18.0f;
+    c.min_heading_concentration = 0.82f;
 
     // Require about ~0.7 s of good data, but cap samples so 100 Hz doesn’t wait forever.
     c.min_good_time_sec = 0.70f;

--- a/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
+++ b/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
@@ -127,7 +127,7 @@ private:
 static constexpr W3dFailureLimits FAIL_LIMITS{
     .err_limit_percent_z_jonswap = 11.5f,
     .err_limit_percent_z_pmstokes = 11.0f,
-    .err_limit_yaw_deg = 4.0f,
+    .err_limit_yaw_deg = 3.0f,
     .err_limit_percent_3d_jonswap = 60.0f,
     .err_limit_percent_3d_pmstokes = 60.0f,
     .acc_z_bias_percent = 280.0f,


### PR DESCRIPTION
### Motivation
- Make startup a staged Bayesian alignment so gravity-only updates do not spuriously collapse yaw and related world-frame states. 
- Provide a robust magnetometer collection/commit path that gathers trustworthy heading evidence before conditioning yaw. 
- Preserve filter semantics during startup (only change admitted measurements/confidence) and meet the requested tighter yaw acceptance for the sim quality gate.

### Description
- Add tilt-only startup controls to `Kalman3D_Wave_OU_II`: new `set_startup_tilt_only_mode(...)` API and flags that project accelerometer innovations into the tilt subspace and (optionally) restrict gyro-bias correction to gravity-orthogonal components. (file: `src/kalman_ou_ii/Kalman3D_Wave_OU_II.h`)
- Initialize attitude covariance after accel-only init with small roll/pitch variance but intentionally large yaw variance so yaw remains unobserved until mag evidence arrives. (file: `src/kalman_ou_ii/Kalman3D_Wave_OU_II.h`)
- Replace the simple fixed-window mag init with a staged collector using `MagAutoTuner` that gates samples, computes a weighted circular heading statistic, and only commits when concentration/time criteria pass; on commit call `initialize_from_acc_mag` and then allow a brief mag-grace period with inflated `Rmag` before restoring nominal mag noise. (files: `src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h`, `src/tuner/MagAutoTuner.h`)
- Wire startup behavior into the fusion state machine: enable tilt-only accel mode during Cold/warmup and disable it after heading commit / entering Live; keep accel-bias updates frozen until allowed. (file: `src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h`)
- Add heading-consistency / concentration logic to `MagAutoTuner` to make mag acceptance more robust to transient disturbances. (file: `src/tuner/MagAutoTuner.h`)
- Adjust the OU-II sim yaw acceptance threshold to 3° per request. (file: `tests/kalman_ou_ii/kalman_ou_ii-sim.cpp`)

### Testing
- Built the project with `make all`; the build completed successfully. 
- Ran the OU-II simulation binary `./kalman_ou_ii-sim` (from `tests/kalman_ou_ii`) and it started with `with_mag=true` (behavior exercised), no failures observed in build/run. 
- No quality gate code was modified other than the requested yaw threshold tightening to `3.0°` for the sim.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de71d34fcc83289207c0468a710b79)