### PR TITLE
Update full INS NMEA reporting cadence

### DIFF
--- a/sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino
+++ b/sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino
@@ -68,6 +68,9 @@ static constexpr uint32_t LOOP_PERIOD_US = static_cast<uint32_t>(1000000.0f / LO
 static constexpr uint32_t UI_REFRESH_MS   = 100;
 static constexpr uint32_t DEBUG_SERIAL_MS = 100;
 static constexpr uint32_t NMEA_SERIAL_MS  = 80;
+static constexpr uint32_t NMEA_WAVE_MS    = 2000;
+static constexpr uint32_t NMEA_STATUS_MS  = 5000;
+static constexpr uint32_t NMEA_TEMP_MS    = 500;
 
 static constexpr float ROT_BIAS_TAU_S       = 5.0f;
 static constexpr float ROT_STILL_G_TOL_FRAC = 0.12f;
@@ -302,8 +305,11 @@ private:
   uint32_t tap_deadline_ms_ = 0;
 #endif
 
-  uint32_t last_ui_ms_     = 0;
-  uint32_t last_serial_ms_ = 0;
+  uint32_t last_ui_ms_          = 0;
+  uint32_t last_serial_ms_      = 0;
+  uint32_t last_wave_nmea_ms_   = 0;
+  uint32_t last_status_nmea_ms_ = 0;
+  uint32_t last_temp_nmea_ms_   = 0;
 
   Fusion fusion_{};
 
@@ -320,6 +326,7 @@ private:
   float heading_deg_      = 0.0f;
   bool  heading_valid_    = false;
   float heave_m_          = 0.0f;
+  float heave_speed_mps_  = 0.0f;
   float wave_envelope_m_  = 0.0f;
   float wave_hz_          = FREQ_GUESS;
 
@@ -331,6 +338,7 @@ private:
   bool  wave_sign_ok_        = false;
   float wave_dir_deg_        = NAN;
   bool  wave_dir_ok_         = false;
+  float wave_dir_conf_pct_   = 0.0f;
 
   float heave_raw_m_        = 0.0f;
   float heave_baseline_m_   = 0.0f;
@@ -341,6 +349,7 @@ private:
   bool  mag_fresh_       = false;
   float mag_norm_uT_     = NAN;
   float heading_mag_deg_ = NAN;
+  float imu_temp_c_      = NAN;
   bool  heading_mag_ok_  = false;
 
   uint16_t stale_frame_count_ = 0;
@@ -350,8 +359,16 @@ private:
 
   bool     rot_inited_    = false;
   float    rot_dpm_filt_  = 0.0f;
-  bool     gyro_bias_ok_  = false;
-  Vector3f gyro_bias_ema_ = Vector3f::Zero();
+  bool     gyro_bias_ok_       = false;
+  bool     gyro_bias_learning_ = false;
+  bool     acc_bias_estimating_ = false;
+  Vector3f gyro_bias_ema_      = Vector3f::Zero();
+
+  uint32_t rate_window_ms_   = 0;
+  uint32_t imu_sample_count_ = 0;
+  uint32_t mag_sample_count_ = 0;
+  float    imu_sample_hz_    = 0.0f;
+  float    mag_sample_hz_    = 0.0f;
 
 private:
   static void waitForNextLoopTick_(uint32_t loop_start_us) {
@@ -451,6 +468,11 @@ private:
     mag_gate_last_ms_ = 0;
 
     last_skipped_total_ = 0;
+    rate_window_ms_ = millis();
+    imu_sample_count_ = 0;
+    mag_sample_count_ = 0;
+    imu_sample_hz_ = 0.0f;
+    mag_sample_hz_ = 0.0f;
     have_last_sample_us_ = false;
     last_sample_us_      = 0;
   }
@@ -513,6 +535,8 @@ private:
     rot_inited_   = false;
     rot_dpm_filt_ = 0.0f;
     gyro_bias_ok_ = false;
+    gyro_bias_learning_ = false;
+    acc_bias_estimating_ = false;
     gyro_bias_ema_.setZero();
 
     heading_deg_   = 0.0f;
@@ -523,11 +547,13 @@ private:
     mag_fresh_        = false;
     mag_norm_uT_      = NAN;
     heading_mag_deg_  = NAN;
+    imu_temp_c_       = NAN;
     heading_mag_ok_   = false;
 
     stale_frame_count_ = 0;
     have_last_sample_us_ = false;
     last_sample_us_      = 0;
+    heave_speed_mps_     = 0.0f;
     heave_raw_m_         = 0.0f;
     heave_baseline_m_    = 0.0f;
     heave_wave_raw_m_    = 0.0f;
@@ -541,6 +567,7 @@ private:
     wave_sign_ok_       = false;
     wave_dir_deg_       = NAN;
     wave_dir_ok_        = false;
+    wave_dir_conf_pct_  = 0.0f;
   }
 
 #if SEA_STATE_ENABLE_WIZARD
