### PR TITLE
Staged Bayesian startup heading alignment for OU II fusion

### DIFF
--- a/src/kalman_ou_ii/Kalman3D_Wave_OU_II.h
+++ b/src/kalman_ou_ii/Kalman3D_Wave_OU_II.h
@@ -252,6 +252,7 @@ class Kalman3D_Wave_OU_II {
     // Measurement updates (operate on extended state internally)
     void measurement_update_acc_only(Vector3 const& acc, T tempC = tempC_ref);
     void measurement_update_mag_only(Vector3 const& mag);
+    void measurement_update_heading_only(T heading_rad_meas, T heading_std_rad);
 
     // Extended-only API:
     // 3D pseudo-measurement on position p (world, NED):
@@ -884,6 +885,24 @@ class Kalman3D_Wave_OU_II {
     // convenience getters
     Matrix3 R_wb() const { return qref.toRotationMatrix(); }               // world→body'
     Matrix3 R_bw() const { return qref.toRotationMatrix().transpose(); }   // body'→world
+
+    static T wrap_pi_(T a) {
+        const T pi = T(M_PI);
+        const T two_pi = T(2) * pi;
+        while (a > pi) a -= two_pi;
+        while (a < -pi) a += two_pi;
+        return a;
+    }
+
+    static T yaw_from_quat_bw_(const Eigen::Quaternion<T>& q_bw) {
+        const T qx = q_bw.x();
+        const T qy = q_bw.y();
+        const T qz = q_bw.z();
+        const T qw = q_bw.w();
+        const T siny_cosp = T(2) * (qw * qz + qx * qy);
+        const T cosy_cosp = T(1) - T(2) * (qy * qy + qz * qz);
+        return std::atan2(siny_cosp, cosy_cosp);
+    }
 
     // Helpers
     Matrix3 skew_symmetric_matrix(const Eigen::Ref<const Vector3>& vec) const;
@@ -2243,6 +2262,78 @@ void Kalman3D_Wave_OU_II<T, with_gyro_bias, with_accel_bias>::measurement_update
     joseph_update3_(K, S_mat, PCt);
     applyQuaternionCorrectionFromErrorState();
     last_mag_diag_.accepted = true;
+}
+
+template<typename T, bool with_gyro_bias, bool with_accel_bias>
+void Kalman3D_Wave_OU_II<T, with_gyro_bias, with_accel_bias>::measurement_update_heading_only(
+    T heading_rad_meas, T heading_std_rad)
+{
+    if (!std::isfinite(heading_rad_meas) || !std::isfinite(heading_std_rad)) return;
+    const T sigma = std::max(T(1e-5), heading_std_rad);
+    const T R = sigma * sigma;
+
+    const T yaw_pred = yaw_from_quat_bw_(quaternion_boat());
+    const T r = wrap_pi_(heading_rad_meas - yaw_pred);
+    if (!std::isfinite(r)) return;
+
+    // Numerical Jacobian d(yaw)/d(delta_theta) at current attitude.
+    Eigen::Matrix<T,1,3> Hth;
+    Hth.setZero();
+
+    constexpr T eps = T(1e-4);
+    for (int i = 0; i < 3; ++i) {
+        Vector3 d = Vector3::Zero();
+        d(i) = eps;
+        Eigen::Quaternion<T> q_plus = quat_from_delta_theta(d) * qref;
+        q_plus.normalize();
+        const T yaw_plus = yaw_from_quat_bw_(q_plus.conjugate());
+
+        d(i) = -eps;
+        Eigen::Quaternion<T> q_minus = quat_from_delta_theta(d) * qref;
+        q_minus.normalize();
+        const T yaw_minus = yaw_from_quat_bw_(q_minus.conjugate());
+
+        const T dy = wrap_pi_(yaw_plus - yaw_minus);
+        Hth(i) = dy / (T(2) * eps);
+    }
+
+    Eigen::Matrix<T,1,NX> H;
+    H.setZero();
+    H.template block<1,3>(0,0) = Hth;
+
+    if (!linear_block_enabled_) {
+        H.template block<1,9>(0, OFF_V).setZero();
+    }
+    if constexpr (with_accel_bias) {
+        if (!acc_bias_updates_enabled_) {
+            H.template block<1,3>(0, OFF_BA).setZero();
+        }
+    }
+
+    const Eigen::Matrix<T,NX,1> PHt = Pext * H.transpose();
+    T S = (H * PHt)(0,0) + R;
+    if (!(S > T(0)) || !std::isfinite(S)) return;
+
+    Eigen::Matrix<T,NX,1> K = PHt / S;
+    if (!linear_block_enabled_) {
+        K.template block<9,1>(OFF_V,0).setZero();
+    }
+    if constexpr (with_accel_bias) {
+        if (!acc_bias_updates_enabled_) {
+            K.template block<3,1>(OFF_BA,0).setZero();
+        }
+    }
+
+    xext.noalias() += K * r;
+
+    // Joseph scalar form:
+    // P = P - K*PHt' - PHt*K' + K*S*K'
+    Pext.noalias() -= K * PHt.transpose();
+    Pext.noalias() -= PHt * K.transpose();
+    Pext.noalias() += K * S * K.transpose();
+    symmetrize_Pext_();
+
+    applyQuaternionCorrectionFromErrorState();
 }
 
 // specific force prediction (BODY'):

--- a/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
+++ b/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
@@ -1149,19 +1149,39 @@ private:
         if (!mag_init_tuner_.getResult(acc_mean, mag_raw_mean, mag_unit_mean)) return;
 
         (void)mag_unit_mean;
-        northLockFromAccelMag_(acc_mean, mag_raw_mean);
+        float heading_mean = 0.0f;
+        float heading_var = NAN;
+        float heading_neff = 0.0f;
+        if (!mag_init_tuner_.getHeadingEstimate(heading_mean, heading_var, heading_neff)) return;
+
+        northLockFromAccelMag_(acc_mean, mag_raw_mean, heading_mean, heading_var, heading_neff);
     }
 
     void northLockFromAccelMag_(const Eigen::Vector3f& acc_body,
-                                const Eigen::Vector3f& mag_body)
+                                const Eigen::Vector3f& mag_body,
+                                float heading_mean_rad,
+                                float heading_var_rad2,
+                                float heading_neff)
     {
         if (!finiteVec_(acc_body) || !finiteVec_(mag_body)) return;
         if (!(acc_body.norm() > 1e-6f) || !(mag_body.norm() > 1e-3f)) return;
+        if (!std::isfinite(heading_mean_rad) || !std::isfinite(heading_var_rad2) || !(heading_neff > 0.0f)) return;
 
-        // initialize_from_acc_mag() already computes and stores the consistent
-        // world magnetic reference internally, so there is no need to recompute
-        // and re-apply set_mag_world_ref() here.
-        impl_.mekf().initialize_from_acc_mag(acc_body, mag_body);
+        // Bayesian heading commit:
+        //  1) re-lock tilt only (preserve current yaw frame),
+        //  2) apply a single heading pseudo-measurement using circular stats,
+        //  3) set world magnetic reference from committed attitude + raw mag mean.
+        impl_.mekf().initialize_from_acc_preserve_yaw(acc_body);
+
+        const float var_floor = std::pow(1.5f * static_cast<float>(M_PI) / 180.0f, 2.0f);
+        const float heading_var_eff = var_floor + heading_var_rad2 / heading_neff;
+        const float heading_std = std::sqrt(std::max(1.0e-6f, heading_var_eff));
+        impl_.mekf().measurement_update_heading_only(heading_mean_rad, heading_std);
+
+        const Eigen::Vector3f mag_world = impl_.mekf().quaternion_boat().toRotationMatrix() * mag_body;
+        if (mag_world.allFinite() && mag_world.norm() > 1.0e-3f) {
+            impl_.mekf().set_mag_world_ref(mag_world);
+        }
         mag_ref_set_ = true;
 
         // End startup tilt-only accel phase once heading has been initialized.

--- a/src/tuner/MagAutoTuner.h
+++ b/src/tuner/MagAutoTuner.h
@@ -89,6 +89,7 @@ public:
     heading_C_ = 0.0f;
     heading_S_ = 0.0f;
     heading_wsum_ = 0.0f;
+    heading_wsum_sq_ = 0.0f;
   }
 
   // Call only when you actually have a NEW mag sample.
