### PR TITLE
Constrain OU II/III gravity startup sweep, disable mag/tau/sigma tuning, and add detailed progress logging

### DIFF
--- a/tools/ou_tuning_sweep.py
+++ b/tools/ou_tuning_sweep.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python3
-import argparse, csv, math, os, random, re, subprocess
+import argparse, csv, math, os, random, re, subprocess, time
 from collections import defaultdict
+from datetime import datetime
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 REPORTS = ROOT / 'reports' / 'results'
+MAX_BOOT_TIMEOUT_SEC = 15.0
+MIN_MARGIN_SEC = 1.0
+MAX_MARGIN_SEC = 4.0
+REJECTED_KEYS = {'OU_TAU_COEFF', 'OU_SIGMA_COEFF'}
+REJECTED_PREFIXES = ('SF_MAG_',)
 
 GRAVITY_RANGES = {
     'OU_II': {
@@ -13,13 +19,13 @@ GRAVITY_RANGES = {
         'SF_ONLINE_TUNE_WARMUP_SEC': (5.0, 10.0),
     },
     'OU_III': {
-        'SF_BOOT_TILT_ACC_TAU': (1.5, 3.2), 'SF_BOOT_GRAV_SLOW_TAU': (3.5, 7.0), 'SF_BOOT_GRAV_ALIGN_MAX_SIN': (0.10, 0.20),
-        'SF_BOOT_GRAV_HOLD_SEC': (0.6, 2.0), 'SF_BOOT_GRAV_MIN_SEC': (4.0, 9.0), 'SF_BOOT_GRAV_NORM_FRAC': (0.25, 0.49),
+        'SF_BOOT_TILT_ACC_TAU': (1.5, 3.0), 'SF_BOOT_GRAV_SLOW_TAU': (3.5, 6.5), 'SF_BOOT_GRAV_ALIGN_MAX_SIN': (0.10, 0.20),
+        'SF_BOOT_GRAV_HOLD_SEC': (0.6, 1.8), 'SF_BOOT_GRAV_MIN_SEC': (4.0, 8.5), 'SF_BOOT_GRAV_NORM_FRAC': (0.25, 0.49),
         'SF_ONLINE_TUNE_WARMUP_SEC': (5.0, 12.0),
     }
 }
 OU_COMMON = {
-    'OU_ACC_NOISE_FLOOR_SIGMA': (0.10, 0.18), 'OU_SIGMA_COEFF': (0.70, 0.95), 'OU_TAU_COEFF': (1.3, 1.8),
+    'OU_ACC_NOISE_FLOOR_SIGMA': (0.10, 0.18),
     'OU_ADAPT_TAU_SEC': (1.5, 3.5), 'OU_ADAPT_EVERY_SECS': (0.08, 0.20)
 }
 OU_II_ONLY = {'OU_P_FACTOR': (1.2, 1.8), 'OU_R_P0_XY_FACTOR': (0.20, 0.40), 'OU_R_P0_COEFF': (1.2, 2.2), 'OU_R_V0_COEFF': (1.1, 2.0)}
@@ -35,13 +41,51 @@ def minimal_candidates():
     {'SF_ONLINE_TUNE_WARMUP_SEC':8.0},{'SF_BOOT_GRAV_HOLD_SEC':1.0,'SF_BOOT_GRAV_MIN_SEC':6.0},{'SF_BOOT_GRAV_NORM_FRAC':0.35,'SF_BOOT_GRAV_SLOW_TAU':5.0},
     {'SF_BOOT_TILT_ACC_TAU':2.0,'SF_BOOT_GRAV_HOLD_SEC':1.0},{'SF_ONLINE_TUNE_WARMUP_SEC':8.0,'SF_BOOT_GRAV_MIN_SEC':6.0}], start=1)]
 