@@ -588,6 +615,8 @@ private:
   void updateFilter_(const ImuSample& s) {
     dt_ = computeFusionDtFromSampleTimestamp_(s);
     const float tempC = std::isfinite(s.tempC) ? s.tempC : 35.0f;
+    imu_temp_c_ = tempC;
+    ++imu_sample_count_;
 
     const Vector3f a_raw = s.a;
     const Vector3f w_raw = s.w;
@@ -601,6 +630,7 @@ private:
     mag_norm_uT_ = m_cal_.norm();
     mag_ok_ = std::isfinite(mag_norm_uT_) && (mag_norm_uT_ > 5.0f) && (mag_norm_uT_ < 200.0f);
     mag_fresh_ = updateMagFreshGate_(mag_ok_, millis());
+    if (mag_fresh_) ++mag_sample_count_;
 
     const bool still =
         (fabsf(a_cal_.norm() - g_std) < ROT_STILL_G_TOL_FRAC * g_std) &&
@@ -642,6 +672,8 @@ private:
       }
     }
 
+    gyro_bias_learning_ = still;
+
     if (still) {
       const float alpha_b = 1.0f - expf(-dt_ / ROT_BIAS_TAU_S);
       if (!gyro_bias_ok_) {
@@ -668,6 +700,9 @@ private:
       rot_dpm_filt_ += alpha_r * (rot_dpm_meas - rot_dpm_filt_);
     }
 
+    const Vector3f velocity_ned_mps = fusion_.raw().mekf().get_velocity();
+    heave_speed_mps_ = -velocity_ned_mps.z();
+
     const Vector3f displacement_raw_up_m = fusion_.displacementUpMeters();
     const auto& displacement_det_out = fusion_.displacementDetrend();
 
@@ -689,6 +724,20 @@ private:
         wave_dir_deg_);
 
     wave_dir_ok_ = wave_dir_ok_ && fusion_.isLive();
+    wave_dir_conf_pct_ = wave_dir_ok_ ? 100.0f : (wave_axis_ok_ ? 50.0f : 0.0f);
+    acc_bias_estimating_ = fusion_.isLive();
+
+    const uint32_t now_ms = millis();
+    if (rate_window_ms_ == 0) rate_window_ms_ = now_ms;
+    const uint32_t rate_elapsed_ms = now_ms - rate_window_ms_;
+    if (rate_elapsed_ms >= 1000u) {
+      const float scale = 1000.0f / static_cast<float>(rate_elapsed_ms);
+      imu_sample_hz_ = static_cast<float>(imu_sample_count_) * scale;
+      mag_sample_hz_ = static_cast<float>(mag_sample_count_) * scale;
+      imu_sample_count_ = 0;
+      mag_sample_count_ = 0;
+      rate_window_ms_ = now_ms;
+    }
 
     heave_raw_m_        = heave_m_;
     heave_baseline_m_   = displacement_det_out.baseline_slow.z();
@@ -779,9 +828,33 @@ private:
     }
     nmea_xdr_pitch_roll(SEA_STATE_NMEA_TALKER, pitch_deg_, roll_deg_);
     nmea_xdr_heave(SEA_STATE_NMEA_TALKER, heave_wave_clean_m_);
