### PR TITLE
Use world-frame nautical Euler for OU II/III sim attitude comparison

### DIFF
--- a/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
+++ b/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
@@ -74,17 +74,17 @@ public:
         s.acc_est_zu = ned_to_zu(filter.mekf().get_world_accel());
 
         const Quaternionf q_bw_ned = filter.mekf().quaternion_boat().normalized();
+        const Matrix3f C_bw_ned = q_bw_ned.toRotationMatrix();
+        const Matrix3f C_wb_zu = rot_bw_ned_to_wb_zu(C_bw_ned);
+        const Quaternionf q_wb_zu(C_wb_zu);
 
         float roll_deg  = 0.0f;
         float pitch_deg = 0.0f;
         float yaw_deg   = 0.0f;
-
-        // Use the exact same finite-angle conversion path as the sim truth side.
-        quat_to_euler_nautical(q_bw_ned, roll_deg, pitch_deg, yaw_deg);
+        // Compare world-frame nautical Euler (ENU/Z-up, world->body), exactly
+        // like the q_wb_zu reference path used by W3dSimCommon.
+        quat_wb_zu_to_euler_nautical(q_wb_zu, roll_deg, pitch_deg, yaw_deg);
         (void)with_mag_;
-        // q_bw_ned is already expressed in world/NED when using the fixed
-        // WMM world-field prior (cfg_.use_fixed_mag_world_ref=true), so yaw
-        // is already true heading. Do not apply declination again.
         s.euler_nautical_deg = Vector3f(roll_deg, pitch_deg, wrapDeg(yaw_deg));
 
         s.acc_bias_est_ned = filter.mekf().get_acc_bias();

--- a/tests/kalman_ou_iii/kalman_ou_iii-sim.cpp
+++ b/tests/kalman_ou_iii/kalman_ou_iii-sim.cpp
@@ -74,16 +74,16 @@ public:
         s.vel_est_zu = ned_to_zu(filter.mekf().get_velocity());
         s.acc_est_zu = ned_to_zu(filter.mekf().get_world_accel());
         const Quaternionf q_bw_ned = filter.mekf().quaternion_boat().normalized();
+        const Matrix3f C_bw_ned = q_bw_ned.toRotationMatrix();
+        const Matrix3f C_wb_zu = rot_bw_ned_to_wb_zu(C_bw_ned);
+        const Quaternionf q_wb_zu(C_wb_zu);
 
         float roll_deg  = 0.0f;
         float pitch_deg = 0.0f;
         float yaw_deg   = 0.0f;
-
-        quat_to_euler_nautical(q_bw_ned, roll_deg, pitch_deg, yaw_deg);
-        if (with_mag_) {
-            // Convert magnetic heading to true/world heading for chart output.
-            yaw_deg -= MagSim_WMM::default_declination_deg;
-        }
+        // Compare world-frame nautical Euler (ENU/Z-up, world->body), exactly
+        // like the q_wb_zu reference path used by W3dSimCommon.
+        quat_wb_zu_to_euler_nautical(q_wb_zu, roll_deg, pitch_deg, yaw_deg);
         s.euler_nautical_deg = Vector3f(roll_deg, pitch_deg, wrapDeg(yaw_deg));
         s.acc_bias_est_ned = filter.mekf().get_acc_bias();
         s.gyro_bias_est_ned = filter.mekf().gyroscope_bias();


### PR DESCRIPTION
### Motivation
- The sim side computes reference Euler angles in world-frame nautical (ENU/Z-up) convention, but the OU II/III sim snapshots derived estimated attitude with a different path, producing inconsistent roll/pitch/yaw for comparison.

### Description
- Adjusted `tests/kalman_ou_ii/kalman_ou_ii-sim.cpp` to convert the filter boat quaternion via `q_bw_ned -> C_bw_ned -> rot_bw_ned_to_wb_zu -> q_wb_zu` and then use `quat_wb_zu_to_euler_nautical` so estimated Euler matches the world-frame nautical reference.
- Applied the same change to `tests/kalman_ou_iii/kalman_ou_iii-sim.cpp` and removed the extra magnetic-declination yaw subtraction so `yaw` stays in the same world-frame convention as `yaw_ref`.

### Testing
- Ran `make all` from the repository root and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e18485c630832892f73ace1720a44d)