### PR TITLE
Expose mag_min_samples, add env-driven simulator overrides, and add OU tuning sweep tool

### DIFF
--- a/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
+++ b/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
@@ -817,6 +817,7 @@ public:
         float mag_tilt_fallback_sec       = 6.0f;
         float mag_extreme_gyro_dps        = 90.0f; // veto only truly violent motion
         float mag_init_min_mag_norm       = 1e-3f;
+        int   mag_min_samples             = 48;
 
         // Bootstrap tilt observer for dynamic motion in waves.
         float bootstrap_tilt_obs_acc_tau_sec  = 1.50f; // accel correction time constant
@@ -846,7 +847,7 @@ public:
         mag_ref_set_ = false;
         MagAutoTuner::Config mag_cfg;
         mag_cfg.mag_norm_min = cfg_.mag_init_min_mag_norm;
-        mag_cfg.min_samples  = 48;
+        mag_cfg.min_samples  = cfg_.mag_min_samples;
         mag_auto_tuner_.setConfig(mag_cfg);
 
         resetTiltInit_();

--- a/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
+++ b/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
@@ -828,6 +828,7 @@ public:
         float mag_tilt_fallback_sec       = 6.0f;
         float mag_extreme_gyro_dps        = 90.0f; // veto only truly violent motion
         float mag_init_min_mag_norm       = 1e-3f;
+        int   mag_min_samples             = 48;
 
         // Bootstrap tilt observer for dynamic motion in waves.
         float bootstrap_tilt_obs_acc_tau_sec  = 1.50f; // accel correction time constant
@@ -857,7 +858,7 @@ public:
         mag_ref_set_ = false;
         MagAutoTuner::Config mag_cfg;
         mag_cfg.mag_norm_min = cfg_.mag_init_min_mag_norm;
-        mag_cfg.min_samples  = 48;
+        mag_cfg.min_samples  = cfg_.mag_min_samples;
         mag_auto_tuner_.setConfig(mag_cfg);
 
         resetTiltInit_();

--- a/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
+++ b/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
@@ -1,5 +1,6 @@
 #include <filesystem>
 #include <iostream>
+#include <cstdlib>
 #include <string>
 #include <vector>
 
@@ -38,6 +39,7 @@ public:
         cfg_.mag_delay_sec = MAG_DELAY_SEC;
         cfg_.freeze_acc_bias_until_live = true;
         cfg_.Racc_warmup_std = 0.5f;
+        apply_env_overrides();
 
         fusion_.begin(cfg_);
         auto& filter = fusion_.raw();
@@ -52,7 +54,36 @@ public:
             filter.enableLinearBlock(true);
             filter.enableTuner(true);
             filter.enableClamp(true);
+            if (const char* s = std::getenv("OU_P_FACTOR")) filter.setPFactor(std::atof(s));
+            if (const char* s = std::getenv("OU_R_P0_XY_FACTOR")) filter.setR_p0_XYFactor(std::atof(s));
+            if (const char* s = std::getenv("OU_TAU_COEFF")) filter.setTauCoeff(std::atof(s));
+            if (const char* s = std::getenv("OU_SIGMA_COEFF")) filter.setSigmaCoeff(std::atof(s));
+            if (const char* s = std::getenv("OU_R_P0_COEFF")) filter.setR_p0_Coeff(std::atof(s));
+            if (const char* s = std::getenv("OU_R_V0_COEFF")) filter.setR_v0_Coeff(std::atof(s));
+            if (const char* s = std::getenv("OU_ACC_NOISE_FLOOR_SIGMA")) filter.setAccNoiseFloorSigma(std::atof(s));
+            if (const char* s = std::getenv("OU_ADAPT_TAU_SEC")) filter.setAdaptationTimeConstants(std::atof(s));
+            if (const char* s = std::getenv("OU_ADAPT_EVERY_SECS")) filter.setAdaptationUpdatePeriod(std::atof(s));
+            if (const char* s = std::getenv("OU_FREQ_INPUT_CUTOFF_HZ")) filter.setFreqInputCutoffHz(std::atof(s));
         }
