### PR TITLE
Refactor common SeaState fusion initialization and stillness logic

### DIFF
--- a/src/kalman_common/SeaStateFusionFilterCommon.h
+++ b/src/kalman_common/SeaStateFusionFilterCommon.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cmath>
+#include <algorithm>
 
 namespace seastate::common {
 
@@ -102,6 +103,112 @@ struct StillnessAdapter {
 private:
     float gravity_std_;
 };
+
+
+
+struct StartupTiltObserver {
+    Eigen::Vector3f s_body = Eigen::Vector3f(0.0f, 0.0f, -1.0f); // predicted specific-force dir at rest
+    bool initialized = false;
+
+    void reset() {
+        s_body = Eigen::Vector3f(0.0f, 0.0f, -1.0f);
+        initialized = false;
+    }
+
+    Eigen::Vector3f step(const Eigen::Vector3f& gyro_body_ned,
+                         const Eigen::Vector3f& acc_body_ned,
+                         float dt,
+                         float acc_tau_sec,
+                         float g_ref,
+                         float norm_frac)
+    {
+        if (!(dt > 0.0f) || !std::isfinite(dt)) {
+            return s_body;
+        }
+
+        // Initialize directly from first valid accel direction.
+        if (!initialized) {
+            if (acc_body_ned.allFinite()) {
+                const float an = acc_body_ned.norm();
+                if (std::isfinite(an) && an > 1e-6f) {
+                    s_body = acc_body_ned / an;
+                    initialized = true;
+                }
+            }
+            return s_body;
+        }
+
+        // Propagate with gyro: s_dot = -omega x s
+        Eigen::Vector3f s_pred = s_body;
+        if (gyro_body_ned.allFinite()) {
+            s_pred += dt * (-gyro_body_ned.cross(s_pred));
+            const float sn = s_pred.norm();
+            if (std::isfinite(sn) && sn > 1e-6f) {
+                s_pred /= sn;
+            } else {
+                s_pred = s_body;
+            }
+        }
+
+        // Correct slowly toward measured accel direction, with norm-based weighting.
+        if (acc_body_ned.allFinite()) {
+            const float an = acc_body_ned.norm();
+            if (std::isfinite(an) && an > 1e-6f) {
+                const Eigen::Vector3f u_a = acc_body_ned / an;
+
+                const float rel_err =
+                    std::fabs(an - g_ref) / std::max(g_ref, 1e-6f);
+
+                float w = 1.0f - rel_err / std::max(norm_frac, 1e-3f);
+                w = std::min(std::max(w, 0.0f), 1.0f);
+
+                const float tau = std::max(acc_tau_sec, 1.0e-3f);
+                const float alpha = w * (1.0f - std::exp(-dt / tau));
+
+                Eigen::Vector3f s_upd = (1.0f - alpha) * s_pred + alpha * u_a;
+                const float un = s_upd.norm();
+                if (std::isfinite(un) && un > 1e-6f) {
+                    s_body = s_upd / un;
+                } else {
+                    s_body = s_pred;
+                }
+                return s_body;
+            }
+        }
+
+        s_body = s_pred;
+        return s_body;
+    }
+};
+
+template<typename DetrenderConfig>
+inline DetrenderConfig defaultDisplacementDetrenderConfig(float freq_guess_hz) {
+    DetrenderConfig dcfg;
+    dcfg.init_wave_freq_hz = freq_guess_hz;
+    dcfg.min_wave_freq_hz  = 0.02f;
+    dcfg.max_wave_freq_hz  = 1.20f;
+    dcfg.baseline_cutoff_fraction = 0.25f;
+    dcfg.min_baseline_cutoff_hz   = 0.003f;
+    dcfg.max_baseline_cutoff_hz   = 0.25f;
+    dcfg.freq_smooth_tau_s = 12.0f;
+    dcfg.slope_lpf_tau_s   = 0.20f;
+    dcfg.slope_rms_tau_s   = 8.0f;
+    dcfg.freq_learn_axis   = 2;
+    dcfg.threshold_rms_fraction  = 0.15f;
+    dcfg.min_slope_threshold_abs = 0.002f;
+    dcfg.max_slope_threshold_abs = 1.0e9f;
+    dcfg.startup_hold_s      = 2.0f;
+    dcfg.freq_timeout_cycles = 3.0f;
+    dcfg.enable_wave_cleanup     = true;
+    dcfg.cleanup_cutoff_fraction = 1.0f;
+    dcfg.min_cleanup_cutoff_hz   = 0.003f;
+    dcfg.max_cleanup_cutoff_hz   = 0.50f;
+    dcfg.cleanup_stages          = 2;
+    dcfg.min_dt_s = 1.0e-4f;
+    dcfg.max_dt_s = 0.25f;
+    dcfg.output_abs_limit = 0.0f;
+    return dcfg;
+}
 
 template<typename MekfPtr, typename EnterColdFn, typename ApplyTuneFn>
 inline void finalizeInitialization(MekfPtr& mekf, EnterColdFn&& enterCold, ApplyTuneFn&& applyTune) {

--- a/src/kalman_common/SeaStateFusionFilterCommon.h
+++ b/src/kalman_common/SeaStateFusionFilterCommon.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <cmath>
+
+namespace seastate::common {
+
+struct FreqInputLPF {
+    float state       = 0.0f;
+    float fc_hz       = 1.0f;
+    bool  initialized = false;
+
+    void setCutoff(float fc) {
+        if (std::isfinite(fc) && fc > 0.0f) {
+            fc_hz = fc;
+        }
+    }
+
+    float step(float x, float dt) {
+        const float alpha = std::exp(-2.0f * static_cast<float>(M_PI) * fc_hz * dt);
+
+        if (!initialized) {
+            state       = x;
+            initialized = true;
+            return state;
+        }
+
+        state = (1.0f - alpha) * x + alpha * state;
+        return state;
+    }
+};
+
+struct StillnessAdapter {
+    explicit StillnessAdapter(float gravity_std = 9.80665f,
+                              float target_freq_hz_in = 0.2f,
+                              float freq_guess = 0.3f)
+        : gravity_std_(gravity_std),
+          target_freq_hz(target_freq_hz_in),
+          freq_state(freq_guess) {}
+
+    float energy_ema      = 0.0f;
+    float energy_alpha    = 0.05f;
+    float energy_thresh   = 8e-4f;
+
+    float still_time_sec  = 0.0f;
+    float still_thresh_s  = 2.0f;
+
+    float relax_tau_sec   = 1.0f;
+    float target_freq_hz;
+
+    bool  freq_init       = false;
+    float freq_state;
+
+    bool  last_is_still   = false;
+
+    void setTargetFreqHz(float f) {
+        if (std::isfinite(f) && f > 0.0f) {
+            target_freq_hz = f;
+        }
+    }
+
+    float step(float a_z_body_proxy_lp, float dt, float freq_in) {
+        if (!(dt > 0.0f) || !std::isfinite(freq_in)) {
+            return freq_in;
+        }
+
+        if (!freq_init || !std::isfinite(freq_state)) {
+            freq_state = freq_in;
+            freq_init  = true;
+        }
+
+        const float a_norm      = a_z_body_proxy_lp / gravity_std_;
+        const float inst_energy = a_norm * a_norm;
+
+        energy_ema = (1.0f - energy_alpha) * energy_ema + energy_alpha * inst_energy;
+        const bool is_still = (energy_ema < energy_thresh);
+        last_is_still = is_still;
+
+        if (is_still) {
+            still_time_sec += dt;
+            if (still_time_sec > 60.0f) {
+                still_time_sec = 60.0f;
+            }
+
+            if (still_time_sec > still_thresh_s) {
+                const float relax_alpha = 1.0f - std::exp(-dt / relax_tau_sec);
+                freq_state += relax_alpha * (target_freq_hz - freq_state);
+            } else {
+                freq_state = freq_in;
+            }
+        } else {
+            still_time_sec = 0.0f;
+            freq_state     = freq_in;
+        }
+
+        return freq_state;
+    }
+
+    bool  isStill()      const { return last_is_still; }
+    float getStillTime() const { return still_time_sec; }
+    float getEnergyEma() const { return energy_ema; }
+
+private:
+    float gravity_std_;
+};
+
+template<typename MekfPtr, typename EnterColdFn, typename ApplyTuneFn>
+inline void finalizeInitialization(MekfPtr& mekf, EnterColdFn&& enterCold, ApplyTuneFn&& applyTune) {
+    enterCold();
+    applyTune();
+    mekf->set_exact_att_bias_Qd(true);
+}
+
+}  // namespace seastate::common

--- a/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
+++ b/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
@@ -873,31 +873,8 @@ public:
             if (cfg_.use_custom_displacement_detrend_cfg) {
                 displacement_detrender_.setConfig(cfg_.displacement_detrend_cfg);
             } else {
-                AdaptiveWaveDetrender3D::Config dcfg;
-                dcfg.init_wave_freq_hz = FREQ_GUESS;
-                dcfg.min_wave_freq_hz  = 0.02f;
-                dcfg.max_wave_freq_hz  = 1.20f;
-                dcfg.baseline_cutoff_fraction = 0.25f;
-                dcfg.min_baseline_cutoff_hz   = 0.003f;
-                dcfg.max_baseline_cutoff_hz   = 0.25f;
-                dcfg.freq_smooth_tau_s = 12.0f;
-                dcfg.slope_lpf_tau_s   = 0.20f;
-                dcfg.slope_rms_tau_s   = 8.0f;
-                dcfg.freq_learn_axis   = 2;
-                dcfg.threshold_rms_fraction  = 0.15f;
-                dcfg.min_slope_threshold_abs = 0.002f;
-                dcfg.max_slope_threshold_abs = 1.0e9f;
-                dcfg.startup_hold_s      = 2.0f;
-                dcfg.freq_timeout_cycles = 3.0f;
-                dcfg.enable_wave_cleanup     = true;
-                dcfg.cleanup_cutoff_fraction = 1.0f;
-                dcfg.min_cleanup_cutoff_hz   = 0.003f;
-                dcfg.max_cleanup_cutoff_hz   = 0.50f;
-                dcfg.cleanup_stages          = 2;
-                dcfg.min_dt_s = 1.0e-4f;
-                dcfg.max_dt_s = 0.25f;
-                dcfg.output_abs_limit = 0.0f;
-                displacement_detrender_.setConfig(dcfg);
+                displacement_detrender_.setConfig(
+                    seastate::common::defaultDisplacementDetrenderConfig<AdaptiveWaveDetrender3D::Config>(FREQ_GUESS));
             }
             displacement_detrender_.reset(0.0f, 0.0f, 0.0f);
         }
@@ -1149,80 +1126,7 @@ private:
         }
     };
 
