### PR TITLE
Staged startup: tilt-only accel and mag-grace for OU III fusion

### DIFF
--- a/src/kalman_ou_iii/Kalman3D_Wave_OU_III.h
+++ b/src/kalman_ou_iii/Kalman3D_Wave_OU_III.h
@@ -263,6 +263,8 @@ class Kalman3D_Wave_OU_III {
     // Measurement updates preserved (operate on extended state internally)
     void measurement_update_acc_only(Vector3 const& acc, T tempC = tempC_ref);
     void measurement_update_mag_only(Vector3 const& mag);
+    void set_acc_tilt_only_mode(bool on) { accel_tilt_only_mode_ = on; }
+    bool acc_tilt_only_mode() const { return accel_tilt_only_mode_; }
 
     // Extended-only API:
     // Apply zero pseudo-measurement on S (integral drift correction)
@@ -660,6 +662,7 @@ class Kalman3D_Wave_OU_III {
 
     bool linear_block_enabled_ = true;
     bool acc_bias_updates_enabled_ = true;
+    bool accel_tilt_only_mode_ = false;
 
     bool has_cross_cov_a_xy = false;
     bool use_exact_att_bias_Qd_ = true;
@@ -1894,9 +1897,7 @@ void Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::measurement_updat
     }
 
     const Vector3 f_meas = acc_meas;
-    const Vector3 r = f_meas - f_pred;
-
-    last_acc_diag_.r = r;
+    const Vector3 r_raw = f_meas - f_pred;
 
     // Jacobians from linearization at CoG-only part (lever-arm is attitude-independent)
     Matrix3 J_att;
@@ -1914,9 +1915,37 @@ void Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::measurement_updat
         J_aw.setZero(); // no aw Jacobian when linear is OFF
     }
 
+    Matrix3 M_tilt = Matrix3::Identity();
+    if (accel_tilt_only_mode_) {
+        Vector3 ghat_b = R_wb() * g_world;
+        const T gn = ghat_b.norm();
+        if (gn > T(1e-9)) {
+            ghat_b /= gn;
+            M_tilt = Matrix3::Identity() - ghat_b * ghat_b.transpose();
+        }
+    }
+    const Vector3 r = M_tilt * r_raw;
+    last_acc_diag_.r = r;
+    J_att = M_tilt * J_att;
+    J_aw  = M_tilt * J_aw;
+    if constexpr (with_gyro_bias) {
+        J_bg = M_tilt * J_bg;
+    }
+
     // Innovation covariance S = C P Cᵀ + Racc (3×3)
     Matrix3& S_mat = S_scratch_;
