### PR TITLE
Delay OU2/OU3 magnetic north lock until Live startup stage

### DIFF
--- a/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
+++ b/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
@@ -1039,8 +1039,12 @@ public:
         if (stage_ == Stage::Uninitialized) return;
         if (t_ < cfg_.mag_delay_sec) return;
 
-        // Learn magnetic world reference from measurements only.
+        // Learn magnetic world reference only after the startup wrapper reaches Live.
+        // This avoids committing a north frame from early warmup transients that can
+        // create persistent yaw/acc-bias coupling under waves.
         if (!mag_ref_set_) {
+            if (stage_ != Stage::Live) return;
+
             if (have_last_imu_ &&
                 mag_auto_tuner_.addSample(last_acc_body_ned_, last_gyro_body_ned_, mag_body_ned))
             {

--- a/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
+++ b/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
@@ -1136,7 +1136,12 @@ public:
         if (stage_ == Stage::Uninitialized) return;
         if (t_ < cfg_.mag_delay_sec) return;
 
+        // Learn magnetic world reference only after wrapper startup reaches Live.
+        // This avoids locking north from early warmup transients that can create
+        // persistent yaw/acc-bias coupling under waves.
         if (!mag_ref_set_) {
+            if (stage_ != Stage::Live) return;
+
             if (have_last_imu_ &&
                 mag_auto_tuner_.addSample(last_acc_body_ned_, last_gyro_body_ned_, mag_body_ned))
             {


### PR DESCRIPTION
### Motivation
- OU2/OU3 runs were occasionally failing quality gates because the filter learned a magnetic north reference during early warmup transients, producing a persistent yaw/acc-bias coupling that did not wash out.

### Description
- Gate magnetic-world reference learning in `SeaStateFusion_OU_II::updateMag` so the `MagAutoTuner` will not commit a north frame until the wrapper startup `stage_` reaches `Stage::Live` and the wrapper has converged.
- Apply the same `Stage::Live` gating policy to `SeaStateFusion_OU_III::updateMag` for consistent behavior across both trackers.
- Add explanatory comments around the new gating logic to document the rationale and intended effect.
- Modified files: `src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h` and `src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h`.

### Testing
- Ran `cd tests/kalman_ou_ii && make clean && make && bash run_tests.sh` and the OU2 test suite completed successfully (quality gates passed). 
- Ran `cd tests/kalman_ou_iii && make clean && make && bash run_tests.sh` and the OU3 test suite completed successfully (quality gates passed). 
- Ran the full project validation with `make all` and it completed successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3e4e23e3083288839f0bce5bafbd8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Magnetometer world reference initialization now properly gates to the Live operational stage, preventing premature calibration attempts and ensuring consistent sensor fusion behavior during system startup in both filter implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->