### PR TITLE
Add wave-sim frame/sign convention checker for generated IMU data

### DIFF
--- a/tests/wave_sim/Makefile
+++ b/tests/wave_sim/Makefile
@@ -1,3 +1,16 @@
+CC = g++
+CFLAGS = -O3 -std=c++20 -funroll-loops -fno-finite-math-only -I./../../src $(CPPFLAGS)
+TARGETS = wave-convention-check
+
 .PHONY: all
-all:
-	@true
+all: $(TARGETS)
+
+wave-convention-check: wave-convention-check.o
+	$(CC) $(CFLAGS) -o $@ $^
+
+%.o: %.cpp
+	$(CC) $(CFLAGS) -c $< -o $@
+
+.PHONY: clean
+clean:
+	rm -f *.o $(TARGETS) *.exe

--- a/tests/wave_sim/run_tests.sh
+++ b/tests/wave_sim/run_tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -e
 
-echo "Nothing to be done."
+./wave-convention-check

--- a/tests/wave_sim/wave-convention-check.cpp
+++ b/tests/wave_sim/wave-convention-check.cpp
@@ -1,0 +1,132 @@
+#include <cmath>
+#include <filesystem>
+#include <iostream>
+#include <string>
+
+#define EIGEN_NON_ARDUINO
+#include "util/WaveFilesSupport.h"
+#include "ahrs/FrameConversions.h"
+
+using Eigen::Quaternionf;
+using Eigen::Vector3f;
+
+namespace {
+float wrap_deg(float a) {
+    a = std::fmod(a + 180.0f, 360.0f);
+    if (a < 0.0f) a += 360.0f;
+    return a - 180.0f;
+}
+
+float diff_deg(float est_deg, float ref_deg) {
+    return wrap_deg(est_deg - ref_deg);
+}
+
+struct Accum3 {
+    double sx = 0.0, sy = 0.0, sz = 0.0;
+    std::size_t n = 0;
+    void add(const Vector3f& e) { sx += e.x()*e.x(); sy += e.y()*e.y(); sz += e.z()*e.z(); ++n; }
+    Vector3f rms() const {
+        if (n == 0) return Vector3f::Zero();
+        return Vector3f(std::sqrt(float(sx / n)), std::sqrt(float(sy / n)), std::sqrt(float(sz / n)));
+    }
+};
+
+Quaternionf quat_from_sample(const IMU_Sample& imu) {
+    Quaternionf q(imu.q_wb_zu_w, imu.q_wb_zu_x, imu.q_wb_zu_y, imu.q_wb_zu_z);
+    if (!std::isfinite(q.w()) || !std::isfinite(q.x()) || !std::isfinite(q.y()) || !std::isfinite(q.z()) || q.norm() < 1e-6f) {
+        return Quaternionf::Identity();
+    }
+    q.normalize();
+    return q;
+}
+
+Vector3f body_rate_from_quat_delta(const Quaternionf& q_prev, const Quaternionf& q_cur, float dt_sec) {
+    if (!(dt_sec > 0.0f)) return Vector3f::Zero();
+    Quaternionf dq = q_cur * q_prev.conjugate();
+    if (dq.w() < 0.0f) dq.coeffs() *= -1.0f;
+    const Vector3f v(dq.x(), dq.y(), dq.z());
+    const float s = v.norm();
+    if (s < 1e-9f) return Vector3f::Zero();
+    const float angle = 2.0f * std::atan2(s, std::max(1e-9f, dq.w()));
+    return (angle / dt_sec) * (v / s);
+}
+
+int check_file(const std::filesystem::path& file, bool& prefer_inverted_out) {
+    WaveDataCSVReader reader(file.string());
+    bool has_prev = false;
+    Wave_Data_Sample prev{};
+    Accum3 gyro_err_same{}, gyro_err_invert{}, euler_err{};
+
+    reader.for_each_record([&](const Wave_Data_Sample& rec) {
+        const auto q = quat_from_sample(rec.imu);
+        float r_q = 0.0f, p_q = 0.0f, y_q = 0.0f;
+        quat_wb_zu_to_euler_nautical(q, r_q, p_q, y_q);
+        euler_err.add(Vector3f(diff_deg(rec.imu.roll_deg, r_q), diff_deg(rec.imu.pitch_deg, p_q), diff_deg(rec.imu.yaw_deg, y_q)));
+        if (has_prev) {
+            const float dt = float(rec.time - prev.time);
+            const auto q_prev = quat_from_sample(prev.imu);
+            const Vector3f w_from_q = body_rate_from_quat_delta(q_prev, q, dt);
+            const Vector3f w_csv(rec.imu.gyro_x, rec.imu.gyro_y, rec.imu.gyro_z);
+            gyro_err_same.add(w_csv - w_from_q);
+            gyro_err_invert.add(w_csv + w_from_q);
+        }
+        prev = rec;
+        has_prev = true;
+    });
+
+    const Vector3f rms_e = euler_err.rms();
+    const float norm_same = gyro_err_same.rms().norm();
+    const float norm_inv = gyro_err_invert.rms().norm();
+    prefer_inverted_out = norm_inv < norm_same;
+
+    std::cout << "[convention] " << file.filename().string() << "\n"
+              << "  Euler CSV-vs-q RMS deg: roll=" << rms_e.x() << " pitch=" << rms_e.y() << " yaw=" << rms_e.z() << "\n"
+              << "  Gyro RMS (csv - dQ):      " << norm_same << " rad/s\n"
+              << "  Gyro RMS (csv + dQ):      " << norm_inv << " rad/s\n"
+              << "  Preferred gyro sign:      " << (prefer_inverted_out ? "inverted (csv ~= -dQ)" : "same (csv ~= +dQ)") << "\n";
+
+    bool ok = true;
+    if (rms_e.x() > 2.0f || rms_e.y() > 2.0f || rms_e.z() > 2.0f) ok = false;
+    if (std::min(norm_same, norm_inv) > 0.25f) ok = false;
+    if (!ok) {
+        std::cerr << "ERROR: convention mismatch in " << file.filename().string() << "\n";
+        return 1;
+    }
+    return 0;
+}
+} // namespace
+
+int main() {
+    int failures = 0;
+    bool sign_initialized = false;
+    bool prefer_inverted_ref = false;
+    int checked = 0;
+
+    for (const auto& entry : std::filesystem::directory_iterator(".")) {
+        if (!entry.is_regular_file()) continue;
+        const auto name = entry.path().filename().string();
+        if (name.rfind("wave_data_jonswap_", 0) == 0 || name.rfind("wave_data_pmstokes_", 0) == 0) {
+            ++checked;
+            bool prefer_inverted = false;
+            failures += check_file(entry.path(), prefer_inverted);
+            if (!sign_initialized) {
+                sign_initialized = true;
+                prefer_inverted_ref = prefer_inverted;
+            } else if (prefer_inverted != prefer_inverted_ref) {
+                std::cerr << "ERROR: Mixed gyro sign conventions detected across files.\n";
+                ++failures;
+            }
+        }
+    }
+
+    if (checked == 0) {
+        std::cerr << "ERROR: No wave_data_jonswap_/wave_data_pmstokes_ CSV files found in current directory.\n";
+        return 1;
+    }
+    if (failures) {
+        std::cerr << "Convention check failures: " << failures << "\n";
+        return 1;
+    }
+    std::cout << "Convention checks passed.\n";
+    return 0;
+}


