### PR TITLE
Fix compiler warnings and make Eigen includes system headers

### DIFF
--- a/src/avg/AngleAveraging.h
+++ b/src/avg/AngleAveraging.h
@@ -2,6 +2,7 @@
 #define ANGLE_AVERAGING_H
 
 #include <math.h>
+#include <numbers>
 
 /*
   Copyright 2025, Mikhail Grushinskiy
@@ -22,11 +23,12 @@
 
 class AngleAverager {
 public:
+    static constexpr float PI = std::numbers::pi_v<float>;
     // Structure for filtered angle and quality metrics
     struct AngleEstimate {
         float angle = 0.0f;                    // Filtered angle in degrees
         float magnitude = 1e-12f;              // Confidence (0–1)
-        float variance = M_PI * M_PI / 4.0f;   // Estimated circular variance (rad²)
+        float variance = PI * PI / 4.0f;   // Estimated circular variance (rad²)
         float consistency = 0.0f;              // Dot product similarity [0–1]
     };
 
@@ -37,7 +39,7 @@ public:
     // Explicitly set initial angle and reset variance
     void reset(float angle_deg) {
         angle_prev = angle_deg;
-        variance_prev = M_PI * M_PI / 4.0f;
+        variance_prev = PI * PI / 4.0f;
         initialized = true;
     }
 
@@ -114,11 +116,11 @@ public:
     }
 
     static inline float deg2rad(float angle_deg) {
-        return angle_deg * (M_PI / 180.0f);
+        return angle_deg * (PI / 180.0f);
     }
 
     static inline float rad2deg(float angle_rad) {
-        return angle_rad * (180.0f / M_PI);
+        return angle_rad * (180.0f / PI);
     }
 
     static inline float magnitude(float x, float y) {
@@ -138,10 +140,10 @@ private:
     float alpha;
     bool initialized = false;
     float angle_prev = 0.0f;
-    float variance_prev = M_PI * M_PI / 4.0f;
+    float variance_prev = PI * PI / 4.0f;
 
     static inline float estimate_variance(float mag) {
-        if (mag <= 0.0f) return M_PI * M_PI;
+        if (mag <= 0.0f) return PI * PI;
         if (mag > 0.999f) return 0.0f;
         return -2.0f * logf(mag);
     }

--- a/src/freq/SchmittTriggerZCFreqTracker.h
+++ b/src/freq/SchmittTriggerZCFreqTracker.h
@@ -32,20 +32,20 @@ class SchmittTriggerZCFreqTracker {
     // periodsInCycle must be positive integer
     // fallbackToLowFreqTime must be positive time in seconds
     explicit SchmittTriggerZCFreqTracker(
-      float hysteresis = 0.1f,
-      unsigned int periodsInCycle = 1,
-      float fallbackToLowFreqTime = SCHMITT_TRIGGER_FALLBACK_TIME)
-      : hysteresis(std::fabs(hysteresis)),
-        upperThreshold(std::fabs(hysteresis)),
-        lowerThreshold(-std::fabs(hysteresis)),
+      float hysteresis_in = 0.1f,
+      unsigned int periods_in_cycle = 1,
+      float fallback_to_low_freq_time = SCHMITT_TRIGGER_FALLBACK_TIME)
+      : hysteresis(std::fabs(hysteresis_in)),
+        upperThreshold(std::fabs(hysteresis_in)),
+        lowerThreshold(-std::fabs(hysteresis_in)),
         state(State::WAS_NOT_SET),
         frequency(SCHMITT_TRIGGER_FREQ_INIT),
-        fallbackToLowFreqTime(fallbackToLowFreqTime),
+        fallbackToLowFreqTime(fallback_to_low_freq_time),
         lastPeriodEstimate(0.0f),
         periodVariance(0.0f),
         amplitudeRatio(0.0f),
         isFallback(true),
-        periodsInCycle(periodsInCycle),
+        periodsInCycle(periods_in_cycle),
         timeInCycle(0.0f),
         lastLowTime(0.0f),
         lastHighTime(0.0f),

--- a/src/kalman_ou_ii/Kalman3D_Wave_OU_II.h
+++ b/src/kalman_ou_ii/Kalman3D_Wave_OU_II.h
@@ -1266,10 +1266,10 @@ Kalman3D_Wave_OU_II<T, with_gyro_bias, with_accel_bias>::Kalman3D_Wave_OU_II(
     Vector3 const& sigma_g,
     Vector3 const& sigma_m,
     T Pq0, T Pb0, T b0, T R_p0_noise_var, T R_v0_noise_var, T gravity_magnitude)
-  : Qbase(initialize_Q(sigma_g, b0)),
-    gravity_magnitude_(gravity_magnitude),
-    Racc(sigma_a.array().square().matrix().asDiagonal()),
-    Rmag(sigma_m.array().square().matrix().asDiagonal())
+  : gravity_magnitude_(gravity_magnitude),
+    Rmag(sigma_m.array().square().matrix().asDiagonal()),
+    Qbase(initialize_Q(sigma_g, b0)),
+    Racc(sigma_a.array().square().matrix().asDiagonal())
 {
     qref.setIdentity();  // quaternion init
 

--- a/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
+++ b/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
@@ -50,6 +50,7 @@
 #endif
 
 #include <cmath>
+#include <numbers>
 #include <memory>
 #include <algorithm>
 
@@ -496,7 +497,7 @@ public:
         const float tau   = smoothed ? tune_.tau_applied   : tau_target_;
         const float sigma = smoothed ? tune_.sigma_applied : sigma_target_;
         if (!std::isfinite(sigma) || !std::isfinite(tau)) return NAN;
-        constexpr float C_HS = 2.0f * std::sqrt(2.0f) / (M_PI * M_PI);
+        constexpr float C_HS = 2.0f * std::sqrt(2.0f) / (std::numbers::pi_v<float> * std::numbers::pi_v<float>);
         return C_HS * sigma * tau * tau / 2.0f;
     }
 
@@ -504,7 +505,7 @@ public:
         const float tau   = smoothed ? tune_.tau_applied   : tau_target_;
         const float sigma = smoothed ? tune_.sigma_applied : sigma_target_;
         if (!(tau > 1e-6f) || !std::isfinite(tau) || !std::isfinite(sigma)) return NAN;
-        constexpr float K = std::sqrt(2.0f) / M_PI;
+        constexpr float K = std::sqrt(2.0f) / std::numbers::pi_v<float>;
         const float v_env = K * sigma * tau;
         return std::isfinite(v_env) ? v_env : NAN;
     }

--- a/src/kalman_ou_iii/Kalman3D_Wave_OU_III.h
+++ b/src/kalman_ou_iii/Kalman3D_Wave_OU_III.h
@@ -1200,10 +1200,10 @@ Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::Kalman3D_Wave_OU_III(
     Vector3 const& sigma_g,
     Vector3 const& sigma_m,
     T Pq0, T Pb0, T b0, T R_S_noise_var, T gravity_magnitude)
-  : Qbase(initialize_Q(sigma_g, b0)),
-    gravity_magnitude_(gravity_magnitude),
-    Racc(sigma_a.array().square().matrix().asDiagonal()),
-    Rmag(sigma_m.array().square().matrix().asDiagonal())
+  : gravity_magnitude_(gravity_magnitude),
+    Rmag(sigma_m.array().square().matrix().asDiagonal()),
+    Qbase(initialize_Q(sigma_g, b0)),
+    Racc(sigma_a.array().square().matrix().asDiagonal())
 {
     qref.setIdentity();  // quaternion init
 
@@ -1247,8 +1247,8 @@ Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::Kalman3D_Wave_OU_III(
 	    sigma_acc0.z() = std::sqrt(std::max(T(0), Racc(2,2)));
 
 	    // R_S in your ctor is "variance" scalar; convert to std
-	    const T sigma_S0 = std::sqrt(std::max(T(1e-12), R_S_noise_var));
-	    Vector3 sigma_S0v = Vector3::Constant(sigma_S0);
+	    const T sigma_S_noise_std = std::sqrt(std::max(T(1e-12), R_S_noise_var));
+	    Vector3 sigma_S0v = Vector3::Constant(sigma_S_noise_std);
 
 	    log_sigma_acc_f_.x = clamp_pos_vec_(sigma_acc0, sigma_acc_min_, sigma_acc_max_).array().log().matrix();
 	    log_sigma_S_f_.x   = clamp_pos_vec_(sigma_S0v,  sigma_S_min_,   sigma_S_max_  ).array().log().matrix();

--- a/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
+++ b/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
@@ -48,6 +48,7 @@
 #endif
 
 #include <cmath>
+#include <numbers>
 #include <memory>
 #include <algorithm>
 
@@ -479,7 +480,7 @@ public:
         const float tau = smoothed ? tune_.tau_applied : tau_target_;
         const float sigma = smoothed ? tune_.sigma_applied : sigma_target_;
         if (!std::isfinite(sigma) || !std::isfinite(tau)) return NAN;
-        constexpr float C_HS  = 2.0f * std::sqrt(2.0f) / (M_PI * M_PI);
+        constexpr float C_HS  = 2.0f * std::sqrt(2.0f) / (std::numbers::pi_v<float> * std::numbers::pi_v<float>);
         return C_HS * sigma * tau * tau / 2.0f;
     }
 
@@ -487,7 +488,7 @@ public:
         const float tau   = smoothed ? tune_.tau_applied   : tau_target_;
         const float sigma = smoothed ? tune_.sigma_applied : sigma_target_;
         if (!(tau > 1e-6f) || !std::isfinite(tau) || !std::isfinite(sigma)) return NAN;
-        constexpr float K = std::sqrt(2.0f) / M_PI;
+        constexpr float K = std::sqrt(2.0f) / std::numbers::pi_v<float>;
         const float v_env = K * sigma * tau;
         return std::isfinite(v_env) ? v_env : NAN;
     }

--- a/src/tuner/SeaStateFusionTunerCommon.h
+++ b/src/tuner/SeaStateFusionTunerCommon.h
@@ -34,9 +34,9 @@ struct StillnessAdapter {
     explicit StillnessAdapter(float gravity_std = 9.80665f,
                               float target_freq_hz_in = 0.2f,
                               float freq_guess = 0.3f)
-        : gravity_std_(gravity_std),
-          target_freq_hz(target_freq_hz_in),
-          freq_state(freq_guess) {}
+        : target_freq_hz(target_freq_hz_in),
+          freq_state(freq_guess),
+          gravity_std_(gravity_std) {}
 
     float energy_ema      = 0.0f;
     float energy_alpha    = 0.05f;

--- a/src/util/W3dSimCommon.cpp
+++ b/src/util/W3dSimCommon.cpp
@@ -535,6 +535,8 @@ void print_summary_and_fail_if_needed(const W3dSimulationRunResult& result,
               << " Y=" << (gyrb_ry * rad2deg)
               << " Z=" << (gyrb_rz * rad2deg)
               << " |3D|=" << (gyrb_r3 * rad2deg) << "\n";
+    std::cout << "Bias error RMS (mag, uT): X=" << magb_rx << " Y=" << magb_ry << " Z=" << magb_rz
+              << " |3D|=" << magb_r3 << "\n";
 
     auto pct_of_max = [](float rms, float maxv) -> float {
         return (maxv > 1e-12f && std::isfinite(rms)) ? (100.f * rms / maxv) : NAN;

--- a/src/util/W3dSimCommon.h
+++ b/src/util/W3dSimCommon.h
@@ -35,8 +35,9 @@ inline float diffDeg(float est_deg, float ref_deg) {
     return wrapDeg(est_deg - ref_deg);
 }
 
-static inline float deg_to_rad(float d) { return d * float(std::numbers::pi_v<float> / 180.0); }
-static inline float rad_to_deg(float r) { return r * float(180.0 / std::numbers::pi_v<float>); }
+static inline float deg_to_rad(float d) { return d * (std::numbers::pi_v<float> / 180.0f); }
+static inline float rad_to_deg(float r) { return r * (180.0f / std::numbers::pi_v<float>); }
+static inline float rad_to_deg(double r) { return static_cast<float>(r * (180.0 / std::numbers::pi)); }
 
 inline float wrapAxialDeg90(float a) {
     a = std::fmod(a + 180.0f, 360.0f);
@@ -82,7 +83,7 @@ inline T percentile_vec(std::vector<T> v, double p01) {
     if (p01 <= 0) return *std::min_element(v.begin(), v.end());
     if (p01 >= 1) return *std::max_element(v.begin(), v.end());
     std::sort(v.begin(), v.end());
-    double idx = p01 * (v.size() - 1);
+    double idx = p01 * static_cast<double>(v.size() - 1);
     size_t i = size_t(std::floor(idx));
     double frac = idx - double(i);
     if (i + 1 >= v.size()) return v[i];

--- a/src/wave_dir/KalmanWaveDirection.h
+++ b/src/wave_dir/KalmanWaveDirection.h
@@ -14,6 +14,7 @@
 #endif
 
 #include <cmath>
+#include <numbers>
 #include <algorithm>
 
 #include "avg/AngleAveraging.h"
@@ -137,7 +138,7 @@ public:
 
         // Convert to 2σ uncertainty in degrees (95% confidence)
         float angle_rad = 2.0f * angular_std_rad;
-        float angle_deg = angle_rad * (180.0f / M_PI);
+        float angle_deg = angle_rad * (180.0f / std::numbers::pi_v<float>);
 
         // Clamp to [0, 180] degrees for safety
         return std::max(0.0f, std::min(angle_deg, 180.0f));
@@ -177,7 +178,7 @@ public:
 
 private:
     void updatePhase(float deltaT) {
-        phase = std::remainder(phase + omega * deltaT, 2.0f * M_PI);
+        phase = std::remainder(phase + omega * deltaT, 2.0f * std::numbers::pi_v<float>);
     }
 
     void updateStableDirection() {
@@ -200,7 +201,7 @@ private:
         const float alpha = 0.05f;
         lastStableDir = ((1.0f - alpha) * lastStableDir + alpha * newDir).normalized();
 
-        direction_deg_raw = std::atan2(lastStableDir.y(), lastStableDir.x()) * (180.0f / M_PI);
+        direction_deg_raw = std::atan2(lastStableDir.y(), lastStableDir.x()) * (180.0f / std::numbers::pi_v<float>);
         if (direction_deg_raw < 0.0f) direction_deg_raw += 180.0f;
         if (direction_deg_raw >= 180.0f) direction_deg_raw -= 180.0f;
         direction_deg_smoothed = direction_report_avg.average180(direction_deg_raw).angle;
@@ -246,7 +247,7 @@ void KalmanWaveDirection_test_signal(float t,
   float amp = 0.8f + 0.4f * std::sin(0.005f * t);
 
   // Convert frequency in Hz to angular frequency in rad/s
-  float omega = 2.0f * M_PI * freq_hz;
+  float omega = 2.0f * std::numbers::pi_v<float> * freq_hz;
   float phase = omega * t;
 
   Eigen::Vector2f dir(1.0f, 1.5f);
@@ -267,7 +268,7 @@ void KalmanWaveDirection_test_1() {
   // Frequency of the test wave in Hz
   const float freq_hz = 0.5f;
   // Convert to angular frequency in rad/s for the filter
-  const float omega = 2.0f * M_PI * freq_hz;
+  const float omega = 2.0f * std::numbers::pi_v<float> * freq_hz;
 
   const int num_steps = 2000;
 

--- a/tests/kalman_ou_ii/Makefile
+++ b/tests/kalman_ou_ii/Makefile
@@ -4,7 +4,7 @@ CC = g++
 TEST_DIR := $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 REPO_ROOT := $(abspath $(TEST_DIR)/../..)
 EIGEN_DIR ?= $(REPO_ROOT)/third_party/eigen
-EIGEN_CPPFLAGS := $(if $(wildcard $(EIGEN_DIR)/Eigen/Dense),-I$(EIGEN_DIR),-I/usr/include/eigen3)
+EIGEN_CPPFLAGS := $(if $(wildcard $(EIGEN_DIR)/Eigen/Dense),-isystem $(EIGEN_DIR),-isystem /usr/include/eigen3)
 BASEFLAGS = -O3 -std=c++20 -Wall -Wextra -Wshadow -Wconversion -funroll-loops -fno-finite-math-only -I$(REPO_ROOT)/src $(EIGEN_CPPFLAGS) $(CPPFLAGS)
 
 UNAME_S := $(shell uname -s)

--- a/tests/kalman_ou_iii/Makefile
+++ b/tests/kalman_ou_iii/Makefile
@@ -4,7 +4,7 @@ CC = g++
 TEST_DIR := $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 REPO_ROOT := $(abspath $(TEST_DIR)/../..)
 EIGEN_DIR ?= $(REPO_ROOT)/third_party/eigen
-EIGEN_CPPFLAGS := $(if $(wildcard $(EIGEN_DIR)/Eigen/Dense),-I$(EIGEN_DIR),-I/usr/include/eigen3)
+EIGEN_CPPFLAGS := $(if $(wildcard $(EIGEN_DIR)/Eigen/Dense),-isystem $(EIGEN_DIR),-isystem /usr/include/eigen3)
 BASEFLAGS = -O3 -std=c++20 -Wall -Wextra -Wshadow -Wconversion -funroll-loops -fno-finite-math-only -I$(REPO_ROOT)/src $(EIGEN_CPPFLAGS) $(CPPFLAGS)
 
 UNAME_S := $(shell uname -s)


### PR DESCRIPTION
### Motivation
- Clean up g++ warnings triggered by `-Wall -Wextra -Wshadow -Wconversion` such as shadowed parameter names, double→float conversions, initializer reorder, and unused variables.
- Preserve numeric intent while removing warning noise that can obscure real issues during builds and CI.
- Keep builds portable by preferring vendored Eigen or falling back to `/usr/include/eigen3` while treating those includes as system headers to suppress Eigen-internal warnings in test builds.

### Description
- Renamed constructor parameters in `SchmittTriggerZCFreqTracker` to avoid shadowing of members (`hysteresis_in`, `periods_in_cycle`, `fallback_to_low_freq_time`).
- Replaced uses of `M_PI`/double literals with `std::numbers::pi_v<float>` (and added a `float` PI constant in `AngleAveraging`) and added an explicit `rad_to_deg(double)` overload to silence `-Wfloat-conversion` while preserving semantics.
- Reordered initializer lists in `Kalman3D_Wave_OU_II` / `Kalman3D_Wave_OU_III` constructors to match member declaration order and renamed a local sigma variable (`sigma_S_noise_std`) to avoid shadowing.
- Fixed an unused-variable / reporting omission by printing magnetometer RMS in `print_summary_and_fail_if_needed` and tightened `percentile_vec` index arithmetic via an explicit cast to `double`.
- Included `<numbers>` where needed and adjusted a few trig/omega computations to use `std::numbers::pi_v<float>`.
- Made test Makefiles use `-isystem` for Eigen includes when a vendored copy is not present (`tests/kalman_ou_ii/Makefile`, `tests/kalman_ou_iii/Makefile`) to keep Eigen warnings out of the project build output.

### Testing
- Ran `make all` (full project test run which downloads sim data when missing) and it completed successfully with the expected test outputs and quality gates passing.
- Built the Kalman OU II test: `make -C tests/kalman_ou_ii build` succeeded without new warnings.
- Built the Kalman OU III test: `make -C tests/kalman_ou_iii build` succeeded without new warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a013044248328958e6a16318d2362)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added magnetometer RMS bias error reporting to quality summary, displaying X/Y/Z component values and 3D magnitude for improved diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bareboat-necessities/ocean-imu/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->