### PR TITLE
Fix OU_III live tilt reset to preserve yaw/north frame

### DIFF
--- a/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
+++ b/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
@@ -221,12 +221,12 @@ public:
             }
 
             if (tilt_over_limit_sec_ >= TILT_RESET_HOLD_SEC && tilt_reset_cooldown_sec_ <= 0.0f) {
-                // Re-lock attitude to gravity.
-                mekf_->initialize_from_acc(acc);
-
-                // Only force full Cold re-entry while not yet fully live. In Live, keep
-                // linear states running to avoid long "frozen heave" plateaus.
-                if (startup_stage_ != StartupStage::Live) {
+                if (startup_stage_ == StartupStage::Live) {
+                    // In Live, re-lock only tilt while preserving yaw/north frame.
+                    mekf_->initialize_from_acc_preserve_yaw(acc);
+                } else {
+                    // During startup stages, accel-only re-lock is acceptable.
+                    mekf_->initialize_from_acc(acc);
                     enterCold_();
                     resetTrackingState_();
                 }


### PR DESCRIPTION
### Motivation
- OU_III was performing an accel-only tilt re-lock during live operation which could reset the yaw/north frame and diverge from OU_II behavior.

### Description
- Update `SeaStateFusionFilter_OU_III` so the tilt-reset path uses `mekf_->initialize_from_acc_preserve_yaw(acc)` when `startup_stage_ == StartupStage::Live`, while keeping the accel-only `initialize_from_acc(acc)` plus `enterCold_()` and `resetTrackingState_()` for non-live startup stages.

### Testing
- Ran `make all` which compiled the test binaries and completed successfully with no build errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfde9beb9c8328b9d987dcc605fe6a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attitude relock behavior when tilt exceeds reset threshold. The system now intelligently handles recovery based on operational state—preserving yaw orientation during live mode while properly resetting tracking state in initialization phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->