### PR TITLE
Report true/world yaw for OU_II and OU_III chart outputs

### DIFF
--- a/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
+++ b/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
@@ -28,6 +28,7 @@ public:
                         const Vector3f& sigma_g,
                         const Vector3f& sigma_m,
                         const Vector3f& mag_world_a)
+        : with_mag_(with_mag)
     {
         cfg_.with_mag = with_mag;
         cfg_.sigma_a = sigma_a_init;
@@ -80,9 +81,11 @@ public:
 
         // Use the exact same finite-angle conversion path as the sim truth side.
         quat_to_euler_nautical(q_bw_ned, roll_deg, pitch_deg, yaw_deg);
-        // Keep yaw in the same reference as OU_III simulation reporting.
-        // (No extra declination correction in post-processing.)
-        s.euler_nautical_deg = Vector3f(roll_deg, pitch_deg, yaw_deg);
+        if (with_mag_) {
+            // Convert magnetic heading to true/world heading for chart output.
+            yaw_deg -= MagSim_WMM::default_declination_deg;
+        }
+        s.euler_nautical_deg = Vector3f(roll_deg, pitch_deg, wrapDeg(yaw_deg));
 
         s.acc_bias_est_ned = filter.mekf().get_acc_bias();
         s.gyro_bias_est_ned = filter.mekf().gyroscope_bias();
@@ -116,6 +119,7 @@ public:
     }
 
 private:
+    bool with_mag_ = true;
     using Fusion = SeaStateFusion_OU_II<TrackerType::KALMANF>;
     mutable Fusion fusion_;
     Fusion::Config cfg_{};

--- a/tests/kalman_ou_iii/kalman_ou_iii-sim.cpp
+++ b/tests/kalman_ou_iii/kalman_ou_iii-sim.cpp
@@ -29,6 +29,7 @@ public:
                          const Vector3f& sigma_g,
                          const Vector3f& sigma_m,
                          const Vector3f& mag_world_a)
+        : with_mag_(with_mag)
     {
         cfg_.with_mag = with_mag;
         cfg_.sigma_a = sigma_a_init;
@@ -79,8 +80,11 @@ public:
         float yaw_deg   = 0.0f;
 
         quat_to_euler_nautical(q_bw_ned, roll_deg, pitch_deg, yaw_deg);
-        //yaw_deg = wrapDeg(yaw_deg + MagSim_WMM::default_declination_deg);
-        s.euler_nautical_deg = Vector3f(roll_deg, pitch_deg, yaw_deg);
+        if (with_mag_) {
+            // Convert magnetic heading to true/world heading for chart output.
+            yaw_deg -= MagSim_WMM::default_declination_deg;
+        }
+        s.euler_nautical_deg = Vector3f(roll_deg, pitch_deg, wrapDeg(yaw_deg));
         s.acc_bias_est_ned = filter.mekf().get_acc_bias();
         s.gyro_bias_est_ned = filter.mekf().gyroscope_bias();
         s.mag_bias_est_ned_uT = get_mag_bias_est_uT(filter.mekf());
@@ -113,6 +117,7 @@ public:
     }
 
 private:
+    bool with_mag_ = true;
     using Fusion = SeaStateFusion_OU_III<TrackerType::KALMANF>;
     mutable Fusion fusion_;
     Fusion::Config cfg_{};


### PR DESCRIPTION
### Motivation
- OU_II/OU_III test runners were emitting magnetic heading directly to chart/CSV outputs, but charts should show yaw as true/world-frame heading (declination-compensated) when the magnetometer is used.

### Description
- Update `tests/kalman_ou_ii/kalman_ou_ii-sim.cpp` to persist `with_mag` in `FusionAdapter_OU_II` and, in `snapshot()`, subtract `MagSim_WMM::default_declination_deg` from the reported yaw when magnetometer output is enabled, then wrap the angle via `wrapDeg` before storing in `euler_nautical_deg`.
- Apply the same change to `tests/kalman_ou_iii/kalman_ou_iii-sim.cpp` by adding `with_mag_` and declination compensation in `FusionAdapter_OU_III::snapshot()`.
- Changes are minimal and limited to test simulation output post-processing; public APIs, filenames and build targets were not altered.

### Testing
- Ran `make all` from the repository root which rebuilt test targets and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e15029de008328942400643b08ee70)