### PR TITLE
Tune OU_II/OU_III startup and magnetic initialization defaults

### DIFF
--- a/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
+++ b/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
@@ -801,32 +801,32 @@ public:
         bool with_mag = true;
 
         float mag_delay_sec          = MAG_DELAY_SEC;
-        float online_tune_warmup_sec = ONLINE_TUNE_WARMUP_SEC;
+        float online_tune_warmup_sec = 10.0f;
 
         bool  freeze_acc_bias_until_live = true;
-        float Racc_warmup_std = 0.5f;
+        float Racc_warmup_std = 1.2f;
 
         Eigen::Vector3f sigma_a = Eigen::Vector3f(0.2f, 0.2f, 0.2f);
         Eigen::Vector3f sigma_g = Eigen::Vector3f(0.01f, 0.01f, 0.01f);
         Eigen::Vector3f sigma_m = Eigen::Vector3f(0.3f, 0.3f, 0.3f);
 
         // Mag-start gate: gravity-direction agreement using current tilt.
-        float mag_gravity_align_max_sin   = 0.156f; // sin(deg)
-        float mag_gravity_align_hold_sec  = 0.486f;
-        float mag_gravity_align_lpf_tau   = 0.35f;
-        float mag_tilt_fallback_sec       = 6.0f;
-        float mag_extreme_gyro_dps        = 90.0f; // veto only truly violent motion
+        float mag_gravity_align_max_sin   = 0.070f; // sin(deg)
+        float mag_gravity_align_hold_sec  = 2.0f;
+        float mag_gravity_align_lpf_tau   = 1.0f;
+        float mag_tilt_fallback_sec       = 30.0f;
+        float mag_extreme_gyro_dps        = 45.0f; // veto only truly violent motion
         float mag_init_min_mag_norm       = 1e-3f;
-        int   mag_min_samples             = 48;
+        int   mag_min_samples             = 300;
 
         // Bootstrap tilt observer for dynamic motion in waves.
-        float bootstrap_tilt_obs_acc_tau_sec  = 1.50f; // accel correction time constant
-        float bootstrap_gravity_slow_tau_sec  = 3.50f; // slow gravity reference LPF
-        float bootstrap_gravity_align_max_sin = 0.193f; // sin(deg)
-        float bootstrap_gravity_hold_sec      = 0.617f;
-        float bootstrap_gravity_min_sec       = 4.0f;
-        float bootstrap_gravity_timeout_sec   = 6.0f;
-        float bootstrap_gravity_norm_frac     = 0.49f; // downweight accel when |a| departs from g
+        float bootstrap_tilt_obs_acc_tau_sec  = 2.50f; // accel correction time constant
+        float bootstrap_gravity_slow_tau_sec  = 6.0f; // slow gravity reference LPF
+        float bootstrap_gravity_align_max_sin = 0.070f; // sin(deg)
+        float bootstrap_gravity_hold_sec      = 2.0f;
+        float bootstrap_gravity_min_sec       = 8.0f;
+        float bootstrap_gravity_timeout_sec   = 15.0f;
+        float bootstrap_gravity_norm_frac     = 0.25f; // downweight accel when |a| departs from g
 
         bool enable_displacement_detrend = false;
         bool use_custom_displacement_detrend_cfg = false;

--- a/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
+++ b/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
@@ -812,32 +812,32 @@ public:
         bool with_mag = true;
 
         float mag_delay_sec          = MAG_DELAY_SEC;
-        float online_tune_warmup_sec = ONLINE_TUNE_WARMUP_SEC;
+        float online_tune_warmup_sec = 10.0f;
 
         bool  freeze_acc_bias_until_live = true;
-        float Racc_warmup_std = 0.5f;
+        float Racc_warmup_std = 1.2f;
 
         Eigen::Vector3f sigma_a = Eigen::Vector3f(0.2f, 0.2f, 0.2f);
         Eigen::Vector3f sigma_g = Eigen::Vector3f(0.01f, 0.01f, 0.01f);
         Eigen::Vector3f sigma_m = Eigen::Vector3f(0.3f, 0.3f, 0.3f);
 
         // Mag-start gate: gravity-direction agreement using current tilt.
-        float mag_gravity_align_max_sin   = 0.156f; // sin(deg)
-        float mag_gravity_align_hold_sec  = 0.486f;
-        float mag_gravity_align_lpf_tau   = 0.35f;
-        float mag_tilt_fallback_sec       = 6.0f;
-        float mag_extreme_gyro_dps        = 90.0f; // veto only truly violent motion
+        float mag_gravity_align_max_sin   = 0.070f; // sin(deg)
+        float mag_gravity_align_hold_sec  = 2.0f;
+        float mag_gravity_align_lpf_tau   = 1.0f;
+        float mag_tilt_fallback_sec       = 30.0f;
+        float mag_extreme_gyro_dps        = 45.0f; // veto only truly violent motion
         float mag_init_min_mag_norm       = 1e-3f;
