### PR TITLE
Fix kalman_ou_ii yaw output to avoid double declination correction

### DIFF
--- a/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
+++ b/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
@@ -82,10 +82,10 @@ public:
 
         // Use the exact same finite-angle conversion path as the sim truth side.
         quat_to_euler_nautical(q_bw_ned, roll_deg, pitch_deg, yaw_deg);
-        if (with_mag_) {
-            // Convert magnetic heading to true/world heading for chart output.
-            yaw_deg -= MagSim_WMM::default_declination_deg;
-        }
+        (void)with_mag_;
+        // q_bw_ned is already expressed in world/NED when using the fixed
+        // WMM world-field prior (cfg_.use_fixed_mag_world_ref=true), so yaw
+        // is already true heading. Do not apply declination again.
         s.euler_nautical_deg = Vector3f(roll_deg, pitch_deg, wrapDeg(yaw_deg));
 
         s.acc_bias_est_ned = filter.mekf().get_acc_bias();


### PR DESCRIPTION
### Motivation
- The OU II simulation was applying `MagSim_WMM::default_declination_deg` to the snapshot yaw even though the filter is configured with a fixed WMM world-field prior (`cfg_.use_fixed_mag_world_ref=true`), causing yaw to be offset by roughly the local declination and producing false RMS failures.

### Description
- Removed the extra `yaw_deg -= MagSim_WMM::default_declination_deg` in `tests/kalman_ou_ii/kalman_ou_ii-sim.cpp` and left a short comment clarifying that the filter yaw is already in true/world heading when the WMM prior is used.

### Testing
- Ran `make all` which completed successfully.
- Ran `cd tests/kalman_ou_ii && bash run_tests.sh` which completed successfully and no longer produces the declination-sized yaw RMS failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e17dfe78c88328baf1ea458796fb10)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected magnetic declination handling in heading calculations to ensure consistent and accurate yaw and Euler angle computations in simulation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->