@@ -137,6 +138,7 @@ public:
     heading_C_ += w * std::cos(heading_rad);
     heading_S_ += w * std::sin(heading_rad);
     heading_wsum_ += w;
+    heading_wsum_sq_ += w * w;
     if (heading_wsum_ > 1.0e-6f) {
       heading_mean_rad_ = std::atan2(heading_S_, heading_C_);
       have_heading_mean_ = true;
@@ -202,6 +204,33 @@ public:
     const float C = heading_C_ / heading_wsum_;
     const float S = heading_S_ / heading_wsum_;
     return std::sqrt(C * C + S * S);
+  }
+
+  float headingMeanRad() const {
+    return have_heading_mean_ ? heading_mean_rad_ : 0.0f;
+  }
+
+  float headingCircularVarianceRad2() const {
+    const float conc = std::max(1.0e-6f, headingConcentration());
+    return -2.0f * std::log(conc);
+  }
+
+  float headingEffectiveSamples() const {
+    if (!(heading_wsum_sq_ > 1.0e-12f)) return 0.0f;
+    return (heading_wsum_ * heading_wsum_) / heading_wsum_sq_;
+  }
+
+  bool getHeadingEstimate(float& heading_mean_rad,
+                          float& heading_var_rad2,
+                          float& heading_neff) const {
+    if (!ready_ || !have_heading_mean_) return false;
+    heading_mean_rad = heading_mean_rad_;
+    heading_var_rad2 = headingCircularVarianceRad2();
+    heading_neff = headingEffectiveSamples();
+    return std::isfinite(heading_mean_rad) &&
+           std::isfinite(heading_var_rad2) &&
+           std::isfinite(heading_neff) &&
+           heading_neff > 0.0f;
   }
 
 private:
