### PR TITLE
Add OU gravity/tilt tuning CI job and refactor tuning sweep tool

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,6 +113,36 @@ jobs:
           path: release-svg/${{ matrix.dir }}/**/*.svg
           if-no-files-found: error
 
+
+  ou-gravity-tilt-tuning:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Download sim data from oceanography-waves-lib GitHub repo release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download v1.1.3 --repo bareboat-necessities/oceanography-waves-lib --pattern "sim-data-files.zip" --clobber
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++ make libeigen3-dev unzip
+      - name: Unpack simulation data
+        run: |
+          unzip -o sim-data-files.zip -d ${{ github.workspace }}/tests/kalman_ou_ii
+          unzip -o sim-data-files.zip -d ${{ github.workspace }}/tests/kalman_ou_iii
+      - name: Run deterministic gravity/tilt Monte Carlo sweep
+        run: |
+          python3 tools/ou_tuning_sweep.py --samples 100 --seed 42 --family both
+      - name: Upload tuning reports
+        uses: actions/upload-artifact@v6
+        with:
+          name: ou-gravity-tilt-tuning-reports
+          path: reports/results/*
+          if-no-files-found: error
+
   release:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest

--- a/tools/ou_tuning_sweep.py
+++ b/tools/ou_tuning_sweep.py
@@ -1,23 +1,89 @@
 #!/usr/bin/env python3
-import os, re, csv, subprocess
+import argparse, csv, math, os, random, re, subprocess
+from collections import defaultdict
 from pathlib import Path
-ROOT=Path(__file__).resolve().parents[1]
-CASES=[("baseline",{}),("racc_0_8",{"SF_RACC_WARMUP_STD":"0.8"}),("racc_1_2",{"SF_RACC_WARMUP_STD":"1.2"}),("racc_1_6",{"SF_RACC_WARMUP_STD":"1.6"}),("startup_A_300",{"SF_MAG_DELAY_SEC":"15","SF_MAG_GRAV_ALIGN_MAX_SIN":"0.07","SF_MAG_GRAV_ALIGN_HOLD_SEC":"2.0","SF_MAG_GRAV_ALIGN_LPF_TAU":"1.0","SF_MAG_TILT_FALLBACK_SEC":"30","SF_MAG_EXTREME_GYRO_DPS":"45","SF_BOOT_TILT_ACC_TAU":"2.5","SF_BOOT_GRAV_SLOW_TAU":"6.0","SF_BOOT_GRAV_ALIGN_MAX_SIN":"0.07","SF_BOOT_GRAV_HOLD_SEC":"2.0","SF_BOOT_GRAV_MIN_SEC":"8.0","SF_BOOT_GRAV_TIMEOUT_SEC":"15.0","SF_BOOT_GRAV_NORM_FRAC":"0.25","SF_ONLINE_TUNE_WARMUP_SEC":"10.0","SF_RACC_WARMUP_STD":"1.2","SF_MAG_MIN_SAMPLES":"300"}),("startup_A_600",{"SF_MAG_MIN_SAMPLES":"600","SF_MAG_DELAY_SEC":"15","SF_MAG_GRAV_ALIGN_MAX_SIN":"0.07","SF_MAG_GRAV_ALIGN_HOLD_SEC":"2.0","SF_MAG_GRAV_ALIGN_LPF_TAU":"1.0","SF_MAG_TILT_FALLBACK_SEC":"30","SF_MAG_EXTREME_GYRO_DPS":"45","SF_BOOT_TILT_ACC_TAU":"2.5","SF_BOOT_GRAV_SLOW_TAU":"6.0","SF_BOOT_GRAV_ALIGN_MAX_SIN":"0.07","SF_BOOT_GRAV_HOLD_SEC":"2.0","SF_BOOT_GRAV_MIN_SEC":"8.0","SF_BOOT_GRAV_TIMEOUT_SEC":"15.0","SF_BOOT_GRAV_NORM_FRAC":"0.25","SF_ONLINE_TUNE_WARMUP_SEC":"10.0","SF_RACC_WARMUP_STD":"1.2"})]
-metric_re=re.compile(r"Angles RMS \(deg\): Roll=([0-9.eE+-]+) Pitch=([0-9.eE+-]+) Yaw=([0-9.eE+-]+)")
-xyz_re=re.compile(r"XYZ RMS \(m\): X=([0-9.eE+-]+) Y=([0-9.eE+-]+) Z=([0-9.eE+-]+)")
-def run_family(fam):
- tdir=ROOT/"tests"/("kalman_ou_ii" if fam=="OU_II" else "kalman_ou_iii")
- bin_name="./kalman_ou_ii-sim" if fam=="OU_II" else "./kalman_ou_iii-sim"; out=[]
- for cid,env_add in CASES:
-  env=os.environ.copy(); env.update(env_add)
-  p=subprocess.run([bin_name],cwd=tdir,env=env,text=True,capture_output=True)
-  text=p.stdout+p.stderr; y=[float(m.group(3)) for m in metric_re.finditer(text)]; z=[float(m.group(3)) for m in xyz_re.finditer(text)]
-  out.append(dict(family=fam,candidate=cid,returncode=p.returncode,yaw_rms_mean=(sum(y)/len(y) if y else 1e9),z_rms_mean=(sum(z)/len(z) if z else 1e9)))
+
+ROOT=Path(__file__).resolve().parents[1]; REPORTS=ROOT/'reports'/'results'
+
+COMMON={"SF_BOOT_TILT_ACC_TAU":(1.5,5.0),"SF_BOOT_GRAV_SLOW_TAU":(3.5,10.0),"SF_BOOT_GRAV_ALIGN_MAX_SIN":(0.04,0.12),"SF_BOOT_GRAV_HOLD_SEC":(1.0,5.0),"SF_BOOT_GRAV_MIN_SEC":(5.0,16.0),"SF_BOOT_GRAV_TIMEOUT_SEC":(10.0,30.0),"SF_BOOT_GRAV_NORM_FRAC":(0.15,0.40),"SF_ONLINE_TUNE_WARMUP_SEC":(8.0,20.0),"OU_ACC_NOISE_FLOOR_SIGMA":(0.10,0.25),"OU_SIGMA_COEFF":(0.60,1.00),"OU_TAU_COEFF":(1.2,2.2),"OU_ADAPT_TAU_SEC":(1.5,5.0),"OU_ADAPT_EVERY_SECS":(0.05,0.25)}
+OU2={"OU_P_FACTOR":(1.0,2.2),"OU_R_P0_XY_FACTOR":(0.10,0.60),"OU_R_P0_COEFF":(1.0,3.0),"OU_R_V0_COEFF":(1.0,3.0)}
+MAG={"SF_MAG_DELAY_SEC":(5.0,25.0),"SF_MAG_GRAV_ALIGN_MAX_SIN":(0.04,0.16),"SF_MAG_GRAV_ALIGN_HOLD_SEC":(0.2,4.0),"SF_MAG_GRAV_ALIGN_LPF_TAU":(0.2,2.0),"SF_MAG_TILT_FALLBACK_SEC":(3.0,40.0),"SF_MAG_EXTREME_GYRO_DPS":(35.0,130.0),"SF_MAG_MIN_SAMPLES":(24,800),"SF_MAG_INIT_MIN_MAG_NORM":(1e-4,5e-3)}
+
+RX={
+'ds':re.compile(r"Processing\s+(.+?\.csv)"),
+'ang':re.compile(r"Angles RMS \(deg\): Roll=([0-9.eE+-]+) Pitch=([0-9.eE+-]+) Yaw=([0-9.eE+-]+)"),
+'xyz':re.compile(r"XYZ RMS \(m\): X=([0-9.eE+-]+) Y=([0-9.eE+-]+) Z=([0-9.eE+-]+)"),
+'r3d':re.compile(r"3D RMS \(m\):\s*([0-9.eE+-]+)"),
+'accb':re.compile(r"Bias error RMS \(acc, m/s\^2\): X=([0-9.eE+-]+) Y=([0-9.eE+-]+) Z=([0-9.eE+-]+) \|3D\|=([0-9.eE+-]+)")}
+
+def lhs(r,n,rng):
+ a=[rng[0]+(i+r.random())/n*(rng[1]-rng[0]) for i in range(n)]; r.shuffle(a); return a
+
+def cands(fam,samples,seed,with_mag):
+ r=random.Random(seed+(0 if fam=='OU_II' else 1_000_000)); out=[('baseline',{})]
+ explicit={"SF_BOOT_TILT_ACC_TAU":2.5,"SF_BOOT_GRAV_SLOW_TAU":6.0,"SF_BOOT_GRAV_ALIGN_MAX_SIN":0.070,"SF_BOOT_GRAV_HOLD_SEC":2.0,"SF_BOOT_GRAV_MIN_SEC":8.0,"SF_BOOT_GRAV_TIMEOUT_SEC":15.0,"SF_BOOT_GRAV_NORM_FRAC":0.25,"SF_ONLINE_TUNE_WARMUP_SEC":10.0}
+ for rr in (0.8,1.2,1.6): out.append((f'explicit_racc_{str(rr).replace('.','_')}',{**explicit,'SF_RACC_WARMUP_STD':rr}))
+ for rr in (0.8,1.2,1.6): out.append((f'racc_{str(rr).replace('.','_')}',{'SF_RACC_WARMUP_STD':rr}))
+ space=dict(COMMON); 
+ if fam=='OU_II': space.update(OU2)
+ if with_mag: space.update(MAG)
+ S={k:lhs(r,samples,v) for k,v in space.items()}
+ for i in range(samples):
+  p={k:S[k][i] for k in S}; p['SF_RACC_WARMUP_STD']=(0.8,1.2,1.6)[i%3];
+  if 'SF_MAG_MIN_SAMPLES' in p: p['SF_MAG_MIN_SAMPLES']=int(round(p['SF_MAG_MIN_SAMPLES']))
+  out.append((f'mc_{i:04d}',p))
  return out
-subprocess.run(["make","-C",str(ROOT/"tests/kalman_ou_ii"),"build"],check=True)
-subprocess.run(["make","-C",str(ROOT/"tests/kalman_ou_iii"),"build"],check=True)
-rows=run_family("OU_II")+run_family("OU_III")
-outp=ROOT/"tests"/"tuning_sweep_results.csv"
-with outp.open("w",newline="") as f:
- w=csv.DictWriter(f,fieldnames=rows[0].keys()); w.writeheader(); w.writerows(rows)
-print(outp)
+
+def parse(text):
+ ds=RX['ds'].findall(text); ang=[m.groups() for m in RX['ang'].finditer(text)]; xyz=[m.groups() for m in RX['xyz'].finditer(text)]; r3d=[m.group(1) for m in RX['r3d'].finditer(text)]; accb=[m.groups() for m in RX['accb'].finditer(text)]
+ n=max(len(ds),len(ang),len(xyz),len(accb),1); out=[]
+ for i in range(n):
+  g=lambda arr,j,idx=float('nan'): float(arr[j][idx]) if j<len(arr) else float('nan')
+  out.append(dict(wave_dataset=ds[i] if i<len(ds) else f'dataset_{i}',roll_rms=g(ang,i,0),pitch_rms=g(ang,i,1),yaw_rms=g(ang,i,2),x_rms=g(xyz,i,0),y_rms=g(xyz,i,1),z_rms=g(xyz,i,2),rms_3d=float(r3d[i]) if i<len(r3d) else float('nan'),acc_bias_rms_x=g(accb,i,0),acc_bias_rms_y=g(accb,i,1),acc_bias_rms_z=g(accb,i,2),acc_bias_rms_3d=g(accb,i,3)))
+ return out
+
+def run_family(fam,args):
+ tdir=ROOT/'tests'/('kalman_ou_ii' if fam=='OU_II' else 'kalman_ou_iii'); bin_name='./kalman_ou_ii-sim' if fam=='OU_II' else './kalman_ou_iii-sim'; rows=[]
+ for cid,p in cands(fam,args.samples,args.seed,args.with_mag_sweep):
+  env=os.environ.copy(); env.update({k:f'{v:.6g}' if isinstance(v,float) else str(v) for k,v in p.items()})
+  pr=subprocess.run([bin_name],cwd=tdir,text=True,capture_output=True,env=env)
+  for m in parse(pr.stdout+'\n'+pr.stderr):
+   m.update(dict(family=fam,candidate=cid,seed=args.seed,returncode=pr.returncode,quality_gate_pass=(pr.returncode==0),fail_reason='' if pr.returncode==0 else 'nonzero_return_or_gate_fail',roll_pitch_rms_norm=math.hypot(m['roll_rms'],m['pitch_rms']) if math.isfinite(m['roll_rms']) and math.isfinite(m['pitch_rms']) else float('nan'),xy_rms=math.hypot(m['x_rms'],m['y_rms']) if math.isfinite(m['x_rms']) and math.isfinite(m['y_rms']) else float('nan')))
+   for k,v in p.items(): m[k]=v
+   rows.append(m)
+ return rows
+
+def score(rows):
+ base={(r['family'],r['wave_dataset'],r['seed']):r for r in rows if r['candidate']=='baseline'}
+ for r in rows:
+  b=base.get((r['family'],r['wave_dataset'],r['seed']),r)
+  def fv(x,d=100.0):
+   try:v=float(x); return v if math.isfinite(v) else d
+   except:return d
+  acc=fv(r['acc_bias_rms_3d']); rp=fv(r['roll_pitch_rms_norm']); yaw=fv(r['yaw_rms']); z=fv(r['z_rms']); xy=fv(r['xy_rms']); bz=fv(b['z_rms']); bxy=fv(b['xy_rms'])
+  r['score']=8*acc+3*rp+1*yaw+2*max(0,z-bz)+2*max(0,xy-bxy)+(0 if r['quality_gate_pass'] else 1e6)+(0 if int(r['returncode'])==0 else 1e6)
+
+def report(rows,args):
+ REPORTS.mkdir(parents=True,exist_ok=True)
+ out=REPORTS/f'ou_sweep_seed{args.seed}_n{args.samples}_mag{int(args.with_mag_sweep)}.csv'
+ with out.open('w',newline='') as f: w=csv.DictWriter(f,fieldnames=list(rows[0].keys())); w.writeheader(); w.writerows(rows)
+ for fam in sorted({r['family'] for r in rows}):
+  fr=[r for r in rows if r['family']==fam]; by=defaultdict(list)
+  for r in fr: by[r['candidate']].append(r)
+  agg=[]
+  for c,it in by.items(): agg.append((sum(float(x['score']) for x in it)/len(it),c,it))
+  best=min(agg,key=lambda x:x[0])
+  md=REPORTS/f'{fam.lower()}_best_report.md'
+  with md.open('w') as f:
+   f.write(f'family: {fam}\nbest_candidate: {best[1]}\nmean_score: {best[0]:.6f}\nquality_rows: {sum(1 for x in best[2] if x["quality_gate_pass"])} / {len(best[2])}\n')
+   f.write('priority: accel_bias_rms_3d > attitude(r/p norm) > yaw\n')
+ return out
+
+def main():
+ ap=argparse.ArgumentParser(); ap.add_argument('--samples',type=int,default=100); ap.add_argument('--seed',type=int,default=42); ap.add_argument('--family',choices=['OU_II','OU_III','both'],default='both'); ap.add_argument('--with-mag-sweep',action='store_true',default=True)
+ a=ap.parse_args(); subprocess.run(['make','-C',str(ROOT/'tests/kalman_ou_ii'),'build'],check=True); subprocess.run(['make','-C',str(ROOT/'tests/kalman_ou_iii'),'build'],check=True)
+ fams=['OU_II','OU_III'] if a.family=='both' else [a.family]; rows=[]
+ for fam in fams: rows.extend(run_family(fam,a))
+ score(rows); out=report(rows,a); print(out)
+
+if __name__=='__main__': main()


### PR DESCRIPTION
### Motivation
- Automate gravity/tilt tuning for OU Kalman filters by running a deterministic Monte Carlo sweep in CI and producing searchable reports. 
- Replace a minimal one-off script with a reusable, configurable tuning tool that samples parameter space, parses simulator outputs, and scores candidates.

### Description
- Add a new GitHub Actions job `ou-gravity-tilt-tuning` that checks out the repo, downloads `sim-data-files.zip` from the `bareboat-necessities/oceanography-waves-lib` release via `gh release download`, installs dependencies, unpacks simulation data into `tests/kalman_ou_ii` and `tests/kalman_ou_iii`, runs `python3 tools/ou_tuning_sweep.py --samples 100 --seed 42 --family both`, and uploads `reports/results/*` as artifacts.
- Replace `tools/ou_tuning_sweep.py` with a full-featured CLI tool that builds the simulators via `make -C ... build`, generates candidate parameter sets (including explicit candidates and Latin hypercube sampled Monte Carlo candidates) across configurable parameter spaces (`COMMON`, `OU2`, `MAG`), runs `kalman_ou_ii/iii` sims, parses simulator stdout/stderr with regexes, computes derived metrics and a composite `score`, and writes both a CSV to `reports/results` and per-family best-candidate markdown reports.
- The tool exposes CLI options `--samples`, `--seed`, `--family`, and `--with-mag-sweep`, defaults to `--samples 100`, `--seed 42`, `--family both`, and `--with-mag-sweep` enabled, and marks rows with `quality_gate_pass` and `returncode` for filtering.
- Parsing and scoring were made more robust (capture stdout+stderr, numeric sanitization, integer casting for sample counts, and large-penalty handling for failed runs) and outputs are placed under `reports/results`.

### Testing
- No automated tests were executed as part of this PR change; the new CI job is added to the workflow and will run in GitHub Actions when triggered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8c54f9a488328a6f9abee055ec975)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated parameter tuning to the CI/CD pipeline with configurable sweep options (`--samples`, `--seed`, `--family`).
  * Enhanced tuning script to support flexible parameter exploration and generate detailed per-family reports.
  * Improved artifact reporting for tuning results visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->