### PR TITLE
Add periodic progress reporting to OU tuning sweep

### DIFF
--- a/tools/ou_tuning_sweep.py
+++ b/tools/ou_tuning_sweep.py
@@ -65,8 +65,11 @@ def run_candidate(fam,cid,p,tier,seed,collect):
  return rows
 
 def eval_set(fam, cand_list, tier='quick', collect=True, seed=42):
- rows=[]
- for cid,p in cand_list: rows.extend(run_candidate(fam,cid,p,tier,seed,collect))
+ rows=[]; total=len(cand_list); report_every=max(1,total//10)
+ for i,(cid,p) in enumerate(cand_list,1):
+  rows.extend(run_candidate(fam,cid,p,tier,seed,collect))
+  if i==1 or i==total or i%report_every==0:
+   print(f'[{fam}] progress: {i}/{total} candidates complete')
  return rows
 
 def percentile(vals,p):


### PR DESCRIPTION
### Motivation
- Provide periodic terminal status updates while `tools/ou_tuning_sweep.py` evaluates many candidates so long-running sweeps are easier to monitor.

### Description
- Update `eval_set()` in `tools/ou_tuning_sweep.py` to compute `total` and `report_every`, iterate with `enumerate`, call `run_candidate` per candidate, and `print` progress for the first candidate, at ~10% intervals, and on completion; no other behavior or public interfaces were changed.

### Testing
- Ran `python -m py_compile tools/ou_tuning_sweep.py`, which completed successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f913793ab483288149100e1b7587a8)