### PR TITLE
Remove unused header helper functions

### DIFF
--- a/src/AtomS3R/AtomS3R_ImuCal.h
+++ b/src/AtomS3R/AtomS3R_ImuCal.h
@@ -117,10 +117,6 @@ static inline Vector3f map_sensor_xyz_to_body_ned_(float sx, float sy, float sz,
   return Vector3f(sy * scale, sx * scale, -sz * scale);
 }
 
-static inline Vector3f map_sensor_vec_to_body_ned_(const Vector3f& v_sensor, float scale = 1.0f) {
-  return map_sensor_xyz_to_body_ned_(v_sensor.x(), v_sensor.y(), v_sensor.z(), scale);
-}
-
 static inline Vector3f map_acc_to_body_ned_(const m5::imu_3d_t& a_g) {
   return map_sensor_xyz_to_body_ned_(a_g.x, a_g.y, a_g.z, ImuCalCfg::g_std);
 }

--- a/src/detrend/AdaptiveWaveDetrender3D.h
+++ b/src/detrend/AdaptiveWaveDetrender3D.h
@@ -360,10 +360,6 @@ private:
     return out;
   }
 
-  static float getAxis_(const Vec3& v, int axis) {
-    return v(axis);
-  }
-
   // Convert 1st-order LP cutoff frequency to equivalent time constant.
   static float cutoffToTau_(float cutoff_hz) {
     cutoff_hz = maxf_(cutoff_hz, 1.0e-6f);

--- a/src/imu_calibrate/CalibrateIMU.h
+++ b/src/imu_calibrate/CalibrateIMU.h
@@ -210,9 +210,6 @@ static inline bool degeneracy_check_coverage3(
 }
 
 template <typename T>
-static inline T sqr(T x) { return x*x; }
-
-template <typename T>
 static inline void sort_small(T* a, int n) {
   // Simple insertion sort (n <= ~400)
   for (int i = 1; i < n; ++i) {


### PR DESCRIPTION
### Motivation
- Remove small, unreferenced inline helpers from headers to reduce dead code, silence static analysis warnings, and keep public APIs unchanged.

### Description
- Deleted `map_sensor_vec_to_body_ned_` from `src/AtomS3R/AtomS3R_ImuCal.h` because the scalar `map_sensor_xyz_to_body_ned_` is the used conversion.
- Deleted `getAxis_` from `src/detrend/AdaptiveWaveDetrender3D.h` as it was an unused accessor wrapper around `v(axis)`.
- Deleted the unused `sqr` helper from `src/imu_calibrate/CalibrateIMU.h` since it was not referenced and `sort_small` remains.
- Changes are minimal and localized to header files and preserve existing public APIs and behavior.

### Testing
- Ran the repository build and test workflow with `make all`, which completed successfully and exercised the test suites under `tests/*`.
- Verified removals with an `rg` search: `rg -n "map_sensor_vec_to_body_ned_|getAxis_|\\bsqr\\s*\\(" src tests` to ensure no remaining references.
- Ran static-analysis tooling (`cppcheck` and `clang-tidy` checks) and confirmed that the previous unused-function reports for these helpers are resolved and no new errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a54ba35948328a21d3fd58df9a53c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to IMU calibration utilities and sensor mapping functions for code maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bareboat-necessities/ocean-imu/pull/177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->