### PR TITLE
Fix north-lock initialization in MagAutoTuner

### DIFF
--- a/src/tuner/MagAutoTuner.h
+++ b/src/tuner/MagAutoTuner.h
@@ -63,7 +63,17 @@ public:
     Eigen::Quaternionf q_tilt = tiltOnlyQuatFromAccel_(acc_mean);
     q_tilt.normalize();
 
-    mag_world_ref_ = q_tilt * mag_mean;
+    const Eigen::Vector3f mag_world_tilt = q_tilt * mag_mean;
+    const float horiz = std::sqrt(mag_world_tilt.x() * mag_world_tilt.x() +
+                                  mag_world_tilt.y() * mag_world_tilt.y());
+    if (!(horiz > cfg_.mag_norm_min) || !std::isfinite(horiz)) {
+      ready_ = false;
+      return false;
+    }
+
+    // Define world frame so that +X is magnetic north and +Z is down.
+    // Keep measured dip (Z component), but remove unknown yaw by forcing E=0.
+    mag_world_ref_ = Eigen::Vector3f(horiz, 0.0f, mag_world_tilt.z());
     ready_ = mag_world_ref_.allFinite() && (mag_world_ref_.norm() > cfg_.mag_norm_min);
     return ready_;
   }


### PR DESCRIPTION
### Motivation
- Fix compass startup behavior where heading stayed tied to the device's initial yaw because the tilt-only rotation preserved unknown yaw when forming the world magnetic reference.

### Description
- In `src/tuner/MagAutoTuner.h` `addSample`, replace `q_tilt * mag_mean` with a world reference that preserves the measured dip (Z) but forces the east component to zero so `+X` is magnetic north, and add a guard that rejects initialization if the horizontal magnetic magnitude is too small.

### Testing
- Ran `make all` from the repository root and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e05e8f5f488328bd1f750e536a9a2b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved magnetic field validation during calibration to prevent the system from entering invalid readiness states. Enhanced validation checks now verify that the horizontal magnetic component magnitude meets configured minimum thresholds and ensure all measurements are finite and valid, resulting in more reliable and accurate magnetometer-based navigation performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->