### PR TITLE
Add Eigen include fallback to tests/wave_sim Makefile

### DIFF
--- a/tests/wave_sim/Makefile
+++ b/tests/wave_sim/Makefile
@@ -1,5 +1,7 @@
 CC = g++
-CFLAGS = -O3 -std=c++20 -funroll-loops -fno-finite-math-only -I./../../src $(CPPFLAGS)
+EIGEN_DIR ?= ../../third_party/eigen
+EIGEN_CPPFLAGS := $(if $(wildcard $(EIGEN_DIR)/Eigen/Dense),-I$(EIGEN_DIR),-I/usr/include/eigen3)
+CFLAGS = -O3 -std=c++20 -funroll-loops -fno-finite-math-only -I./../../src $(EIGEN_CPPFLAGS) $(CPPFLAGS)
 TARGETS = wave-convention-check
 
 .PHONY: all


### PR DESCRIPTION
### Motivation
- Fix the build failure in `tests/wave_sim` caused by missing `Eigen/Dense` by preferring a vendored `../../third_party/eigen` include and falling back to `/usr/include/eigen3`, while preserving existing `CPPFLAGS` behavior.

### Description
- Update `tests/wave_sim/Makefile` to add `EIGEN_DIR ?= ../../third_party/eigen`, compute `EIGEN_CPPFLAGS` with `$(wildcard ...)` to choose `-I$(EIGEN_DIR)` or `-I/usr/include/eigen3`, and include that in `CFLAGS` so the test can find Eigen without changing targets or public APIs.

### Testing
- Ran `make all` from the repository root which completed successfully and then ran `make clean` to remove generated test binaries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e113558cf08328bdb0f720e3f060a8)