### PR TITLE
Add workflow flag to enable/disable ou-tuning job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: build
 on: [push, pull_request]
 
+env:
+  ENABLE_OU_TUNING: 'true'
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -115,6 +118,7 @@ jobs:
 
 
   ou-tuning:
+    if: ${{ env.ENABLE_OU_TUNING == 'true' }}
     runs-on: ubuntu-latest
     needs: build
     steps:


### PR DESCRIPTION
### Motivation
- Make the `ou-tuning` workflow job configurable from the YAML so it can be turned on or off without editing job definitions or removing the job.

### Description
- Add a top-level workflow environment variable `ENABLE_OU_TUNING: 'true'` in `.github/workflows/build.yml` and guard the `ou-tuning` job with `if: ${{ env.ENABLE_OU_TUNING == 'true' }}` so the job can be toggled via the YAML.

### Testing
- Verified the change with `git diff -- .github/workflows/build.yml` and committed the updated file with `git commit` (both succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa10c9ea30832899b5e6cd7da9707d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to conditionally execute optimization processes based on configuration flags.

---

**Note:** This release contains internal infrastructure updates with no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->