-    nmea_xdr_wave_axis_rel(SEA_STATE_NMEA_TALKER, wave_axis_deg_, wave_axis_ok_);
-    nmea_xdr_wave_direction_rel(SEA_STATE_NMEA_TALKER, wave_dir_deg_, wave_dir_ok_);
-    nmea_txt_wave_direction_sign(SEA_STATE_NMEA_TALKER, wave_sign_raw_, wave_sign_polarity_, wave_sign_ok_);
+    nmea_xdr_heave_speed(SEA_STATE_NMEA_TALKER, heave_speed_mps_);
+
+    if (now_ms - last_wave_nmea_ms_ >= NMEA_WAVE_MS) {
+      last_wave_nmea_ms_ = now_ms;
+      nmea_xdr_wave_axis_rel(SEA_STATE_NMEA_TALKER, wave_axis_deg_, wave_axis_ok_);
+      nmea_xdr_wave_direction_rel(SEA_STATE_NMEA_TALKER, wave_dir_deg_, wave_dir_ok_);
+      nmea_txt_wave_direction_sign(SEA_STATE_NMEA_TALKER, wave_sign_raw_, wave_sign_polarity_, wave_sign_ok_);
+      nmea_txt_wave_direction_confidence(SEA_STATE_NMEA_TALKER, wave_dir_conf_pct_, fusion_.isLive());
+    }
+
+    if (now_ms - last_temp_nmea_ms_ >= NMEA_TEMP_MS) {
+      last_temp_nmea_ms_ = now_ms;
+      nmea_xdr_imu_temp(SEA_STATE_NMEA_TALKER, imu_temp_c_);
+    }
+
+    if (now_ms - last_status_nmea_ms_ >= NMEA_STATUS_MS) {
+      last_status_nmea_ms_ = now_ms;
+      nmea_txt_ins_status(SEA_STATE_NMEA_TALKER,
+                          valid,
+                          fusion_.isLive() && std::isfinite(heave_wave_clean_m_),
+                          fusion_.hasMagNorthLock(),
+                          gyro_bias_learning_,
+                          acc_bias_estimating_,
+                          imu_sample_hz_,
+                          mag_sample_hz_);
+    }
+
     //nmea_xdr_freq(SEA_STATE_NMEA_TALKER, wave_hz_);
     nmea_rot(SEA_STATE_NMEA_TALKER, rot_dpm_filt_, valid);
 #else

