### PR TITLE
Export true world-frame heading (yaw) in W3d CSV outputs

### DIFF
--- a/src/util/W3dSimCommon.cpp
+++ b/src/util/W3dSimCommon.cpp
@@ -211,14 +211,6 @@ std::optional<W3dSimulationRunResult> W3dSimulationRunner::run(const std::string
         return q;
     };
 
-    auto wrap_deg = [](float deg) -> float {
-        float wrapped = std::fmod(deg + 180.0f, 360.0f);
-        if (wrapped < 0.0f) wrapped += 360.0f;
-        return wrapped - 180.0f;
-    };
-
-    auto diff_deg = [&](float a, float b) -> float { return wrap_deg(a - b); };
-
     auto reference_euler_from_csv = [&](const IMU_Sample& imu,
                                         const Quaternionf& q_wb_zu,
                                         float& roll_deg,
@@ -226,39 +218,12 @@ std::optional<W3dSimulationRunResult> W3dSimulationRunner::run(const std::string
                                         float& yaw_deg) {
         float r_w = 0.0f, p_w = 0.0f, y_w = 0.0f;
         quat_wb_zu_to_euler_nautical(q_wb_zu, r_w, p_w, y_w);
-
-        const bool finite_csv =
-            std::isfinite(imu.roll_deg) && std::isfinite(imu.pitch_deg) && std::isfinite(imu.yaw_deg);
-        if (!finite_csv) {
-            roll_deg = r_w;
-            pitch_deg = p_w;
-            yaw_deg = y_w;
-            return;
-        }
-
-        float r_b = 0.0f, p_b = 0.0f, y_b = 0.0f;
-        matrix_to_euler_zyx_deg(q_wb_zu.conjugate().toRotationMatrix(), r_b, p_b, y_b);
-
-        const float err_world =
-            std::abs(diff_deg(imu.roll_deg, r_w)) +
-            std::abs(diff_deg(imu.pitch_deg, p_w)) +
-            std::abs(diff_deg(imu.yaw_deg, y_w));
-        const float err_body =
-            std::abs(diff_deg(imu.roll_deg, r_b)) +
-            std::abs(diff_deg(imu.pitch_deg, p_b)) +
-            std::abs(diff_deg(imu.yaw_deg, y_b));
-
-        // Upstream datasets may encode legacy Euler conventions; choose the
-        // quaternion-consistent interpretation instead of trusting CSV Euler blindly.
-        if (std::min(err_world, err_body) <= 6.0f) {
-            roll_deg = imu.roll_deg;
-            pitch_deg = imu.pitch_deg;
-            yaw_deg = imu.yaw_deg;
-        } else {
-            roll_deg = r_w;
-            pitch_deg = p_w;
-            yaw_deg = y_w;
-        }
+        (void)imu;
+        // For reference CSV output, always use nautical world-frame Euler
+        // angles from q_wb_zu so yaw_ref is true heading in world frame.
+        roll_deg = r_w;
+        pitch_deg = p_w;
+        yaw_deg = y_w;
     };
 
     WaveDataCSVReader reader(filename);


### PR DESCRIPTION
### Motivation
- PM and JONSWAP CSV outputs contained Euler yaw values that did not reliably represent true heading in the world frame due to mixed legacy Euler conventions in source CSVs.
- Quaternions stored in the CSV (`q_wb_zu`) are authoritative for orientation, so reference Euler angles (especially yaw) should be derived from that quaternion to guarantee a consistent world-frame heading.

### Description
- Always derive reference roll/pitch/yaw from `q_wb_zu` using `quat_wb_zu_to_euler_nautical` and emit those values as the CSV reference Euler angles.
- Removed the previous heuristic that compared CSV Euler conventions (world vs body) and conditionally trusted CSV Euler columns.
- Change implemented in `src/util/W3dSimCommon.cpp` inside the `reference_euler_from_csv` helper so `yaw_ref` is now true heading for produced `w3d_*_fusion*.csv` files.

### Testing
- Ran `make all` which completed successfully and built all test targets. 
- Ran `make clean` which completed successfully. 
- The project compiled after the change with no build errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e150e3a8ac8328b041971bb6bc18c8)