### PR TITLE
Experiment: retune OU-II and OU-III after PR2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: PR2 targeted gyro-scale sweep
+name: PR2 full gyro-scale sweep
 
 on:
   push:
@@ -14,7 +14,7 @@ env:
   DATA_RELEASE: v1.1.3
 
 jobs:
-  targeted-gyro-scale:
+  full-gyro-scale:
     runs-on: ubuntu-24.04-arm
     strategy:
       fail-fast: false
@@ -22,10 +22,8 @@ jobs:
         include:
           - family: OU_II
             subdir: kalman_ou_ii
-            target_glob: "*jonswap_H4.000*.csv"
           - family: OU_III
             subdir: kalman_ou_iii
-            target_glob: "*jonswap_H0.270*.csv"
 
     steps:
       - name: Checkout experiment branch
@@ -54,12 +52,11 @@ jobs:
           path.write_text(text.replace(needle, replacement))
           PY
 
-      - name: Download only the targeted regression dataset
+      - name: Download complete simulation dataset
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SUBDIR: ${{ matrix.subdir }}
-          TARGET_GLOB: ${{ matrix.target_glob }}
         run: |
           set -euo pipefail
           gh release download "$DATA_RELEASE" \
@@ -67,12 +64,8 @@ jobs:
             --pattern "sim-data-files.zip" \
             --clobber
           rm -f "tests/$SUBDIR"/wave_data_*.csv
-          mkdir -p /tmp/sim-data
-          unzip -o sim-data-files.zip -d /tmp/sim-data
-          mapfile -t matches < <(find /tmp/sim-data -type f -name "$TARGET_GLOB" | sort)
-          test "${#matches[@]}" -eq 1
-          cp "${matches[0]}" "tests/$SUBDIR/"
-          ls -l "tests/$SUBDIR"/wave_data_*.csv
+          unzip -j -o sim-data-files.zip 'wave_data_*.csv' -d "tests/$SUBDIR"
+          test "$(find "tests/$SUBDIR" -maxdepth 1 -name 'wave_data_*.csv' | wc -l)" -eq 20
 
       - name: Install build dependencies
         run: |
@@ -82,7 +75,7 @@ jobs:
       - name: Build ${{ matrix.family }} once
         run: make -C "tests/${{ matrix.subdir }}" build
 
-      - name: Run targeted unchanged gate at four gyro scales
+      - name: Run unchanged full gate at four gyro scales
         shell: bash
         env:
           SUBDIR: ${{ matrix.subdir }}
@@ -91,7 +84,6 @@ jobs:
         run: |
           set -u
           mkdir -p "/tmp/results/$FAMILY"
-          overall=0
           for scale in 1.0 0.3 0.1 0.070710678; do
             label="${scale//./p}"
             log="/tmp/results/$FAMILY/gyro_scale_${label}.log"
@@ -102,15 +94,13 @@ jobs:
             status=$?
             printf '%s\n' "$status" > "/tmp/results/$FAMILY/gyro_scale_${label}.status"
             echo "===== $FAMILY gyro_scale=$scale status=$status ====="
-            grep -E 'Processing|XYZ RMS|Angles RMS|Bias error RMS \(acc|Bias error RMS \(% of max TRUE bias\) \(acc\)|QUALITY_GATE' "$log" || true
-            if [ "$status" -eq 0 ]; then overall=1; fi
+            grep -E 'Processing|XYZ RMS|3D RMS|Angles RMS|Bias error RMS \(% of max TRUE bias\) \(acc\)|tau_applied|QUALITY_GATE|^ERROR:' "$log" || true
           done
-          echo "ANY_CANDIDATE_PASSED=$overall"
           exit 0
 
-      - name: Upload targeted sweep results
+      - name: Upload full sweep results
         uses: actions/upload-artifact@v6
         with:
