### PR TITLE
Fix OU II sim magnetometer startup delay and yaw reference

### DIFF
--- a/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
+++ b/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
@@ -33,7 +33,7 @@ public:
         cfg_.sigma_a = sigma_a_init;
         cfg_.sigma_g = sigma_g;
         cfg_.sigma_m = sigma_m;
-        cfg_.mag_delay_sec = 0.0f; //MAG_DELAY_SEC;
+        cfg_.mag_delay_sec = MAG_DELAY_SEC;
         cfg_.use_fixed_mag_world_ref = false;
         cfg_.mag_world_ref = mag_world_a;
         cfg_.freeze_acc_bias_until_live = true;
@@ -80,10 +80,8 @@ public:
 
         // Use the exact same finite-angle conversion path as the sim truth side.
         quat_to_euler_nautical(q_bw_ned, roll_deg, pitch_deg, yaw_deg);
-        // Reporting correction: mag-based north lock is magnetic-north-referenced,
-        // while truth yaw is true-north-referenced in the wave CSV data.
-        // Convert estimated yaw to true-north heading using WMM declination.
-        yaw_deg = wrapDeg(yaw_deg + MagSim_WMM::default_declination_deg);
+        // Keep yaw in the same reference as OU_III simulation reporting.
+        // (No extra declination correction in post-processing.)
         s.euler_nautical_deg = Vector3f(roll_deg, pitch_deg, yaw_deg);
 
         s.acc_bias_est_ned = filter.mekf().get_acc_bias();


### PR DESCRIPTION
### Motivation
- OU II simulation was forcing immediate magnetometer updates and applying an extra declination correction to reported yaw, producing an artificial yaw offset relative to the OU III path; the intent is to align OU II sim startup and yaw reference with OU III.

### Description
- Update `tests/kalman_ou_ii/kalman_ou_ii-sim.cpp` to set `cfg_.mag_delay_sec = MAG_DELAY_SEC` instead of `0.0f` and remove the post-processing `yaw_deg = wrapDeg(yaw_deg + MagSim_WMM::default_declination_deg)` so OU II uses the configured mag startup delay and the same yaw reference as OU III.

### Testing
- Ran `make all` from the repository root and the build completed successfully. 
- Built and ran the OU II simulation binary with `./tests/kalman_ou_ii/kalman_ou_ii-sim --no-noise`, which started and printed `Simulation starting with_mag=true, mag_delay=8 sec, noise=false`, confirming the mag delay is applied; a full metrics sweep was not produced here due to missing wave CSV data files in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc77db5b88328a0455b78843def42)