### PR TITLE
Introduce SIM_MAG_DELAY_SEC and use it for mag delay in kalman_ou_ii simulator

### DIFF
--- a/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
+++ b/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
@@ -20,6 +20,7 @@ using Eigen::Vector3f;
 
 bool add_noise = true;
 bool attitude_only = false;
+static constexpr float SIM_MAG_DELAY_SEC = 0.0f;
 
 class FusionAdapter_OU_II final : public IW3dFusionAdapter {
 public:
@@ -33,7 +34,7 @@ public:
         cfg_.sigma_a = sigma_a_init;
         cfg_.sigma_g = sigma_g;
         cfg_.sigma_m = sigma_m;
-        cfg_.mag_delay_sec = 0.0f; //MAG_DELAY_SEC;
+        cfg_.mag_delay_sec = SIM_MAG_DELAY_SEC;
         cfg_.use_fixed_mag_world_ref = false;
         cfg_.mag_world_ref = mag_world_a;
         cfg_.freeze_acc_bias_until_live = true;
@@ -163,7 +164,7 @@ int main(int argc, char* argv[]) {
     }
 
     std::cout << "Simulation starting with_mag=" << (with_mag ? "true" : "false")
-              << ", mag_delay=" << MAG_DELAY_SEC
+              << ", mag_delay=" << SIM_MAG_DELAY_SEC
               << " sec, noise=" << (add_noise ? "true" : "false")
               << "\n";
 


### PR DESCRIPTION
### Motivation
- Centralize the simulation magnetic delay constant and replace scattered hardcoded values to make the simulator configuration consistent and avoid referencing an external macro.

### Description
- Add `static constexpr float SIM_MAG_DELAY_SEC = 0.0f;` to `tests/kalman_ou_ii/kalman_ou_ii-sim.cpp` and use it to initialize `cfg_.mag_delay_sec` instead of the previous literal, and update the console print to report `SIM_MAG_DELAY_SEC`.

### Testing
- Built the `tests/kalman_ou_ii/kalman_ou_ii-sim` test binary and ran a smoke execution of the simulator to verify it starts and prints the configured mag delay; the build and run succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de8cdf95e48328ba55ed11da39b22d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved magnetometer delay configuration in the simulation test suite by introducing a configurable constant, replacing hardcoded values and enhancing test maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->