-        int   mag_min_samples             = 48;
+        int   mag_min_samples             = 300;
 
         // Bootstrap tilt observer for dynamic motion in waves.
-        float bootstrap_tilt_obs_acc_tau_sec  = 1.50f; // accel correction time constant
-        float bootstrap_gravity_slow_tau_sec  = 3.50f; // slow gravity reference LPF
-        float bootstrap_gravity_align_max_sin = 0.193f; // sin(deg)
-        float bootstrap_gravity_hold_sec      = 0.617f;
-        float bootstrap_gravity_min_sec       = 4.0f;
-        float bootstrap_gravity_timeout_sec   = 6.0f;
-        float bootstrap_gravity_norm_frac     = 0.49f; // downweight accel when |a| departs from g
+        float bootstrap_tilt_obs_acc_tau_sec  = 2.50f; // accel correction time constant
+        float bootstrap_gravity_slow_tau_sec  = 6.0f; // slow gravity reference LPF
+        float bootstrap_gravity_align_max_sin = 0.070f; // sin(deg)
+        float bootstrap_gravity_hold_sec      = 2.0f;
+        float bootstrap_gravity_min_sec       = 8.0f;
+        float bootstrap_gravity_timeout_sec   = 15.0f;
+        float bootstrap_gravity_norm_frac     = 0.25f; // downweight accel when |a| departs from g
 
         bool enable_displacement_detrend = false;
         bool use_custom_displacement_detrend_cfg = false;


### PR DESCRIPTION
### Motivation
- Reduce persistent startup yaw/attitude bias learned in waves by making magnetic-reference capture and gravity alignment more conservative and by increasing early accelerometer-warmup noise/tracking patience.
- Apply the same cautious startup profile to both OU_II and OU_III so production defaults are aligned and robust to wave-biased initial tilt.

### Description
- Updated production defaults in both filter families (`SeaStateFusion_OU_II` and `SeaStateFusion_OU_III`) in these files: `src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h` and `src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h`.
- Key parameter changes (old -> new): `online_tune_warmup_sec: ONLINE_TUNE_WARMUP_SEC -> 10.0`, `Racc_warmup_std: 0.5 -> 1.2`, `mag_gravity_align_max_sin: 0.156 -> 0.070`, `mag_gravity_align_hold_sec: 0.486 -> 2.0`, `mag_gravity_align_lpf_tau: 0.35 -> 1.0`, `mag_tilt_fallback_sec: 6.0 -> 30.0`, `mag_extreme_gyro_dps: 90/120 -> 45.0`, `mag_min_samples: 48 -> 300`, `bootstrap_tilt_obs_acc_tau_sec: 1.50 -> 2.50`, `bootstrap_gravity_slow_tau_sec: 3.50 -> 6.0`, `bootstrap_gravity_align_max_sin: 0.193 -> 0.070`, `bootstrap_gravity_hold_sec: 0.617 -> 2.0`, `bootstrap_gravity_min_sec: 4.0 -> 8.0`, `bootstrap_gravity_timeout_sec: 6.0 -> 15.0`, and `bootstrap_gravity_norm_frac: 0.49 -> 0.25`.
- Changes are minimal and restricted to default config fields; no public APIs, filenames, or build targets were altered.

### Testing
- Commands executed (automated): `make all`, `python3 tools/ou_tuning_sweep.py`, `bash tests/kalman_ou_ii/run_tests.sh`, and `bash tests/kalman_ou_iii/run_tests.sh`.
- Results: `make all` completed and downloaded required sim-data (sim-data-files.zip) successfully; both `tests/kalman_ou_ii` and `tests/kalman_ou_iii` simulator runs completed (exit code 0) and their quality gates printed `PASS` for the datasets exercised in those scripts.
- Notes and next steps: the changes implement the suggested cautious candidate profile from the tuning plan and were validated with the repository build and the simulator test scripts, but a full smart Monte Carlo-style sweep (multi-seed/multi-dataset Pareto ranking) was not completed in this PR; a dedicated tuning-runner sweep across the suggested parameter ranges and seeds is recommended as the next step to confirm and possibly refine these defaults before further changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8b7eafec483289167768e9b42c94f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted filter initialization, warmup, and magnetometer calibration parameters across sensor fusion variants to improve fusion stability and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->