### PR TITLE
Add workflow_dispatch input to toggle ou-tuning job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,17 @@
 name: build
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      run_ou_tuning:
+        description: "Run ou-tuning job"
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
 
 jobs:
   build:
@@ -115,6 +127,7 @@ jobs:
 
 
   ou-tuning:
+    if: github.event_name != 'workflow_dispatch' || inputs.run_ou_tuning == 'true'
     runs-on: ubuntu-latest
     needs: build
     steps:


### PR DESCRIPTION
### Motivation
- Allow manual workflow dispatches to skip the long OU tuning sweep while preserving existing behavior for `push` and `pull_request` runs.

### Description
- Added a `workflow_dispatch` input `run_ou_tuning` (choice `true`/`false`) to `.github/workflows/build.yml` and an `if: github.event_name != 'workflow_dispatch' || inputs.run_ou_tuning == 'true'` condition on the `ou-tuning` job so it runs by default but can be disabled for manual runs.

### Testing
- Verified the change by inspecting the YAML and diffs with `git diff -- .github/workflows/build.yml`, viewed the updated file with `nl -ba .github/workflows/build.yml`, and committed the update successfully (`git commit`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa112153948328a4056c371d112f80)