-    S_mat = Racc;
+    S_mat = M_tilt * Racc * M_tilt.transpose();
+    if (accel_tilt_only_mode_) {
+        Vector3 ghat_b = R_wb() * g_world;
+        const T gn = ghat_b.norm();
+        if (gn > T(1e-9)) {
+            ghat_b /= gn;
+            const T sigma_parallel = std::max(T(1e-3), Racc.trace() / T(3)) * T(1e3);
+            S_mat.noalias() += sigma_parallel * (ghat_b * ghat_b.transpose());
+        } else {
+            S_mat.noalias() += Matrix3::Identity() * T(1e-3);
+        }
+    }
     {
         constexpr int OFF_TH = 0;
         const int off_aw = OFF_AW;
@@ -1944,31 +1973,31 @@ void Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::measurement_updat
 		    if (use_ba) {
 		        const Matrix3 P_th_ba = Pext.template block<3,3>(OFF_TH, off_ba);
 
-		        // J_ba = I
+		        const Matrix3 J_ba = M_tilt;
 		        S_mat.noalias() += J_att * P_th_ba;
 		        S_mat.noalias() += P_th_ba.transpose() * J_att.transpose();
-		        S_mat.noalias() += P_ba_ba;
+		        S_mat.noalias() += J_ba * P_ba_ba * J_ba.transpose();
 
 		        if (linear_block_enabled_) {
 		            const Matrix3 P_aw_ba = Pext.template block<3,3>(off_aw, off_ba);
-		            S_mat.noalias() += J_aw * P_aw_ba;
-		            S_mat.noalias() += P_aw_ba.transpose() * J_aw.transpose();
+		            S_mat.noalias() += J_aw * P_aw_ba * J_ba.transpose();
+		            S_mat.noalias() += J_ba * P_aw_ba.transpose() * J_aw.transpose();
 		        }
 		    } else {
 		        // BA frozen: marginalize its uncertainty (and any existing cross-cov) into S.
 		        // (If code already zeroed P_th_ba/P_aw_ba when disabling BA updates, these are 0 anyway.)
 		        const Matrix3 P_th_ba = Pext.template block<3,3>(OFF_TH, off_ba);
 
-		        // J_ba = I
+		        const Matrix3 J_ba = M_tilt;
 		        S_mat.noalias() += J_att * P_th_ba;
 		        S_mat.noalias() += P_th_ba.transpose() * J_att.transpose();
 
 		        if (linear_block_enabled_) {
 		            const Matrix3 P_aw_ba = Pext.template block<3,3>(off_aw, off_ba);
-		            S_mat.noalias() += J_aw * P_aw_ba;
-		            S_mat.noalias() += P_aw_ba.transpose() * J_aw.transpose();
+		            S_mat.noalias() += J_aw * P_aw_ba * J_ba.transpose();
+		            S_mat.noalias() += J_ba * P_aw_ba.transpose() * J_aw.transpose();
 		        }
-		        S_mat.noalias() += P_ba_ba;
+		        S_mat.noalias() += J_ba * P_ba_ba * J_ba.transpose();
 		    }
 		}
         if constexpr (with_gyro_bias) {
@@ -1990,8 +2019,9 @@ void Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::measurement_updat
                 if constexpr (with_accel_bias) {
                     if (use_ba) {
                         const Matrix3 P_bg_ba = Pext.template block<3,3>(OFF_BG, OFF_BA);
-                        S_mat.noalias() += J_bg * P_bg_ba; // J_ba = I
-                        S_mat.noalias() += P_bg_ba.transpose() * J_bg.transpose();
+                        const Matrix3 J_ba = M_tilt;
+                        S_mat.noalias() += J_bg * P_bg_ba * J_ba.transpose();
+                        S_mat.noalias() += J_ba * P_bg_ba.transpose() * J_bg.transpose();
                     }
                 }
             }
