### PR TITLE
Include all row keys in CSV output of ou_tuning_sweep

### DIFF
--- a/tools/ou_tuning_sweep.py
+++ b/tools/ou_tuning_sweep.py
@@ -66,7 +66,10 @@ def score(rows):
 def report(rows,args):
  REPORTS.mkdir(parents=True,exist_ok=True)
  out=REPORTS/f'ou_sweep_seed{args.seed}_n{args.samples}_mag{int(args.with_mag_sweep)}.csv'
- with out.open('w',newline='') as f: w=csv.DictWriter(f,fieldnames=list(rows[0].keys())); w.writeheader(); w.writerows(rows)
+ first_fields=list(rows[0].keys())
+ extra_fields=sorted({k for r in rows for k in r.keys()}-set(first_fields))
+ all_fields=first_fields+extra_fields
+ with out.open('w',newline='') as f: w=csv.DictWriter(f,fieldnames=all_fields); w.writeheader(); w.writerows(rows)
  for fam in sorted({r['family'] for r in rows}):
   fr=[r for r in rows if r['family']==fam]; by=defaultdict(list)
   for r in fr: by[r['candidate']].append(r)


### PR DESCRIPTION
### Motivation
- The CSV writer previously used only the first row's keys which could omit additional fields present in other rows, producing incomplete CSVs.

### Description
- Build `all_fields` by preserving the first row's key order and appending any extra keys found across all rows (sorted), then use that list as the `fieldnames` for the `csv.DictWriter` so all columns are written.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8e14ec15883289782c9082cbdcf51)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CSV report generation to include all columns from all data rows, preventing columns that appear only in later rows from being omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->