+    }
+    void apply_env_overrides() {
+        if (const char* s = std::getenv("SF_MAG_DELAY_SEC")) cfg_.mag_delay_sec = std::atof(s);
+        if (const char* s = std::getenv("SF_MAG_GRAV_ALIGN_MAX_SIN")) cfg_.mag_gravity_align_max_sin = std::atof(s);
+        if (const char* s = std::getenv("SF_MAG_GRAV_ALIGN_HOLD_SEC")) cfg_.mag_gravity_align_hold_sec = std::atof(s);
+        if (const char* s = std::getenv("SF_MAG_GRAV_ALIGN_LPF_TAU")) cfg_.mag_gravity_align_lpf_tau = std::atof(s);
+        if (const char* s = std::getenv("SF_MAG_TILT_FALLBACK_SEC")) cfg_.mag_tilt_fallback_sec = std::atof(s);
+        if (const char* s = std::getenv("SF_MAG_EXTREME_GYRO_DPS")) cfg_.mag_extreme_gyro_dps = std::atof(s);
+        if (const char* s = std::getenv("SF_MAG_INIT_MIN_MAG_NORM")) cfg_.mag_init_min_mag_norm = std::atof(s);
+        if (const char* s = std::getenv("SF_MAG_MIN_SAMPLES")) cfg_.mag_min_samples = std::atoi(s);
+        if (const char* s = std::getenv("SF_RACC_WARMUP_STD")) cfg_.Racc_warmup_std = std::atof(s);
+        if (const char* s = std::getenv("SF_ONLINE_TUNE_WARMUP_SEC")) cfg_.online_tune_warmup_sec = std::atof(s);
+        if (const char* s = std::getenv("SF_BOOT_TILT_ACC_TAU")) cfg_.bootstrap_tilt_obs_acc_tau_sec = std::atof(s);
+        if (const char* s = std::getenv("SF_BOOT_GRAV_SLOW_TAU")) cfg_.bootstrap_gravity_slow_tau_sec = std::atof(s);
+        if (const char* s = std::getenv("SF_BOOT_GRAV_ALIGN_MAX_SIN")) cfg_.bootstrap_gravity_align_max_sin = std::atof(s);
+        if (const char* s = std::getenv("SF_BOOT_GRAV_HOLD_SEC")) cfg_.bootstrap_gravity_hold_sec = std::atof(s);
+        if (const char* s = std::getenv("SF_BOOT_GRAV_MIN_SEC")) cfg_.bootstrap_gravity_min_sec = std::atof(s);
+        if (const char* s = std::getenv("SF_BOOT_GRAV_TIMEOUT_SEC")) cfg_.bootstrap_gravity_timeout_sec = std::atof(s);
+        if (const char* s = std::getenv("SF_BOOT_GRAV_NORM_FRAC")) cfg_.bootstrap_gravity_norm_frac = std::atof(s);
     }
 
     void updateMag(const Vector3f& mag_body_ned) override {

--- a/tests/kalman_ou_iii/kalman_ou_iii-sim.cpp
+++ b/tests/kalman_ou_iii/kalman_ou_iii-sim.cpp
@@ -1,5 +1,6 @@
 #include <filesystem>
 #include <iostream>
+#include <cstdlib>
 #include <string>
 #include <vector>
 
@@ -38,6 +39,7 @@ public:
         cfg_.mag_delay_sec = MAG_DELAY_SEC;
         cfg_.freeze_acc_bias_until_live = true;
         cfg_.Racc_warmup_std = 0.5f;
+        apply_env_overrides();
 
         fusion_.begin(cfg_);
         auto& filter = fusion_.raw();
@@ -52,7 +54,32 @@ public:
             filter.enableLinearBlock(true);
             filter.enableTuner(true);
             filter.enableClamp(true);
+            if (const char* s = std::getenv("OU_TAU_COEFF")) filter.setTauCoeff(std::atof(s));
+            if (const char* s = std::getenv("OU_SIGMA_COEFF")) filter.setSigmaCoeff(std::atof(s));
+            if (const char* s = std::getenv("OU_ACC_NOISE_FLOOR_SIGMA")) filter.setAccNoiseFloorSigma(std::atof(s));
+            if (const char* s = std::getenv("OU_ADAPT_TAU_SEC")) filter.setAdaptationTimeConstants(std::atof(s));
+            if (const char* s = std::getenv("OU_ADAPT_EVERY_SECS")) filter.setAdaptationUpdatePeriod(std::atof(s));
+            if (const char* s = std::getenv("OU_FREQ_INPUT_CUTOFF_HZ")) filter.setFreqInputCutoffHz(std::atof(s));
         }