-    struct StartupTiltObserver {
-        Eigen::Vector3f s_body = Eigen::Vector3f(0.0f, 0.0f, -1.0f); // predicted specific-force dir at rest
-        bool initialized = false;
-
-        void reset() {
-            s_body = Eigen::Vector3f(0.0f, 0.0f, -1.0f);
-            initialized = false;
-        }
-
-        Eigen::Vector3f step(const Eigen::Vector3f& gyro_body_ned,
-                             const Eigen::Vector3f& acc_body_ned,
-                             float dt,
-                             float acc_tau_sec,
-                             float g_ref,
-                             float norm_frac)
-        {
-            if (!(dt > 0.0f) || !std::isfinite(dt)) {
-                return s_body;
-            }
-
-            // Initialize directly from first valid accel direction.
-            if (!initialized) {
-                if (acc_body_ned.allFinite()) {
-                    const float an = acc_body_ned.norm();
-                    if (std::isfinite(an) && an > 1e-6f) {
-                        s_body = acc_body_ned / an;
-                        initialized = true;
-                    }
-                }
-                return s_body;
-            }
-
-            // Propagate with gyro: s_dot = -omega x s
-            Eigen::Vector3f s_pred = s_body;
-            if (gyro_body_ned.allFinite()) {
-                s_pred += dt * (-gyro_body_ned.cross(s_pred));
-                const float sn = s_pred.norm();
-                if (std::isfinite(sn) && sn > 1e-6f) {
-                    s_pred /= sn;
-                } else {
-                    s_pred = s_body;
-                }
-            }
-
-            // Correct slowly toward measured accel direction, with norm-based weighting.
-            if (acc_body_ned.allFinite()) {
-                const float an = acc_body_ned.norm();
-                if (std::isfinite(an) && an > 1e-6f) {
-                    const Eigen::Vector3f u_a = acc_body_ned / an;
-
-                    const float rel_err =
-                        std::fabs(an - g_ref) / std::max(g_ref, 1e-6f);
-
-                    float w = 1.0f - rel_err / std::max(norm_frac, 1e-3f);
-                    w = std::min(std::max(w, 0.0f), 1.0f);
-
-                    const float tau = std::max(acc_tau_sec, 1.0e-3f);
-                    const float alpha = w * (1.0f - std::exp(-dt / tau));
-
-                    Eigen::Vector3f s_upd = (1.0f - alpha) * s_pred + alpha * u_a;
-                    const float un = s_upd.norm();
-                    if (std::isfinite(un) && un > 1e-6f) {
-                        s_body = s_upd / un;
-                    } else {
-                        s_body = s_pred;
-                    }
-                    return s_body;
-                }
-            }
-
-            s_body = s_pred;
-            return s_body;
-        }
-    };
+    using StartupTiltObserver = seastate::common::StartupTiltObserver;
 
     void resetTiltInit_() {
         bootstrap_tilt_obs_.reset();

--- a/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
+++ b/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
@@ -61,6 +61,7 @@
 #include "wave_dir/KalmanWaveDirection.h"
 #include "wave_dir/WaveDirectionDetector.h"
 #include "detrend/AdaptiveWaveDetrender3D.h"
+#include "kalman_common/SeaStateFusionFilterCommon.h"
 
 // Shared constants
 extern const float g_std;
@@ -149,9 +150,10 @@ public:
                     const Eigen::Vector3f& sigma_m)
     {
         mekf_ = std::make_unique<Kalman3D_Wave_OU_II<float>>(sigma_a, sigma_g, sigma_m);
-        enterCold_();      // applies freeze + warmup Racc + disables linear block
-        apply_ou_tune_();
-        mekf_->set_exact_att_bias_Qd(true);
+        seastate::common::finalizeInitialization(
+            mekf_,
+            [this]() { enterCold_(); },
+            [this]() { apply_ou_tune_(); });
     }
 
     void initialize_ext(const Eigen::Vector3f& sigma_a,
@@ -163,9 +165,10 @@ public:
     {
         mekf_ = std::make_unique<Kalman3D_Wave_OU_II<float>>(
             sigma_a, sigma_g, sigma_m, Pq0, Pb0, b0, R_p0_var_init, R_v0_var_init, gravity_magnitude);
-        enterCold_();      // applies freeze + warmup Racc + disables linear block
-        apply_ou_tune_();
-        mekf_->set_exact_att_bias_Qd(true);
+        seastate::common::finalizeInitialization(
+            mekf_,
+            [this]() { enterCold_(); },
+            [this]() { apply_ou_tune_(); });
     }
 
     void initialize_from_acc(const Eigen::Vector3f& acc_body_ned) {
@@ -520,87 +523,8 @@ public:
 
 private:
 
-    struct FreqInputLPF {
-        float state       = 0.0f;
-        float fc_hz       = 1.0f;
-        bool  initialized = false;
-
-        void setCutoff(float fc) {
-            if (std::isfinite(fc) && fc > 0.0f) fc_hz = fc;
-        }
-
-        float step(float x, float dt) {
-            const float alpha = std::exp(-2.0f * static_cast<float>(M_PI) * fc_hz * dt);
-
-            if (!initialized) {
-                state = x;
-                initialized = true;
-                return state;
-            }
-            state = (1.0f - alpha) * x + alpha * state;
-            return state;
-        }
-    };
-
-    struct StillnessAdapter {
-        float energy_ema      = 0.0f;
-        float energy_alpha    = 0.05f;
-        float energy_thresh   = 8e-4f;
-
-        float still_time_sec  = 0.0f;
-        float still_thresh_s  = 2.0f;
-
-        float relax_tau_sec   = 1.0f;
-        float target_freq_hz  = MIN_FREQ_HZ;
-
-        bool  freq_init       = false;
-        float freq_state      = FREQ_GUESS;
-
-        bool  last_is_still   = false;
-
-        void setTargetFreqHz(float f) {
-            if (std::isfinite(f) && f > 0.0f) target_freq_hz = f;
-        }
-
-        // a_z_body_proxy_lp:
-        //   low-passed BODY-Z-based up-positive proxy acceleration (m/s²)
-        //   used for tracker/stillness logic. Not true world vertical.
-        float step(float a_z_body_proxy_lp, float dt, float freq_in) {
-            if (!(dt > 0.0f) || !std::isfinite(freq_in)) return freq_in;
-
-            if (!freq_init || !std::isfinite(freq_state)) {
-                freq_state = freq_in;
-                freq_init = true;
-            }
-
-            const float a_norm      = a_z_body_proxy_lp / g_std;
-            const float inst_energy = a_norm * a_norm;
-
-            energy_ema = (1.0f - energy_alpha) * energy_ema + energy_alpha * inst_energy;
-            const bool is_still = (energy_ema < energy_thresh);
-            last_is_still = is_still;
-
-            if (is_still) {
-                still_time_sec += dt;
-                if (still_time_sec > 60.0f) still_time_sec = 60.0f;
-
-                if (still_time_sec > still_thresh_s) {
-                    const float relax_alpha = 1.0f - std::exp(-dt / relax_tau_sec);
-                    freq_state += relax_alpha * (target_freq_hz - freq_state);
-                } else {
-                    freq_state = freq_in;
-                }
-            } else {
-                still_time_sec = 0.0f;
-                freq_state = freq_in;
-            }
-            return freq_state;
-        }
-
-        bool  isStill()      const { return last_is_still; }
-        float getStillTime() const { return still_time_sec; }
-        float getEnergyEma() const { return energy_ema; }
-    };
+    using FreqInputLPF = seastate::common::FreqInputLPF;
+    using StillnessAdapter = seastate::common::StillnessAdapter;
 
     void apply_ou_tune_() {
         if (!mekf_) return;
@@ -727,7 +651,7 @@ private:
     void resetTrackingState_() {
         tracker_policy_ = TrackingPolicy{};
         freq_input_lpf_ = FreqInputLPF{};
-        freq_stillness_ = StillnessAdapter{};
+        freq_stillness_ = StillnessAdapter(g_std, min_freq_hz_, FREQ_GUESS);
         freq_input_lpf_.setCutoff(max_freq_hz_);
         freq_stillness_.setTargetFreqHz(min_freq_hz_);
 

--- a/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
+++ b/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
@@ -884,31 +884,8 @@ public:
             if (cfg_.use_custom_displacement_detrend_cfg) {
                 displacement_detrender_.setConfig(cfg_.displacement_detrend_cfg);
             } else {
-                AdaptiveWaveDetrender3D::Config dcfg;
-                dcfg.init_wave_freq_hz = FREQ_GUESS;
-                dcfg.min_wave_freq_hz  = 0.02f;
-                dcfg.max_wave_freq_hz  = 1.20f;
-                dcfg.baseline_cutoff_fraction = 0.25f;
-                dcfg.min_baseline_cutoff_hz   = 0.003f;
-                dcfg.max_baseline_cutoff_hz   = 0.25f;
-                dcfg.freq_smooth_tau_s = 12.0f;
-                dcfg.slope_lpf_tau_s   = 0.20f;
-                dcfg.slope_rms_tau_s   = 8.0f;
-                dcfg.freq_learn_axis   = 2;
-                dcfg.threshold_rms_fraction  = 0.15f;
-                dcfg.min_slope_threshold_abs = 0.002f;
-                dcfg.max_slope_threshold_abs = 1.0e9f;
-                dcfg.startup_hold_s      = 2.0f;
-                dcfg.freq_timeout_cycles = 3.0f;
-                dcfg.enable_wave_cleanup     = true;
-                dcfg.cleanup_cutoff_fraction = 1.0f;
-                dcfg.min_cleanup_cutoff_hz   = 0.003f;
-                dcfg.max_cleanup_cutoff_hz   = 0.50f;
-                dcfg.cleanup_stages          = 2;
-                dcfg.min_dt_s = 1.0e-4f;
-                dcfg.max_dt_s = 0.25f;
-                dcfg.output_abs_limit = 0.0f;
-                displacement_detrender_.setConfig(dcfg);
+                displacement_detrender_.setConfig(
+                    seastate::common::defaultDisplacementDetrenderConfig<AdaptiveWaveDetrender3D::Config>(FREQ_GUESS));
             }
             displacement_detrender_.reset(0.0f, 0.0f, 0.0f);
         }
@@ -1161,80 +1138,7 @@ private:
         }
     };
 
-    struct StartupTiltObserver {
-        Eigen::Vector3f s_body = Eigen::Vector3f(0.0f, 0.0f, -1.0f); // predicted specific-force dir at rest
-        bool initialized = false;
-
-        void reset() {
-            s_body = Eigen::Vector3f(0.0f, 0.0f, -1.0f);
-            initialized = false;
-        }
-
-        Eigen::Vector3f step(const Eigen::Vector3f& gyro_body_ned,
-                             const Eigen::Vector3f& acc_body_ned,
-                             float dt,
-                             float acc_tau_sec,
-                             float g_ref,
-                             float norm_frac)
-        {
-            if (!(dt > 0.0f) || !std::isfinite(dt)) {
-                return s_body;
-            }
-
-            // Initialize directly from first valid accel direction.
-            if (!initialized) {
-                if (acc_body_ned.allFinite()) {
-                    const float an = acc_body_ned.norm();
-                    if (std::isfinite(an) && an > 1e-6f) {
-                        s_body = acc_body_ned / an;
-                        initialized = true;
-                    }
-                }
-                return s_body;
-            }
-
-            // Propagate with gyro: s_dot = -omega x s
-            Eigen::Vector3f s_pred = s_body;
-            if (gyro_body_ned.allFinite()) {
-                s_pred += dt * (-gyro_body_ned.cross(s_pred));
-                const float sn = s_pred.norm();
-                if (std::isfinite(sn) && sn > 1e-6f) {
-                    s_pred /= sn;
-                } else {
-                    s_pred = s_body;
-                }
-            }
-
-            // Correct slowly toward measured accel direction, with norm-based weighting.
-            if (acc_body_ned.allFinite()) {
-                const float an = acc_body_ned.norm();
-                if (std::isfinite(an) && an > 1e-6f) {
-                    const Eigen::Vector3f u_a = acc_body_ned / an;
-
-                    const float rel_err =
-                        std::fabs(an - g_ref) / std::max(g_ref, 1e-6f);
-
-                    float w = 1.0f - rel_err / std::max(norm_frac, 1e-3f);
-                    w = std::min(std::max(w, 0.0f), 1.0f);
-
-                    const float tau = std::max(acc_tau_sec, 1.0e-3f);
-                    const float alpha = w * (1.0f - std::exp(-dt / tau));
-
-                    Eigen::Vector3f s_upd = (1.0f - alpha) * s_pred + alpha * u_a;
-                    const float un = s_upd.norm();
-                    if (std::isfinite(un) && un > 1e-6f) {
-                        s_body = s_upd / un;
-                    } else {
-                        s_body = s_pred;
-                    }
-                    return s_body;
-                }
-            }
-
-            s_body = s_pred;
-            return s_body;
-        }
-    };
+    using StartupTiltObserver = seastate::common::StartupTiltObserver;
 
     void resetTiltInit_() {
         bootstrap_tilt_obs_.reset();

--- a/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
+++ b/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
@@ -60,6 +60,7 @@
 #include "wave_dir/KalmanWaveDirection.h"
 #include "wave_dir/WaveDirectionDetector.h"
 #include "detrend/AdaptiveWaveDetrender3D.h"
+#include "kalman_common/SeaStateFusionFilterCommon.h"
 
 // Shared constants
 extern const float g_std;
@@ -144,9 +145,10 @@ public:
                     const Eigen::Vector3f& sigma_m)
     {
         mekf_ = std::make_unique<Kalman3D_Wave_OU_III<float>>(sigma_a, sigma_g, sigma_m);
-        enterCold_();      // applies freeze + warmup Racc + disables linear block
-        apply_ou_tune_();
-        mekf_->set_exact_att_bias_Qd(true);
+        seastate::common::finalizeInitialization(
+            mekf_,
+            [this]() { enterCold_(); },
+            [this]() { apply_ou_tune_(); });
     }
 
     void initialize_ext(const Eigen::Vector3f& sigma_a,
@@ -157,9 +159,10 @@ public:
                         float gravity_magnitude)
     {
         mekf_ = std::make_unique<Kalman3D_Wave_OU_III<float>>(sigma_a, sigma_g, sigma_m, Pq0, Pb0, b0, R_S_noise, gravity_magnitude);
-        enterCold_();      // applies freeze + warmup Racc + disables linear block
-        apply_ou_tune_();
-        mekf_->set_exact_att_bias_Qd(true);
+        seastate::common::finalizeInitialization(
+            mekf_,
+            [this]() { enterCold_(); },
+            [this]() { apply_ou_tune_(); });
     }
 
     void initialize_from_acc(const Eigen::Vector3f& acc_body_ned) {
@@ -541,91 +544,8 @@ public:
 private:
 
     // Simple first-order low-pass filter for vertical accel → tracker input
-    struct FreqInputLPF {
-        float state       = 0.0f;
-        float fc_hz       = 1.0f;
-        bool  initialized = false;
-
-        void setCutoff(float fc) {
-            if (std::isfinite(fc) && fc > 0.0f) {
-                fc_hz = fc;
-            }
-        }
-
-        float step(float x, float dt) {
-            const float alpha = std::exp(-2.0f * static_cast<float>(M_PI) * fc_hz * dt);
-
-            if (!initialized) {
-                state       = x;
-                initialized = true;
-                return state;
-            }
-            state = (1.0f - alpha) * x + alpha * state;
-            return state;
-        }
-    };
-
-    // Detect “stillness” from vertical accel and relax frequency when still.
-    struct StillnessAdapter {
-        float energy_ema      = 0.0f;
-        float energy_alpha    = 0.05f;
-        float energy_thresh   = 8e-4f;
-
-        float still_time_sec  = 0.0f;
-        float still_thresh_s  = 2.0f;
-
-        float relax_tau_sec   = 1.0f;
-        float target_freq_hz  = MIN_FREQ_HZ;
-
-        bool  freq_init       = false;
-        float freq_state      = FREQ_GUESS;
-
-        bool  last_is_still   = false;
-
-        void setTargetFreqHz(float f) {
-            if (std::isfinite(f) && f > 0.0f) {
-                target_freq_hz = f;
-            }
-        }
-
-        float step(float a_z_body_proxy_lp, float dt, float freq_in) {
-            if (!(dt > 0.0f) || !std::isfinite(freq_in)) {
-                return freq_in;
-            }
-
-            if (!freq_init || !std::isfinite(freq_state)) {
-                freq_state = freq_in;
-                freq_init  = true;
-            }
-
-            const float a_norm      = a_z_body_proxy_lp / g_std;
-            const float inst_energy = a_norm * a_norm;
-
-            energy_ema = (1.0f - energy_alpha) * energy_ema + energy_alpha * inst_energy;
-            const bool is_still = (energy_ema < energy_thresh);
-            last_is_still = is_still;
-
-            if (is_still) {
-                still_time_sec += dt;
-                if (still_time_sec > 60.0f) still_time_sec = 60.0f;
-
-                if (still_time_sec > still_thresh_s) {
-                    const float relax_alpha = 1.0f - std::exp(-dt / relax_tau_sec);
-                    freq_state += relax_alpha * (target_freq_hz - freq_state);
-                } else {
-                    freq_state = freq_in;
-                }
-            } else {
-                still_time_sec = 0.0f;
-                freq_state     = freq_in;
-            }
-            return freq_state;
-        }
-
-        bool  isStill()       const { return last_is_still; }
-        float getStillTime()  const { return still_time_sec; }
-        float getEnergyEma()  const { return energy_ema; }
-    };
+    using FreqInputLPF = seastate::common::FreqInputLPF;
+    using StillnessAdapter = seastate::common::StillnessAdapter;
 
     void apply_ou_tune_() {
         if (!mekf_) return;
@@ -748,7 +668,7 @@ private:
     void resetTrackingState_() {
         tracker_policy_       = TrackingPolicy{};
         freq_input_lpf_       = FreqInputLPF{};
-        freq_stillness_       = StillnessAdapter{};
+        freq_stillness_       = StillnessAdapter(g_std, min_freq_hz_, FREQ_GUESS);
         freq_input_lpf_.setCutoff(max_freq_hz_);
         freq_stillness_.setTargetFreqHz(min_freq_hz_);
 


### PR DESCRIPTION
### Motivation
- Reduce duplicated code between `SeaStateFusionFilter_OU_II` and `SeaStateFusionFilter_OU_III` by extracting shared low-pass / stillness and post-construction initialization logic. 
- Keep behavior identical while centralizing implementation to simplify future maintenance. 

### Description
- Added `src/kalman_common/SeaStateFusionFilterCommon.h` which implements `FreqInputLPF`, `StillnessAdapter`, and a `finalizeInitialization(...)` helper. 
- Updated `src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h` and `src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h` to `#include` the new common header, replace inline `FreqInputLPF`/`StillnessAdapter` with `using` aliases, and call `seastate::common::finalizeInitialization(...)` from both `initialize(...)` and `initialize_ext(...)`. 
- Ensured reset logic explicitly constructs `StillnessAdapter(g_std, min_freq_hz_, FREQ_GUESS)` in both filters so runtime behavior is preserved. 
- Change is internal-only: no public API, filename, or build target changes. 

### Testing
- Ran the full build and tests with `make all`, which completed successfully. 
- The `kalman_ou_ii` and `kalman_ou_iii` test suites executed as part of `make all` and passed during the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea44b27b808328a523398cb05877d8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal sea-state fusion filter implementations to improve code consistency and maintainability across filter variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->