### PR TITLE
Fix pii_observer yaw bias by compensating WMM declination

### DIFF
--- a/tests/pii_observer/pii_observer-adaptive.cpp
+++ b/tests/pii_observer/pii_observer-adaptive.cpp
@@ -102,6 +102,10 @@ public:
         float yaw_sim_deg = hs.yaw_deg;
         if (!with_mag_) {
             yaw_sim_deg = 0.0f;
+        } else {
+            // Mahony yaw is magnetic heading unless the reference field is
+            // explicitly declination-compensated. Test truth yaw is true heading.
+            yaw_sim_deg -= MagSim_WMM::default_declination_deg;
         }
         s.euler_nautical_deg = Vector3f(roll_sim_deg, pitch_sim_deg, wrapDeg(yaw_sim_deg));
 


### PR DESCRIPTION
### Motivation
- Tests showed a ~12.6–12.7° yaw offset between the Mahony-derived magnetic heading and the simulation CSV truth (true heading), causing inflated yaw RMS in the `pii_observer` test harness.

### Description
- Adjusted the PII observer test reporter in `tests/pii_observer/pii_observer-adaptive.cpp` to compensate Mahony yaw by subtracting `MagSim_WMM::default_declination_deg` when magnetometer fusion is enabled, aligning magnetic heading to true heading for comparison.
- Change is deliberately minimal and scoped to the test harness reporting path and does not modify any public API, build targets, or algorithm code.

### Testing
- Built the affected test with `make -C tests/pii_observer all` which completed successfully.
- Ran full repository build with `make all` which completed successfully.
- Executed the test binary `cd tests/pii_observer && ./pii_observer-adaptive` and observed the large fixed yaw offset removed (previous ~24°/12.7° bias corrected), but one high-sea-state case still exceeds the strict yaw RMS gate (observed ~3.13° > 1.5°), so the test run overall still reports a failing quality gate for that case.
- Executed without noise `cd tests/pii_observer && ./pii_observer-adaptive --no-noise` with the same outcome: declination correction fixed the systematic offset but one case remains above the yaw RMS threshold (observed ~4.09° > 1.5°).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dff759509c83288e26d4297e6ca585)