-def sample_params(space, n, r):
- S={k:lhs(r,n,v) for k,v in space.items()}; out=[]
- for i in range(n):
-  p={k:S[k][i] for k in S}
-  margin=2.0+r.random()*6.0; p['SF_BOOT_GRAV_TIMEOUT_SEC']=p['SF_BOOT_GRAV_MIN_SEC']+p['SF_BOOT_GRAV_HOLD_SEC']+margin
-  out.append(p)
+def explicit_practical_candidates():
+ base = {
+   'SF_BOOT_TILT_ACC_TAU':2.5, 'SF_BOOT_GRAV_SLOW_TAU':5.5, 'SF_BOOT_GRAV_ALIGN_MAX_SIN':0.12,
+   'SF_BOOT_GRAV_HOLD_SEC':1.2, 'SF_BOOT_GRAV_MIN_SEC':6.0, 'SF_BOOT_GRAV_NORM_FRAC':0.35,
+   'SF_ONLINE_TUNE_WARMUP_SEC':8.0
+ }
+ out = []
+ for i, timeout in enumerate((8.0, 10.0, 12.0, 15.0), 1):
+  p = dict(base)
+  p['SF_BOOT_GRAV_TIMEOUT_SEC'] = timeout
+  out.append((f'practical_{i:03d}', p))
  return out
+
+def apply_timeout_constraint(p, r):
+ min_sec = p['SF_BOOT_GRAV_MIN_SEC']
+ hold_sec = p['SF_BOOT_GRAV_HOLD_SEC']
+ margin_max = min(MAX_MARGIN_SEC, MAX_BOOT_TIMEOUT_SEC - min_sec - hold_sec)
+ if margin_max < MIN_MARGIN_SEC:
+  return False
+ margin = MIN_MARGIN_SEC + r.random() * (margin_max - MIN_MARGIN_SEC)
+ p['SF_BOOT_GRAV_TIMEOUT_SEC'] = min_sec + hold_sec + margin
+ return p['SF_BOOT_GRAV_TIMEOUT_SEC'] <= MAX_BOOT_TIMEOUT_SEC
+
+def sample_params(space, n, r, gravity=False):
+ S={k:lhs(r,n,v) for k,v in space.items()}; out=[]
+ i = 0
+ while i < n:
+  p={k:S[k][i] for k in S}
+  if gravity and not apply_timeout_constraint(p, r):
+   continue
+  out.append(p)
+  i += 1
+ return out
+
+def validate_candidate(p):
+ bad = []
+ timeout = p.get('SF_BOOT_GRAV_TIMEOUT_SEC')
+ if timeout is not None and timeout > MAX_BOOT_TIMEOUT_SEC:
+  bad.append(f'SF_BOOT_GRAV_TIMEOUT_SEC>{MAX_BOOT_TIMEOUT_SEC}')
+ for key in p:
+  if key in REJECTED_KEYS:
+   bad.append(f'forbidden_key:{key}')
+  if key.startswith(REJECTED_PREFIXES):
+   bad.append(f'forbidden_key:{key}')
+ return len(bad)==0, ';'.join(bad)
 
 def parse(text):
  ds=RX['ds'].findall(text); ang=[m.groups() for m in RX['ang'].finditer(text)]; xyz=[m.groups() for m in RX['xyz'].finditer(text)]; r3d=[m.group(1) for m in RX['r3d'].finditer(text)]; accb=[m.groups() for m in RX['accb'].finditer(text)]; gates=[m.groups() for m in RX['gate'].finditer(text)]
@@ -60,16 +104,50 @@ def run_candidate(fam,cid,p,tier,seed,collect):
  pr=subprocess.run([bin_name,'--nomag'],cwd=tdir,text=True,capture_output=True,env=env)
  rows=parse(pr.stdout+'\n'+pr.stderr)
  for r in rows:
-  r.update({'family':fam,'candidate':cid,'seed':seed,'tier':tier,'returncode':pr.returncode,'roll_pitch_rms_norm':math.hypot(r['roll_rms'],r['pitch_rms']),'xy_rms':math.hypot(r['x_rms'],r['y_rms'])})
+  r.update({'family':fam,'candidate':cid,'seed':seed,'tier':tier,'mode':'gravity' if cid.startswith(('grav_','practical_','minimal_')) or cid in ('baseline',) else 'ou', 'returncode':pr.returncode,'roll_pitch_rms_norm':math.hypot(r['roll_rms'],r['pitch_rms']),'xy_rms':math.hypot(r['x_rms'],r['y_rms'])})
   r.update(p)
+  r['SF_BOOT_GRAV_TIMEOUT_SEC']=p.get('SF_BOOT_GRAV_TIMEOUT_SEC', float('nan'))
+  r['timeout_valid']=int((not math.isnan(r['SF_BOOT_GRAV_TIMEOUT_SEC'])) and r['SF_BOOT_GRAV_TIMEOUT_SEC'] <= MAX_BOOT_TIMEOUT_SEC)
+  r['rejected_before_run']=0
+  r['reject_reason']=''
  return rows
 
