### PR TITLE
Fix nautical yaw extraction for world->body quaternions

### DIFF
--- a/src/ahrs/FrameConversions.h
+++ b/src/ahrs/FrameConversions.h
@@ -87,6 +87,7 @@ static inline Quaternionf quat_wb_zu_from_csv(float w, float x, float y, float z
     return q.normalized();
 }
 
+// Extract ZYX Euler from a BODY->WORLD rotation matrix.
 static inline void matrix_to_euler_zyx_deg(const Matrix3f& R,
                                            float& roll_deg,
                                            float& pitch_deg,
@@ -111,7 +112,8 @@ static inline void quat_wb_zu_to_euler_nautical(const Quaternionf& q_wb_zu,
                                                 float& yaw)
 {
     const Matrix3f C_wb_zu = q_wb_zu.normalized().toRotationMatrix();
-    matrix_to_euler_zyx_deg(C_wb_zu, roll, pitch, yaw);
+    const Matrix3f C_bw_zu = C_wb_zu.transpose();
+    matrix_to_euler_zyx_deg(C_bw_zu, roll, pitch, yaw);
 }
 
 // Aerospace Euler convention in this file:
@@ -146,14 +148,16 @@ static inline void quat_to_euler_nautical(const Quaternionf& q_bw_ned,
 {
     const Matrix3f C_bw_ned = q_bw_ned.normalized().toRotationMatrix();
     const Matrix3f C_wb_zu = rot_bw_ned_to_wb_zu(C_bw_ned);
-    matrix_to_euler_zyx_deg(C_wb_zu, roll, pitch, yaw);
+    const Matrix3f C_bw_zu = C_wb_zu.transpose();
+    matrix_to_euler_zyx_deg(C_bw_zu, roll, pitch, yaw);
 }
 
 // Finite-angle conversion: aerospace BODY->WORLD NED -> nautical WORLD->BODY ENU/Z-up.
 static inline void aero_to_nautical(float& roll, float& pitch, float& yaw) {
     const Matrix3f C_bw_ned = quat_from_euler(roll, pitch, yaw).toRotationMatrix();
     const Matrix3f C_wb_zu = rot_bw_ned_to_wb_zu(C_bw_ned);
-    matrix_to_euler_zyx_deg(C_wb_zu, roll, pitch, yaw);
+    const Matrix3f C_bw_zu = C_wb_zu.transpose();
+    matrix_to_euler_zyx_deg(C_bw_zu, roll, pitch, yaw);
 }
 
 // Finite-angle conversion: nautical WORLD->BODY ENU/Z-up -> aerospace BODY->WORLD NED.


### PR DESCRIPTION
### Motivation
- Correct extraction of nautical Euler angles from stored world→body (`q_wb_zu`) quaternions because applying the ZYX Euler formula directly to a world→body matrix produces a spurious yaw coupling when roll and pitch are non-zero.

### Description
- Transpose the `C_wb_zu` (world→body) matrix to a body→world matrix before calling `matrix_to_euler_zyx_deg`, by updating `quat_wb_zu_to_euler_nautical`, `quat_to_euler_nautical`, and `aero_to_nautical`, and added a clarifying comment that `matrix_to_euler_zyx_deg` expects a BODY->WORLD rotation matrix in `src/ahrs/FrameConversions.h`.

### Testing
- Built the project with `make all` and ran `bash run_tests.sh` in `tests/kalman_ou_ii` and `tests/kalman_ou_iii`, and all invoked automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e18e2f31e88328b1c8d1ef8adc7e99)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected rotation matrix handling in Euler angle conversion functions to ensure proper extraction of attitude angles from quaternion and aerodynamic conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->