### PR TITLE
Limit vertical accel drift test processing to first 60 seconds

### DIFF
--- a/tests/wave_sim/vertical-accel-drift-test.cpp
+++ b/tests/wave_sim/vertical-accel-drift-test.cpp
@@ -40,6 +40,7 @@ bool should_process_file(const std::string& name) {
 
 int main() {
     constexpr float dt_default = 0.005f;
+    constexpr double max_test_time_s = 60.0;
 
     // Keep coefficients aligned with src/util/W3dSimCommon.h process_wave_file_for_tracker.
     const float acc_sigma = 1.51e-3f * g_std;
@@ -82,6 +83,8 @@ int main() {
         const std::string wave_type = (file.find("pmstokes") != std::string::npos) ? "pmstokes" : "jonswap";
 
         reader.for_each_record([&](const Wave_Data_Sample& rec) {
+            if (rec.time > max_test_time_s) return;
+
             const float acc_truth_z = rec.wave.acc_z;
             const Vector3f noisy_xyz = apply_imu_noise(Vector3f::UnitZ() * acc_truth_z,
                                                         accel_world_noise,


### PR DESCRIPTION
### Motivation
- Reduce runtime and focus the vertical acceleration drift test on the initial behavior by capping per-file processing to the first 60 seconds.

### Description
- Add `constexpr double max_test_time_s = 60.0;` to `tests/wave_sim/vertical-accel-drift-test.cpp`.
- Skip records with `rec.time > max_test_time_s` inside the `reader.for_each_record` callback so CSV output and drift statistics only cover the first minute.

### Testing
- Ran `make all`, which invoked the build across tests; the change compiles, but the overall build failed in an unrelated target when compiling `kalman_ou_iii`.
- Failing command: `g++ -O3 -std=c++20 -funroll-loops -fno-finite-math-only -I/workspace/ocean-imu/src -I/usr/include/eigen3  -march=native -c kalman_ou_iii-sim.cpp -o kalman_ou_iii-sim.o`; failing error: `SeaStateFusionFilter_OU_II` was not declared in `src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h` (compile error reported during `tests/kalman_ou_iii` build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4ee4b561883288a63812a868fb3ce)