--- a/sensors/full_marine_ins/atomS3R_ins_kalman_ou3/atomS3R_ins_kalman_ou3.ino
+++ b/sensors/full_marine_ins/atomS3R_ins_kalman_ou3/atomS3R_ins_kalman_ou3.ino
@@ -68,6 +68,9 @@ static constexpr uint32_t LOOP_PERIOD_US = static_cast<uint32_t>(1000000.0f / LO
 static constexpr uint32_t UI_REFRESH_MS   = 100;
 static constexpr uint32_t DEBUG_SERIAL_MS = 100;
 static constexpr uint32_t NMEA_SERIAL_MS  = 80;
+static constexpr uint32_t NMEA_WAVE_MS    = 2000;
+static constexpr uint32_t NMEA_STATUS_MS  = 5000;
+static constexpr uint32_t NMEA_TEMP_MS    = 500;
 
 static constexpr float ROT_BIAS_TAU_S       = 5.0f;
 static constexpr float ROT_STILL_G_TOL_FRAC = 0.12f;
@@ -302,8 +305,11 @@ private:
   uint32_t tap_deadline_ms_ = 0;
 #endif
 
-  uint32_t last_ui_ms_     = 0;
-  uint32_t last_serial_ms_ = 0;
+  uint32_t last_ui_ms_          = 0;
+  uint32_t last_serial_ms_      = 0;
+  uint32_t last_wave_nmea_ms_   = 0;
+  uint32_t last_status_nmea_ms_ = 0;
+  uint32_t last_temp_nmea_ms_   = 0;
 
   Fusion fusion_{};
 
@@ -320,6 +326,7 @@ private:
   float heading_deg_      = 0.0f;
   bool  heading_valid_    = false;
   float heave_m_          = 0.0f;
+  float heave_speed_mps_  = 0.0f;
   float wave_envelope_m_  = 0.0f;
   float wave_hz_          = FREQ_GUESS;
 
@@ -331,6 +338,7 @@ private:
   bool  wave_sign_ok_        = false;
   float wave_dir_deg_        = NAN;
   bool  wave_dir_ok_         = false;
+  float wave_dir_conf_pct_   = 0.0f;
 
   float heave_raw_m_        = 0.0f;
   float heave_baseline_m_   = 0.0f;
@@ -341,6 +349,7 @@ private:
   bool  mag_fresh_       = false;
   float mag_norm_uT_     = NAN;
   float heading_mag_deg_ = NAN;
+  float imu_temp_c_      = NAN;
   bool  heading_mag_ok_  = false;
 
   uint16_t stale_frame_count_ = 0;
@@ -350,8 +359,16 @@ private:
 
   bool     rot_inited_    = false;
   float    rot_dpm_filt_  = 0.0f;
-  bool     gyro_bias_ok_  = false;
-  Vector3f gyro_bias_ema_ = Vector3f::Zero();
+  bool     gyro_bias_ok_       = false;
+  bool     gyro_bias_learning_ = false;
+  bool     acc_bias_estimating_ = false;
+  Vector3f gyro_bias_ema_      = Vector3f::Zero();
+
+  uint32_t rate_window_ms_   = 0;
+  uint32_t imu_sample_count_ = 0;
+  uint32_t mag_sample_count_ = 0;
+  float    imu_sample_hz_    = 0.0f;
+  float    mag_sample_hz_    = 0.0f;
 
 private:
   static void waitForNextLoopTick_(uint32_t loop_start_us) {
@@ -451,6 +468,11 @@ private:
     mag_gate_last_ms_ = 0;
 
     last_skipped_total_ = 0;
+    rate_window_ms_ = millis();
+    imu_sample_count_ = 0;
+    mag_sample_count_ = 0;
+    imu_sample_hz_ = 0.0f;
+    mag_sample_hz_ = 0.0f;
     have_last_sample_us_ = false;
     last_sample_us_      = 0;
   }
@@ -512,6 +534,8 @@ private:
     rot_inited_   = false;
     rot_dpm_filt_ = 0.0f;
     gyro_bias_ok_ = false;
+    gyro_bias_learning_ = false;
+    acc_bias_estimating_ = false;
     gyro_bias_ema_.setZero();
 
     heading_deg_   = 0.0f;
@@ -522,11 +546,13 @@ private:
     mag_fresh_        = false;
     mag_norm_uT_      = NAN;
     heading_mag_deg_  = NAN;
+    imu_temp_c_       = NAN;
     heading_mag_ok_   = false;
 
     stale_frame_count_ = 0;
     have_last_sample_us_ = false;
     last_sample_us_      = 0;
+    heave_speed_mps_     = 0.0f;
     heave_raw_m_         = 0.0f;
     heave_baseline_m_    = 0.0f;
     heave_wave_raw_m_    = 0.0f;
@@ -540,6 +566,7 @@ private:
     wave_sign_ok_       = false;
     wave_dir_deg_       = NAN;
     wave_dir_ok_        = false;
+    wave_dir_conf_pct_  = 0.0f;
   }
 
 #if SEA_STATE_ENABLE_WIZARD
@@ -587,6 +614,8 @@ private:
   void updateFilter_(const ImuSample& s) {
     dt_ = computeFusionDtFromSampleTimestamp_(s);
     const float tempC = std::isfinite(s.tempC) ? s.tempC : 35.0f;
+    imu_temp_c_ = tempC;
+    ++imu_sample_count_;
 
     const Vector3f a_raw = s.a;
     const Vector3f w_raw = s.w;
@@ -600,6 +629,7 @@ private:
     mag_norm_uT_ = m_cal_.norm();
     mag_ok_ = std::isfinite(mag_norm_uT_) && (mag_norm_uT_ > 5.0f) && (mag_norm_uT_ < 200.0f);
     mag_fresh_ = updateMagFreshGate_(mag_ok_, millis());
+    if (mag_fresh_) ++mag_sample_count_;
 
     const bool still =
         (fabsf(a_cal_.norm() - g_std) < ROT_STILL_G_TOL_FRAC * g_std) &&
@@ -641,6 +671,8 @@ private:
       }
     }
 
