### PR TITLE
docs(kalman_ou_iii): align LaTeX formulas with Kalman3D_Wave_OU_III implementation

### DIFF
--- a/doc/kalman_ou_iii/w3d-analytic-coeff.tex-part
+++ b/doc/kalman_ou_iii/w3d-analytic-coeff.tex-part
@@ -17,13 +17,13 @@ For the attitude error + gyro-bias (size \(3{+}3\)), the algorithm uses a struct
 path that matches the Q-MEKF with piecewise-constant \(\hat{\vct{\omega}}=
 \vct{\omega}_m-\vct{b}_g\) over the step:
 \begin{itemize}
-  \item \(\matg{\Phi}_{\!AA}(h)\) implements the right-multiplicative small-angle
+  \item \(\matg{\Phi}_{\!AA}(h)\) implements the left-multiplicative small-angle
         transition: the \(\delta\vct{\theta}\)-block is the Rodrigues
         expression
         \(\Phi_{\theta\theta}(h)=\Id - \sin\theta\,\mat{D} + (1-\cos\theta)\,\mat{D}^2\)
         with \(\theta=\|\hat{\vct{\omega}}\|h\) and
         \(\mat{D}=\Skew{\hat{\vct{\omega}}/\|\hat{\vct{\omega}}\|}\);
-        the \(\delta\vct{\theta}\)–\(\vct{b}_g\) block is \(-\Id\,h\).
+        the \(\delta\vct{\theta}\)–\(\vct{b}_g\) block is \(+\Id\,h\) to match the left-multiplicative error model.
   \item \(\matg{Q}_{\!AA}(h)\) is built from rotation integrals:
         \[
         \matg{Q}_{\theta\theta}=\int_0^{h}\! \Rot(s)\,\matg{Q}_g\,\Rot(s)^\top ds

--- a/doc/kalman_ou_iii/w3d-intro.tex-part
+++ b/doc/kalman_ou_iii/w3d-intro.tex-part
@@ -2,7 +2,7 @@
 \label{sec:intro}
 
 This paper presents a complete mathematical and algorithmic formulation of a
-\emph{quaternion right-multiplicative extended Kalman filter} (Q-MEKF)
+\emph{quaternion left-multiplicative extended Kalman filter} (Q-MEKF)
 augmented with an Ornstein--Uhlenbeck (OU) process model for latent
 acceleration. The filter is designed for marine inertial sensing and
 wave-kinematics reconstruction. The proposed framework unifies
@@ -21,7 +21,7 @@ excitation and MEMS errors in an efficient, embedded-friendly framework.
 \subsection*{From Standard Q-MEKF to Extended Kinematics}
 
 We start from a standard Q-MEKF \cite{Markley2003AttitudeError}, which estimates body attitude and
-gyroscope bias using a right-multiplicative quaternion error
+gyroscope bias using a left-multiplicative quaternion error
 representation. To enable full wave motion estimation, the state vector
 is augmented to include additional translational quantities:
 world-frame acceleration, velocity, displacement, and the integral of
@@ -107,7 +107,7 @@ The main contributions of this work are:
 \begin{itemize}
   \item A full analytic formulation of a 21-state Q-MEKF incorporating
         latent OU-driven acceleration, integral drift suppression, and
-        right-multiplicative quaternion error dynamics.
+        left-multiplicative quaternion error dynamics.
   \item Closed-form discrete-time transition and covariance matrices for
         the OU process and linear kinematic chain, with numerically
         stable small-step series expansions.

--- a/doc/kalman_ou_iii/w3d-kalm-up.tex-part
+++ b/doc/kalman_ou_iii/w3d-kalm-up.tex-part
@@ -26,12 +26,12 @@ The gyroscope does not enter the rank--3 correction formulas above because it is
 \hat{\vct{\omega}} \;=\; \vct{\omega}_{\text{meas}} - \hat{\vct{b}}_g .
 \]
 The nominal quaternion is advanced by $\hat{\vct{\omega}}$ via the discrete kinematics
-(e.g.\ $q^- = q^+ \otimes \exp_q(\tfrac{1}{2}\hat{\vct{\omega}}\,h)$), while the gyro noise and bias random walk
+(e.g.\ $q^- = \exp_q\!\left(-\tfrac{1}{2}\hat{\vct{\omega}}\,h\right) \otimes q^+$), while the gyro noise and bias random walk
 enter the \emph{process} covariance $\mat{Q}_d$ of the attitude/bias block (Sec.~\ref{sec:block-Phi-Qd}).
 
 If an ``un-heeled'' effective body frame $B'$ is enabled, the measured triads are first mapped as
