### PR TITLE
Align adaptive PII observer sim attitude output to world-frame nautical angles

### DIFF
--- a/tests/pii_observer/pii_observer-adaptive.cpp
+++ b/tests/pii_observer/pii_observer-adaptive.cpp
@@ -95,11 +95,15 @@ public:
         s.vel_est_zu  = Vector3f(0.0f, 0.0f, filter_.velocity());
         s.acc_est_zu  = Vector3f(0.0f, 0.0f, filter_.accelFiltered());
 
-        // Report the filter's own estimated Euler angles so CSV/charts/RMS
-        // reflect the observer output directly.
-        float roll_sim_deg = hs.roll_deg;
-        float pitch_sim_deg = hs.pitch_deg;
-        float yaw_sim_deg = hs.yaw_deg;
+        // Report world-frame nautical Euler angles derived from the current
+        // Mahony world->body quaternion so we compare in the same frame as
+        // simulation truth (q_wb_zu / wave angles).
+        const auto& q_wb = hs.q_world_to_body;
+        Quaternionf q_wb_zu(float(q_wb.w), float(q_wb.x), float(q_wb.y), float(q_wb.z));
+        float roll_sim_deg = 0.0f;
+        float pitch_sim_deg = 0.0f;
+        float yaw_sim_deg = 0.0f;
+        quat_wb_zu_to_euler_nautical(q_wb_zu, roll_sim_deg, pitch_sim_deg, yaw_sim_deg);
         if (!with_mag_) {
             yaw_sim_deg = 0.0f;
         } else {


### PR DESCRIPTION
### Motivation
- The adaptive PII observer test exported Euler angles from cached Mahony Euler fields which were not guaranteed to be in the same world nautical frame as the simulation truth `q_wb_zu`, causing mismatched angle comparisons.
- The intent is to compare estimated attitude against simulated wave/world angles in the same frame so RMS/error metrics are meaningful.

### Description
- Changed `tests/pii_observer/pii_observer-adaptive.cpp` to derive reported attitude from the Mahony `hs.q_world_to_body` quaternion by calling `quat_wb_zu_to_euler_nautical(...)` instead of using `hs.roll_deg`, `hs.pitch_deg`, and `hs.yaw_deg` directly.
- Preserved existing yaw behavior so `--nomag` still forces yaw to `0` and magnetometer runs still apply the declination compensation using `MagSim_WMM::default_declination_deg`.

### Testing
- Ran `make all` from the repository root and the build completed successfully.
- The modified test `pii_observer-adaptive` was compiled as part of `make all` without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e185857300832893ecd0d8b36db702)