### PR DESCRIPTION
### Motivation

- There was no automated verification that wave-simulation CSV outputs use the same attitude/gyro conventions expected by the downstream IMU/AHRS code, which can lead to subtle yaw/gyro sign/frame mismatches that break tests and analysis.

### Description

- Add a focused validator `tests/wave_sim/wave-convention-check.cpp` that reads `wave_data_jonswap_*` and `wave_data_pmstokes_*` CSV files and compares Euler columns to quaternion-derived nautical Euler and gyro columns to quaternion-delta angular rates under both sign hypotheses, and enforces a consistent gyro sign across files.
- Update `tests/wave_sim/Makefile` to build the `wave-convention-check` binary and to honor top-level `CPPFLAGS` (so Eigen include overrides work consistently with CI/local builds).
- Update `tests/wave_sim/run_tests.sh` to execute the new checker instead of being a no-op.

### Testing

- Ran `make all CPPFLAGS+='-I/usr/include/eigen3'` and the project built the new test binary successfully (no build errors reported). — Success.
- Ran `make fetch-sim-data` to obtain the generator CSVs required by the checker — Success.
- Ran `bash tests/wave_sim/run_tests.sh` which invoked the new `wave-convention-check` binary; the tool inspected all `wave_data_jonswap_*` / `wave_data_pmstokes_*` CSV files and reported per-file convention statistics and a final pass: `Convention checks passed.` — Success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e10a1db2388328935de4666d019661)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new test to validate wave simulation data conventions, including checks for quaternion-to-Euler angle conversions and consistent gyro sign conventions across data files. The test provides diagnostics when conventions are inconsistent.

* **Chores**
  * Updated the build system and test runner script to compile and execute the new wave data validation test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->