-$\vct{f}^{\,B'}_{\text{meas}}=\Rot_x(-h)\vct{f}^{\,B}_{\text{meas}}$ and
-$\vct{m}^{\,B'}_{\text{meas}}=\Rot_x(-h)\vct{m}^{\,B}_{\text{meas}}$; the attitude state is then interpreted as
+$\vct{f}^{\,B'}_{\text{meas}}=\Rot_x(-\phi_h)\vct{f}^{\,B}_{\text{meas}}$ and
+$\vct{m}^{\,B'}_{\text{meas}}=\Rot_x(-\phi_h)\vct{m}^{\,B}_{\text{meas}}$; the attitude state is then interpreted as
 world$\to B'$. For notational simplicity we continue to write $\Rot_{wb}$ for the world$\to$(effective body) rotation
 used by the measurement models.
 
@@ -116,7 +116,7 @@ This characterization makes no algorithmic assumption: it is a direct algebraic 
 
 \paragraph{Magnetometer (attitude--only)}
 For a world-frame reference field $\vct{B}_w$ (in physical units), the measurement vector is
-$\vct{z}_{\text{mag}}=\vct{m}_{\text{meas}}$ and the model (with the standard sign fix) is
+$\vct{z}_{\text{mag}}=\vct{m}_{\text{meas}}$ and the model is
 \[
 \fitcol{
 \vct{z}_{\text{mag}} \;=\; \Rot_{wb}\,\vct{B}_w + \vct{\nu}_m,\qquad
@@ -137,7 +137,7 @@ It follows that
 \mat{K} \;=\; (\mat{P}\mat{C}^\top)\, \matg{\Lambda}^{-1}.
 }
 \]
-The posterior covariance then follows from the Joseph form, and the right--multiplicative attitude correction is applied to the quaternion, after which the attitude error subvector is reset.
+The posterior covariance then follows from the Joseph form, and the left--multiplicative attitude correction is applied to the quaternion, after which the attitude error subvector is reset.
 
 \paragraph{Accelerometer (attitude + latent $\vct{a}_w$ + bias $\vct{b}_a$)}
 For specific force in body coordinates, the measurement vector is $\vct{z}_{\text{acc}}=\vct{f}_{\text{meas}}$ and
@@ -172,7 +172,7 @@ After each correction, the small-angle attitude increment
 $\delta\vct{\theta}$ is converted back into a unit quaternion
 via
 \[
-q \leftarrow q \otimes \exp_q(\tfrac{1}{2}\delta\vct{\theta}),
+q \leftarrow \exp_q(\tfrac{1}{2}\delta\vct{\theta}) \otimes q,
 \qquad \delta\vct{\theta} \leftarrow \vct{0},
 \]
 closing the multiplicative EKF loop on~$SO(3)$.
@@ -185,7 +185,7 @@ $\mat{P}\mat{C}^\top$ with the $3\times 3$ inverse of $\matg{\Lambda}$. The post
 satisfies the usual invariants:
 \begin{itemize}\itemsep2pt
 \item $\mat{P}^{+}$ is symmetric and (to numerical precision) PSD under the Joseph update.
-\item The right--multiplicative quaternion correction preserves unit norm and keeps the
+\item The left--multiplicative quaternion correction preserves unit norm and keeps the
       linearization point consistent with the reset $\delta\vct{\theta}^{+}=0$.
 \end{itemize}
 This is precisely the form realized by the implementation: the block algebra expresses the method’s intrinsic

--- a/doc/kalman_ou_iii/w3d-meas.tex-part
+++ b/doc/kalman_ou_iii/w3d-meas.tex-part
@@ -33,7 +33,7 @@ where
 \end{itemize}
 
 The corresponding Jacobians, consistent with the
-right-multiplicative attitude convention, are
+left-multiplicative attitude convention, are
 \begin{align}
 \frac{\partial \vct{f}_b}{\partial \vct{\theta}}
   &= -\Skew{\hat{\vct{f}}_{\mathrm{cog},b}}, &

--- a/doc/kalman_ou_iii/w3d-proc-cont.tex-part
+++ b/doc/kalman_ou_iii/w3d-proc-cont.tex-part
@@ -1,7 +1,7 @@
 \section{Process Model (Continuous Time)}
 \label{sec:proc}
 
-We separate (i) the quaternion attitude subsystem used by the right--multiplicative
+We separate (i) the quaternion attitude subsystem used by the left--multiplicative
 EKF and (ii) the linear OU--driven kinematic chain. The former is propagated on
 the manifold (nominal quaternion); the latter is a vector LTI SDE in continuous time.
 
@@ -11,7 +11,7 @@ and $\vct{n}_g$ gyro noise (white, zero–mean). The \emph{nominal} quaternion
 $q$ (world$\to$body) obeys
 \begin{equation}
 \begin{aligned}
-\dot{q} =& \tfrac12\,\Omega\!\left(\vct{\omega}_m-\vct{b}_g\right)\,q,
+\dot{q} =& -\tfrac12\,\Omega\!\left(\vct{\omega}_m-\vct{b}_g\right)\,q,
 \qquad
 q \in \mathbb{H}_1,\qquad\\
 \Omega(\vct{\omega}) =&
@@ -30,13 +30,14 @@ with unit–norm enforcement in implementation. The gyro bias follows a random w
 \end{equation}
 where $\matg{Q}_{bg}$ is the continuous–time spectral density (per axis).
 
-For the right--multiplicative error state, we use a small rotation vector
-$\delta\vct{\theta}$ so that $q^+ = q\otimes\exp(\tfrac12\,\delta\vct{\theta})$.
+For the left--multiplicative error state, we use a small rotation vector
+$\delta\vct{\theta}$ so that $q^+ = \exp(\tfrac12\,\delta\vct{\theta})\otimes q$.
 Linearizing the attitude error dynamics gives the standard Q--MEKF form
 \begin{equation}
 \dot{\delta\vct{\theta}}
 \;\approx\;
 -\Skew{\vct{\omega}_m-\vct{b}_g}\,\delta\vct{\theta}
+\;+\;\delta\vct{b}_g
 \;-\;\vct{n}_g,
 \qquad
 \vct{n}_g\sim\mathcal N(\vct{0},\ \matg{Q}_g),
@@ -117,7 +118,7 @@ and take the block structure
 \mat{F} =
 \begingroup\setlength\arraycolsep{4pt}
 \begin{bmatrix}
--\Skew{\vct{\omega}_m-\vct{b}_g} & -\Id & \mat{0} & \mat{0} & \mat{0} & \mat{0} & \mat{0}\\
+-\Skew{\vct{\omega}_m-\vct{b}_g} & +\Id & \mat{0} & \mat{0} & \mat{0} & \mat{0} & \mat{0}\\
 \mat{0} & \mat{0} & \mat{0} & \mat{0} & \mat{0} & \mat{0} & \mat{0}\\
 \mat{0} & \mat{0} & \mat{0} & \mat{0} & \mat{0} & \Id & \mat{0}\\
 \mat{0} & \mat{0} & \Id & \mat{0} & \mat{0} & \mat{0} & \mat{0}\\

--- a/doc/kalman_ou_iii/w3d-state.tex-part
+++ b/doc/kalman_ou_iii/w3d-state.tex-part
@@ -21,7 +21,7 @@ where each subvector has the following physical meaning:
 \begin{itemize}
   \item $\delta\vct{\theta}\in\mathbb{R}^3$ --- small attitude-error
         vector used in the multiplicative EKF formulation
-        (right-multiplicative quaternion correction).
+        (left-multiplicative quaternion correction).
   \item $\vct{b}_g\in\mathbb{R}^3$ --- gyroscope bias, modeled as a
         random-walk process.
   \item $\vct{v}\in\mathbb{R}^3$ --- velocity in the world (NED) frame.


### PR DESCRIPTION
### Motivation
- Keep the documentation in `doc/kalman_ou_iii` consistent with the actual `Kalman3D_Wave_OU_III` implementation so the paper formulas and narrative reflect the code behavior. 
- Correct multiplicative-convention, sign, and small-block algebra mismatches that could mislead readers implementing or validating the filter.
- Fix a few notational inaccuracies (de-heel symbol, outdated magnetometer wording) that diverged from the code.

### Description
- Change the quaternion error/propagation convention in the docs from right- to left-multiplicative, and update all related narrative and Jacobian wording to match the implementation. 
- Align the continuous-time attitude equations with the code by flipping the quaternion propagation sign and adding the `+\delta\vct{b}_g` term in the linearized attitude-error dynamics, and change the corresponding `F` block sign so the `\delta\vct{\theta}`–`\vct{b}_g` entry is `+\mathbf I`. 
- Update discrete/analytic notes to match the code: use the implementation's quaternion propagation expression `q^- = \exp_q(-\tfrac{1}{2}\hat{\vct{\omega}}h) \otimes q^+`, change `Rot_x(-h)` to `Rot_x(-\phi_h)` for de-heel mapping, and remove an outdated magnetometer “sign-fix” mention. 
- Modified files: `doc/kalman_ou_iii/w3d-intro.tex-part`, `doc/kalman_ou_iii/w3d-state.tex-part`, `doc/kalman_ou_iii/w3d-proc-cont.tex-part`, `doc/kalman_ou_iii/w3d-analytic-coeff.tex-part`, `doc/kalman_ou_iii/w3d-kalm-up.tex-part`, and `doc/kalman_ou_iii/w3d-meas.tex-part` to reflect these changes.

### Testing
- Ran `git diff --check` to detect whitespace/conflict markers and ensure no leftover merge artifacts, and it completed with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0067e258c8328af8ba9fdc4ade253)