+    }
+    void apply_env_overrides() {
+        if (const char* s = std::getenv("SF_MAG_DELAY_SEC")) cfg_.mag_delay_sec = std::atof(s);
+        if (const char* s = std::getenv("SF_MAG_GRAV_ALIGN_MAX_SIN")) cfg_.mag_gravity_align_max_sin = std::atof(s);
+        if (const char* s = std::getenv("SF_MAG_GRAV_ALIGN_HOLD_SEC")) cfg_.mag_gravity_align_hold_sec = std::atof(s);
+        if (const char* s = std::getenv("SF_MAG_GRAV_ALIGN_LPF_TAU")) cfg_.mag_gravity_align_lpf_tau = std::atof(s);
+        if (const char* s = std::getenv("SF_MAG_TILT_FALLBACK_SEC")) cfg_.mag_tilt_fallback_sec = std::atof(s);
+        if (const char* s = std::getenv("SF_MAG_EXTREME_GYRO_DPS")) cfg_.mag_extreme_gyro_dps = std::atof(s);
+        if (const char* s = std::getenv("SF_MAG_INIT_MIN_MAG_NORM")) cfg_.mag_init_min_mag_norm = std::atof(s);
+        if (const char* s = std::getenv("SF_MAG_MIN_SAMPLES")) cfg_.mag_min_samples = std::atoi(s);
+        if (const char* s = std::getenv("SF_RACC_WARMUP_STD")) cfg_.Racc_warmup_std = std::atof(s);
+        if (const char* s = std::getenv("SF_ONLINE_TUNE_WARMUP_SEC")) cfg_.online_tune_warmup_sec = std::atof(s);
+        if (const char* s = std::getenv("SF_BOOT_TILT_ACC_TAU")) cfg_.bootstrap_tilt_obs_acc_tau_sec = std::atof(s);
+        if (const char* s = std::getenv("SF_BOOT_GRAV_SLOW_TAU")) cfg_.bootstrap_gravity_slow_tau_sec = std::atof(s);
+        if (const char* s = std::getenv("SF_BOOT_GRAV_ALIGN_MAX_SIN")) cfg_.bootstrap_gravity_align_max_sin = std::atof(s);
+        if (const char* s = std::getenv("SF_BOOT_GRAV_HOLD_SEC")) cfg_.bootstrap_gravity_hold_sec = std::atof(s);
+        if (const char* s = std::getenv("SF_BOOT_GRAV_MIN_SEC")) cfg_.bootstrap_gravity_min_sec = std::atof(s);
+        if (const char* s = std::getenv("SF_BOOT_GRAV_TIMEOUT_SEC")) cfg_.bootstrap_gravity_timeout_sec = std::atof(s);
+        if (const char* s = std::getenv("SF_BOOT_GRAV_NORM_FRAC")) cfg_.bootstrap_gravity_norm_frac = std::atof(s);
     }
 
     void updateMag(const Vector3f& mag_body_ned) override {

--- a/tools/ou_tuning_sweep.py
+++ b/tools/ou_tuning_sweep.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+import os, re, csv, subprocess
+from pathlib import Path
+ROOT=Path(__file__).resolve().parents[1]
+CASES=[("baseline",{}),("racc_0_8",{"SF_RACC_WARMUP_STD":"0.8"}),("racc_1_2",{"SF_RACC_WARMUP_STD":"1.2"}),("racc_1_6",{"SF_RACC_WARMUP_STD":"1.6"}),("startup_A_300",{"SF_MAG_DELAY_SEC":"15","SF_MAG_GRAV_ALIGN_MAX_SIN":"0.07","SF_MAG_GRAV_ALIGN_HOLD_SEC":"2.0","SF_MAG_GRAV_ALIGN_LPF_TAU":"1.0","SF_MAG_TILT_FALLBACK_SEC":"30","SF_MAG_EXTREME_GYRO_DPS":"45","SF_BOOT_TILT_ACC_TAU":"2.5","SF_BOOT_GRAV_SLOW_TAU":"6.0","SF_BOOT_GRAV_ALIGN_MAX_SIN":"0.07","SF_BOOT_GRAV_HOLD_SEC":"2.0","SF_BOOT_GRAV_MIN_SEC":"8.0","SF_BOOT_GRAV_TIMEOUT_SEC":"15.0","SF_BOOT_GRAV_NORM_FRAC":"0.25","SF_ONLINE_TUNE_WARMUP_SEC":"10.0","SF_RACC_WARMUP_STD":"1.2","SF_MAG_MIN_SAMPLES":"300"}),("startup_A_600",{"SF_MAG_MIN_SAMPLES":"600","SF_MAG_DELAY_SEC":"15","SF_MAG_GRAV_ALIGN_MAX_SIN":"0.07","SF_MAG_GRAV_ALIGN_HOLD_SEC":"2.0","SF_MAG_GRAV_ALIGN_LPF_TAU":"1.0","SF_MAG_TILT_FALLBACK_SEC":"30","SF_MAG_EXTREME_GYRO_DPS":"45","SF_BOOT_TILT_ACC_TAU":"2.5","SF_BOOT_GRAV_SLOW_TAU":"6.0","SF_BOOT_GRAV_ALIGN_MAX_SIN":"0.07","SF_BOOT_GRAV_HOLD_SEC":"2.0","SF_BOOT_GRAV_MIN_SEC":"8.0","SF_BOOT_GRAV_TIMEOUT_SEC":"15.0","SF_BOOT_GRAV_NORM_FRAC":"0.25","SF_ONLINE_TUNE_WARMUP_SEC":"10.0","SF_RACC_WARMUP_STD":"1.2"})]
+metric_re=re.compile(r"Angles RMS \(deg\): Roll=([0-9.eE+-]+) Pitch=([0-9.eE+-]+) Yaw=([0-9.eE+-]+)")
+xyz_re=re.compile(r"XYZ RMS \(m\): X=([0-9.eE+-]+) Y=([0-9.eE+-]+) Z=([0-9.eE+-]+)")
+def run_family(fam):
+ tdir=ROOT/"tests"/("kalman_ou_ii" if fam=="OU_II" else "kalman_ou_iii")
+ bin_name="./kalman_ou_ii-sim" if fam=="OU_II" else "./kalman_ou_iii-sim"; out=[]
+ for cid,env_add in CASES:
+  env=os.environ.copy(); env.update(env_add)
+  p=subprocess.run([bin_name],cwd=tdir,env=env,text=True,capture_output=True)
+  text=p.stdout+p.stderr; y=[float(m.group(3)) for m in metric_re.finditer(text)]; z=[float(m.group(3)) for m in xyz_re.finditer(text)]
+  out.append(dict(family=fam,candidate=cid,returncode=p.returncode,yaw_rms_mean=(sum(y)/len(y) if y else 1e9),z_rms_mean=(sum(z)/len(z) if z else 1e9)))
+ return out
+subprocess.run(["make","-C",str(ROOT/"tests/kalman_ou_ii"),"build"],check=True)
+subprocess.run(["make","-C",str(ROOT/"tests/kalman_ou_iii"),"build"],check=True)
+rows=run_family("OU_II")+run_family("OU_III")
+outp=ROOT/"tests"/"tuning_sweep_results.csv"
+with outp.open("w",newline="") as f:
+ w=csv.DictWriter(f,fieldnames=rows[0].keys()); w.writeheader(); w.writerows(rows)
+print(outp)


### PR DESCRIPTION
### Motivation
- Make the magnetometer auto-tuner sample threshold configurable instead of a hardcoded value to allow longer/shorter mag startup gating. 
- Enable runtime tuning of fusion filter parameters from environment variables in the simulator binaries to accelerate parameter sweeps and experiments. 
- Add a small orchestration script to run and collect results from multiple tuning candidates automatically.

### Description
- Added a `mag_min_samples` field to `SeaStateFusion_OU_II::Config` and `SeaStateFusion_OU_III::Config` and wired it into `MagAutoTuner::Config` (`mag_cfg.min_samples = cfg_.mag_min_samples`) replacing the hardcoded `48` value. 
- Extended `tests/kalman_ou_ii/kalman_ou_ii-sim.cpp` and `tests/kalman_ou_iii/kalman_ou_iii-sim.cpp` to include `<cstdlib>`, added an `apply_env_overrides()` helper that reads many `SF_*` environment variables and applies them to the simulator `Config`, and added additional `getenv`-based overrides for various OU tuner parameters used by the filter instance. 
- Added `tools/ou_tuning_sweep.py`, a script that builds the OU_II/OU_III simulators, runs a set of predefined environment-variable candidate configurations, parses angle/position RMS metrics from the simulator output, and writes results to `tests/tuning_sweep_results.csv`.

### Testing
- Built the modified simulators via `make -C tests/kalman_ou_ii build` and `make -C tests/kalman_ou_iii build`, and the builds completed successfully. 
- Executed the simulator binaries with and without environment overrides using the new `tools/ou_tuning_sweep.py` script which runs the builds and candidate runs and produced `tests/tuning_sweep_results.csv` as output. 
- Verified that the simulators accept and apply environment overrides at startup and that the mag auto-tuner now uses the configured `mag_min_samples` value during initialization.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f78c2e76508328bddb84cdfef0f59e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `mag_min_samples` configuration parameter to Sea State Fusion filters, enabling customization of magnetometer sample requirements (default: 48 samples) instead of hardcoded values.
  * Environment variable support added for runtime configuration overrides of filter parameters during testing.

* **Tools**
  * New tuning sweep automation script added for optimization analysis across filter variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->