### PR TITLE
Optimize structured covariance reset in OU II/III filters

### DIFF
--- a/src/kalman_ou_ii/Kalman3D_Wave_OU_II.h
+++ b/src/kalman_ou_ii/Kalman3D_Wave_OU_II.h
@@ -2274,11 +2274,20 @@ void Kalman3D_Wave_OU_II<T, with_gyro_bias, with_accel_bias>::apply_error_state_
     const Matrix3 G =
         Matrix3::Identity() + T(0.5) * skew_symmetric_matrix(dtheta_injected);
 
-    MatrixNX Tm = MatrixNX::Identity();
-    Tm.template block<3,3>(0,0) = G;
+    // Structured similarity update for Tm = diag(G, I):
+    //   Paa' = G * Paa * Gᵀ
+    //   Pax' = G * Pax
+    //   Pxa' = Pax'ᵀ  (enforce symmetry)
+    //   Pxx' = Pxx    (unchanged)
+    const Matrix3 Paa_old = Pext.template block<3,3>(0, 0);
+    const Matrix<T, 3, NX - 3> Pax_old = Pext.template block<3, NX - 3>(0, 3);
 
-    MatrixNX Pnew = Tm * Pext * Tm.transpose();
-    Pext = T(0.5) * (Pnew + Pnew.transpose());
+    Pext.template block<3,3>(0, 0).noalias() = G * Paa_old * G.transpose();
+    Pext.template block<3, NX - 3>(0, 3).noalias() = G * Pax_old;
+    Pext.template block<NX - 3, 3>(3, 0) = Pext.template block<3, NX - 3>(0, 3).transpose();
+
+    // Keep covariance exactly symmetric against floating-point noise.
+    Pext = T(0.5) * (Pext + Pext.transpose());
 }
 
 template<typename T, bool with_gyro_bias, bool with_accel_bias>

--- a/src/kalman_ou_iii/Kalman3D_Wave_OU_III.h
+++ b/src/kalman_ou_iii/Kalman3D_Wave_OU_III.h
@@ -2203,11 +2203,20 @@ void Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::apply_error_state
     const Matrix3 G =
         Matrix3::Identity() + T(0.5) * skew_symmetric_matrix(dtheta_injected);
 
-    MatrixNX Tm = MatrixNX::Identity();
-    Tm.template block<3,3>(0,0) = G;
+    // Structured similarity update for Tm = diag(G, I):
+    //   Paa' = G * Paa * Gᵀ
+    //   Pax' = G * Pax
+    //   Pxa' = Pax'ᵀ  (enforce symmetry)
+    //   Pxx' = Pxx    (unchanged)
+    const Matrix3 Paa_old = Pext.template block<3,3>(0, 0);
+    const Matrix<T, 3, NX - 3> Pax_old = Pext.template block<3, NX - 3>(0, 3);
 
-    MatrixNX Pnew = Tm * Pext * Tm.transpose();
-    Pext = T(0.5) * (Pnew + Pnew.transpose());
+    Pext.template block<3,3>(0, 0).noalias() = G * Paa_old * G.transpose();
+    Pext.template block<3, NX - 3>(0, 3).noalias() = G * Pax_old;
+    Pext.template block<NX - 3, 3>(3, 0) = Pext.template block<3, NX - 3>(0, 3).transpose();
+
+    // Keep covariance exactly symmetric against floating-point noise.
+    Pext = T(0.5) * (Pext + Pext.transpose());
 }
 
 template<typename T, bool with_gyro_bias, bool with_accel_bias>


### PR DESCRIPTION
### Motivation
- The error-state reset previously performed a full `Tm * Pext * Tm.transpose()` similarity transform even though `Tm` is `diag(G, I)` so only the attitude-error block and its cross-covariances change.  
- For typical `NX ≈ 18` the dense transform is wasteful at high update rates, so a structured update reduces CPU work while preserving the intended reset behavior.

### Description
- Replaced the dense similarity transform in `apply_error_state_reset_jacobian_` with a structured block update in both `src/kalman_ou_ii/Kalman3D_Wave_OU_II.h` and `src/kalman_ou_iii/Kalman3D_Wave_OU_III.h`.  
- The new code updates only the affected blocks using `Paa' = G * Paa * G.transpose()`, `Pax' = G * Pax`, and `Pxa' = Pax'.transpose()`, leaving `Pxx` unchanged.  
- Final covariance is symmetrized with `Pext = 0.5 * (Pext + Pext.transpose())` to retain numerical robustness.  
- All public APIs and function signatures are unchanged.

### Testing
- Ran `make all` successfully after the header changes and the build completed without errors.  
- Ran `make clean` successfully to remove generated artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e01c0e853883288016a50ec4af5573)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized Kalman filter covariance reset computation for improved efficiency and numerical stability in wave-based positioning modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->