### PR TITLE
Improve Monte Carlo best-report output and quality-gate enforcement

### DIFF
--- a/tools/ou_tuning_sweep.py
+++ b/tools/ou_tuning_sweep.py
@@ -78,12 +78,29 @@ def report(rows,args):
   fr=[r for r in rows if r['family']==fam]; by=defaultdict(list)
   for r in fr: by[r['candidate']].append(r)
   agg=[]
-  for c,it in by.items(): agg.append((sum(float(x['score']) for x in it)/len(it),c,it))
+  for c,it in by.items():
+   if not all(bool(x.get('quality_gate_pass')) and int(x.get('returncode',1))==0 for x in it): continue
+   agg.append((sum(float(x['score']) for x in it)/len(it),c,it))
+  if not agg:
+   raise RuntimeError(f'No quality-gate-passing candidates found for {fam}')
   best=min(agg,key=lambda x:x[0])
-  md=REPORTS/f'{fam.lower()}_best_report.md'
-  with md.open('w') as f:
+  txt=REPORTS/f'{fam.lower()}_best_report.txt'
+  with txt.open('w') as f:
    f.write(f'family: {fam}\nbest_candidate: {best[1]}\nmean_score: {best[0]:.6f}\nquality_rows: {sum(1 for x in best[2] if x["quality_gate_pass"])} / {len(best[2])}\n')
    f.write('priority: accel_bias_rms_3d > attitude(r/p norm) > yaw\n')
+   f.write('\n')
+   param_keys=sorted({k for k in best[2][0].keys() if k.startswith('SF_') or k.startswith('OU_')})
+   f.write('best_found_parameters:\n')
+   for k in param_keys: f.write(f'  {k}: {best[2][0][k]}\n')
+   f.write('\n')
+   f.write('per_wave_rms:\n')
+   for r in sorted(best[2],key=lambda x:x['wave_dataset']):
+    f.write(f"  wave_dataset: {r['wave_dataset']}\n")
+    f.write(f"    xyz_rms_m: X={r['x_rms']}, Y={r['y_rms']}, Z={r['z_rms']}\n")
+    f.write(f"    rms_3d_m: {r['rms_3d']}\n")
+    f.write(f"    angles_rms_deg: Roll={r['roll_rms']}, Pitch={r['pitch_rms']}, Yaw={r['yaw_rms']}\n")
+    f.write(f"    acc_bias_rms_mps2: X={r['acc_bias_rms_x']}, Y={r['acc_bias_rms_y']}, Z={r['acc_bias_rms_z']}, |3D|={r['acc_bias_rms_3d']}\n")
+    f.write(f"    quality_gate_pass: {r['quality_gate_pass']}\n")
  return out
 
 def main():


### PR DESCRIPTION
### Motivation
- The OU Monte Carlo sweep reports omitted the actual best-found parameter values and per-wave RMS details, making results hard to act on. 
- The report format used `.md` which did not match the required `.txt` report extension. 
- Best-candidate selection should only consider candidates that pass quality gates across all wave rows to avoid returning invalid results. 

### Description
- Updated `tools/ou_tuning_sweep.py` to only consider candidates where every row has `quality_gate_pass == true` and `returncode == 0` when computing the best candidate. 
- Added an explicit failure (`RuntimeError`) when no candidate satisfies the quality-gate requirement for a family. 
- Changed best-candidate output files from `{family}_best_report.md` to `{family}_best_report.txt` while preserving the CSV sweep summary output. 
- Expanded the best-report content to include `best_found_parameters` (all `SF_*` / `OU_*` keys) and a `per_wave_rms` section listing XYZ RMS, 3D RMS, angle RMS, accel-bias RMS and per-wave quality-gate status. 

### Testing
- Ran `make all` from the repo root which built all test binaries, fetched required simulation data, and executed test scripts; the build and test run completed successfully. 
- The repository quality gates and test suites executed as part of `make all` and produced expected outputs with no failing quality-gate errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9020202ec83289010171aa7c63c1e)