### PR TITLE
Fix yaw-reference convention mismatch in W3D simulation reader

### DIFF
--- a/src/util/W3dSimCommon.cpp
+++ b/src/util/W3dSimCommon.cpp
@@ -235,10 +235,15 @@ std::optional<W3dSimulationRunResult> W3dSimulationRunner::run(const std::string
         const Quaternionf q_ref_wb_zu = quat_from_csv(rec.imu);
         const Matrix3f C_wb_zu = q_ref_wb_zu.toRotationMatrix();
 
-        float r_ref_out = 0.0f;
-        float p_ref_out = 0.0f;
-        float y_ref_out = 0.0f;
-        quat_wb_zu_to_euler_nautical(q_ref_wb_zu, r_ref_out, p_ref_out, y_ref_out);
+        // Use the Euler angles recorded in the CSV as reference outputs.
+        //
+        // The simulator can generate a pure tilt orientation (no physical yaw), but
+        // decomposing a generic quaternion with ZYX Euler can introduce an apparent
+        // yaw term due to rotation-order coupling. Reading the explicit CSV Euler
+        // fields avoids this convention mismatch in error statistics.
+        const float r_ref_out = rec.imu.roll_deg;
+        const float p_ref_out = rec.imu.pitch_deg;
+        const float y_ref_out = rec.imu.yaw_deg;
       
         fusion_adapter_.update(options_.dt, gyr_meas_ned, acc_meas_ned, options_.temperature_c);
         if (options_.with_mag) {


### PR DESCRIPTION
### Motivation
- The reference-reading path decomposed `q_wb_zu` into ZYX Euler angles which can produce an apparent non-zero yaw for tilt-only generator orientations due to rotation-order coupling.

### Description
- Replace quaternion ZYX decomposition used for reference outputs with the explicit CSV Euler fields `rec.imu.roll_deg`, `rec.imu.pitch_deg`, and `rec.imu.yaw_deg` in `W3dSimulationRunner::run` (`src/util/W3dSimCommon.cpp`).
- Keep quaternion usage for rotation-matrix-driven magnetometer synthesis unchanged so simulation behavior is stable.
- Add an inline comment explaining why quaternion decomposition can introduce spurious yaw for tilt-only orientations.

### Testing
- Ran `make all` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deff6991ac8328b632e9390d943455)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated reference orientation values (roll, pitch, yaw) to use directly recorded CSV data instead of computed values, ensuring more accurate error calculations and statistics reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->