+    gyro_bias_learning_ = still;
+
     if (still) {
       const float alpha_b = 1.0f - expf(-dt_ / ROT_BIAS_TAU_S);
       if (!gyro_bias_ok_) {
@@ -667,6 +699,9 @@ private:
       rot_dpm_filt_ += alpha_r * (rot_dpm_meas - rot_dpm_filt_);
     }
 
+    const Vector3f velocity_ned_mps = fusion_.raw().mekf().get_velocity();
+    heave_speed_mps_ = -velocity_ned_mps.z();
+
     const Vector3f displacement_raw_up_m = fusion_.displacementUpMeters();
     const auto& displacement_det_out = fusion_.displacementDetrend();
 
@@ -688,6 +723,20 @@ private:
         wave_dir_deg_);
 
     wave_dir_ok_ = wave_dir_ok_ && fusion_.isLive();
+    wave_dir_conf_pct_ = wave_dir_ok_ ? 100.0f : (wave_axis_ok_ ? 50.0f : 0.0f);
+    acc_bias_estimating_ = fusion_.isLive();
+
+    const uint32_t now_ms = millis();
+    if (rate_window_ms_ == 0) rate_window_ms_ = now_ms;
+    const uint32_t rate_elapsed_ms = now_ms - rate_window_ms_;
+    if (rate_elapsed_ms >= 1000u) {
+      const float scale = 1000.0f / static_cast<float>(rate_elapsed_ms);
+      imu_sample_hz_ = static_cast<float>(imu_sample_count_) * scale;
+      mag_sample_hz_ = static_cast<float>(mag_sample_count_) * scale;
+      imu_sample_count_ = 0;
+      mag_sample_count_ = 0;
+      rate_window_ms_ = now_ms;
+    }
 
     heave_raw_m_        = heave_m_;
     heave_baseline_m_   = displacement_det_out.baseline_slow.z();
@@ -778,9 +827,33 @@ private:
     }
     nmea_xdr_pitch_roll(SEA_STATE_NMEA_TALKER, pitch_deg_, roll_deg_);
     nmea_xdr_heave(SEA_STATE_NMEA_TALKER, heave_wave_clean_m_);
-    nmea_xdr_wave_axis_rel(SEA_STATE_NMEA_TALKER, wave_axis_deg_, wave_axis_ok_);
-    nmea_xdr_wave_direction_rel(SEA_STATE_NMEA_TALKER, wave_dir_deg_, wave_dir_ok_);
-    nmea_txt_wave_direction_sign(SEA_STATE_NMEA_TALKER, wave_sign_raw_, wave_sign_polarity_, wave_sign_ok_);
+    nmea_xdr_heave_speed(SEA_STATE_NMEA_TALKER, heave_speed_mps_);
+
+    if (now_ms - last_wave_nmea_ms_ >= NMEA_WAVE_MS) {
+      last_wave_nmea_ms_ = now_ms;
+      nmea_xdr_wave_axis_rel(SEA_STATE_NMEA_TALKER, wave_axis_deg_, wave_axis_ok_);
+      nmea_xdr_wave_direction_rel(SEA_STATE_NMEA_TALKER, wave_dir_deg_, wave_dir_ok_);
+      nmea_txt_wave_direction_sign(SEA_STATE_NMEA_TALKER, wave_sign_raw_, wave_sign_polarity_, wave_sign_ok_);
+      nmea_txt_wave_direction_confidence(SEA_STATE_NMEA_TALKER, wave_dir_conf_pct_, fusion_.isLive());
+    }
+
+    if (now_ms - last_temp_nmea_ms_ >= NMEA_TEMP_MS) {
+      last_temp_nmea_ms_ = now_ms;
+      nmea_xdr_imu_temp(SEA_STATE_NMEA_TALKER, imu_temp_c_);
+    }
+
+    if (now_ms - last_status_nmea_ms_ >= NMEA_STATUS_MS) {
+      last_status_nmea_ms_ = now_ms;
+      nmea_txt_ins_status(SEA_STATE_NMEA_TALKER,
+                          valid,
+                          fusion_.isLive() && std::isfinite(heave_wave_clean_m_),
+                          fusion_.hasMagNorthLock(),
+                          gyro_bias_learning_,
+                          acc_bias_estimating_,
+                          imu_sample_hz_,
+                          mag_sample_hz_);
+    }
+
     //nmea_xdr_freq(SEA_STATE_NMEA_TALKER, wave_hz_);
     nmea_rot(SEA_STATE_NMEA_TALKER, rot_dpm_filt_, valid);
 #else