@@ -311,6 +340,7 @@ private:
   float heading_C_ = 0.0f;
   float heading_S_ = 0.0f;
   float heading_wsum_ = 0.0f;
+  float heading_wsum_sq_ = 0.0f;
 
   // Heel-safe accel direction EMA
   Eigen::Vector3f acc_dir_ema_ = Eigen::Vector3f::Zero();


### PR DESCRIPTION
### Motivation
- Make startup alignment mathematically consistent and robust by treating yaw initialization as a staged Bayesian problem (tilt → mag-collect → heading commit → mag grace) rather than a hard one-shot reset.
- Prevent accel-only updates from spuriously collapsing yaw uncertainty and ensure covariance-consistent yaw conditioning and cross-covariance updates.
- Provide the mag-init collector with statistically meaningful heading confidence (circular variance and effective sample count) so the heading commit can be a single, principled EKF/MEKF update.
- Preserve existing quality-gate criteria and ensure the yaw criterion is 3 degrees for test passing (`err_limit_yaw_deg = 3.0f`).

### Description
- Implemented staged startup heading commit in `SeaStateFusion_OU_II` by replacing the hard `initialize_from_acc_mag()` path with: re-lock tilt preserving yaw via `initialize_from_acc_preserve_yaw()`, compute a single heading pseudo-measurement from `MagAutoTuner` circular statistics, apply a covariance-consistent heading update, then seed the world mag reference and enter a brief mag-grace period (files changed: `src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h`).
- Added a new MEKF API `measurement_update_heading_only(T heading_rad_meas, T heading_std_rad)` to `Kalman3D_Wave_OU_II` that computes a wrapped heading residual, numerically forms the yaw Jacobian w.r.t. the 3× attitude error, and performs a Joseph-form scalar covariance update with consistent quaternion error-state injection (file changed: `src/kalman_ou_ii/Kalman3D_Wave_OU_II.h`).
- Extended `MagAutoTuner` to expose circular-heading outputs needed for a Bayesian commit: weighted circular mean, circular-variance proxy, and an `N_eff` (effective samples) estimate; added bookkeeping for weighted-sum-of-squares to compute `N_eff` (file changed: `src/tuner/MagAutoTuner.h`).
- Numerical and implementation hygiene: heading residuals use wrapping, the heading update respects existing startup freezes (linear block and accel-bias freeze), and covariance updates use Joseph form and `symmetrize` where applicable.

### Testing
- Ran `make all` successfully in this environment with `CPPFLAGS` include path to Eigen (`/usr/include/eigen3`).
- Built and executed the OU-II sim binary `tests/kalman_ou_ii/kalman_ou_ii-sim`, which started successfully with `with_mag=true` and no runtime errors observed; the environment does not contain the wave CSV dataset so per-file quality summaries were not produced here.
- Confirmed the yaw test gate remains `3.0f` (`tests/kalman_ou_ii/kalman_ou_ii-sim.cpp: .err_limit_yaw_deg = 3.0f`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de858a2e988328baa62d7b3e882796)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added heading-only measurement updates to enable improved scalar heading estimation accuracy.
  * Enhanced initialization sequence with Bayesian heading estimates from magnetometer and accelerometer data for better magnetic north alignment.
  * Added new heading estimate accessors with circular variance and effective sample calculations for better sensor fusion diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->