### PR TITLE
Add vertical-accel-drift regression test, plotting script and LaTeX charts

### DIFF
--- a/doc/wave_sim/wave_sim-vertical-accel-drift-charts.tex
+++ b/doc/wave_sim/wave_sim-vertical-accel-drift-charts.tex
@@ -1,0 +1,31 @@
+\documentclass[11pt,letterpaper]{article}
+\usepackage{amsmath}
+\usepackage{amssymb}
+\usepackage{fullpage}
+\usepackage{graphicx}
+\usepackage{pgf}
+\usepackage{float}
+\usepackage{microtype}
+
+\providecommand{\mathdefault}[1]{#1}
+
+\title{Vertical Acceleration Double-Integration Drift}
+\author{Mikhail Grushinskiy}
+\date{2026}
+
+\begin{document}
+\maketitle
+
+\begin{figure}[H]\centering
+\resizebox{\textwidth}{!}{\input{pmstokes_vertical_accel_drift.pgf}}
+\caption{PM/Stokes datasets: reference vertical displacement, displacement from direct double integration of noisy world-frame vertical acceleration, and the same displacement after AdaptiveWaveDetrender.}
+\label{fig:pmstokes_vertical_accel_drift}
+\end{figure}
+
+\begin{figure}[H]\centering
+\resizebox{\textwidth}{!}{\input{jonswap_vertical_accel_drift.pgf}}
+\caption{JONSWAP datasets: reference vertical displacement, displacement from direct double integration of noisy world-frame vertical acceleration, and the same displacement after AdaptiveWaveDetrender.}
+\label{fig:jonswap_vertical_accel_drift}
+\end{figure}
+
+\end{document}

--- a/plots/wave_sim/draw_plots.sh
+++ b/plots/wave_sim/draw_plots.sh
@@ -3,3 +3,4 @@
 python3 wave_sim-plots.py
 python3 wave_sim-theories.py --formats png svg pgf --output-dir . --basename wave_sim-theories
 python3 wave_sim-fenton.py
+python3 wave_sim-vertical-accel-drift-plots.py

--- a/plots/wave_sim/wave_sim-vertical-accel-drift-plots.py
+++ b/plots/wave_sim/wave_sim-vertical-accel-drift-plots.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import csv
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+
+mpl.use("pgf")
+plt.rcParams.update({
+    "pgf.texsystem": "xelatex",
+    "font.family": "serif",
+    "text.usetex": True,
+    "pgf.rcfonts": False,
+    "pgf.preamble": "\n".join([
+        r"\usepackage{fontspec}",
+        r"\usepackage{unicode-math}",
+        r"\usepackage{amsmath}",
+        r"\setmainfont{DejaVu Serif}",
+        r"\setmathfont{Latin Modern Math}",
+        r"\providecommand{\mathdefault}[1]{#1}",
+    ]),
+})
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+TEST_DIR = SCRIPT_DIR.parent.parent / "tests" / "wave_sim"
+CSV_PATH = TEST_DIR / "vertical_accel_drift_timeseries.csv"
+
+
+def short_name(name: str) -> str:
+    stem = name.replace("wave_data_", "").replace(".csv", "")
+    return stem.replace("_", r"\_")
+
+
+def read_rows():
+    with CSV_PATH.open(newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def unique_files(rows, wave_type: str):
+    names = sorted({r["wave_file"] for r in rows if r["wave_type"] == wave_type})
+    return names
+
+
+def float_col(rows, key):
+    return [float(r[key]) for r in rows]
+
+
+def make_plot(rows, wave_type: str, out_name: str) -> None:
+    files = unique_files(rows, wave_type)
+    if not files:
+        print(f"no rows for {wave_type}")
+        return
+
+    n = len(files)
+    fig, axes = plt.subplots(n, 1, figsize=(14, max(3.3 * n, 5.0)), sharex=False)
+    if n == 1:
+        axes = [axes]
+
+    for ax, file in zip(axes, files):
+        case = [r for r in rows if r["wave_type"] == wave_type and r["wave_file"] == file]
+        t = float_col(case, "time_s")
+        ref = float_col(case, "disp_ref_z_m")
+        dint = float_col(case, "disp_int_z_m")
+        ddet = float_col(case, "disp_int_detrended_z_m")
+
+        ax.plot(t, ref, color="black", linewidth=1.2, linestyle="--", label="reference $z$")
+        ax.plot(t, dint, color="#d62728", linewidth=1.0, label="double-integrated noisy $a_z$")
+        ax.plot(t, ddet, color="#1f77b4", linewidth=1.0, label="double-integrated + detrender")
+        ax.set_title(short_name(file), fontsize=10)
+        ax.set_ylabel("z [m]")
+        ax.grid(True, alpha=0.35)
+
+    axes[-1].set_xlabel("time [s]")
+    axes[0].legend(ncol=3, fontsize=8, loc="upper center")
+    fig.tight_layout()
+
+    pgf_path = SCRIPT_DIR / out_name
+    svg_path = pgf_path.with_suffix(".svg")
+    fig.savefig(pgf_path, bbox_inches="tight")
+    fig.savefig(svg_path, bbox_inches="tight")
+    plt.close(fig)
+    print(f"saved {pgf_path}")
+
+
+def main() -> None:
+    rows = read_rows()
+    make_plot(rows, "pmstokes", "pmstokes_vertical_accel_drift.pgf")
+    make_plot(rows, "jonswap", "jonswap_vertical_accel_drift.pgf")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/wave_sim/Makefile
+++ b/tests/wave_sim/Makefile
@@ -4,7 +4,7 @@ REPO_ROOT := $(abspath $(TEST_DIR)/../..)
 EIGEN_DIR ?= $(REPO_ROOT)/third_party/eigen
 EIGEN_CPPFLAGS := $(if $(wildcard $(EIGEN_DIR)/Eigen/Dense),-I$(EIGEN_DIR),-I/usr/include/eigen3)
 CFLAGS = -O3 -std=c++20 -funroll-loops -fno-finite-math-only -I$(REPO_ROOT)/src $(EIGEN_CPPFLAGS) $(CPPFLAGS)
-TARGETS = wave-convention-check
+TARGETS = wave-convention-check vertical-accel-drift-test
 
 .PHONY: all build test ensure-sim-data
 all: build test
@@ -20,9 +20,15 @@ ensure-sim-data:
 wave-convention-check: wave-convention-check.o
 	$(CC) $(CFLAGS) -o $@ $^
 
+W3dSimCommon.o: $(REPO_ROOT)/src/util/W3dSimCommon.cpp
+	$(CC) $(CFLAGS) -c $< -o $@
+
 %.o: %.cpp
 	$(CC) $(CFLAGS) -c $< -o $@
 
 .PHONY: clean
 clean:
 	rm -f *.o $(TARGETS) *.exe
+
+vertical-accel-drift-test: vertical-accel-drift-test.o W3dSimCommon.o
+	$(CC) $(CFLAGS) -o $@ $^

--- a/tests/wave_sim/run_tests.sh
+++ b/tests/wave_sim/run_tests.sh
@@ -1,3 +1,4 @@
 #!/bin/bash -e
 
 ./wave-convention-check
+./vertical-accel-drift-test

--- a/tests/wave_sim/vertical-accel-drift-test.cpp
+++ b/tests/wave_sim/vertical-accel-drift-test.cpp
@@ -1,0 +1,152 @@
+#include <algorithm>
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#define EIGEN_NON_ARDUINO
+#include "detrend/AdaptiveWaveDetrender.h"
+#include "util/W3dSimCommon.h"
+
+namespace {
+
+struct DriftStats {
+    std::string file;
+    float rms_integrated = 0.0f;
+    float rms_detrended = 0.0f;
+};
+
+float wave_freq_from_filename(const std::string& filename) {
+    auto parsed = WaveFileNaming::parse_to_params(filename);
+    if (!parsed) return 0.12f;
+
+    const auto [kind, type, wp] = *parsed;
+    (void)kind;
+    (void)type;
+    if (wp.period <= 0.0f || !std::isfinite(wp.period)) return 0.12f;
+    return 1.0f / wp.period;
+}
+
+bool should_process_file(const std::string& name) {
+    return name.rfind("wave_data_pmstokes_", 0) == 0 ||
+           name.rfind("wave_data_jonswap_", 0) == 0;
+}
+
+} // namespace
+
+int main() {
+    constexpr float dt_default = 0.005f;
+
+    // Keep coefficients aligned with src/util/W3dSimCommon.h process_wave_file_for_tracker.
+    const float acc_sigma = 1.51e-3f * g_std;
+    const float acc_bias_range = 8e-3f * g_std;
+    const float acc_bias_rw = 0.0005f;
+
+    std::ofstream ofs("vertical_accel_drift_timeseries.csv");
+    if (!ofs.is_open()) {
+        std::cerr << "ERROR: failed to open vertical_accel_drift_timeseries.csv\n";
+        return 1;
+    }
+
+    ofs << "wave_file,wave_type,time_s,disp_ref_z_m,vel_ref_z_m,acc_ref_z_mps2,"
+        << "acc_noisy_z_mps2,disp_int_z_m,disp_int_detrended_z_m,"
+        << "err_int_m,err_detrended_m\n";
+    ofs << std::fixed << std::setprecision(9);
+
+    std::vector<DriftStats> stats;
+
+    for (const auto& entry : std::filesystem::directory_iterator(".")) {
+        if (!entry.is_regular_file()) continue;
+        const std::string file = entry.path().filename().string();
+        if (!should_process_file(file)) continue;
+
+        WaveDataCSVReader reader(file);
+        ImuNoiseModel accel_world_noise = make_imu_noise_model(acc_sigma, acc_bias_range, acc_bias_rw, 1234);
+
+        AdaptiveWaveDetrender detrender;
+        const float wave_freq_hz = wave_freq_from_filename(file);
+
+        bool initialized = false;
+        double t_prev = 0.0;
+        float vel_int = 0.0f;
+        float disp_int = 0.0f;
+
+        double sum_err2_int = 0.0;
+        double sum_err2_det = 0.0;
+        std::size_t n_err = 0;
+
+        const std::string wave_type = (file.find("pmstokes") != std::string::npos) ? "pmstokes" : "jonswap";
+
+        reader.for_each_record([&](const Wave_Data_Sample& rec) {
+            const float acc_truth_z = rec.wave.acc_z;
+            const Vector3f noisy_xyz = apply_imu_noise(Vector3f::UnitZ() * acc_truth_z,
+                                                        accel_world_noise,
+                                                        dt_default);
+            const float acc_noisy_z = noisy_xyz.z();
+
+            if (!initialized) {
+                initialized = true;
+                t_prev = rec.time;
+                vel_int = rec.wave.vel_z;
+                disp_int = rec.wave.disp_z;
+                detrender.reset(disp_int);
+            } else {
+                const float dt = static_cast<float>(std::max(1e-6, rec.time - t_prev));
+                vel_int += acc_noisy_z * dt;
+                disp_int += vel_int * dt;
+                t_prev = rec.time;
+            }
+
+            const auto det_out = detrender.update(disp_int, dt_default, wave_freq_hz, true);
+            const float disp_det = det_out.wave_clean;
+            const float err_int = disp_int - rec.wave.disp_z;
+            const float err_det = disp_det - rec.wave.disp_z;
+
+            sum_err2_int += double(err_int) * double(err_int);
+            sum_err2_det += double(err_det) * double(err_det);
+            ++n_err;
+
+            ofs << file << ','
+                << wave_type << ','
+                << rec.time << ','
+                << rec.wave.disp_z << ','
+                << rec.wave.vel_z << ','
+                << acc_truth_z << ','
+                << acc_noisy_z << ','
+                << disp_int << ','
+                << disp_det << ','
+                << err_int << ','
+                << err_det << '\n';
+        });
+
+        if (n_err == 0) continue;
+        const float rms_int = std::sqrt(float(sum_err2_int / n_err));
+        const float rms_det = std::sqrt(float(sum_err2_det / n_err));
+        stats.push_back({file, rms_int, rms_det});
+
+        std::cout << "[vertical-accel-drift] " << file
+                  << " rms(integrated)=" << rms_int
+                  << " m, rms(detrended)=" << rms_det
+                  << " m\n";
+    }
+
+    if (stats.empty()) {
+        std::cerr << "ERROR: no wave_data_pmstokes_/wave_data_jonswap_ files found\n";
+        return 1;
+    }
+
+    std::ofstream summary("vertical_accel_drift_summary.csv");
+    summary << "wave_file,rms_integrated_m,rms_detrended_m,improvement_ratio\n";
+    summary << std::fixed << std::setprecision(9);
+    for (const auto& s : stats) {
+        const float ratio = (s.rms_detrended > 0.0f) ? (s.rms_integrated / s.rms_detrended) : 0.0f;
+        summary << s.file << ',' << s.rms_integrated << ',' << s.rms_detrended << ',' << ratio << '\n';
+    }
+
+    std::cout << "Wrote vertical_accel_drift_timeseries.csv and vertical_accel_drift_summary.csv\n";
+    return 0;
+}


### PR DESCRIPTION
### Motivation
- Demonstrate the large low-frequency drift that appears when naively double-integrating noisy vertical acceleration in world frame. 
- Reuse existing IMU noise models and their coefficients so the comparison uses realistic, consistent noise assumptions.

### Description
- Add `tests/wave_sim/vertical-accel-drift-test.cpp` which injects the same IMU noise (via `make_imu_noise_model`/`apply_imu_noise`) into world-frame vertical acceleration, performs direct double integration using exact initial `vel_z`/`disp_z` from the reference CSVs, applies `AdaptiveWaveDetrender` to the integrated trace, and emits `vertical_accel_drift_timeseries.csv` and `vertical_accel_drift_summary.csv`.
- Update `tests/wave_sim/Makefile` and `tests/wave_sim/run_tests.sh` to build and run the new test and add an explicit compile rule to link `W3dSimCommon.o` for noise utilities used by the test.
- Add `plots/wave_sim/wave_sim-vertical-accel-drift-plots.py` and hook it into `plots/wave_sim/draw_plots.sh` to produce PGF/SVG charts comparing reference displacement, raw double-integrated displacement, and detrendered displacement for PM Stokes and JONSWAP datasets.
- Add `doc/wave_sim/wave_sim-vertical-accel-drift-charts.tex` to assemble the generated PGF charts into a PDF report.

### Testing
- Ran `make all` from repository root which fetched the required simulation data and built the test suite (data download and many suites were executed as part of this run). 
- Initial build failed when the new test was linked due to undefined references (linker error from `vertical-accel-drift-test` referencing `g_std`, `make_imu_noise_model` and `apply_imu_noise`), the failing link step was: `g++ ... -o vertical-accel-drift-test vertical-accel-drift-test.o` and errors included `undefined reference to 'g_std'` and `undefined reference to 'make_imu_noise_model(float, float, float, unsigned int)'`, which was fixed by adding `W3dSimCommon.o` compile/link rules to the test Makefile.
- After fixing the Makefile, `cd tests/wave_sim && make test` completed and the test wrote `vertical_accel_drift_timeseries.csv` and `vertical_accel_drift_summary.csv` and printed per-file RMS results (showing very large naive-integrated drift vs much smaller detrended RMS in the summary).
- Attempted to run the plotting script (`cd plots/wave_sim && python3 wave_sim-vertical-accel-drift-plots.py`) but it failed in this environment with `ModuleNotFoundError: No module named 'matplotlib'`, so PGF/SVG outputs could not be produced here due to missing Python plotting dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4e3e329408328b78bcd080b1b3a67)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added article on vertical acceleration double-integration drift analysis.

* **New Features**
  * Introduced visualization plots for vertical acceleration drift test results.

* **Tests**
  * Added comprehensive test suite for vertical acceleration drift simulation and analysis, generating detailed timeseries and summary metrics.

* **Chores**
  * Updated build configuration to compile and execute new test infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->