### PR TITLE
Use fixed WMM magnetic world reference in OU II/III simulation adapters

### DIFF
--- a/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
+++ b/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
@@ -35,7 +35,8 @@ public:
         cfg_.sigma_g = sigma_g;
         cfg_.sigma_m = sigma_m;
         cfg_.mag_delay_sec = MAG_DELAY_SEC;
-        cfg_.use_fixed_mag_world_ref = false;
+        // Force WMM world-field prior so yaw is tied to known declination from startup.
+        cfg_.use_fixed_mag_world_ref = true;
         cfg_.mag_world_ref = mag_world_a;
         cfg_.freeze_acc_bias_until_live = true;
         cfg_.Racc_warmup = 0.5f;

--- a/tests/kalman_ou_iii/kalman_ou_iii-sim.cpp
+++ b/tests/kalman_ou_iii/kalman_ou_iii-sim.cpp
@@ -36,7 +36,8 @@ public:
         cfg_.sigma_g = sigma_g;
         cfg_.sigma_m = sigma_m;
         cfg_.mag_delay_sec = MAG_DELAY_SEC;
-        cfg_.use_fixed_mag_world_ref = false;
+        // Force WMM world-field prior so yaw is tied to known declination from startup.
+        cfg_.use_fixed_mag_world_ref = true;
         cfg_.mag_world_ref = mag_world_a;
         cfg_.freeze_acc_bias_until_live = true;
         cfg_.Racc_warmup = 0.5f;


### PR DESCRIPTION
### Motivation
- The OU II/III test simulators occasionally produced elevated yaw RMS because the world magnetic field was being learned at startup instead of being fixed to the known WMM prior, so yaw must be deterministically anchored to the WMM declination for these tests.

### Description
- Set `cfg_.use_fixed_mag_world_ref = true` (with an explanatory comment) in `tests/kalman_ou_ii/kalman_ou_ii-sim.cpp` and `tests/kalman_ou_iii/kalman_ou_iii-sim.cpp`, with no changes to public APIs, filenames, or build targets.

### Testing
- Ran `make all` from repository root which completed successfully, and built/ran `tests/kalman_ou_iii/kalman_ou_iii-sim --no-noise` to verify the simulator startup path (simulation binary started; dataset files were not present so only startup was exercised).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e15a82a1288328871096768ec688fe)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Kalman filter adapter test configurations to use fixed WMM world-field reference instead of variable magnetic reference, affecting yaw declination handling in test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->