--- a/sensors/full_marine_ins/atomS3R_ins_pii_observer/atomS3R_ins_pii_observer.ino
+++ b/sensors/full_marine_ins/atomS3R_ins_pii_observer/atomS3R_ins_pii_observer.ino
@@ -109,6 +109,8 @@ static constexpr uint32_t LOOP_PERIOD_US = static_cast<uint32_t>(1000000.0f / LO
 static constexpr uint32_t UI_REFRESH_MS = 100;
 static constexpr uint32_t DEBUG_SERIAL_MS = 100;
 static constexpr uint32_t NMEA_SERIAL_MS = 80;
+static constexpr uint32_t NMEA_STATUS_MS = 5000;
+static constexpr uint32_t NMEA_TEMP_MS = 500;
 
 static constexpr float ROT_BIAS_TAU_S = 5.0f;
 static constexpr float ROT_STILL_G_TOL_FRAC = 0.12f;
@@ -253,6 +255,8 @@ class FusionApp {
 
   uint32_t last_ui_ms_ = 0;
   uint32_t last_serial_ms_ = 0;
+  uint32_t last_status_nmea_ms_ = 0;
+  uint32_t last_temp_nmea_ms_ = 0;
 
   Fusion fusion_{};
 
@@ -276,6 +280,7 @@ class FusionApp {
   bool heading_valid_ = false;
 
   float heave_m_ = 0.0f;
+  float heave_speed_mps_ = 0.0f;
   float wave_envelope_m_ = 0.0f;
   float wave_hz_ = APP_FREQ_GUESS;
 
@@ -289,6 +294,7 @@ class FusionApp {
   bool mag_fresh_ = false;
   bool mag_used_ = false;
   float mag_norm_uT_ = NAN;
+  float imu_temp_c_ = NAN;
 
   uint16_t stale_frame_count_ = 0;
   bool have_last_sample_us_ = false;
@@ -297,7 +303,14 @@ class FusionApp {
   bool rot_inited_ = false;
   float rot_dpm_filt_ = 0.0f;
   bool gyro_bias_ok_ = false;
+  bool gyro_bias_learning_ = false;
   Vector3f gyro_bias_ema_ = Vector3f::Zero();
+
+  uint32_t rate_window_ms_ = 0;
+  uint32_t imu_sample_count_ = 0;
+  uint32_t mag_sample_count_ = 0;
+  float imu_sample_hz_ = 0.0f;
+  float mag_sample_hz_ = 0.0f;
 
   bool mahony_seeded_ = false;
 
@@ -454,6 +467,11 @@ class FusionApp {
 
     mag_gate_last_ms_ = 0;
     last_mag_correction_ms_ = 0;
+    rate_window_ms_ = millis();
+    imu_sample_count_ = 0;
+    mag_sample_count_ = 0;
+    imu_sample_hz_ = 0.0f;
+    mag_sample_hz_ = 0.0f;
 
     have_last_sample_us_ = false;
     last_sample_us_ = 0;
@@ -489,6 +507,7 @@ class FusionApp {
     rot_inited_ = false;
     rot_dpm_filt_ = 0.0f;
     gyro_bias_ok_ = false;
+    gyro_bias_learning_ = false;
     gyro_bias_ema_.setZero();
     mahony_seeded_ = false;
 
@@ -508,12 +527,14 @@ class FusionApp {
     mag_fresh_ = false;
     mag_used_ = false;
     mag_norm_uT_ = NAN;
+    imu_temp_c_ = NAN;
 
     stale_frame_count_ = 0;
     have_last_sample_us_ = false;
     last_sample_us_ = 0;
 
     heave_m_ = 0.0f;
+    heave_speed_mps_ = 0.0f;
     wave_envelope_m_ = 0.0f;
     wave_hz_ = APP_FREQ_GUESS;
 
@@ -600,6 +621,8 @@ class FusionApp {
 
     dt_ = computeFusionDtFromSampleTimestamp_(s);
     const float tempC = std::isfinite(s.tempC) ? s.tempC : 35.0f;
+    imu_temp_c_ = tempC;
+    ++imu_sample_count_;
 
     a_raw_norm_ = s.a.norm();
 
@@ -620,6 +643,7 @@ class FusionApp {
         mag_norm_uT_ <= MAG_FIELD_MAX_UT;
 
     mag_fresh_ = updateMagFreshGate_(mag_present_, now_ms);
+    if (mag_fresh_) ++mag_sample_count_;
 
 #if SEA_STATE_USE_STRICT_MAG_FIELD_GATE
     const bool mag_usable = mag_present_ && mag_field_sane_;
@@ -675,6 +699,8 @@ class FusionApp {
         (fabsf(a_cal_.norm() - APP_G_STD) < ROT_STILL_G_TOL_FRAC * APP_G_STD) &&
         (w_cal_.norm() < ROT_STILL_GYRO_RAD_S);
 
+    gyro_bias_learning_ = still;
+
     if (still) {
       const float alpha_b = 1.0f - expf(-dt_ / ROT_BIAS_TAU_S);
 
@@ -705,6 +731,7 @@ class FusionApp {
     const auto hs = fusion_.snapshot();
 
     heave_m_ = fusion_.displacement();
+    heave_speed_mps_ = fusion_.velocity();
     heave_raw_m_ = heave_m_;
 
     /*
@@ -734,6 +761,17 @@ class FusionApp {
     heave_baseline_m_ = z_det.baseline_slow;
     heave_wave_raw_m_ = z_det.wave_raw;
     heave_wave_clean_m_ = z_det.wave_clean;
+
+    if (rate_window_ms_ == 0) rate_window_ms_ = now_ms;
+    const uint32_t rate_elapsed_ms = now_ms - rate_window_ms_;
+    if (rate_elapsed_ms >= 1000u) {
+      const float scale = 1000.0f / static_cast<float>(rate_elapsed_ms);
+      imu_sample_hz_ = static_cast<float>(imu_sample_count_) * scale;
+      mag_sample_hz_ = static_cast<float>(mag_sample_count_) * scale;
+      imu_sample_count_ = 0;
+      mag_sample_count_ = 0;
+      rate_window_ms_ = now_ms;
+    }
   }
 
   void drawHomeStatic_() {
@@ -852,6 +890,25 @@ class FusionApp {
 
     nmea_xdr_pitch_roll(SEA_STATE_NMEA_TALKER, pitch_deg_, roll_deg_);
     nmea_xdr_heave(SEA_STATE_NMEA_TALKER, heave_wave_clean_m_);
+    nmea_xdr_heave_speed(SEA_STATE_NMEA_TALKER, heave_speed_mps_);
+
+    if (now_ms - last_temp_nmea_ms_ >= NMEA_TEMP_MS) {
+      last_temp_nmea_ms_ = now_ms;
+      nmea_xdr_imu_temp(SEA_STATE_NMEA_TALKER, imu_temp_c_);
+    }
+
+    if (now_ms - last_status_nmea_ms_ >= NMEA_STATUS_MS) {
+      last_status_nmea_ms_ = now_ms;
+      nmea_txt_ins_status(SEA_STATE_NMEA_TALKER,
+                          heading_valid_,
+                          fusion_.envelopeReady() && std::isfinite(heave_wave_clean_m_),
+                          heading_valid_ && mag_used_,
+                          gyro_bias_learning_,
+                          false,
+                          imu_sample_hz_,
+                          mag_sample_hz_);
+    }
+
     //nmea_xdr_freq(SEA_STATE_NMEA_TALKER, wave_hz_);
     nmea_rot(SEA_STATE_NMEA_TALKER, rot_dpm_filt_, heading_valid_);
 

--- a/src/nmea/NmeaCompass.h
+++ b/src/nmea/NmeaCompass.h
@@ -58,6 +58,23 @@ static inline void nmea_xdr_freq(const char* talker2, float freq_hz) {
   nmea_send(s);
 }
 
+// $--XDR,V,x.xxx,M,VHSPD*hh  (vertical heave speed, meters/second, up-positive)
+static inline void nmea_xdr_heave_speed(const char* talker2, float heave_speed_mps) {
+  char s[82];
+  snprintf(s, sizeof(s), "$%sXDR,V,%.3f,M,VHSPD", talker2, (double)heave_speed_mps);
+  nmea_send(s);
+}
+
+// $--XDR,C,x.x,C,IMUT*hh  (IMU chip temperature, degrees C)
+static inline void nmea_xdr_imu_temp(const char* talker2, float temp_c) {
+  if (!std::isfinite(temp_c)) {
+    return;
+  }
+  char s[82];
+  snprintf(s, sizeof(s), "$%sXDR,C,%.1f,C,IMUT", talker2, (double)temp_c);
+  nmea_send(s);
+}
+
 static inline uint8_t nmeaChecksumBody_(const char* body) {
   uint8_t cs = 0;
   while (*body) {
@@ -98,5 +115,40 @@ static inline void nmea_txt_wave_direction_sign(const char* talker, int raw_sign
   }
   char body[96];
   snprintf(body, sizeof(body), "%.2sTXT,01,01,00,WAVSGN=%d POL=%d", talker, raw_sign, polarity);
+  nmeaPrintBody_(body);
+}
+
+static inline void nmea_txt_wave_direction_confidence(const char* talker, float confidence_pct, bool valid)
+{
+  if (!valid || !std::isfinite(confidence_pct)) {
+    return;
+  }
+  char body[96];
+  if (confidence_pct < 0.0f) confidence_pct = 0.0f;
+  if (confidence_pct > 100.0f) confidence_pct = 100.0f;
+  snprintf(body, sizeof(body), "%.2sTXT,01,01,00,WAVCONF=%.0f", talker, static_cast<double>(confidence_pct));
+  nmeaPrintBody_(body);
+}
+
+static inline void nmea_txt_ins_status(const char* talker,
+                                       bool attitude_good,
+                                       bool heave_good,
+                                       bool mag_locked,
+                                       bool gyro_bias_learning,
+                                       bool acc_bias_estimating,
+                                       float imu_hz,
+                                       float mag_hz)
+{
+  char body[96];
+  snprintf(body, sizeof(body),
+           "%.2sTXT,01,01,00,ATT=%c HEV=%c MAG=%c GB=%c AB=%c IHz=%.1f MHz=%.1f",
+           talker,
+           attitude_good ? 'Y' : 'N',
+           heave_good ? 'Y' : 'N',
+           mag_locked ? 'Y' : 'N',
+           gyro_bias_learning ? 'Y' : 'N',
+           acc_bias_estimating ? 'Y' : 'N',
+           static_cast<double>(imu_hz),
+           static_cast<double>(mag_hz));
   nmeaPrintBody_(body);
 }


### PR DESCRIPTION
### Motivation
- Reduce noisy/high-rate wave-direction chatter and provide compact confidence/health telemetry over NMEA at controlled cadences. 
- Add a small set of NMEA fields for IMU temperature and vertical heave speed plus a concise INS status summary to aid diagnostics and downstream logging.

### Description
- Added NMEA helpers in `src/nmea/NmeaCompass.h`: `nmea_xdr_heave_speed` (VHSPD), `nmea_xdr_imu_temp` (IMUT), `nmea_txt_wave_direction_confidence` (WAVCONF) and `nmea_txt_ins_status` (compact TXT status). 
- Introduced timing constants and per-sketch state for new cadences: `NMEA_WAVE_MS = 2000` (wave dir/confidence), `NMEA_TEMP_MS = 500` (IMU temp) and `NMEA_STATUS_MS = 5000` (INS status) and per-second sample-rate tracking fields. Changes applied to OU2, OU3 and PII observer sketches under `sensors/full_marine_ins/`.
- Emit vertical heave speed alongside attitude XDRs (using fusion velocity), throttle wave axis/direction/sign+WAVCONF to every 2s, emit IMUT every 0.5s, and emit a compact 5s TXT containing attitude/heave/mag/gyro-bias/acc-bias flags and IMU/mag sample rates.
- Track IMU and magnetometer sample counts in a 1 s window to report approximate runtime sample rates in the TXT status sentence and expose gyro-bias-learning / accel-bias-estimating indicators.

### Testing
- Ran the repository validation `make all`, which built and exercised the test suites (including AHRS, detrend, freq, imu_calibrate, kalman_ou_ii/iii, pii_observer and wave-sim suites) and completed successfully with the simulation data fetched automatically. 
- No test failures were observed during the run (`make all` passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dab9887a483289b8b2d2371255a5e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added heave speed velocity to NMEA telemetry output
  * Added IMU temperature monitoring and reporting
  * Added wave direction confidence percentage metrics
  * Enhanced INS status messages with gyro and accelerometer bias learning state indicators
  * Implemented IMU and magnetometer sample rate calculation and reporting for system diagnostics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->