-          name: targeted-gyro-sweep-${{ matrix.family }}
+          name: full-gyro-sweep-${{ matrix.family }}
           path: /tmp/results/${{ matrix.family }}/*
           if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,317 +1,127 @@
-name: build
+name: PR2 OU gyro-scale sweep
+
 on:
   push:
-  pull_request:
+    branches: [agent/pr2-retune-experiments]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+env:
+  DATA_RELEASE: v1.1.3
+
 jobs:
-  build:
+  gyro-scale:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        dir: [wave_sim, freq, spectrum, ahrs, pii_observer, kalman_ou_ii, kalman_ou_iii, imu_calibrate, detrend, nlo]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Download sim data from oceanography-waves-lib GitHub repo release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release download v1.1.3 --repo bareboat-necessities/oceanography-waves-lib --pattern "sim-data-files.zip" --clobber
-
-      - name: Unpack simulation data (${{ matrix.dir }})
-        run: |
-          unzip -o sim-data-files.zip -d ${{ github.workspace }}/plots/${{ matrix.dir }}
-
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y g++ make libeigen3-dev \
-            texlive-xetex texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra texlive-fonts-extra dvipng \
-            inkscape graphviz python3-pip python3-matplotlib python3-numpy python3-pandas
-
-      - name: Compile tests (${{ matrix.dir }})
-        run: |
-          cd tests/${{ matrix.dir }}
-          make build
-
-      - name: Copy test data (${{ matrix.dir }})
-        run: |
-          cp ${{ github.workspace }}/plots/${{ matrix.dir }}/*.csv tests/${{ matrix.dir }}
-
-      - name: Run tests (${{ matrix.dir }})
-        run: |
-          cd tests/${{ matrix.dir }}
-          chmod +x *.sh
-          ./run_tests.sh
-          cp *.csv ../../plots/${{ matrix.dir }}
-          make clean
-
-      - name: Generate PGF plots (${{ matrix.dir }})
-        shell: bash
-        run: |
-          cd plots/${{ matrix.dir }}
-          chmod +x *.sh
-          ./draw_plots.sh
-          mv -v *.pgf ../../doc/${{ matrix.dir }}/ || true
-          mv -v *.svg ../../doc/${{ matrix.dir }}/ || true
-          mv -v *.png ../../doc/${{ matrix.dir }}/ || true
-
-      - name: Compile LaTeX document (${{ matrix.dir }})
-        uses: xu-cheng/latex-action@v4
-        with:
-          root_file: "*.tex"
-          pre_compile: |
-            echo "openout_any = a" | tee -a $(kpsewhich texmf.cnf)
-            curl -L https://github.com/plantuml/plantuml/releases/download/v1.2025.4/plantuml.jar -o plantuml.jar
-            export PLANTUML_JAR=$(pwd)/plantuml.jar
-            curl -L https://mirrors.ctan.org/macros/luatex/latex/plantuml/plantuml.sty -o plantuml.sty
-            echo ">> Debug: TeX config patched, now checking PlantUML installation"
-            plantuml -version || true
-            java -version || true
-            if [ "${{ matrix.dir }}" = "kalman_ou_iii" ]; then
-              cp -v ${{ github.workspace }}/img/devices/AtomS3R_device.svg ${{ github.workspace }}/doc/${{ matrix.dir }}/AtomS3R_device.svg
-            fi
-          work_in_root_file_dir: true
-          working_directory: doc/${{ matrix.dir }}
-          latexmk_use_lualatex: true
-          latexmk_shell_escape: true
-          args: "-shell-escape"
-          extra_system_packages: "inkscape ghostscript graphviz ncurses openjdk11-jre"
-        env:
-          PLANTUML_JAR: ${{ github.workspace }}/doc/${{ matrix.dir }}/plantuml.jar
-
-      - name: Upload PDF artifacts (${{ matrix.dir }})
-        uses: actions/upload-artifact@v6
-        with:
-          name: latex-pdfs-${{ matrix.dir }}
-          path: doc/${{ matrix.dir }}/**/*.pdf
-          if-no-files-found: error
-
-      - name: Find SVGs (${{ matrix.dir }})
-        id: find_svgs
-        shell: bash
-        run: |
-          shopt -s nullglob globstar
-          files=(
-            doc/${{ matrix.dir }}/**/*pmstokes*H1.5*.svg
-            doc/${{ matrix.dir }}/**/*pmstokes*medium*.svg
-          )
-
-          if [ ${#files[@]} -gt 0 ]; then
-            mkdir -p release-svg/${{ matrix.dir }}
-            for f in "${files[@]}"; do
-              cp -v "$f" release-svg/${{ matrix.dir }}/
-            done
-            echo "found=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "found=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Upload SVG artifacts (${{ matrix.dir }})
-        if: steps.find_svgs.outputs.found == 'true'
-        uses: actions/upload-artifact@v6
-        with:
-          name: release-svgs-${{ matrix.dir }}
-          path: release-svg/${{ matrix.dir }}/**/*.svg
-          if-no-files-found: error
-
-  ou-tuning:
-    if: ${{ (false && github.event_name == 'push') }}
-    runs-on: ubuntu-latest
-
     strategy:
       fail-fast: false
       matrix:
         include:
           - family: OU_II
             subdir: kalman_ou_ii
-            report_name: ou_ii
+            label: scale_1p0
+            gyro_scale: "1.0"
+          - family: OU_II
+            subdir: kalman_ou_ii
+            label: scale_0p3
+            gyro_scale: "0.3"
+          - family: OU_II
+            subdir: kalman_ou_ii
+            label: scale_0p1
+            gyro_scale: "0.1"
+          - family: OU_II
+            subdir: kalman_ou_ii
+            label: scale_density
+            gyro_scale: "0.070710678"
           - family: OU_III
             subdir: kalman_ou_iii
-            report_name: ou_iii
+            label: scale_1p0
+            gyro_scale: "1.0"
+          - family: OU_III
+            subdir: kalman_ou_iii
+            label: scale_0p3
+            gyro_scale: "0.3"
+          - family: OU_III
+            subdir: kalman_ou_iii
+            label: scale_0p1
+            gyro_scale: "0.1"
+          - family: OU_III
+            subdir: kalman_ou_iii
+            label: scale_density
+            gyro_scale: "0.070710678"
 
     steps:
-      - name: Checkout
+      - name: Checkout experiment branch
         uses: actions/checkout@v6
 
-      - name: Download sim data from oceanography-waves-lib GitHub repo release
+      - name: Add experimental gyro-scale override
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+          import os
+
+          subdir = os.environ["SUBDIR"]
+          path = Path("tests") / subdir / f"{subdir}-sim.cpp"
+          text = path.read_text()
+          needle = '        if (env_float("SF_MAG_DELAY_SEC", vf)) cfg_.mag_delay_sec = vf;'
+          replacement = (
+              '        if (env_float("OU_GYRO_SCALE", vf)) cfg_.sigma_g *= vf;\n'
+              + needle
+          )
+          if text.count(needle) != 1:
+              raise RuntimeError(f"unexpected override location in {path}")
+          path.write_text(text.replace(needle, replacement))
+          PY
+        env:
+          SUBDIR: ${{ matrix.subdir }}
+
+      - name: Download simulation data
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release download v1.1.3 \
+          gh release download "$DATA_RELEASE" \
             --repo bareboat-necessities/oceanography-waves-lib \
             --pattern "sim-data-files.zip" \
             --clobber
+          mkdir -p "plots/${{ matrix.subdir }}"
+          unzip -o sim-data-files.zip -d "plots/${{ matrix.subdir }}"
+          cp "plots/${{ matrix.subdir }}"/*.csv "tests/${{ matrix.subdir }}/"
 
-      - name: Install tuning dependencies
+      - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y g++ make libeigen3-dev unzip python3
+          sudo apt-get install -y g++ make libeigen3-dev
 
-      - name: Unpack simulation data for ${{ matrix.family }}
-        run: |
-          unzip -o sim-data-files.zip -d "${{ github.workspace }}/tests/${{ matrix.subdir }}"
+      - name: Build ${{ matrix.family }}
+        run: make -C "tests/${{ matrix.subdir }}" build
 
-      - name: Run ${{ matrix.family }} tuning sweep
+      - name: Run unchanged quality gate
         shell: bash
+        env:
+          OU_GYRO_SCALE: ${{ matrix.gyro_scale }}
+          W3D_COLLECT_ALL_GATES: "1"
         run: |
-          set -o pipefail
-          mkdir -p reports/results
+          set +e
+          log="/tmp/${{ matrix.family }}_${{ matrix.label }}.log"
+          (
+            cd "tests/${{ matrix.subdir }}"
+            chmod +x run_tests.sh
+            ./run_tests.sh
+          ) >"$log" 2>&1
+          status=$?
+          cat "$log"
+          printf '%s\n' "$status" > "/tmp/${{ matrix.family }}_${{ matrix.label }}.status"
+          exit "$status"
 
-          python3 -u tools/ou_tuning_sweep.py \
-            --family ${{ matrix.family }} \
-            --mode full \
-            --samples 52 \
-            --seed 77 \
-            --tier all \
-            --top-k 8 \
-            --out-csv reports/results/ou_tuning_${{ matrix.report_name }}.csv \
-            2>&1 | tee reports/results/ou_tuning_${{ matrix.report_name }}.log
-
-      - name: Upload ${{ matrix.family }} tuning reports
+      - name: Upload sweep result
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: ou-tuning-reports-${{ matrix.report_name }}
-          path: reports/results/*
+          name: gyro-sweep-${{ matrix.family }}-${{ matrix.label }}
+          path: |
+            /tmp/${{ matrix.family }}_${{ matrix.label }}.log
+            /tmp/${{ matrix.family }}_${{ matrix.label }}.status
           if-no-files-found: warn
-          
-  release:
-    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-    runs-on: ubuntu-latest
-    needs: [build, build-MCU]
-
-    steps:
-      - name: Download all workflow artifacts
-        uses: actions/download-artifact@v8
-        with:
-          path: release-assets
-          merge-multiple: false
-
-      - name: Show downloaded files
-        shell: bash
-        run: |
-          find release-assets -type f | sort
-
-      - name: Upload PDFs to release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: release-assets/latex-pdfs-*/*.pdf
-          tag: ${{ github.ref == 'refs/heads/main' && 'vTest' || github.ref_name }}
-          overwrite: true
-          file_glob: true
-
-      - name: Upload SVGs to release
-        shell: bash
-        run: |
-          shopt -s nullglob globstar
-          files=(release-assets/release-svgs-*/*.svg)
-          if [ ${#files[@]} -eq 0 ]; then
-            echo "No matching SVG files to upload."
-            exit 0
-          fi
-          printf '%s\n' "${files[@]}" > svg_files.txt
-          cat svg_files.txt
-
-      - name: Upload SVGs to release (serialized)
-        if: hashFiles('release-assets/release-svgs-*/*.svg') != ''
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: release-assets/release-svgs-*/*.svg
-          tag: ${{ github.ref == 'refs/heads/main' && 'vTest' || github.ref_name }}
-          overwrite: true
-          file_glob: true
-
-      - name: Upload MCU binaries to release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: release-assets/mcu-binaries-*/*.zip
-          tag: ${{ github.ref == 'refs/heads/main' && 'vTest' || github.ref_name }}
-          overwrite: true
-          file_glob: true
-
-  build-MCU:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        ino_dir: [ "full_marine_ins", "compass_ahrs", "imu_basic" ]
-  
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-  
-      - name: Compile sketch
-        uses: ArminJo/arduino-test-compile@v3
-        with:
-          arduino-board-fqbn: esp32:esp32:m5stack_atoms3:CDCOnBoot=cdc,USBMode=hwcdc
-          arduino-platform: esp32:esp32@3.3.7
-          platform-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
-          required-libraries: M5Unified@0.2.13,M5GFX@0.2.19,Eigen@0.3.2
-          sketch-names: "*.ino"
-          sketch-names-find-start: sensors/${{ matrix.ino_dir }}/*
-          build-properties: >-
-            { "All": "-funroll-loops -fno-finite-math-only" }
-          extra-arduino-cli-args: >-
-            --warnings default
-            --library ${{ github.workspace }}
-            --build-property compiler.libraries.ldflags=-Wl,--allow-multiple-definition
-          set-build-path: true
-
-      - name: Make merged MCU binaries (${{ matrix.ino_dir }})
-        shell: bash
-        run: |
-          set -euo pipefail
-          ESPTOOL="$(find "$HOME/.arduino15/packages/esp32/tools/esptool_py" -type f -name esptool | sort -V | tail -n 1)"
-          BOOT_APP0="$(find "$HOME/.arduino15/packages/esp32/hardware/esp32" -path '*/tools/partitions/boot_app0.bin' | sort -V | tail -n 1)"
-          if [ -z "$ESPTOOL" ] || [ -z "$BOOT_APP0" ]; then
-            echo "Unable to find esptool or boot_app0.bin."
-            exit 1
-          fi
-          for sketch in sensors/${{ matrix.ino_dir }}/*/*.ino; do
-            sketch_dir="$(dirname "$sketch")"
-            sketch_name="$(basename "$sketch" .ino)"
-            build_dir="$sketch_dir/build"
-            if [ ! -d "$build_dir" ]; then
-              echo "Missing build directory: $build_dir"
-              exit 1
-            fi
-            "$ESPTOOL" --chip esp32s3 merge_bin -o "$build_dir/${sketch_name}_firmware.bin" \
-              --flash_mode dio --flash_freq 80m --flash_size 8MB \
-              0x0 "$build_dir/${sketch_name}.ino.bootloader.bin" \
-              0x8000 "$build_dir/${sketch_name}.ino.partitions.bin" \
-              0xe000 "$BOOT_APP0" \
-              0x10000 "$build_dir/${sketch_name}.ino.bin"
-          done
-
-      - name: Package MCU binaries (${{ matrix.ino_dir }})
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p mcu-binaries
-          shopt -s nullglob
-          for build_dir in sensors/${{ matrix.ino_dir }}/*/build; do
-            sketch_name="$(basename "$(dirname "$build_dir")")"
-            files=("$build_dir"/*.bin "$build_dir"/*.csv)
-            if [ ${#files[@]} -eq 0 ]; then
-              echo "No binary files found in $build_dir"
-              exit 1
-            fi
-            zip -j "mcu-binaries/${sketch_name}_bin-$(date +%Y-%m-%d).zip" "${files[@]}"
-          done
-          ls -la mcu-binaries
-
-      - name: Upload MCU binary artifacts (${{ matrix.ino_dir }})
-        uses: actions/upload-artifact@v6
-        with:
-          name: mcu-binaries-${{ matrix.ino_dir }}
-          path: mcu-binaries/*.zip
-          if-no-files-found: error
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   targeted-gyro-scale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: PR2 OU gyro-scale sweep
 on:
   push:
     branches: [agent/pr2-retune-experiments]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: PR2 OU gyro-scale sweep
+name: PR2 targeted gyro-scale sweep
 
 on:
   push:
@@ -14,44 +14,18 @@ env:
   DATA_RELEASE: v1.1.3
 
 jobs:
-  gyro-scale:
-    runs-on: macos-latest
+  targeted-gyro-scale:
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
           - family: OU_II
             subdir: kalman_ou_ii
-            label: scale_1p0
-            gyro_scale: "1.0"
-          - family: OU_II
-            subdir: kalman_ou_ii
-            label: scale_0p3
-            gyro_scale: "0.3"
-          - family: OU_II
-            subdir: kalman_ou_ii
-            label: scale_0p1
-            gyro_scale: "0.1"
-          - family: OU_II
-            subdir: kalman_ou_ii
-            label: scale_density
-            gyro_scale: "0.070710678"
+            target_glob: "*jonswap_H4.000*.csv"
           - family: OU_III
             subdir: kalman_ou_iii
-            label: scale_1p0
-            gyro_scale: "1.0"
-          - family: OU_III
-            subdir: kalman_ou_iii
-            label: scale_0p3
-            gyro_scale: "0.3"
-          - family: OU_III
-            subdir: kalman_ou_iii
-            label: scale_0p1
-            gyro_scale: "0.1"
-          - family: OU_III
-            subdir: kalman_ou_iii
-            label: scale_density
-            gyro_scale: "0.070710678"
+            target_glob: "*jonswap_H0.270*.csv"
 
     steps:
       - name: Checkout experiment branch
@@ -59,6 +33,8 @@ jobs:
 
       - name: Add experimental gyro-scale override
         shell: bash
+        env:
+          SUBDIR: ${{ matrix.subdir }}
         run: |
           set -euo pipefail
           python3 - <<'PY'
@@ -77,54 +53,64 @@ jobs:
               raise RuntimeError(f"unexpected override location in {path}")
           path.write_text(text.replace(needle, replacement))
           PY
-        env:
-          SUBDIR: ${{ matrix.subdir }}
 
-      - name: Download simulation data
+      - name: Download only the targeted regression dataset
+        shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SUBDIR: ${{ matrix.subdir }}
+          TARGET_GLOB: ${{ matrix.target_glob }}
         run: |
+          set -euo pipefail
           gh release download "$DATA_RELEASE" \
             --repo bareboat-necessities/oceanography-waves-lib \
             --pattern "sim-data-files.zip" \
             --clobber
-          mkdir -p "plots/${{ matrix.subdir }}"
-          unzip -o sim-data-files.zip -d "plots/${{ matrix.subdir }}"
-          cp "plots/${{ matrix.subdir }}"/*.csv "tests/${{ matrix.subdir }}/"
+          rm -f "tests/$SUBDIR"/wave_data_*.csv
+          mkdir -p /tmp/sim-data
+          unzip -o sim-data-files.zip -d /tmp/sim-data
+          mapfile -t matches < <(find /tmp/sim-data -type f -name "$TARGET_GLOB" | sort)
+          test "${#matches[@]}" -eq 1
+          cp "${matches[0]}" "tests/$SUBDIR/"
+          ls -l "tests/$SUBDIR"/wave_data_*.csv
 
-      - name: Install Eigen
-        run: brew install eigen
-
-      - name: Build ${{ matrix.family }}
-        shell: bash
+      - name: Install build dependencies
         run: |
-          make -C "tests/${{ matrix.subdir }}" \
-            EIGEN_DIR="$(brew --prefix eigen)/include/eigen3" build
+          sudo apt-get update
+          sudo apt-get install -y g++ make libeigen3-dev
 
-      - name: Run unchanged quality gate
+      - name: Build ${{ matrix.family }} once
+        run: make -C "tests/${{ matrix.subdir }}" build
+
+      - name: Run targeted unchanged gate at four gyro scales
         shell: bash
         env:
-          OU_GYRO_SCALE: ${{ matrix.gyro_scale }}
+          SUBDIR: ${{ matrix.subdir }}
+          FAMILY: ${{ matrix.family }}
           W3D_COLLECT_ALL_GATES: "1"
         run: |
-          set +e
-          log="/tmp/${{ matrix.family }}_${{ matrix.label }}.log"
-          (
-            cd "tests/${{ matrix.subdir }}"
-            chmod +x run_tests.sh
-            ./run_tests.sh
-          ) >"$log" 2>&1
-          status=$?
-          cat "$log"
-          printf '%s\n' "$status" > "/tmp/${{ matrix.family }}_${{ matrix.label }}.status"
-          exit "$status"
+          set -u
+          mkdir -p "/tmp/results/$FAMILY"
+          overall=0
+          for scale in 1.0 0.3 0.1 0.070710678; do
+            label="${scale//./p}"
+            log="/tmp/results/$FAMILY/gyro_scale_${label}.log"
+            (
+              cd "tests/$SUBDIR"
+              OU_GYRO_SCALE="$scale" ./run_tests.sh
+            ) >"$log" 2>&1
+            status=$?
+            printf '%s\n' "$status" > "/tmp/results/$FAMILY/gyro_scale_${label}.status"
+            echo "===== $FAMILY gyro_scale=$scale status=$status ====="
+            grep -E 'Processing|XYZ RMS|Angles RMS|Bias error RMS \(acc|Bias error RMS \(% of max TRUE bias\) \(acc\)|QUALITY_GATE' "$log" || true
+            if [ "$status" -eq 0 ]; then overall=1; fi
+          done
+          echo "ANY_CANDIDATE_PASSED=$overall"
+          exit 0
 
-      - name: Upload sweep result
-        if: always()
+      - name: Upload targeted sweep results
         uses: actions/upload-artifact@v6
         with:
-          name: gyro-sweep-${{ matrix.family }}-${{ matrix.label }}
-          path: |
-            /tmp/${{ matrix.family }}_${{ matrix.label }}.log
-            /tmp/${{ matrix.family }}_${{ matrix.label }}.status
-          if-no-files-found: warn
+          name: targeted-gyro-sweep-${{ matrix.family }}
+          path: /tmp/results/${{ matrix.family }}/*
+          if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: PR2 full gyro-scale sweep
+name: PR2 exact-case gyro-scale sweep
 
 on:
   push:
@@ -14,7 +14,7 @@ env:
   DATA_RELEASE: v1.1.3
 
 jobs:
-  full-gyro-scale:
+  exact-case-gyro-scale:
     runs-on: ubuntu-24.04-arm
     strategy:
       fail-fast: false
@@ -22,8 +22,10 @@ jobs:
         include:
           - family: OU_II
             subdir: kalman_ou_ii
+            target_file: wave_data_jonswap_H4.000_L112.766_A30.00_P30.00.csv
           - family: OU_III
             subdir: kalman_ou_iii
+            target_file: wave_data_jonswap_H0.270_L14.047_A30.00_P60.00.csv
 
     steps:
       - name: Checkout experiment branch
@@ -52,11 +54,12 @@ jobs:
           path.write_text(text.replace(needle, replacement))
           PY
 
-      - name: Download complete simulation dataset
+      - name: Download exact regression dataset
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SUBDIR: ${{ matrix.subdir }}
+          TARGET_FILE: ${{ matrix.target_file }}
         run: |
           set -euo pipefail
           gh release download "$DATA_RELEASE" \
@@ -64,8 +67,8 @@ jobs:
             --pattern "sim-data-files.zip" \
             --clobber
           rm -f "tests/$SUBDIR"/wave_data_*.csv
-          unzip -j -o sim-data-files.zip 'wave_data_*.csv' -d "tests/$SUBDIR"
-          test "$(find "tests/$SUBDIR" -maxdepth 1 -name 'wave_data_*.csv' | wc -l)" -eq 20
+          unzip -j -o sim-data-files.zip "$TARGET_FILE" -d "tests/$SUBDIR"
+          test -f "tests/$SUBDIR/$TARGET_FILE"
 
       - name: Install build dependencies
         run: |
@@ -75,7 +78,7 @@ jobs:
       - name: Build ${{ matrix.family }} once
         run: make -C "tests/${{ matrix.subdir }}" build
 
-      - name: Run unchanged full gate at four gyro scales
+      - name: Run unchanged exact-case gate at four gyro scales
         shell: bash
         env:
           SUBDIR: ${{ matrix.subdir }}
@@ -98,9 +101,9 @@ jobs:
           done
           exit 0
 
-      - name: Upload full sweep results
+      - name: Upload exact-case sweep results
         uses: actions/upload-artifact@v6
         with:
-          name: full-gyro-sweep-${{ matrix.family }}
+          name: exact-case-gyro-sweep-${{ matrix.family }}
           path: /tmp/results/${{ matrix.family }}/*
           if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   gyro-scale:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
@@ -92,13 +92,14 @@ jobs:
           unzip -o sim-data-files.zip -d "plots/${{ matrix.subdir }}"
           cp "plots/${{ matrix.subdir }}"/*.csv "tests/${{ matrix.subdir }}/"
 
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y g++ make libeigen3-dev
+      - name: Install Eigen
+        run: brew install eigen
 
       - name: Build ${{ matrix.family }}
-        run: make -C "tests/${{ matrix.subdir }}" build
+        shell: bash
+        run: |
+          make -C "tests/${{ matrix.subdir }}" \
+            EIGEN_DIR="$(brew --prefix eigen)/include/eigen3" build
 
       - name: Run unchanged quality gate
         shell: bash

--- a/WEB_DOWNLOAD_LINKS.md
+++ b/WEB_DOWNLOAD_LINKS.md
@@ -1,0 +1,4 @@
+Temporary links for local PR2 reproduction. This file belongs only to experiment PR #192 and must not be merged.
+
+- [Eigen 3.3.7 source ZIP](https://codeload.github.com/eigenteam/eigen-git-mirror/zip/refs/tags/3.3.7)
+- [Oceanography waves v1.1.3 release](https://github.com/bareboat-necessities/oceanography-waves-lib/releases/tag/v1.1.3)

--- a/src/kalman_common/SeaStateFusionFilterCommon.h
+++ b/src/kalman_common/SeaStateFusionFilterCommon.h
@@ -241,6 +241,9 @@ template<typename MekfPtr, typename EnterColdFn, typename ApplyTuneFn>
 inline void finalizeInitialization(MekfPtr& mekf, EnterColdFn&& enterCold, ApplyTuneFn&& applyTune) {
     enterCold();
     applyTune();
+    // Initial tuning changes the stationary OU model before the linear block is
+    // activated. Seed the matching posterior covariance once at initialization.
+    mekf->reset_aw_covariance_to_stationary();
     mekf->set_exact_att_bias_Qd(true);
 }
 

--- a/src/kalman_ou_common/KalmanOUCoreMath.h
+++ b/src/kalman_ou_common/KalmanOUCoreMath.h
@@ -273,6 +273,48 @@ inline void apply_left_error_reset(Eigen::Matrix<T,NX,NX>& covariance,
     }
 }
 
+template<typename T, int N>
+inline void regularize_psd_if_needed(Eigen::Matrix<T,N,N>& S) {
+    S = T(0.5) * (S + S.transpose());
+    T scale = std::max(T(1), S.cwiseAbs().maxCoeff());
+    const T tol = T(64) * std::numeric_limits<T>::epsilon() * scale;
+
+    for (int i = 0; i < N; ++i) {
+        for (int j = 0; j < N; ++j) {
+            if (!std::isfinite(S(i,j))) S(i,j) = (i == j) ? tol : T(0);
+        }
+    }
+
+    Eigen::LDLT<Eigen::Matrix<T,N,N>> ldlt(S);
+    if (ldlt.info() == Eigen::Success && ldlt.vectorD().minCoeff() >= -tol) return;
+
+    Eigen::SelfAdjointEigenSolver<Eigen::Matrix<T,N,N>> es(S);
+    if (es.info() != Eigen::Success) {
+        S.diagonal().array() += tol;
+        S = T(0.5) * (S + S.transpose());
+        return;
+    }
+
+    Eigen::Matrix<T,N,1> eigenvalues = es.eigenvalues();
+    for (int i = 0; i < N; ++i) eigenvalues(i) = std::max(T(0), eigenvalues(i));
+    S = es.eigenvectors() * eigenvalues.asDiagonal() * es.eigenvectors().transpose();
+    S = T(0.5) * (S + S.transpose());
+}
+
+template<typename T>
+inline bool periodic_update_due(T dt, T period, T& elapsed) {
+    if (!(dt > T(0)) || !std::isfinite(dt) || !(period > T(0)) || !std::isfinite(period)) return false;
+    const T total = elapsed + dt;
+    const T tol = T(16) * std::numeric_limits<T>::epsilon() * std::max(T(1), period);
+    if (total + tol < period) {
+        elapsed = total;
+        return false;
+    }
+    elapsed = (total >= period) ? std::fmod(total, period) : T(0);
+    if (!(elapsed >= T(0)) || !std::isfinite(elapsed) || elapsed >= period) elapsed = T(0);
+    return true;
+}
+
 template<typename T, int Integrations>
 struct IntegratedOUChain;
 
@@ -292,25 +334,27 @@ struct IntegratedOUChain<T,2> {
 
     static void process_covariance(T tau, T h, T sigma2, MatrixAxis& Qd) {
         const T tau_eff = std::max(tau, T(1e-7));
-        const T inv_tau = T(1)/tau_eff;
-        const T x = h*inv_tau;
+        const T inv = T(1) / tau_eff;
+        const T x = h * inv;
         if (std::abs(x) < T(1e-2)) {
-            const T i2=inv_tau*inv_tau, i3=i2*inv_tau, i4=i3*inv_tau;
+            const T i2=inv*inv, i3=i2*inv, i4=i3*inv, i5=i4*inv;
+            const T i6=i5*inv, i7=i6*inv, i8=i7*inv, i9=i8*inv;
             const T h2=h*h, h3=h2*h, h4=h3*h, h5=h4*h;
+            const T h6=h5*h, h7=h6*h, h8=h7*h, h9=h8*h;
             Qd.setZero();
-            Qd(0,0)=sigma2*((T(2)/T(3))*h3*inv_tau-(T(1)/T(2))*h4*i2+(T(7)/T(30))*h5*i3);
-            Qd(0,1)=sigma2*((T(1)/T(4))*h4*inv_tau-(T(1)/T(6))*h5*i2);
-            Qd(0,2)=sigma2*(h2*inv_tau-h3*i2+(T(7)/T(12))*h4*i3-(T(1)/T(4))*h5*i4);
+            Qd(0,0)=sigma2*(T(2)/T(3)*h3*inv-T(1)/T(2)*h4*i2+T(7)/T(30)*h5*i3-T(1)/T(12)*h6*i4+T(31)/T(1260)*h7*i5-T(1)/T(160)*h8*i6+T(127)/T(90720)*h9*i7);
+            Qd(0,1)=sigma2*(T(1)/T(4)*h4*inv-T(1)/T(6)*h5*i2+T(5)/T(72)*h6*i3-T(1)/T(45)*h7*i4+T(17)/T(2880)*h8*i5-T(41)/T(30240)*h9*i6);
+            Qd(0,2)=sigma2*(h2*inv-h3*i2+T(7)/T(12)*h4*i3-T(1)/T(4)*h5*i4+T(31)/T(360)*h6*i5-T(1)/T(40)*h7*i6+T(127)/T(20160)*h8*i7-T(17)/T(12096)*h9*i8);
             Qd(1,0)=Qd(0,1);
-            Qd(1,1)=sigma2*((T(1)/T(10))*h5*inv_tau);
-            Qd(1,2)=sigma2*((T(1)/T(3))*h3*inv_tau-(T(1)/T(3))*h4*i2+(T(11)/T(60))*h5*i3);
+            Qd(1,1)=sigma2*(T(1)/T(10)*h5*inv-T(1)/T(18)*h6*i2+T(5)/T(252)*h7*i3-T(1)/T(180)*h8*i4+T(17)/T(12960)*h9*i5);
+            Qd(1,2)=sigma2*(T(1)/T(3)*h3*inv-T(1)/T(3)*h4*i2+T(11)/T(60)*h5*i3-T(13)/T(180)*h6*i4+T(19)/T(840)*h7*i5-T(1)/T(168)*h8*i6+T(247)/T(181440)*h9*i7);
             Qd(2,0)=Qd(0,2); Qd(2,1)=Qd(1,2);
-            Qd(2,2)=sigma2*(T(2)*h*inv_tau-T(2)*h2*i2+(T(4)/T(3))*h3*i3-(T(2)/T(3))*h4*i4);
-            project_psd_ou_ii<T,3>(Qd, T(1e-12));
-            Qd=T(0.5)*(Qd+Qd.transpose());
+            Qd(2,2)=sigma2*(T(2)*h*inv-T(2)*h2*i2+T(4)/T(3)*h3*i3-T(2)/T(3)*h4*i4+T(4)/T(15)*h5*i5-T(4)/T(45)*h6*i6+T(8)/T(315)*h7*i7-T(2)/T(315)*h8*i8+T(4)/T(2835)*h9*i9);
+            regularize_psd_if_needed<T,3>(Qd);
             return;
         }
-        const T a=std::exp(-x), a2=a*a, qc=T(2)*sigma2*inv_tau;
+
+        const T a=std::exp(-x), a2=a*a, qc=T(2)*sigma2*inv;
         const T t2=tau_eff*tau_eff, t3=t2*tau_eff, t4=t3*tau_eff, t5=t4*tau_eff;
         const T x2=x*x, x3=x2*x;
         const T K00=t3*(-a2+T(4)*a+T(2)*x-T(3))/T(2);
@@ -322,8 +366,7 @@ struct IntegratedOUChain<T,2> {
         Qd << qc*K00,qc*K01,qc*K02,
               qc*K01,qc*K11,qc*K12,
               qc*K02,qc*K12,qc*K22;
-        project_psd_ou_ii<T,3>(Qd, T(1e-12));
-        Qd=T(0.5)*(Qd+Qd.transpose());
+        regularize_psd_if_needed<T,3>(Qd);
     }
 };
 
@@ -343,48 +386,47 @@ struct IntegratedOUChain<T,3> {
     }
 
     static void process_covariance(T tau, T h, T sigma2, MatrixAxis& Qd) {
-        const T tau_eff=std::max(tau,T(1e-7));
-        const T inv=T(1)/tau_eff;
-        const T x=h*inv;
-        if (std::abs(x)<T(1e-2)) {
-            const T i2=inv*inv,i3=i2*inv,i4=i3*inv,i5=i4*inv;
-            const T h2=h*h,h3=h2*h,h4=h3*h,h5=h4*h;
-            Qd.setZero();
-            Qd(0,0)=sigma2*((T(2)/T(3))*h3*inv-T(1)/T(2)*h4*i2+T(7)/T(30)*h5*i3);
-            Qd(0,1)=sigma2*(T(1)/T(4)*h4*inv-T(1)/T(6)*h5*i2);
-            Qd(0,2)=sigma2*(T(1)/T(15)*h5*inv);
-            Qd(0,3)=sigma2*(h2*inv-h3*i2+T(7)/T(12)*h4*i3-T(1)/T(4)*h5*i4);
-            Qd(1,0)=Qd(0,1); Qd(1,1)=sigma2*(T(1)/T(10)*h5*inv); Qd(1,2)=T(0);
-            Qd(1,3)=sigma2*(T(1)/T(3)*h3*inv-T(1)/T(3)*h4*i2+T(11)/T(60)*h5*i3);
-            Qd(2,0)=Qd(0,2); Qd(2,1)=T(0); Qd(2,2)=T(0);
-            Qd(2,3)=sigma2*(T(1)/T(12)*h4*inv-T(1)/T(12)*h5*i2);
-            Qd(3,0)=Qd(0,3); Qd(3,1)=Qd(1,3); Qd(3,2)=Qd(2,3);
-            Qd(3,3)=sigma2*(T(2)*h*inv-T(2)*h2*i2+T(4)/T(3)*h3*i3-T(2)/T(3)*h4*i4+T(4)/T(15)*h5*i5);
-            for (int i=0;i<4;++i) for (int j=0;j<4;++j) if (!std::isfinite(Qd(i,j))) Qd(i,j)=(i==j)?T(1e-18):T(0);
-            project_psd_ou_iii<T,4>(Qd,T(1e-12));
-            Qd=T(0.5)*(Qd+Qd.transpose());
-            return;
+        const T tau_eff = std::max(tau, T(1e-7));
+        const T inv = T(1) / tau_eff;
+        const T x = h * inv;
+
+        Eigen::Matrix<T,3,3> marginal;
+        IntegratedOUChain<T,2>::process_covariance(tau_eff, h, sigma2, marginal);
+        Qd.setZero();
+        const int idx[3] = {0,1,3};
+        for (int i = 0; i < 3; ++i) {
+            for (int j = 0; j < 3; ++j) Qd(idx[i],idx[j]) = marginal(i,j);
         }
-        const T a=std::exp(-x),a2=a*a,qc=T(2)*sigma2*inv;
-        const T t2=tau_eff*tau_eff,t3=t2*tau_eff,t4=t3*tau_eff,t5=t4*tau_eff,t6=t5*tau_eff,t7=t6*tau_eff;
-        const T x2=x*x,x3=x2*x,x4=x3*x,x5=x4*x;
-        const T K00=t3*(-a2+T(4)*a+T(2)*x-T(3))/T(2);
-        const T K01=t4*(a2+T(2)*a*(x-T(1))+x2-T(2)*x+T(1))/T(2);
-        const T K02=t5*(-T(3)*a2+T(3)*a*(x2+T(4))+x3-T(3)*x2+T(6)*x-T(9))/T(6);
-        const T K03=t2*(a2-T(2)*a+T(1))/T(2);
-        const T K11=t5*(-a2/T(2)-T(2)*a*x+x3/T(3)-x2+x+T(1)/T(2));
-        const T K12=t6*(a2/T(2)+a*(-x2+T(2)*x-T(2))/T(2)+x4/T(8)-x3/T(2)+x2-x+T(1)/T(2));
-        const T K13=t3*(-a2-T(2)*a*x+T(1))/T(2);
-        const T K22=t7*(-a2/T(2)+a*x2+T(2)*a+x5/T(20)-x4/T(4)+T(2)*x3/T(3)-x2+x-T(3)/T(2));
-        const T K23=t4*(a2-a*(x2+T(2))+T(1))/T(2);
-        const T K33=tau_eff*(T(1)-a2)/T(2);
-        Qd << qc*K00,qc*K01,qc*K02,qc*K03,
-              qc*K01,qc*K11,qc*K12,qc*K13,
-              qc*K02,qc*K12,qc*K22,qc*K23,
-              qc*K03,qc*K13,qc*K23,qc*K33;
-        for (int i=0;i<4;++i) for (int j=0;j<4;++j) if (!std::isfinite(Qd(i,j))) Qd(i,j)=(i==j)?T(1e-18):T(0);
-        project_psd_ou_iii<T,4>(Qd,T(1e-12));
-        Qd=T(0.5)*(Qd+Qd.transpose());
+
+        T qvS, qpS, qSS, qSa;
+        if (std::abs(x) < T(1e-2)) {
+            const T i2=inv*inv, i3=i2*inv, i4=i3*inv, i5=i4*inv, i6=i5*inv;
+            const T h2=h*h, h3=h2*h, h4=h3*h, h5=h4*h;
+            const T h6=h5*h, h7=h6*h, h8=h7*h, h9=h8*h;
+            qvS=sigma2*(T(1)/T(15)*h5*inv-T(1)/T(24)*h6*i2+T(41)/T(2520)*h7*i3-T(7)/T(1440)*h8*i4+T(109)/T(90720)*h9*i5);
+            qpS=sigma2*(T(1)/T(36)*h6*inv-T(1)/T(72)*h7*i2+T(13)/T(2880)*h8*i3-T(1)/T(864)*h9*i4);
+            qSS=sigma2*(T(1)/T(126)*h7*inv-T(1)/T(288)*h8*i2+T(13)/T(12960)*h9*i3);
+            qSa=sigma2*(T(1)/T(12)*h4*inv-T(1)/T(12)*h5*i2+T(2)/T(45)*h6*i3-T(1)/T(60)*h7*i4+T(11)/T(2240)*h8*i5-T(73)/T(60480)*h9*i6);
+        } else {
+            const T a=std::exp(-x), a2=a*a, qc=T(2)*sigma2*inv;
+            const T t4=tau_eff*tau_eff*tau_eff*tau_eff;
+            const T t5=t4*tau_eff, t6=t5*tau_eff, t7=t6*tau_eff;
+            const T x2=x*x, x3=x2*x, x4=x3*x, x5=x4*x;
+            const T K02=t5*(-T(3)*a2+T(3)*a*(x2+T(4))+x3-T(3)*x2+T(6)*x-T(9))/T(6);
+            const T K12=t6*(a2/T(2)+a*(-x2+T(2)*x-T(2))/T(2)+x4/T(8)-x3/T(2)+x2-x+T(1)/T(2));
+            const T K22=t7*(-a2/T(2)+a*x2+T(2)*a+x5/T(20)-x4/T(4)+T(2)*x3/T(3)-x2+x-T(3)/T(2));
+            const T K23=t4*(a2-a*(x2+T(2))+T(1))/T(2);
+            qvS=qc*K02;
+            qpS=qc*K12;
+            qSS=qc*K22;
+            qSa=qc*K23;
+        }
+
+        Qd(0,2)=qvS; Qd(2,0)=qvS;
+        Qd(1,2)=qpS; Qd(2,1)=qpS;
+        Qd(2,2)=qSS;
+        Qd(2,3)=qSa; Qd(3,2)=qSa;
+        regularize_psd_if_needed<T,4>(Qd);
     }
 };
 

--- a/src/kalman_ou_ii/Kalman3D_Wave_OU_II.h
+++ b/src/kalman_ou_ii/Kalman3D_Wave_OU_II.h
@@ -81,7 +81,7 @@ class Kalman3D_Wave_OU_II {
     const MeasDiag3& lastAccDiag() const noexcept { return last_acc_diag_; }
     const MeasDiag3& lastMagDiag() const noexcept { return last_mag_diag_; }
 
-    Kalman3D_Wave_OU_II(Vector3 const& sigma_a, Vector3 const& sigma_g, Vector3 const& sigma_m,
+    Kalman3D_Wave_OU_II(Vector3 const& sigma_a, Vector3 const& gyro_noise_density_rad_sqrt_s, Vector3 const& sigma_m,
                   T Pq0 = T(5e-4), T Pb0 = T(1e-6), T b0 = T(1e-11), T R_p0_noise_var = T(1.5), T R_v0_noise_var = T(0.3),
                   T gravity_magnitude = T(STD_GRAVITY));
 
@@ -188,7 +188,10 @@ class Kalman3D_Wave_OU_II {
                 Pext.template block<3,9>(OFF_BA, OFF_V).setZero();
             }
             // keep cadence sane
-            pseudo_update_counter_ = 0;
+            pseudo_update_elapsed_s_ = T(0);
+        } else if (!linear_block_enabled_ && on) {
+            reset_aw_covariance_to_stationary();
+            pseudo_update_elapsed_s_ = T(0);
         }
         linear_block_enabled_ = on;
     }
@@ -243,12 +246,19 @@ class Kalman3D_Wave_OU_II {
         tau_aw = std::max(T(1e-3), tau_seconds);
     }
 
+    void set_pseudo_update_period_s(T period_s) {
+        if (!(period_s > T(0)) || !std::isfinite(period_s)) return;
+        pseudo_update_period_s_ = std::max(T(1e-4), period_s);
+        pseudo_update_elapsed_s_ = std::fmod(pseudo_update_elapsed_s_, pseudo_update_period_s_);
+    }
+
+    [[nodiscard]] T get_pseudo_update_period_s() const { return pseudo_update_period_s_; }
+
     // OU stationary std [m/s²] for a_w (per axis)
     void set_aw_stationary_std(const Vector3& std_aw) {
-        Sigma_aw_stat = std_aw.array().square().matrix().asDiagonal();
-        has_cross_cov_a_xy = false;
-        Pext.template block<3,3>(OFF_AW, OFF_AW) = Sigma_aw_stat;  // keep consistent
-        symmetrize_Pext_();
+        const Vector3 s = std_aw.cwiseAbs();
+        Sigma_aw_stat = s.array().square().matrix().asDiagonal();
+        aw_process_correlated_ = false;
     }
 
     // Accept a full 3×3 SPD stationary covariance for a_w.
@@ -267,40 +277,34 @@ class Kalman3D_Wave_OU_II {
     //     surface moves upward (negative az), horizontal acceleration is forward.
     //   • Positive rho_corr fits ENU (z up).
     //   • The resulting covariance is projected to SPD for numerical stability.
-    //   • Also reseeds Pext(OFF_AW, OFF_AW) to keep filter covariance consistent.
     void set_aw_stationary_corr_std(const Vector3& std_aw, T rho_xz_corr = T(-0.65), T rho_yz_corr = T(-0.65)) {
-        // Clamp correlation for numerical safety
         rho_xz_corr = std::max(T(-0.999), std::min(rho_xz_corr, T(0.999)));
         rho_yz_corr = std::max(T(-0.999), std::min(rho_yz_corr, T(0.999)));
 
-        const T sx = std::max(T(1e-9), std_aw.x());
-        const T sy = std::max(T(1e-9), std_aw.y());
-        const T sz = std::max(T(1e-9), std_aw.z());
+        const T sx = std::max(T(1e-9), std::abs(std_aw.x()));
+        const T sy = std::max(T(1e-9), std::abs(std_aw.y()));
+        const T sz = std::max(T(1e-9), std::abs(std_aw.z()));
 
-        // Construct correlated covariance (symmetric)
         Matrix3 S;
         S <<
-            sx*sx,  T(0),             rho_xz_corr*sx*sz,
-            T(0),   sy*sy,            rho_yz_corr*sy*sz,
+            sx*sx, T(0), rho_xz_corr*sx*sz,
+            T(0), sy*sy, rho_yz_corr*sy*sz,
             rho_xz_corr*sx*sz, rho_yz_corr*sy*sz, sz*sz;
-
-        // Symmetrize & project to SPD for robustness
         S = T(0.5) * (S + S.transpose());
-        ocean_imu::kalman::ou_detail::project_psd_ou_ii<T,3>(S, T(1e-12));
+        ocean_imu::kalman::ou_detail::regularize_psd_if_needed<T,3>(S);
         Sigma_aw_stat = S;
+        aw_process_correlated_ = true;
+    }
 
-        // Reseed Pext a_w block with new stationary covariance
-        if (!has_cross_cov_a_xy) {
-            Pext.template block<3,3>(OFF_AW, OFF_AW) = Sigma_aw_stat;
-        } else {
-            // Otherwise, softly merge (blend) to avoid discontinuity
-            Pext.template block<3,3>(OFF_AW, OFF_AW) =
-                T(0.8) * Pext.template block<3,3>(OFF_AW, OFF_AW)
-              + T(0.2) * Sigma_aw_stat;
+    void reset_aw_covariance_to_stationary() {
+        for (int i = 0; i < NX; ++i) {
+            if (i < OFF_AW || i >= OFF_AW + 3) {
+                Pext.template block<3,1>(OFF_AW, i).setZero();
+                Pext.template block<1,3>(i, OFF_AW).setZero();
+            }
         }
-        // keep global symmetry
+        Pext.template block<3,3>(OFF_AW, OFF_AW) = Sigma_aw_stat;
         symmetrize_Pext_();
-        has_cross_cov_a_xy = true;
     }
 
     // Covariances for periodic position-zero pseudo-measurement from std dev
@@ -383,6 +387,17 @@ class Kalman3D_Wave_OU_II {
     // Set accelerometer bias temperature coefficient k_a  [m/s^2 per °C] per axis.
     // Model: b_a(tempC) = b_a0 + k_a * (tempC - tempC_ref)
     void set_accel_bias_temp_coeff(const Vector3& ka_per_degC) { k_a_ = ka_per_degC; }
+
+    void set_gyro_noise_density_rad_sqrt_s(const Vector3& density) {
+        const Vector3 d = density.cwiseAbs();
+        Qbase.template topLeftCorner<3,3>() = d.array().square().matrix().asDiagonal();
+    }
+
+    [[nodiscard]] static Vector3 gyro_noise_density_from_sample_std(
+        const Vector3& sample_std_rad_s, T sample_period_s) {
+        if (!(sample_period_s > T(0)) || !std::isfinite(sample_period_s)) return Vector3::Zero();
+        return (sample_std_rad_s.cwiseAbs() * std::sqrt(sample_period_s)).eval();
+    }
 
     // Toggle exact/structured Qd for the attitude+gyro-bias block.
     void set_exact_att_bias_Qd(bool on) { use_exact_att_bias_Qd_ = on; }
@@ -551,13 +566,13 @@ class Kalman3D_Wave_OU_II {
     T tau_aw = T(2.1);            // correlation time [s], tune 1–3.5 s for sea states
     Matrix3 Sigma_aw_stat = Matrix3::Identity() * T(2.2*2.2); // stationary covariance of a_w [ (m/s^2)^2 ]
 
-    int pseudo_update_counter_ = 0;   // counts time_update calls
-    static constexpr int PSEUDO_UPDATE_PERIOD = 3; // every N-th update
+    T pseudo_update_elapsed_s_ = T(0);
+    T pseudo_update_period_s_ = T(0.015);
 
     bool linear_block_enabled_ = true;
     bool acc_bias_updates_enabled_ = true;
 
-    bool has_cross_cov_a_xy = false;
+    bool aw_process_correlated_ = false;
     bool use_exact_att_bias_Qd_ = true;
 
     // IMU lever-arm (off-CoG) support
@@ -685,7 +700,7 @@ class Kalman3D_Wave_OU_II {
     Matrix3 skew_symmetric_matrix(const Eigen::Ref<const Vector3>& vec) const;
     Vector3 accelerometer_measurement_func(T tempC) const;
 
-    static MatrixBaseN initialize_Q(Vector3 sigma_g, T b0);
+    static MatrixBaseN initialize_Q(Vector3 gyro_noise_density_rad_sqrt_s, T b0);
 
     // Inject the current local attitude-error state into qref, then clear the attitude-error slot in xext.
     void applyQuaternionCorrectionFromErrorState();
@@ -1040,12 +1055,12 @@ class Kalman3D_Wave_OU_II {
 template <typename T, bool with_gyro_bias, bool with_accel_bias>
 Kalman3D_Wave_OU_II<T, with_gyro_bias, with_accel_bias>::Kalman3D_Wave_OU_II(
     Vector3 const& sigma_a,
-    Vector3 const& sigma_g,
+    Vector3 const& gyro_noise_density_rad_sqrt_s,
     Vector3 const& sigma_m,
     T Pq0, T Pb0, T b0, T R_p0_noise_var, T R_v0_noise_var, T gravity_magnitude)
   : gravity_magnitude_(gravity_magnitude),
     Rmag(sigma_m.array().square().matrix().asDiagonal()),
-    Qbase(initialize_Q(sigma_g, b0)),
+    Qbase(initialize_Q(gyro_noise_density_rad_sqrt_s, b0)),
     Racc(sigma_a.array().square().matrix().asDiagonal())
 {
     qref.setIdentity();  // quaternion init
@@ -1133,13 +1148,13 @@ Kalman3D_Wave_OU_II<T, with_gyro_bias, with_accel_bias>::Kalman3D_Wave_OU_II(
 template<typename T, bool with_gyro_bias, bool with_accel_bias>
 typename Kalman3D_Wave_OU_II<T, with_gyro_bias, with_accel_bias>::MatrixBaseN
 Kalman3D_Wave_OU_II<T, with_gyro_bias, with_accel_bias>::initialize_Q(
-              typename Kalman3D_Wave_OU_II<T, with_gyro_bias, with_accel_bias>::Vector3 sigma_g, T b0) {
+              typename Kalman3D_Wave_OU_II<T, with_gyro_bias, with_accel_bias>::Vector3 gyro_noise_density_rad_sqrt_s, T b0) {
     MatrixBaseN Q; Q.setZero();
     if constexpr (with_gyro_bias) {
-        Q.template topLeftCorner<3,3>() = sigma_g.array().square().matrix().asDiagonal(); // gyro noise covariance driving attitude error
+        Q.template topLeftCorner<3,3>() = gyro_noise_density_rad_sqrt_s.array().square().matrix().asDiagonal(); // gyro noise covariance driving attitude error
         Q.template bottomRightCorner<3,3>() = Matrix3::Identity() * b0;                   // bias RW
     } else {
-        Q = sigma_g.array().square().matrix().asDiagonal();
+        Q = gyro_noise_density_rad_sqrt_s.array().square().matrix().asDiagonal();
     }
     return Q;
 }
@@ -1147,23 +1162,15 @@ Kalman3D_Wave_OU_II<T, with_gyro_bias, with_accel_bias>::initialize_Q(
 template <typename T, bool with_gyro_bias, bool with_accel_bias>
 void Kalman3D_Wave_OU_II<T, with_gyro_bias, with_accel_bias>::set_aw_stationary_cov_full(const Matrix3& Sigma_in)
 {
-    // Symmetrize + very light SPD projection
     Matrix3 S = T(0.5) * (Sigma_in + Sigma_in.transpose());
-    Eigen::SelfAdjointEigenSolver<Matrix3> es(S);
-    if (es.info() == Eigen::Success) {
-        auto d = es.eigenvalues().cwiseMax(T(1e-12));
-        Sigma_aw_stat = es.eigenvectors() * d.asDiagonal() * es.eigenvectors().transpose();
-    } else {
-        // Fallback: keep only diagonal, clamp to tiny+
-        Matrix3 D = S.diagonal().cwiseMax(T(1e-12)).asDiagonal();
-        Sigma_aw_stat = D;
-    }
-    // Reseed/merge Pext a_w block
-    Pext.template block<3,3>(OFF_AW, OFF_AW) =
-          T(0.2) * Pext.template block<3,3>(OFF_AW, OFF_AW)
-        + T(0.8) * Sigma_aw_stat;
-    symmetrize_Pext_();
-    has_cross_cov_a_xy = true;
+    ocean_imu::kalman::ou_detail::regularize_psd_if_needed<T,3>(S);
+    Sigma_aw_stat = S;
+
+    Matrix3 off = S;
+    off.diagonal().setZero();
+    const T scale = std::max(T(1), S.cwiseAbs().maxCoeff());
+    aw_process_correlated_ = off.cwiseAbs().maxCoeff()
+        > T(64) * std::numeric_limits<T>::epsilon() * scale;
 }
 
 // Initialization from accelerometer + magnetometer
@@ -1589,7 +1596,7 @@ void Kalman3D_Wave_OU_II<T, with_gyro_bias, with_accel_bias>::time_update(
         }
 
         // Build Q_LL
-        if (has_cross_cov_a_xy) {
+        if (aw_process_correlated_) {
             // Correlated vector-OU with shared tau: Q_LL = (Σ ⊗ Qaxis_unit)
             // written directly in group-first order: [v(3), p(3), a(3)].
             Eigen::Matrix<T,3,3> Qaxis_unit;
@@ -1609,7 +1616,6 @@ void Kalman3D_Wave_OU_II<T, with_gyro_bias, with_accel_bias>::time_update(
                 }
             }
             Q_LL = T(0.5) * (Q_LL + Q_LL.transpose());
-            ocean_imu::kalman::ou_detail::project_psd_ou_ii<T,9>(Q_LL, T(1e-12));
         } else {
             // Independent axes (no cross-correlation) — per-axis Qd on the diagonal
             const int idx[3] = {0,3,6};
@@ -1680,25 +1686,22 @@ void Kalman3D_Wave_OU_II<T, with_gyro_bias, with_accel_bias>::time_update(
 
     symmetrize_Pext_();   // Symmetry hygiene
 
-    // Periodic position-zero + velocity-zero pseudo-measurement drift correction
-    if (linear_block_enabled_) {
-        if (++pseudo_update_counter_ >= PSEUDO_UPDATE_PERIOD) {
-            Vector3 sigma_p0;
-            sigma_p0.x() = std::sqrt(std::max(T(0), R_p0(0,0)));
-            sigma_p0.y() = std::sqrt(std::max(T(0), R_p0(1,1)));
-            sigma_p0.z() = std::sqrt(std::max(T(0), R_p0(2,2)));
+    if (linear_block_enabled_ &&
+        ocean_imu::kalman::ou_detail::periodic_update_due(Ts, pseudo_update_period_s_, pseudo_update_elapsed_s_)) {
+        Vector3 sigma_p0;
+        sigma_p0.x() = std::sqrt(std::max(T(0), R_p0(0,0)));
+        sigma_p0.y() = std::sqrt(std::max(T(0), R_p0(1,1)));
+        sigma_p0.z() = std::sqrt(std::max(T(0), R_p0(2,2)));
 
-            Vector3 sigma_v0;
-            sigma_v0.x() = std::sqrt(std::max(T(0), R_v0(0,0)));
-            sigma_v0.y() = std::sqrt(std::max(T(0), R_v0(1,1)));
-            sigma_v0.z() = std::sqrt(std::max(T(0), R_v0(2,2)));
+        Vector3 sigma_v0;
+        sigma_v0.x() = std::sqrt(std::max(T(0), R_v0(0,0)));
+        sigma_v0.y() = std::sqrt(std::max(T(0), R_v0(1,1)));
+        sigma_v0.z() = std::sqrt(std::max(T(0), R_v0(2,2)));
 
-            measurement_update_position_pseudo(Vector3::Zero(), sigma_p0);
-            measurement_update_velocity_pseudo(Vector3::Zero(), sigma_v0);
-            pseudo_update_counter_ = 0;
-        }
-    } else {
-        pseudo_update_counter_ = 0;
+        measurement_update_position_pseudo(Vector3::Zero(), sigma_p0);
+        measurement_update_velocity_pseudo(Vector3::Zero(), sigma_v0);
+    } else if (!linear_block_enabled_) {
+        pseudo_update_elapsed_s_ = T(0);
     }
 }
 

--- a/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
+++ b/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
@@ -694,6 +694,7 @@ private:
         startup_stage_t_ = 0.0f;
 
         if (!mekf_) return;
+        apply_ou_tune_();
         mekf_->set_linear_block_enabled(enable_linear_block_);
 
         if (freeze_acc_bias_until_live_) {
@@ -713,7 +714,6 @@ private:
             }
         }
 
-        apply_ou_tune_();
         if (enable_linear_block_) {
             apply_R_p0_tune_();
             apply_R_v0_tune_();

--- a/src/kalman_ou_iii/Kalman3D_Wave_OU_III.h
+++ b/src/kalman_ou_iii/Kalman3D_Wave_OU_III.h
@@ -83,7 +83,7 @@ class Kalman3D_Wave_OU_III {
     const MeasDiag3& lastMagDiag() const noexcept { return last_mag_diag_; }
 
     // Constructor signatures preserved, additional defaults for linear process noise
-    Kalman3D_Wave_OU_III(Vector3 const& sigma_a, Vector3 const& sigma_g, Vector3 const& sigma_m,
+    Kalman3D_Wave_OU_III(Vector3 const& sigma_a, Vector3 const& gyro_noise_density_rad_sqrt_s, Vector3 const& sigma_m,
                   T Pq0 = T(5e-4), T Pb0 = T(1e-6), T b0 = T(1e-11), T R_S_noise_var = T(1.5),
                   T gravity_magnitude = T(STD_GRAVITY));
 
@@ -192,7 +192,10 @@ class Kalman3D_Wave_OU_III {
                 Pext.template block<3,12>(OFF_BA, OFF_V).setZero();
             }
             // keep cadence sane
-            pseudo_update_counter_ = 0;
+            pseudo_update_elapsed_s_ = T(0);
+        } else if (!linear_block_enabled_ && on) {
+            reset_aw_covariance_to_stationary();
+            pseudo_update_elapsed_s_ = T(0);
         }
         linear_block_enabled_ = on;
     }
@@ -253,13 +256,20 @@ class Kalman3D_Wave_OU_III {
 	    tau_aw = std::max(T(1e-3), tau_seconds);
 	}
 
+    void set_pseudo_update_period_s(T period_s) {
+        if (!(period_s > T(0)) || !std::isfinite(period_s)) return;
+        pseudo_update_period_s_ = std::max(T(1e-4), period_s);
+        pseudo_update_elapsed_s_ = std::fmod(pseudo_update_elapsed_s_, pseudo_update_period_s_);
+    }
+
+    [[nodiscard]] T get_pseudo_update_period_s() const { return pseudo_update_period_s_; }
+
     // OU stationary std [m/s²] for a_w (per axis)
     void set_aw_stationary_std(const Vector3& std_aw) {
-        Sigma_aw_stat = std_aw.array().square().matrix().asDiagonal();
-        has_cross_cov_a_xy = false;
-	    Pext.template block<3,3>(OFF_AW, OFF_AW) = Sigma_aw_stat;  // keep consistent
-	    symmetrize_Pext_();
-	}
+        const Vector3 s = std_aw.cwiseAbs();
+        Sigma_aw_stat = s.array().square().matrix().asDiagonal();
+        aw_process_correlated_ = false;
+    }
 
     // Accept a full 3×3 SPD stationary covariance for a_w.
     void set_aw_stationary_cov_full(const Matrix3& Sigma);
@@ -277,40 +287,34 @@ class Kalman3D_Wave_OU_III {
     //     surface moves upward (negative az), horizontal acceleration is forward.
     //   • Positive rho_corr fits ENU (z up).
     //   • The resulting covariance is projected to SPD for numerical stability.
-    //   • Also reseeds Pext(OFF_AW, OFF_AW) to keep filter covariance consistent.
     void set_aw_stationary_corr_std(const Vector3& std_aw, T rho_xz_corr = T(-0.65), T rho_yz_corr = T(-0.65)) {
-        // Clamp correlation for numerical safety
         rho_xz_corr = std::max(T(-0.999), std::min(rho_xz_corr, T(0.999)));
         rho_yz_corr = std::max(T(-0.999), std::min(rho_yz_corr, T(0.999)));
 
-        const T sx = std::max(T(1e-9), std_aw.x());
-        const T sy = std::max(T(1e-9), std_aw.y());
-        const T sz = std::max(T(1e-9), std_aw.z());
+        const T sx = std::max(T(1e-9), std::abs(std_aw.x()));
+        const T sy = std::max(T(1e-9), std::abs(std_aw.y()));
+        const T sz = std::max(T(1e-9), std::abs(std_aw.z()));
 
-        // Construct correlated covariance (symmetric)
         Matrix3 S;
         S <<
-            sx*sx,  T(0),             rho_xz_corr*sx*sz,
-            T(0),   sy*sy,            rho_yz_corr*sy*sz,
+            sx*sx, T(0), rho_xz_corr*sx*sz,
+            T(0), sy*sy, rho_yz_corr*sy*sz,
             rho_xz_corr*sx*sz, rho_yz_corr*sy*sz, sz*sz;
-
-        // Symmetrize & project to SPD for robustness
         S = T(0.5) * (S + S.transpose());
-        ocean_imu::kalman::ou_detail::project_psd_ou_iii<T,3>(S, T(1e-12));
+        ocean_imu::kalman::ou_detail::regularize_psd_if_needed<T,3>(S);
         Sigma_aw_stat = S;
+        aw_process_correlated_ = true;
+    }
 
-        // Reseed Pext a_w block with new stationary covariance
-        if (!has_cross_cov_a_xy) {
-            Pext.template block<3,3>(OFF_AW, OFF_AW) = Sigma_aw_stat;
-        } else {
-            // Otherwise, softly merge (blend) to avoid discontinuity
-            Pext.template block<3,3>(OFF_AW, OFF_AW) =
-                T(0.8) * Pext.template block<3,3>(OFF_AW, OFF_AW)
-              + T(0.2) * Sigma_aw_stat;
+    void reset_aw_covariance_to_stationary() {
+        for (int i = 0; i < NX; ++i) {
+            if (i < OFF_AW || i >= OFF_AW + 3) {
+                Pext.template block<3,1>(OFF_AW, i).setZero();
+                Pext.template block<1,3>(i, OFF_AW).setZero();
+            }
         }
-        // keep global symmetry
+        Pext.template block<3,3>(OFF_AW, OFF_AW) = Sigma_aw_stat;
         symmetrize_Pext_();
-        has_cross_cov_a_xy = true;
     }
 
     // Covariances for ∫p dt pseudo-measurement
@@ -372,6 +376,17 @@ class Kalman3D_Wave_OU_III {
     // Set accelerometer bias temperature coefficient k_a  [m/s^2 per °C] per axis.
     // Model: b_a(tempC) = b_a0 + k_a * (tempC - tempC_ref)
     void set_accel_bias_temp_coeff(const Vector3& ka_per_degC) { k_a_ = ka_per_degC; }
+
+    void set_gyro_noise_density_rad_sqrt_s(const Vector3& density) {
+        const Vector3 d = density.cwiseAbs();
+        Qbase.template topLeftCorner<3,3>() = d.array().square().matrix().asDiagonal();
+    }
+
+    [[nodiscard]] static Vector3 gyro_noise_density_from_sample_std(
+        const Vector3& sample_std_rad_s, T sample_period_s) {
+        if (!(sample_period_s > T(0)) || !std::isfinite(sample_period_s)) return Vector3::Zero();
+        return (sample_std_rad_s.cwiseAbs() * std::sqrt(sample_period_s)).eval();
+    }
 
     // Toggle exact/structured Qd for the attitude+gyro-bias block.
     void set_exact_att_bias_Qd(bool on) { use_exact_att_bias_Qd_ = on; }
@@ -495,13 +510,13 @@ class Kalman3D_Wave_OU_III {
     T tau_aw = T(2.1);            // correlation time [s], tune 1–3.5 s for sea states
     Matrix3 Sigma_aw_stat = Matrix3::Identity() * T(2.2*2.2); // stationary variance diag [ (m/s^2)^2 ]
 
-    int pseudo_update_counter_ = 0;   // counts time_update calls
-    static constexpr int PSEUDO_UPDATE_PERIOD = 3; // every N-th update
+    T pseudo_update_elapsed_s_ = T(0);
+    T pseudo_update_period_s_ = T(0.015);
 
     bool linear_block_enabled_ = true;
     bool acc_bias_updates_enabled_ = true;
 
-    bool has_cross_cov_a_xy = false;
+    bool aw_process_correlated_ = false;
     bool use_exact_att_bias_Qd_ = true;
 
     // IMU lever-arm (off-CoG) support
@@ -629,7 +644,7 @@ class Kalman3D_Wave_OU_III {
     Matrix3 skew_symmetric_matrix(const Eigen::Ref<const Vector3>& vec) const;
 	Vector3 accelerometer_measurement_func(T tempC) const;
 
-    static MatrixBaseN initialize_Q(Vector3 sigma_g, T b0);
+    static MatrixBaseN initialize_Q(Vector3 gyro_noise_density_rad_sqrt_s, T b0);
 
     // Quaternion & small-angle helpers (kept)
     void applyQuaternionCorrectionFromErrorState(); // apply correction to qref using xext(0..2)
@@ -983,12 +998,12 @@ class Kalman3D_Wave_OU_III {
 template <typename T, bool with_gyro_bias, bool with_accel_bias>
 Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::Kalman3D_Wave_OU_III(
     Vector3 const& sigma_a,
-    Vector3 const& sigma_g,
+    Vector3 const& gyro_noise_density_rad_sqrt_s,
     Vector3 const& sigma_m,
     T Pq0, T Pb0, T b0, T R_S_noise_var, T gravity_magnitude)
   : gravity_magnitude_(gravity_magnitude),
     Rmag(sigma_m.array().square().matrix().asDiagonal()),
-    Qbase(initialize_Q(sigma_g, b0)),
+    Qbase(initialize_Q(gyro_noise_density_rad_sqrt_s, b0)),
     Racc(sigma_a.array().square().matrix().asDiagonal())
 {
     qref.setIdentity();  // quaternion init
@@ -1068,13 +1083,13 @@ Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::Kalman3D_Wave_OU_III(
 template<typename T, bool with_gyro_bias, bool with_accel_bias>
 typename Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::MatrixBaseN
 Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::initialize_Q(
-              typename Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::Vector3 sigma_g, T b0) {
+              typename Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::Vector3 gyro_noise_density_rad_sqrt_s, T b0) {
     MatrixBaseN Q; Q.setZero();
     if constexpr (with_gyro_bias) {
-        Q.template topLeftCorner<3,3>() = sigma_g.array().square().matrix().asDiagonal(); // gyro RW
+        Q.template topLeftCorner<3,3>() = gyro_noise_density_rad_sqrt_s.array().square().matrix().asDiagonal(); // gyro RW
         Q.template bottomRightCorner<3,3>() = Matrix3::Identity() * b0;                   // bias RW
     } else {
-        Q = sigma_g.array().square().matrix().asDiagonal();
+        Q = gyro_noise_density_rad_sqrt_s.array().square().matrix().asDiagonal();
     }
     return Q;
 }
@@ -1082,23 +1097,15 @@ Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::initialize_Q(
 template <typename T, bool with_gyro_bias, bool with_accel_bias>
 void Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::set_aw_stationary_cov_full(const Matrix3& Sigma_in)
 {
-    // Symmetrize + very light SPD projection
     Matrix3 S = T(0.5) * (Sigma_in + Sigma_in.transpose());
-    Eigen::SelfAdjointEigenSolver<Matrix3> es(S);
-    if (es.info() == Eigen::Success) {
-        auto d = es.eigenvalues().cwiseMax(T(1e-12));
-        Sigma_aw_stat = es.eigenvectors() * d.asDiagonal() * es.eigenvectors().transpose();
-    } else {
-        // Fallback: keep only diagonal, clamp to tiny+
-        Matrix3 D = S.diagonal().cwiseMax(T(1e-12)).asDiagonal();
-        Sigma_aw_stat = D;
-    }
-    // Reseed/merge Pext a_w block
-    Pext.template block<3,3>(OFF_AW, OFF_AW) =
-          T(0.2) * Pext.template block<3,3>(OFF_AW, OFF_AW)
-        + T(0.8) * Sigma_aw_stat;
-    symmetrize_Pext_();
-    has_cross_cov_a_xy = true;
+    ocean_imu::kalman::ou_detail::regularize_psd_if_needed<T,3>(S);
+    Sigma_aw_stat = S;
+
+    Matrix3 off = S;
+    off.diagonal().setZero();
+    const T scale = std::max(T(1), S.cwiseAbs().maxCoeff());
+    aw_process_correlated_ = off.cwiseAbs().maxCoeff()
+        > T(64) * std::numeric_limits<T>::epsilon() * scale;
 }
 
 // Initialization from accelerometer + magnetometer
@@ -1528,7 +1535,7 @@ void Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::time_update(
                     F_LL(idx[i] + axis, idx[j] + axis) = Phi_axis(i,j);
         }
         // Build Q_LL
-        if (has_cross_cov_a_xy) {
+        if (aw_process_correlated_) {
             // Correlated vector-OU with shared tau: Q_LL = (Σ ⊗ Qaxis_unit)
             // written directly in group-first order: [v(3), p(3), S(3), a(3)].
             Eigen::Matrix<T,4,4> Qaxis_unit;
@@ -1551,7 +1558,6 @@ void Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::time_update(
             }
             // Symmetry + PSD cleanup
             Q_LL = T(0.5) * (Q_LL + Q_LL.transpose());
-            ocean_imu::kalman::ou_detail::project_psd_ou_iii<T,12>(Q_LL, T(1e-12));
         } else {
             // Independent axes (no cross-correlation) — per-axis Qd on the diagonal
             const int idx[4] = {0,3,6,9};
@@ -1681,14 +1687,11 @@ void Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::time_update(
 
     symmetrize_Pext_();   // Symmetry hygiene
 
-    // Integral pseudo-measurement drift correction (only if linear block is live)
-    if (linear_block_enabled_) {
-        if (++pseudo_update_counter_ >= PSEUDO_UPDATE_PERIOD) {
-            applyIntegralZeroPseudoMeas();
-            pseudo_update_counter_ = 0;
-        }
-    } else {
-        pseudo_update_counter_ = 0;   // avoid weird cadence when re-enabling
+    if (linear_block_enabled_ &&
+        ocean_imu::kalman::ou_detail::periodic_update_due(Ts, pseudo_update_period_s_, pseudo_update_elapsed_s_)) {
+        applyIntegralZeroPseudoMeas();
+    } else if (!linear_block_enabled_) {
+        pseudo_update_elapsed_s_ = T(0);
     }
 }
 

--- a/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
+++ b/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
@@ -673,6 +673,7 @@ private:
         startup_stage_t_ = 0.0f;
 
         if (!mekf_) return;
+        apply_ou_tune_();
         mekf_->set_linear_block_enabled(enable_linear_block_);
 
         if (freeze_acc_bias_until_live_) {
@@ -688,7 +689,6 @@ private:
             warmup_Racc_active_ = false;
         }
 
-        apply_ou_tune_();
         if (enable_linear_block_) apply_RS_tune_();
     }
 

--- a/tests/kalman_ou_iii/kalman_ou_common-test.cpp
+++ b/tests/kalman_ou_iii/kalman_ou_common-test.cpp
@@ -4,67 +4,190 @@
 #include "kalman_ou_ii/Kalman3D_Wave_OU_II.h"
 #include "kalman_ou_iii/Kalman3D_Wave_OU_III.h"
 
+#include <unsupported/Eigen/MatrixFunctions>
+
+#include <array>
 #include <cmath>
 #include <iostream>
 
 namespace detail = ocean_imu::kalman::ou_detail;
 
-int main() {
-    using T = double;
-    using Matrix3 = Eigen::Matrix<T,3,3>;
-    using Matrix4 = Eigen::Matrix<T,4,4>;
-    using Vector3 = Eigen::Matrix<T,3,1>;
+namespace {
 
-    constexpr T tau = 1.7;
-    constexpr T dt = 0.005;
-    constexpr T sigma2 = 0.83;
+using T = double;
+using Matrix3 = Eigen::Matrix<T,3,3>;
+using Matrix4 = Eigen::Matrix<T,4,4>;
+using Vector3 = Eigen::Matrix<T,3,1>;
 
-    Matrix3 phi2, q2;
-    Matrix4 phi3, q3;
-    detail::IntegratedOUChain<T,2>::transition(tau, dt, phi2);
-    detail::IntegratedOUChain<T,2>::process_covariance(tau, dt, sigma2, q2);
-    detail::IntegratedOUChain<T,3>::transition(tau, dt, phi3);
-    detail::IntegratedOUChain<T,3>::process_covariance(tau, dt, sigma2, q3);
+bool check(bool condition, const char* message) {
+    if (!condition) std::cerr << message << '\n';
+    return condition;
+}
 
-    const int idx3[3] = {0, 1, 3};
-    T max_phi_error = T(0);
-    T max_q_error = T(0);
-    for (int i = 0; i < 3; ++i) {
-        for (int j = 0; j < 3; ++j) {
-            max_phi_error = std::max(max_phi_error, std::abs(phi2(i,j) - phi3(idx3[i], idx3[j])));
-            max_q_error = std::max(max_q_error, std::abs(q2(i,j) - q3(idx3[i], idx3[j])));
+template<int N>
+Eigen::Matrix<T,N,N> van_loan_q(T tau, T dt, T sigma2) {
+    Eigen::Matrix<T,N,N> F = Eigen::Matrix<T,N,N>::Zero();
+    F(0,N-1) = T(1);
+    F(1,0) = T(1);
+    if constexpr (N == 4) F(2,1) = T(1);
+    F(N-1,N-1) = -T(1) / tau;
+
+    Eigen::Matrix<T,N,N> Qc = Eigen::Matrix<T,N,N>::Zero();
+    Qc(N-1,N-1) = T(2) * sigma2 / tau;
+
+    Eigen::Matrix<T,2*N,2*N> A = Eigen::Matrix<T,2*N,2*N>::Zero();
+    A.template topLeftCorner<N,N>() = F;
+    A.template topRightCorner<N,N>() = Qc;
+    A.template bottomRightCorner<N,N>() = -F.transpose();
+    const Eigen::Matrix<T,2*N,2*N> E = (A * dt).exp();
+    const Eigen::Matrix<T,N,N> Phi = E.template topLeftCorner<N,N>();
+    return E.template topRightCorner<N,N>() * Phi.transpose();
+}
+
+bool test_ou_covariance() {
+    const std::array<T,4> taus = {T(0.05), T(0.5), T(2.1), T(10)};
+    const std::array<T,6> ratios = {T(1e-5), T(1e-3), T(0.0099), T(0.0101), T(0.1), T(0.8)};
+    const int map[3] = {0,1,3};
+
+    for (T tau : taus) {
+        for (T ratio : ratios) {
+            const T dt = tau * ratio;
+            const T sigma2 = T(0.83);
+            Matrix3 q2;
+            Matrix4 q3;
+            detail::IntegratedOUChain<T,2>::process_covariance(tau, dt, sigma2, q2);
+            detail::IntegratedOUChain<T,3>::process_covariance(tau, dt, sigma2, q3);
+            const Matrix3 ref2 = van_loan_q<3>(tau, dt, sigma2);
+            const Matrix4 ref3 = van_loan_q<4>(tau, dt, sigma2);
+            const T scale2 = std::max(T(1), ref2.cwiseAbs().maxCoeff());
+            const T scale3 = std::max(T(1), ref3.cwiseAbs().maxCoeff());
+            if (!check((q2-ref2).cwiseAbs().maxCoeff() <= T(5e-10)*scale2, "OU-II Qd mismatch")) return false;
+            if (!check((q3-ref3).cwiseAbs().maxCoeff() <= T(5e-10)*scale3, "OU-III Qd mismatch")) return false;
+            for (int i=0; i<3; ++i) {
+                for (int j=0; j<3; ++j) {
+                    if (!check(std::abs(q2(i,j)-q3(map[i],map[j])) <= T(2e-13)*scale2,
+                               "OU-II/OU-III marginal mismatch")) return false;
+                }
+            }
+            Eigen::SelfAdjointEigenSolver<Matrix3> e2(q2);
+            Eigen::SelfAdjointEigenSolver<Matrix4> e3(q3);
+            if (!check(e2.eigenvalues().minCoeff() >= -T(1e-12)*scale2, "OU-II Qd is not PSD")) return false;
+            if (!check(e3.eigenvalues().minCoeff() >= -T(1e-12)*scale3, "OU-III Qd is not PSD")) return false;
         }
     }
-    if (max_phi_error > T(1e-14) || max_q_error > T(1e-10)) {
-        std::cerr << "OU-II/OU-III marginal mismatch: phi=" << max_phi_error
-                  << " q=" << max_q_error << '\n';
-        return 1;
+    return true;
+}
+
+template<typename Filter>
+bool covariance_unchanged(Filter& filter, const Vector3& std_aw) {
+    const auto before = filter.covariance_full();
+    filter.set_aw_stationary_std(std_aw);
+    return (filter.covariance_full() - before).cwiseAbs().maxCoeff() == T(0);
+}
+
+bool test_stationary_setters() {
+    const Vector3 sigma_a = Vector3::Constant(T(0.02));
+    const Vector3 gyro_density = Vector3::Constant(T(0.001));
+    const Vector3 sigma_m = Vector3::Constant(T(0.5));
+    const Vector3 zero = Vector3::Zero();
+    const Vector3 std_aw(T(0.4), T(0.5), T(0.6));
+    Matrix3 full;
+    full << T(0.20), T(0.02), T(-0.01),
+            T(0.02), T(0.30), T(0.015),
+            T(-0.01), T(0.015), T(0.40);
+
+    Kalman3D_Wave_OU_II<T> ou2(sigma_a, gyro_density, sigma_m);
+    Kalman3D_Wave_OU_III<T> ou3(sigma_a, gyro_density, sigma_m);
+    for (int i=0; i<8; ++i) {
+        ou2.time_update(zero, T(0.005));
+        ou3.time_update(zero, T(0.005));
     }
 
+    if (!check(covariance_unchanged(ou2, std_aw), "OU-II std setter changed posterior covariance")) return false;
+    if (!check(covariance_unchanged(ou3, std_aw), "OU-III std setter changed posterior covariance")) return false;
+
+    auto p2 = ou2.covariance_full();
+    auto p3 = ou3.covariance_full();
+    ou2.set_aw_stationary_corr_std(std_aw, T(-0.2), T(0.15));
+    ou3.set_aw_stationary_corr_std(std_aw, T(-0.2), T(0.15));
+    if (!check((ou2.covariance_full()-p2).cwiseAbs().maxCoeff() == T(0), "OU-II corr setter changed posterior covariance")) return false;
+    if (!check((ou3.covariance_full()-p3).cwiseAbs().maxCoeff() == T(0), "OU-III corr setter changed posterior covariance")) return false;
+
+    p2 = ou2.covariance_full();
+    p3 = ou3.covariance_full();
+    ou2.set_aw_stationary_cov_full(full);
+    ou3.set_aw_stationary_cov_full(full);
+    if (!check((ou2.covariance_full()-p2).cwiseAbs().maxCoeff() == T(0), "OU-II full setter changed posterior covariance")) return false;
+    if (!check((ou3.covariance_full()-p3).cwiseAbs().maxCoeff() == T(0), "OU-III full setter changed posterior covariance")) return false;
+
+    ou2.reset_aw_covariance_to_stationary();
+    ou3.reset_aw_covariance_to_stationary();
+    const auto reset2 = ou2.covariance_full();
+    const auto reset3 = ou3.covariance_full();
+    constexpr int aw2 = 12;
+    constexpr int aw3 = 15;
+    if (!check((reset2.template block<3,3>(aw2,aw2)-full).cwiseAbs().maxCoeff() < T(1e-13), "OU-II reset covariance mismatch")) return false;
+    if (!check((reset3.template block<3,3>(aw3,aw3)-full).cwiseAbs().maxCoeff() < T(1e-13), "OU-III reset covariance mismatch")) return false;
+    for (int i=0; i<reset2.rows(); ++i) {
+        if (i < aw2 || i >= aw2+3) {
+            if (!check(reset2.template block<1,3>(i,aw2).cwiseAbs().maxCoeff() == T(0), "OU-II reset retained cross covariance")) return false;
+        }
+    }
+    for (int i=0; i<reset3.rows(); ++i) {
+        if (i < aw3 || i >= aw3+3) {
+            if (!check(reset3.template block<1,3>(i,aw3).cwiseAbs().maxCoeff() == T(0), "OU-III reset retained cross covariance")) return false;
+        }
+    }
+    return true;
+}
+
+bool test_noise_units_and_period() {
+    const Vector3 sample_std = Vector3::Constant(T(0.02));
+    const T dt = T(0.005);
+    const Vector3 expected = sample_std * std::sqrt(dt);
+    const Vector3 converted = Kalman3D_Wave_OU_II<T>::gyro_noise_density_from_sample_std(sample_std, dt);
+    if (!check((converted-expected).cwiseAbs().maxCoeff() < T(1e-15), "gyro noise conversion mismatch")) return false;
+
+    for (int rate : {100, 200, 400}) {
+        T elapsed = T(0);
+        int count = 0;
+        const T step = T(1) / T(rate);
+        for (int i=0; i<rate*3; ++i) {
+            if (detail::periodic_update_due(step, T(0.015), elapsed)) ++count;
+        }
+        if (!check(count == 200, "pseudo update rate depends on sample rate")) return false;
+        if (!check(elapsed >= T(0) && elapsed < T(0.015), "pseudo update remainder is out of range")) return false;
+    }
+    for (int rate : {100, 200, 400}) {
+        float elapsed = 0.0f;
+        int count = 0;
+        const float step = 1.0f / static_cast<float>(rate);
+        for (int sample=0; sample<rate*3; ++sample) {
+            if (detail::periodic_update_due(step, 0.015f, elapsed)) ++count;
+        }
+        if (!check(count == 200, "float pseudo update rate depends on sample rate")) return false;
+        if (!check(elapsed >= 0.0f && elapsed < 0.015f, "float pseudo update remainder is out of range")) return false;
+    }
+    return true;
+}
+
+bool test_attitude_helpers() {
     Vector3 rotation_vector;
     rotation_vector << T(0.01), T(-0.02), T(0.03);
     const auto q = detail::quat_from_delta_theta(rotation_vector);
-    if (std::abs(q.norm() - T(1)) > T(1e-14)) {
-        std::cerr << "Quaternion increment is not unit length\n";
-        return 1;
-    }
-
+    if (!check(std::abs(q.norm()-T(1)) <= T(1e-14), "quaternion increment is not unit length")) return false;
     Matrix3 R, B;
-    detail::rot_and_B_from_wt(rotation_vector, dt, R, B);
-    const Matrix3 orthogonality = R * R.transpose() - Matrix3::Identity();
-    if (orthogonality.cwiseAbs().maxCoeff() > T(1e-13)) {
-        std::cerr << "Rotation transition is not orthogonal\n";
-        return 1;
-    }
+    detail::rot_and_B_from_wt(rotation_vector, T(0.005), R, B);
+    return check((R*R.transpose()-Matrix3::Identity()).cwiseAbs().maxCoeff() <= T(1e-13),
+                 "rotation transition is not orthogonal");
+}
 
-    // Force both public headers and common template code to instantiate in one TU.
-    const Vector3 sigma_a = Vector3::Constant(T(0.02));
-    const Vector3 sigma_g = Vector3::Constant(T(0.001));
-    const Vector3 sigma_m = Vector3::Constant(T(0.5));
-    Kalman3D_Wave_OU_II<T> ou2(sigma_a, sigma_g, sigma_m);
-    Kalman3D_Wave_OU_III<T> ou3(sigma_a, sigma_g, sigma_m);
-    (void)ou2;
-    (void)ou3;
+} // namespace
 
+int main() {
+    if (!test_ou_covariance()) return 1;
+    if (!test_stationary_setters()) return 1;
+    if (!test_noise_units_and_period()) return 1;
+    if (!test_attitude_helpers()) return 1;
     return 0;
 }


### PR DESCRIPTION
Temporary draft PR used only to run parameter sweeps for PR #188. It must not be merged.

Current targeted sweep:
- OU-II: Hs=4.0 JONSWAP regression case
- OU-III: Hs=0.27 JONSWAP regression case
- gyro-density multipliers: 1.0, 0.3, 0.1, 0.070710678

Public release metadata used by the local reproducer: [v1.1.3 release API](https://api.github.com/repos/bareboat-necessities/oceanography-waves-lib/releases/tags/v1.1.3)

The production PR remains #188. This experiment PR must never be merged.