@@ -2012,7 +2042,7 @@ void Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::measurement_updat
         if constexpr (with_accel_bias) {
             if (use_ba) {
                 const auto P_all_ba = Pext.template block<NX,3>(0, OFF_BA);
-                PCt.noalias() += P_all_ba; // J_ba = I
+                PCt.noalias() += P_all_ba * M_tilt.transpose();
             }
         }
         if constexpr (with_gyro_bias) {

--- a/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
+++ b/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
@@ -1228,6 +1228,9 @@ public:
 
         // Used only if dt_mag can’t be inferred
         float mag_odr_guess_hz = 80.0f;
+        int mag_grace_updates = 20;
+        float mag_grace_nis_max = 18.0f;
+        Eigen::Vector3f sigma_m_grace_scale = Eigen::Vector3f(2.5f, 2.5f, 4.0f);
 
         // MagAutoTuner config override (optional)
         bool use_custom_mag_tuner_cfg = false;
@@ -1240,10 +1243,12 @@ public:
         // Reset wrapper state
         begun_ = true;
         stage_ = Stage::Uninitialized;
+        mag_phase_ = MagStartupPhase::TiltWarm;
         t_ = 0.0f;
         stage_t_ = 0.0f;
 
         mag_ref_set_ = false;
+        mag_grace_good_updates_ = 0;
         mag_body_hold_.setZero();
         last_mag_time_sec_ = NAN;
         dt_mag_sec_ = NAN;
@@ -1278,6 +1283,10 @@ public:
 
         impl_.initialize(cfg.sigma_a, cfg.sigma_g, cfg.sigma_m);
         last_impl_startup_stage_ = impl_.getStartupStage();
+        sigma_m_nominal_ = cfg.sigma_m;
+        sigma_m_grace_ = cfg.sigma_m.cwiseProduct(cfg.sigma_m_grace_scale).cwiseMax(Eigen::Vector3f::Constant(1e-4f));
+        impl_.mekf().set_Rmag(sigma_m_grace_);
+        impl_.mekf().set_acc_tilt_only_mode(true);
 
         // IMPORTANT: allow warmup to restore nominal accel measurement noise
         impl_.setNominalRacc(cfg.sigma_a);
@@ -1315,11 +1324,15 @@ public:
         // If internal filter fell back to Cold (tilt reset), force mag ref re-learn
 const auto cur_stage = impl_.getStartupStage();
 
-if (cur_stage != last_impl_startup_stage_) {
+        if (cur_stage != last_impl_startup_stage_) {
     if (cur_stage == SeaStateFusionFilter_OU_III<trackerT>::StartupStage::Cold) {
         // Entered Cold (startup or non-Live tilt reset): reset mag-init ONCE
         mag_ref_set_ = false;
+        mag_phase_ = MagStartupPhase::TiltWarm;
+        mag_grace_good_updates_ = 0;
         mag_auto_.reset();
+        impl_.mekf().set_Rmag(sigma_m_grace_);
+        impl_.mekf().set_acc_tilt_only_mode(true);
 
         last_mag_time_sec_ = NAN;
         dt_mag_sec_ = NAN;
@@ -1336,6 +1349,9 @@ if (cur_stage != last_impl_startup_stage_) {
 
         if (stage_ == Stage::Warming && impl_.isAdaptiveLive()) {
             stage_ = Stage::Live;
+        }
+        if (mag_phase_ != MagStartupPhase::Live) {
+            impl_.mekf().set_acc_tilt_only_mode(true);
         }
     }
 
@@ -1378,75 +1394,86 @@ if (cur_stage != last_impl_startup_stage_) {
             }
         }
 
-        // Respect mag delay for actual mag fusion, but keep learning active
-        // from startup so the first post-delay reference is better conditioned.
+        // Respect mag delay for actual mag fusion, but keep learning active.
         if (t_ < cfg_.mag_delay_sec) return;
 
+        if (mag_phase_ == MagStartupPhase::TiltWarm) {
+            mag_phase_ = MagStartupPhase::MagCollect;
+        }
+
+        if (!mag_ref_set_ && cfg_.use_fixed_mag_world_ref &&
+            cfg_.mag_world_ref.allFinite() && cfg_.mag_world_ref.norm() > 1e-3f) {
+            impl_.mekf().set_mag_world_ref(cfg_.mag_world_ref);
+            mag_ref_set_ = true;
+            mag_phase_ = MagStartupPhase::MagGrace;
+            mag_grace_good_updates_ = 0;
+            impl_.mekf().set_Rmag(sigma_m_grace_);
+        }
+
         if (!mag_ref_set_) {
-            if (cfg_.use_fixed_mag_world_ref) {
-                impl_.mekf().set_mag_world_ref(cfg_.mag_world_ref);
-                mag_ref_set_ = true;
-            } else {
-                // If a valid world-field prior exists (e.g., WMM), use it immediately
-                // once mag fusion window opens. This avoids prolonged yaw drift while
-                // waiting for learned alignment under rough sea/noisy startup.
+            Eigen::Vector3f acc_for_ref = last_acc_body_ned_;
+            Eigen::Vector3f mag_body_for_ref = mag_body_ned;
+            bool have_ref_candidate = false;
+
+            Eigen::Vector3f acc_mean, mag_raw_mean, mag_unit_mean;
+            float heading_mean = 0.0f, heading_sigma = 0.0f, heading_neff = 0.0f;
+            const bool have_tuner_ref = mag_auto_.getResult(acc_mean, mag_raw_mean, mag_unit_mean);
+            const bool have_heading_stats = mag_auto_.getHeadingEstimate(heading_mean, heading_sigma, heading_neff);
+            if (have_tuner_ref && have_heading_stats &&
+                acc_mean.allFinite() && acc_mean.norm() > 1e-3f &&
+                mag_raw_mean.allFinite() && mag_raw_mean.norm() > 1e-3f &&
+                heading_neff >= 8.0f)
+            {
+                acc_for_ref = acc_mean;
+                mag_body_for_ref = mag_raw_mean;
+                have_ref_candidate = true;
+            }
+
+            if (!have_ref_candidate &&
+                std::isfinite(mag_ref_deadline_sec_) && t_ >= mag_ref_deadline_sec_)
+            {
                 if (cfg_.mag_world_ref.allFinite() && cfg_.mag_world_ref.norm() > 1e-3f) {
                     impl_.mekf().set_mag_world_ref(cfg_.mag_world_ref);
                     mag_ref_set_ = true;
-                }
-
-                Eigen::Vector3f mag_body_for_ref = mag_body_ned;
-                Eigen::Vector3f acc_for_ref = last_acc_body_ned_;
-                bool have_ref_candidate = false;
-
-                // Preferred: learned relation from stable samples only.
-                Eigen::Vector3f acc_mean, mag_raw_mean, mag_unit_mean;
-                if (!mag_ref_set_ && mag_auto_.getResult(acc_mean, mag_raw_mean, mag_unit_mean)) {
-                    if (acc_mean.allFinite() && acc_mean.norm() > 1e-3f &&
-                        mag_raw_mean.allFinite() && mag_raw_mean.norm() > 1e-3f)
-                    {
-                        acc_for_ref = acc_mean;
-                        mag_body_for_ref = mag_raw_mean;
-                        have_ref_candidate = true;
-                    }
-                }
-
-                // Timeout fallback policy:
-                //  1) Prefer caller-provided world-field prior if valid.
-                //  2) Else use robust running means (many samples), never one-shot sample.
-                if (!have_ref_candidate &&
-                    std::isfinite(mag_ref_deadline_sec_) && t_ >= mag_ref_deadline_sec_)
+                } else if (fallback_mean_count_ >= 200 &&
+                           fallback_acc_mean_.allFinite() && fallback_acc_mean_.norm() > 1e-3f &&
+                           fallback_mag_mean_.allFinite() && fallback_mag_mean_.norm() > 1e-3f)
                 {
-                    if (cfg_.mag_world_ref.allFinite() && cfg_.mag_world_ref.norm() > 1e-3f) {
-                        impl_.mekf().set_mag_world_ref(cfg_.mag_world_ref);
-                        mag_ref_set_ = true;
-                    } else if (fallback_mean_count_ >= 200 &&
-                               fallback_acc_mean_.allFinite() && fallback_acc_mean_.norm() > 1e-3f &&
-                               fallback_mag_mean_.allFinite() && fallback_mag_mean_.norm() > 1e-3f)
-                    {
-                        acc_for_ref = fallback_acc_mean_;
-                        mag_body_for_ref = fallback_mag_mean_;
-                        have_ref_candidate = true;
-                    } else {
-                        // Keep waiting; extend deadline to avoid busy re-checking.
-                        mag_ref_deadline_sec_ = t_ + cfg_.mag_ref_timeout_sec;
-                    }
+                    acc_for_ref = fallback_acc_mean_;
+                    mag_body_for_ref = fallback_mag_mean_;
+                    have_ref_candidate = true;
+                } else {
+                    mag_ref_deadline_sec_ = t_ + cfg_.mag_ref_timeout_sec;
                 }
+            }
 
-                if (!mag_ref_set_ && have_ref_candidate) {
-                    Eigen::Quaternionf q_tilt = tiltOnlyQuatFromAccel_(acc_for_ref);
-                    q_tilt.normalize();
-
-                    Eigen::Vector3f mag_world_ref_uT = q_tilt * mag_body_for_ref; // keep raw uT
-                    if (mag_world_ref_uT.allFinite() && mag_world_ref_uT.norm() > 1e-3f) {
-                        impl_.mekf().set_mag_world_ref(mag_world_ref_uT);
-                        mag_ref_set_ = true;
-                    }
+            if (!mag_ref_set_ && have_ref_candidate) {
+                Eigen::Quaternionf q_tilt = tiltOnlyQuatFromAccel_(acc_for_ref);
+                q_tilt.normalize();
+                Eigen::Vector3f mag_world_ref_uT = q_tilt * mag_body_for_ref;
+                if (mag_world_ref_uT.allFinite() && mag_world_ref_uT.norm() > 1e-3f) {
+                    impl_.mekf().set_mag_world_ref(mag_world_ref_uT);
+                    mag_ref_set_ = true;
+                    mag_phase_ = MagStartupPhase::MagGrace;
+                    mag_grace_good_updates_ = 0;
+                    impl_.mekf().set_Rmag(sigma_m_grace_);
                 }
             }
         }
-        if (mag_ref_set_) {
-          impl_.updateMag(mag_body_ned);
+
+        if (!mag_ref_set_) return;
+
+        impl_.updateMag(mag_body_ned);
+        const auto& mdiag = impl_.mekf().lastMagDiag();
+        if (mag_phase_ == MagStartupPhase::MagGrace) {
+            if (mdiag.accepted && std::isfinite(mdiag.nis) && mdiag.nis < cfg_.mag_grace_nis_max) {
+                mag_grace_good_updates_++;
+            }
+            if (mag_grace_good_updates_ >= std::max(1, cfg_.mag_grace_updates)) {
+                impl_.mekf().set_Rmag(sigma_m_nominal_);
+                impl_.mekf().set_acc_tilt_only_mode(false);
+                mag_phase_ = MagStartupPhase::Live;
+            }
         }
     }
 
@@ -1460,6 +1487,7 @@ if (cur_stage != last_impl_startup_stage_) {
 
 private:
     enum class Stage { Uninitialized, Warming, Live };
+    enum class MagStartupPhase { TiltWarm, MagCollect, MagGrace, Live };
 
     // Tilt-only (yaw-free) quaternion body->world from accel.
     // We assume “rest accel” direction represents gravity (up to sign convention),
@@ -1510,6 +1538,7 @@ private:
     bool begun_ = false;
 
     Stage stage_ = Stage::Uninitialized;
+    MagStartupPhase mag_phase_ = MagStartupPhase::TiltWarm;
     float t_ = 0.0f;
     float stage_t_ = 0.0f;
     typename SeaStateFusionFilter_OU_III<trackerT>::StartupStage last_impl_startup_stage_ =
@@ -1533,6 +1562,9 @@ private:
     Eigen::Vector3f fallback_acc_mean_ = Eigen::Vector3f::Zero();
     Eigen::Vector3f fallback_mag_mean_ = Eigen::Vector3f::Zero();
     int fallback_mean_count_ = 0;
+    Eigen::Vector3f sigma_m_nominal_ = Eigen::Vector3f(0.3f, 0.3f, 0.3f);
+    Eigen::Vector3f sigma_m_grace_ = Eigen::Vector3f(0.75f, 0.75f, 1.2f);
+    int mag_grace_good_updates_ = 0;
 
     MagAutoTuner mag_auto_;
 };

--- a/src/tuner/MagAutoTuner.h
+++ b/src/tuner/MagAutoTuner.h
@@ -58,6 +58,9 @@ public:
     // Optional heading-consistency gate on tilt-compensated horizontal field.
     float heading_jump_deg_max = 20.0f;
     float min_heading_concentration = 0.75f;
+    float max_heading_sigma_rad = 0.70f; // circular std proxy gate
+    float weight_accel_dyn = 0.10f;
+    float weight_gyro_dyn = 2.0f;
 
     // How many accepted samples we require
     int   min_good_samples  = 40;    // e.g. 0.4s @ 100 Hz mag
@@ -89,6 +92,7 @@ public:
     heading_C_ = 0.0f;
     heading_S_ = 0.0f;
     heading_wsum_ = 0.0f;
+    heading_wsum2_ = 0.0f;
   }
 
   // Call only when you actually have a NEW mag sample.
@@ -133,10 +137,16 @@ public:
     good_count_++;
     t_good_ += dt;
 
-    const float w = 1.0f / std::max(1.0e-6f, mag_norm_ema_);
+    const float acc_dyn = std::fabs(acc_body_ned.norm() - cfg_.g);
+    const float gyro_dyn = gyro_body_ned.norm();
+    const float w = 1.0f / std::max(1.0e-6f,
+                                    mag_norm_ema_
+                                      + cfg_.weight_accel_dyn * acc_dyn * acc_dyn
+                                      + cfg_.weight_gyro_dyn * gyro_dyn * gyro_dyn);
     heading_C_ += w * std::cos(heading_rad);
     heading_S_ += w * std::sin(heading_rad);
     heading_wsum_ += w;
+    heading_wsum2_ += w * w;
     if (heading_wsum_ > 1.0e-6f) {
       heading_mean_rad_ = std::atan2(heading_S_, heading_C_);
       have_heading_mean_ = true;
@@ -152,7 +162,9 @@ public:
         const float mrn = mr.norm();
         if (std::isfinite(mrn) && mrn > cfg_.mag_norm_min) {
           const float conc = headingConcentration();
-          if (std::isfinite(conc) && conc >= cfg_.min_heading_concentration) {
+          const float sigma_psi = headingSigmaRad();
+          if (std::isfinite(conc) && conc >= cfg_.min_heading_concentration &&
+              std::isfinite(sigma_psi) && sigma_psi <= cfg_.max_heading_sigma_rad) {
             ready_ = true;
           }
         }
@@ -202,6 +214,21 @@ public:
     const float C = heading_C_ / heading_wsum_;
     const float S = heading_S_ / heading_wsum_;
     return std::sqrt(C * C + S * S);
+  }
+
+  float headingSigmaRad() const {
+    const float conc = headingConcentration();
+    if (!(conc > 1.0e-6f) || !std::isfinite(conc)) return std::numeric_limits<float>::infinity();
+    return std::sqrt(std::max(0.0f, -2.0f * std::log(std::min(1.0f, conc))));
+  }
+
+  bool getHeadingEstimate(float& heading_mean_rad, float& sigma_heading_rad, float& n_eff) const {
+    if (!ready_ || !have_heading_mean_) return false;
+    if (!(heading_wsum_ > 1.0e-6f) || !(heading_wsum2_ > 1.0e-6f)) return false;
+    heading_mean_rad = heading_mean_rad_;
+    sigma_heading_rad = headingSigmaRad();
+    n_eff = (heading_wsum_ * heading_wsum_) / heading_wsum2_;
+    return std::isfinite(heading_mean_rad) && std::isfinite(sigma_heading_rad) && std::isfinite(n_eff);
   }
 
 private:
@@ -311,6 +338,7 @@ private:
   float heading_C_ = 0.0f;
   float heading_S_ = 0.0f;
   float heading_wsum_ = 0.0f;
+  float heading_wsum2_ = 0.0f;
 
   // Heel-safe accel direction EMA
   Eigen::Vector3f acc_dir_ema_ = Eigen::Vector3f::Zero();
@@ -357,6 +385,9 @@ static inline MagAutoTuner::Config makeDefaultMagInitCfg(float mag_odr_hz) {
 
     c.heading_jump_deg_max = 18.0f;
     c.min_heading_concentration = 0.82f;
+    c.max_heading_sigma_rad = 0.55f;
+    c.weight_accel_dyn = 0.20f;
+    c.weight_gyro_dyn = 2.5f;
 
     // Require about ~0.7 s of good data, but cap samples so 100 Hz doesn’t wait forever.
     c.min_good_time_sec = 0.70f;


### PR DESCRIPTION
### Motivation
- Prevent artificial yaw learning during startup by treating alignment as staged Bayesian conditioning (tilt → collect mag → commit heading → grace → live). 
- Make magnetometer initialization robust under wave dynamics by collecting only stable samples and applying a single, well-conditioned commit with an intermediate grace period.

### Description
- Added a tilt-only accelerometer update mode to `Kalman3D_Wave_OU_III` that projects accel residuals/Jacobians into the gravity-orthogonal subspace and inflates the unobservable (gravity) direction variance; exposed via `set_acc_tilt_only_mode(bool)` and `acc_tilt_only_mode()` (file: `src/kalman_ou_iii/Kalman3D_Wave_OU_III.h`).
- Implemented a staged magnetometer startup state machine in `SeaStateFusion_OU_III`: `TiltWarm -> MagCollect -> MagGrace -> Live`, with learning-from-stable-samples, timeout fallback, an inflated `Rmag` during MagGrace, NIS-based promotion to Live, and automatic disabling of tilt-only accel mode after grace completes (file: `src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h`).
- Improved `MagAutoTuner` scoring to support Bayesian-style batch heading commits by adding dynamic weighting against accel/gyro dynamics, a circular-sigma proxy and effective sample size (`n_eff`), and an API to return heading estimate + sigma + n_eff; added related config knobs and defaults (file: `src/tuner/MagAutoTuner.h`).
- Kept changes focused to startup/path gating and measurement handling only; no public API renames or build-target changes.

### Testing
- Ran `make all` successfully (full build completed without errors). 
- Executed the OU-III simulation `./tests/kalman_ou_iii/kalman_ou_iii-sim` which started with magnetometer enabled and the configured mag delay and printed expected startup output (run completed). 
- Ran `make clean` after the build to verify clean target (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de88b1c0a88328868c3507e3ccd49f)