-def eval_set(fam, cand_list, tier='quick', collect=True, seed=42):
- rows=[]; total=len(cand_list); report_every=max(1,total//10)
- for i,(cid,p) in enumerate(cand_list,1):
-  rows.extend(run_candidate(fam,cid,p,tier,seed,collect))
-  if i==1 or i==total or i%report_every==0:
-   print(f'[{fam}] progress: {i}/{total} candidates complete')
+def progress_line(fam, mode, tier, i, total, cid, seed, rows_count, passed, failed, score, best_cand, best_score, start_ts, out_csv):
+ elapsed = time.time() - start_ts
+ eta = (elapsed / i) * (total - i) if i > 0 else 0
+ fmt = lambda t: time.strftime('%H:%M:%S', time.gmtime(max(t, 0.0)))
+ ts = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+ return f"{ts} [{fam}][{mode}][{tier}] {i}/{total} candidate={cid} seed={seed} rows={rows_count} pass={passed} fail={failed} score={score if score is not None else 'na'} best={best_cand} best_score={best_score if best_score is not None else 'na'} elapsed={fmt(elapsed)} eta={fmt(eta)} out={out_csv}"
+
+def eval_set(fam, cand_list, tier='quick', collect=True, seed=42, out_csv=''):
+ rows=[]; total=len(cand_list); start_ts=time.time(); prog_path=REPORTS/f'ou_sweep_progress_{fam.lower()}_{tier}_seed{seed}.log'
+ best_score = None; best_cand = 'na'; pass_count=0; fail_count=0
+ with prog_path.open('a') as prog:
+  for i,(cid,p) in enumerate(cand_list,1):
+   ok, reason = validate_candidate(p)
+   if not ok:
+    reject_row = {'family':fam,'candidate':cid,'seed':seed,'tier':tier,'mode':'gravity' if cid.startswith(('grav_','practical_','minimal_')) or cid in ('baseline',) else 'ou',
+      'wave_dataset':'rejected_before_run','quality_gate_pass':False,'fail_reason':'rejected_before_run','returncode':-1,'score':float('inf'),'survived_tier':0,
+      'SF_BOOT_GRAV_TIMEOUT_SEC':p.get('SF_BOOT_GRAV_TIMEOUT_SEC', float('nan')),'timeout_valid':0,'rejected_before_run':1,'reject_reason':reason}
+    reject_row.update(p)
+    rows.append(reject_row)
+    fail_count += 1
+   else:
+    c_rows = run_candidate(fam,cid,p,tier,seed,collect)
+    rows.extend(c_rows)
+    cand_fail = any(not r['quality_gate_pass'] for r in c_rows)
+    pass_count += 0 if cand_fail else 1
+    fail_count += 1 if cand_fail else 0
+   score_rows(rows)
+   current = [r for r in rows if r['candidate']==cid and r['family']==fam and r['tier']==tier]
+   cand_score = current[0].get('score') if current else None
+   family_rows = [r for r in rows if r['family']==fam and r['tier']==tier and not r.get('rejected_before_run')]
+   if family_rows:
+    b = min(family_rows, key=lambda x: x.get('score', float('inf')))
+    best_cand, best_score = b['candidate'], b.get('score')
+   line = progress_line(fam, 'gravity' if cid.startswith(('grav_','practical_','minimal_')) or cid in ('baseline',) else 'ou', tier, i, total, cid, seed, len(current), pass_count, fail_count, cand_score, best_cand, best_score, start_ts, out_csv)
+   print(line, flush=True)
+   prog.write(line + '\n'); prog.flush()
  return rows
 
 def percentile(vals,p):
@@ -78,15 +156,16 @@ def percentile(vals,p):
 
 def score_rows(rows):
  by=defaultdict(list)
- for r in rows: by[(r['family'],r['candidate'],r['tier'])].append(r)
- base={(r['family'],r['wave_dataset'],r['seed'],r['tier']):r for r in rows if r['candidate']=='baseline'}
+ for r in rows:
+  if not r.get('rejected_before_run'): by[(r['family'],r['candidate'],r['tier'])].append(r)
+ base={(r['family'],r['wave_dataset'],r['seed'],r['tier']):r for r in rows if r['candidate']=='baseline' and not r.get('rejected_before_run')}
  for _,it in by.items():
   rp=[]; z=[]; r3=[]; yaw=[]; acc=[]; any_fail=False
   for r in it:
    b=base.get((r['family'],r['wave_dataset'],r['seed'],r['tier']),r)
    rf=lambda x: x if math.isfinite(x) and abs(x)>1e-9 else 1e-9
-   r['baseline_roll_pitch_rms_norm']=b['roll_pitch_rms_norm']; r['baseline_z_rms']=b['z_rms']; r['baseline_rms_3d']=b['rms_3d']; r['baseline_yaw_rms']=b['yaw_rms']
-   r['roll_pitch_ratio']=rf(r['roll_pitch_rms_norm'])/rf(b['roll_pitch_rms_norm']); r['z_ratio']=rf(r['z_rms'])/rf(b['z_rms']); r['rms3d_ratio']=rf(r['rms_3d'])/rf(b['rms_3d']); r['yaw_ratio']=rf(r['yaw_rms'])/rf(b['yaw_rms']); r['acc_bias_ratio']=rf(r['acc_bias_rms_3d'])/rf(b['acc_bias_rms_3d'])
+   r['baseline_roll_pitch_rms_norm']=b.get('roll_pitch_rms_norm', float('nan')); r['baseline_z_rms']=b.get('z_rms', float('nan')); r['baseline_rms_3d']=b.get('rms_3d', float('nan')); r['baseline_yaw_rms']=b.get('yaw_rms', float('nan'))
+   r['roll_pitch_ratio']=rf(r['roll_pitch_rms_norm'])/rf(b.get('roll_pitch_rms_norm', float('nan'))); r['z_ratio']=rf(r['z_rms'])/rf(b.get('z_rms', float('nan'))); r['rms3d_ratio']=rf(r['rms_3d'])/rf(b.get('rms_3d', float('nan'))); r['yaw_ratio']=rf(r['yaw_rms'])/rf(b.get('yaw_rms', float('nan'))); r['acc_bias_ratio']=rf(r['acc_bias_rms_3d'])/rf(b.get('acc_bias_rms_3d', float('nan')))
    rp.append(r['roll_pitch_ratio']); z.append(r['z_ratio']); r3.append(r['rms3d_ratio']); yaw.append(r['yaw_ratio']); acc.append(r['acc_bias_ratio']); any_fail = any_fail or (not r['quality_gate_pass'])
   s=4.0*percentile(rp,0.75)+2.0*max(rp)+2.0*max(0,max(z)-1.02)+2.0*max(0,max(r3)-1.02)+0.5*percentile(yaw,0.75)+0.5*percentile(acc,0.75)+(100.0 if any_fail else 0.0)
   for r in it: r['score']=s; r['survived_tier']=int((not any_fail) and max(z)<=1.05 and max(r3)<=1.05)
@@ -95,16 +174,17 @@ def main():
  ap=argparse.ArgumentParser(); ap.add_argument('--mode',choices=['gravity','ou','full'],default='gravity'); ap.add_argument('--family',choices=['OU_II','OU_III','both'],default='both'); ap.add_argument('--samples',type=int,default=100); ap.add_argument('--seed',type=int,default=42); ap.add_argument('--tier',choices=['quick','all','final'],default='quick'); ap.add_argument('--top-k',type=int,default=8); ap.add_argument('--collect-all-gates',action='store_true',default=False)
  a=ap.parse_args(); subprocess.run(['make','-C',str(ROOT/'tests/kalman_ou_ii'),'build'],check=True); subprocess.run(['make','-C',str(ROOT/'tests/kalman_ou_iii'),'build'],check=True)
  fams=['OU_II','OU_III'] if a.family=='both' else [a.family]; rows=[]
+ REPORTS.mkdir(parents=True,exist_ok=True)
+ out=REPORTS/f'ou_sweep_{a.mode}_{a.tier}_seed{a.seed}_n{a.samples}.csv'
  for fam in fams:
-  rng=random.Random(a.seed+(0 if fam=='OU_II' else 1000000)); grav_mc=[(f'grav_mc_{i:04d}',p) for i,p in enumerate(sample_params(GRAVITY_RANGES[fam],a.samples,rng),1)]
-  candidates=[('baseline',{})]+minimal_candidates()+grav_mc
+  rng=random.Random(a.seed+(0 if fam=='OU_II' else 1000000)); grav_mc=[(f'grav_mc_{i:04d}',p) for i,p in enumerate(sample_params(GRAVITY_RANGES[fam],a.samples,rng,gravity=True),1)]
+  candidates=[('baseline',{})]+minimal_candidates()+explicit_practical_candidates()+grav_mc
   if a.mode in ('ou','full'):
-   ou_space=dict(OU_COMMON); 
+   ou_space=dict(OU_COMMON)
    if fam=='OU_II': ou_space.update(OU_II_ONLY)
    candidates += [(f'ou_mc_{i:04d}',p) for i,p in enumerate(sample_params(ou_space,a.samples,rng),1)]
-  rows.extend(eval_set(fam,candidates,tier=a.tier,collect=(a.collect_all_gates or a.tier!='final'),seed=a.seed))
- score_rows(rows); REPORTS.mkdir(parents=True,exist_ok=True)
- out=REPORTS/f'ou_sweep_{a.mode}_{a.tier}_seed{a.seed}_n{a.samples}.csv'
+  rows.extend(eval_set(fam,candidates,tier=a.tier,collect=(a.collect_all_gates or a.tier!='final'),seed=a.seed,out_csv=str(out)))
+ score_rows(rows)
  fields=sorted({k for r in rows for k in r.keys()})
  with out.open('w',newline='') as f: w=csv.DictWriter(f,fieldnames=fields); w.writeheader(); w.writerows(rows)
  print(out)


### PR DESCRIPTION
### Motivation
- Ensure bootstrap gravity initialization remains bounded for OU_II/OU_III by enforcing a hard maximum timeout of 15.0 seconds to avoid impractically long startups.
- Limit the search to only gravity/tilt startup timing and mild OU adaptation/noise parameters while preventing accidental magnetometer or `tau_coeff`/`sigma_coeff` tuning.
- Provide live, detailed progress reporting to track long sweeps and make pre-run candidate rejections visible without running the simulator. 

### Description
- Enforce a maximum bootstrap timeout (`SF_BOOT_GRAV_TIMEOUT_SEC <= 15.0`) by sampling `SF_BOOT_GRAV_MIN_SEC`, `SF_BOOT_GRAV_HOLD_SEC`, and a bounded margin, resampling/clamping the margin so the computed `timeout = min + hold + margin` never exceeds `15.0` (implemented in `apply_timeout_constraint` and `sample_params` in `tools/ou_tuning_sweep.py`).
- Updated gravity parameter ranges for `OU_II` and `OU_III` to the requested bounds in `GRAVITY_RANGES` and added explicit practical candidates (`practical_001..004`) with timeouts `8.0`, `10.0`, `12.0`, and `15.0` seconds.
- Removed `OU_SIGMA_COEFF` and `OU_TAU_COEFF` from the OU search space (`OU_COMMON`) and added pre-run rejection for those keys and any `SF_MAG_*` keys; preserved execution with `--nomag` when invoking the simulators.
- Added pre-run candidate validation (`validate_candidate`) that rejects forbidden keys or timeouts >15s and records `rejected_before_run` and `reject_reason` fields so rejected candidates are logged without running the simulator.
- Added detailed progress reporting to stdout and per-family progress logs under `reports/results/` with timestamp, family/mode/tier, index, candidate id, seed, parsed wave rows, pass/fail counts, candidate score, current best candidate/score, elapsed time, ETA, and output CSV path, with immediate flush (`print(..., flush=True)`).
- Extended CSV output rows with `SF_BOOT_GRAV_TIMEOUT_SEC`, `timeout_valid`, `rejected_before_run`, and `reject_reason` while keeping existing quality gate outputs and scoring logic unchanged.

### Testing
- Verified Python syntax/compilation with `python3 -m py_compile tools/ou_tuning_sweep.py`, which succeeded. 
- Verified CLI help and argument parsing with `python3 tools/ou_tuning_sweep.py --help`, which produced the expected usage output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f929484d388328a2453ba63424ca4a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced gravity parameter tuning with practical preset candidates and improved candidate validation.
  * Added computed performance metrics (roll-pitch RMS, XY RMS) for better evaluation.

* **Refactor**
  * Improved candidate generation and progress tracking with better filtering and reporting of validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->