### PR TITLE
Fix invalid job-level env usage in OU tuning workflow condition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,13 @@
 name: build
-on: [push, pull_request]
-
-env:
-  ENABLE_OU_TUNING: 'false'
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      enable_ou_tuning:
+        description: "Run OU tuning sweep"
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -118,7 +123,7 @@ jobs:
 
 
   ou-tuning:
-    if: ${{ env.ENABLE_OU_TUNING == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.enable_ou_tuning }}
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -132,7 +137,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y g++ make libeigen3-dev unzip
+          sudo apt-get install -y g++ make libeigen3-dev unzip python3
       - name: Unpack simulation data
         run: |
           unzip -o sim-data-files.zip -d ${{ github.workspace }}/tests/kalman_ou_ii


### PR DESCRIPTION
### Motivation
- The workflow used a top-level `env` variable inside a job-level `if`, which is invalid in GitHub Actions and caused workflow validation/runtime failures. 
- OU tuning should only run when explicitly requested, not on normal `push` or `pull_request` events. 
- Provide a manual toggle so maintainers can run the OU tuning sweep via `workflow_dispatch` with a boolean input. 

### Description
- Replaced the top-level `env: ENABLE_OU_TUNING` pattern with a `workflow_dispatch` input `enable_ou_tuning` (boolean, default `false`) and expanded the `on:` block to mapping form. 
- Changed the `ou-tuning` job condition to `if: ${{ github.event_name == 'workflow_dispatch' && inputs.enable_ou_tuning }}` so the job only runs on manual dispatch when requested. 
- Kept `ou-tuning` dependent on `build` (`needs: build`) and preserved existing `build`, `release`, and `build-MCU` behaviors for push/PR events. 
- Added `python3` to the OU tuning job's `apt-get install` line and did not change the OU tuning command itself. 

### Testing
- Verified the edited workflow file contents with `sed -n '1,260p' .github/workflows/build.yml` and confirmed the `workflow_dispatch` input block is present. 
- Inspected the file line-by-line with `nl -ba .github/workflows/build.yml | sed -n '1,60p'` and `nl -ba .github/workflows/build.yml | sed -n '125,175p'` to confirm the updated `ou-tuning` `if` condition and dependency installation include `python3`. 
- Generated PR metadata using the `make_pr` helper to prepare the pull request description.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa134ac5648328a04fef1cd21ebc9f)