### PR TITLE
Synchronize article mathematics with OU implementation

### DIFF
--- a/doc/kalman_ou_iii/w3d-analytic-coeff.tex-part
+++ b/doc/kalman_ou_iii/w3d-analytic-coeff.tex-part
@@ -1,251 +1,205 @@
-\section{Block structure of the discrete transition \texorpdfstring{$\matg{\Phi}$}{Phi} and covariance \texorpdfstring{$\matg{Q}_d$}{Qd}}
+\section{Discrete Transition and Process Covariance}
 \label{sec:block-Phi-Qd}
 
-Let $h>0$ be the sampling step and let the error-state be ordered as in the continuous-time state model.
-We group indices into three blocks:
+Let $h>0$ be the sample interval.  The implementation preserves the group-first
+state ordering
 \[
-\fitcol{
-\underbrace{(\delta\vct{\theta},\ \vct{b}_g)}_{\text{attitude\,+\,gyro-bias}} \in \mathbb R^{N_A},\quad
-\underbrace{(\vct{v},\ \vct{p},\ \vct{S},\ \vct{a}_w)}_{\text{OU-driven linear chain}} \in \mathbb R^{N_L},\quad
-\underbrace{\vct{b}_a}_{\text{accel-bias}}\in \mathbb R^{N_B},
-}
+[\delta\vct{\theta},\vct{b}_g,\vct{v},\vct{p},\vct{S},\vct{a}_w,\vct{b}_a]
 \]
-with $N_A=3$ or $6$ (no/with $\vct{b}_g$), $N_L=12$, $N_B=3$.
+used in Sec.~\ref{sec:state}.  Axis-wise formulas are derived in the compact
+ordering $[v,p,S,a]$, then assembled into the group-first three-dimensional
+blocks without permuting the public state.
 
-\paragraph{Attitude + gyro-bias block \(\matg{\Phi}_{\!AA}(h)\) and \(\matg{Q}_{\!AA}(h)\)}
-For the attitude error + gyro-bias (size \(3{+}3\)), the algorithm uses a structured
-path that matches the Q-MEKF with piecewise-constant \(\hat{\vct{\omega}}=
-\vct{\omega}_m-\vct{b}_g\) over the step:
-\begin{itemize}
-  \item \(\matg{\Phi}_{\!AA}(h)\) implements the left-multiplicative small-angle
-        transition: the \(\delta\vct{\theta}\)-block is the Rodrigues
-        expression
-        \(\Phi_{\theta\theta}(h)=\Id - \sin\theta\,\mat{D} + (1-\cos\theta)\,\mat{D}^2\)
-        with \(\theta=\|\hat{\vct{\omega}}\|h\) and
-        \(\mat{D}=\Skew{\hat{\vct{\omega}}/\|\hat{\vct{\omega}}\|}\);
-        the \(\delta\vct{\theta}\)–\(\vct{b}_g\) block is \(+\Id\,h\) to match the left-multiplicative error model.
-  \item \(\matg{Q}_{\!AA}(h)\) is built from rotation integrals:
-        \[
-        \matg{Q}_{\theta\theta}=\int_0^{h}\! \Rot(s)\,\matg{Q}_g\,\Rot(s)^\top ds
-        \;+\; \int_0^{h}\! \mat{B}(s)\,\matg{Q}_{bg}\,\mat{B}(s)^\top ds,
-        \]
-        \(\matg{Q}_{bb}=\matg{Q}_{bg}\,h\),
-        \(\matg{Q}_{\theta b}=\Big(\int_0^{h}\! \mat{B}(s)\,ds\Big)\matg{Q}_{bg}\),
-        with \(\Rot(s)\triangleq \exp\!\bigl(-\Skew{\hat{\vct{\omega}}}\,s\bigr)\in SO(3)\) the
-        attitude-error rotation (Rodrigues form for constant \(\hat{\vct{\omega}}\)),
-        and \(\mat{B}(s)\) the associated closed-form gyro-bias coupling term
-        (exact for isotropic \(\matg{Q}_g\); Simpson quadrature otherwise).
-\end{itemize}
-
-\paragraph{Linear OU chain block \(\matg{\Phi}_{\!LL}(h)\)}
-The linear \(12\times12\) block corresponds to the stacked axes
-\([\vct{v},\vct{p},\vct{S},\vct{a}_w]\) (3D). It is formed by
-placing three identical \(4\times4\) axis transitions on the block diagonal:
+\subsection{Attitude and gyroscope-bias block}
+For constant $\hat{\vct{\omega}}$ over the step, define
+\[
+\mat{W}=\Skew{\hat{\vct{\omega}}},
+\qquad
+\mat{R}(t)=\exp(-\mat{W}t),
+\qquad
+\mat{B}(t)=\int_0^t\mat{R}(s)\,ds.
+\]
+Then
 \begin{equation}
-\begin{aligned}
-\matg{\Phi}_{\!LL}(h)
-  &= \mathrm{blkdiag}\!\big(
-      \Phi_{\text{axis}},
-      \Phi_{\text{axis}},
-      \Phi_{\text{axis}}
-     \big),\\[4pt]
-\Phi_{\text{axis}}
-  &=
-  \begin{bmatrix}
-  1 & 0 & 0 & \phi_{va}\\
-  h & 1 & 0 & \phi_{pa}\\
-  \tfrac{1}{2}h^2 & h & 1 & \phi_{Sa}\\
-  0 & 0 & 0 & \alpha
-  \end{bmatrix}.
-\end{aligned}
+\matg{\Phi}_{AA}(h)=
+\begin{bmatrix}
+\mat{R}(h)&\mat{B}(h)\\
+0&\Id
+\end{bmatrix}.
+\label{eq:phi-att-bias}
+\end{equation}
+For $\omega=\|\hat{\vct{\omega}}\|>0$,
+\begin{align}
+\mat{R}(h)
+ &=\Id-\frac{\sin(\omega h)}{\omega}\mat{W}
+ +\frac{1-\cos(\omega h)}{\omega^2}\mat{W}^2,\\
+\mat{B}(h)
+ &=h\Id-\frac{1-\cos(\omega h)}{\omega^2}\mat{W}
+ +\frac{\omega h-\sin(\omega h)}{\omega^3}\mat{W}^2.
+\end{align}
+The small-rate limit is
+$\mat{B}(h)=h\Id-\tfrac12h^2\mat{W}+\tfrac16h^3\mat{W}^2+\cdots$;
+therefore replacing this block by $h\Id$ is only a first-order approximation.
+
+The structured process covariance is
+\begin{align}
+\matg{Q}_{\theta\theta}
+ &=\int_0^h\mat{R}(s)\matg{Q}_g\mat{R}^{\top}(s)\,ds
+  +\int_0^h\mat{B}(s)\matg{Q}_{bg}\mat{B}^{\top}(s)\,ds,\\
+\matg{Q}_{\theta b}
+ &=\left(\int_0^h\mat{B}(s)\,ds\right)\matg{Q}_{bg},\\
+\matg{Q}_{bb}&=h\matg{Q}_{bg}.
+\end{align}
+The first integral is exact for isotropic $\matg{Q}_g$; the implementation uses
+Simpson quadrature for anisotropic matrices and for the bias-driven integral.
+
+\subsection{OU-driven linear transition}
+For one axis, let
+\[
+z=[v,p,S,a]^{\top},\qquad x=\frac{h}{\tau},\qquad \alpha=e^{-x}.
+\]
+The exact mean transition is
+\begin{equation}
+\Phi_{\mathrm{axis}}=
+\begin{bmatrix}
+1&0&0&\phi_{va}\\
+h&1&0&\phi_{pa}\\
+\tfrac12h^2&h&1&\phi_{Sa}\\
+0&0&0&\alpha
+\end{bmatrix},
+\label{eq:phi-axis-ou3}
+\end{equation}
+with
+\begin{align}
+\phi_{va}&=-\tau\operatorname{expm1}(-x),\\
+\phi_{pa}&=\tau^2\left(x+\operatorname{expm1}(-x)\right),\\
+\phi_{Sa}&=\tau^3\left(\tfrac12x^2-x-\operatorname{expm1}(-x)\right).
+\end{align}
+For $|x|<10^{-2}$, cancellation-sensitive coefficients are evaluated as
+\begin{align}
+\phi_{pa}&=\tau^2\left(\tfrac12x^2-\tfrac16x^3+\tfrac1{24}x^4\right),\\
+\phi_{Sa}&=\tau^3\left(\tfrac16x^3-\tfrac1{24}x^4+\tfrac1{120}x^5\right).
+\end{align}
+
+In group-first three-dimensional ordering
+$[\vct{v},\vct{p},\vct{S},\vct{a}_w]$, the transition is
+\begin{equation}
+\matg{\Phi}_{LL}=
+\begin{bmatrix}
+\Id&0&0&\phi_{va}\Id\\
+h\Id&\Id&0&\phi_{pa}\Id\\
+\tfrac12h^2\Id&h\Id&\Id&\phi_{Sa}\Id\\
+0&0&0&\alpha\Id
+\end{bmatrix}.
+\label{eq:phi-ll-group-first}
 \end{equation}
 
-where \(x \equiv \frac{h}{\tau}\), and the algorithm uses the following
-expressions:
-\[
-\fitcol{
-\begin{aligned}
-\phi_{va} &= -\tau\,(e^{-x}-1),\qquad
-\phi_{pa} = \tau^2\big(x + (e^{-x}-1)\big),\\
-\phi_{Sa} &= \tau^3\Big(\tfrac12 x^2 - x - (e^{-x}-1)\Big).
-\end{aligned}
-}
-\]
+\subsection{Exact scalar-axis covariance}
+For stationary variance $\sigma^2$, define
+$q_c=2\sigma^2/\tau$.  The exact covariance is
+\begin{equation}
+\matg{Q}_{d,\mathrm{axis}}
+=\int_0^h\Phi_{\mathrm{axis}}(t)
+\begin{bmatrix}0\\0\\0\\1\end{bmatrix}
+q_c
+\begin{bmatrix}0&0&0&1\end{bmatrix}
+\Phi_{\mathrm{axis}}^{\top}(t)\,dt.
+\label{eq:q-axis-integral}
+\end{equation}
+For $|x|>10^{-2}$, write
+$\matg{Q}_{d,\mathrm{axis}}=q_c\,\sym(\mat{K})$, where the upper-triangular
+coefficients in $[v,p,S,a]$ ordering are
+\begin{align}
+K_{vv}&=\tfrac12\tau^3(-\alpha^2+4\alpha+2x-3),\\
+K_{vp}&=\tfrac12\tau^4(\alpha^2+2\alpha(x-1)+x^2-2x+1),\\
+K_{vS}&=\tfrac16\tau^5[-3\alpha^2+3\alpha(x^2+4)+x^3-3x^2+6x-9],\\
+K_{va}&=\tfrac12\tau^2(\alpha^2-2\alpha+1),\\
+K_{pp}&=\tau^5[-\tfrac12\alpha^2-2\alpha x+\tfrac13x^3-x^2+x+\tfrac12],\\
+K_{pS}&=\tau^6[\tfrac12\alpha^2+\tfrac12\alpha(-x^2+2x-2)
++\tfrac18x^4-\tfrac12x^3+x^2-x+\tfrac12],\\
+K_{pa}&=\tfrac12\tau^3(-\alpha^2-2\alpha x+1),\\
+K_{SS}&=\tau^7[-\tfrac12\alpha^2+\alpha(x^2+2)+\tfrac1{20}x^5
+-\tfrac14x^4+\tfrac23x^3-x^2+x-\tfrac32],\\
+K_{Sa}&=\tfrac12\tau^4[\alpha^2-\alpha(x^2+2)+1],\\
+K_{aa}&=\tfrac12\tau(1-\alpha^2).
+\end{align}
 
-\paragraph{Linear OU chain covariance block \(\matg{Q}_{\!LL}(h)\). Uncorrelated axes (diagonal stationary variance)}
+\subsection{Complete small-step branch}
+For $|x|\le10^{-2}$, let $\lambda=1/\tau$.  To avoid cancellation, the
+implementation evaluates the complete symmetric covariance through ninth
+order where required:
+\begin{align}
+Q_{vv}/\sigma^2={}&\tfrac23h^3\lambda-\tfrac12h^4\lambda^2
++\tfrac7{30}h^5\lambda^3-\tfrac1{12}h^6\lambda^4
++\tfrac{31}{1260}h^7\lambda^5-\tfrac1{160}h^8\lambda^6
++\tfrac{127}{90720}h^9\lambda^7,\\
+Q_{vp}/\sigma^2={}&\tfrac14h^4\lambda-\tfrac16h^5\lambda^2
++\tfrac5{72}h^6\lambda^3-\tfrac1{45}h^7\lambda^4
++\tfrac{17}{2880}h^8\lambda^5-\tfrac{41}{30240}h^9\lambda^6,\\
+Q_{vS}/\sigma^2={}&\tfrac1{15}h^5\lambda-\tfrac1{24}h^6\lambda^2
++\tfrac{41}{2520}h^7\lambda^3-\tfrac7{1440}h^8\lambda^4
++\tfrac{109}{90720}h^9\lambda^5,\\
+Q_{va}/\sigma^2={}&h^2\lambda-h^3\lambda^2+\tfrac7{12}h^4\lambda^3
+-\tfrac14h^5\lambda^4+\tfrac{31}{360}h^6\lambda^5
+-\tfrac1{40}h^7\lambda^6+\tfrac{127}{20160}h^8\lambda^7
+-\tfrac{17}{12096}h^9\lambda^8,\\
+Q_{pp}/\sigma^2={}&\tfrac1{10}h^5\lambda-\tfrac1{18}h^6\lambda^2
++\tfrac5{252}h^7\lambda^3-\tfrac1{180}h^8\lambda^4
++\tfrac{17}{12960}h^9\lambda^5,\\
+Q_{pS}/\sigma^2={}&\tfrac1{36}h^6\lambda-\tfrac1{72}h^7\lambda^2
++\tfrac{13}{2880}h^8\lambda^3-\tfrac1{864}h^9\lambda^4,\\
+Q_{pa}/\sigma^2={}&\tfrac13h^3\lambda-\tfrac13h^4\lambda^2
++\tfrac{11}{60}h^5\lambda^3-\tfrac{13}{180}h^6\lambda^4
++\tfrac{19}{840}h^7\lambda^5-\tfrac1{168}h^8\lambda^6
++\tfrac{247}{181440}h^9\lambda^7,\\
+Q_{SS}/\sigma^2={}&\tfrac1{126}h^7\lambda-\tfrac1{288}h^8\lambda^2
++\tfrac{13}{12960}h^9\lambda^3,\\
+Q_{Sa}/\sigma^2={}&\tfrac1{12}h^4\lambda-\tfrac1{12}h^5\lambda^2
++\tfrac2{45}h^6\lambda^3-\tfrac1{60}h^7\lambda^4
++\tfrac{11}{2240}h^8\lambda^5-\tfrac{73}{60480}h^9\lambda^6,\\
+Q_{aa}/\sigma^2={}&2h\lambda-2h^2\lambda^2+\tfrac43h^3\lambda^3
+-\tfrac23h^4\lambda^4+\tfrac4{15}h^5\lambda^5
+-\tfrac4{45}h^6\lambda^6+\tfrac8{315}h^7\lambda^7
+-\tfrac2{315}h^8\lambda^8+\tfrac4{2835}h^9\lambda^9.
+\end{align}
+All remaining entries follow by symmetry.  The $[v,p,a]$ principal marginal is
+computed by the same OU-II routine and embedded into the OU-III matrix, making
+that common marginal identical by construction.
 
-For a single axis with OU correlation time \(\tau>0\), stationary variance
-\(\sigma^2\), and sampling step \(h\), we write
-\[
-\alpha \equiv e^{-x},\qquad
-\alpha_2 \equiv e^{-2x},\qquad
-q_c \equiv \frac{2\sigma^2}{\tau}.
-\]
-The scalar OU process is driven by \cite{UhlenbeckOrnstein1930_OU}
-\(
-da = -\tfrac1{\tau}a\,dt + \sqrt{q_c}\,dW
-\),
-and the stacked state for one axis is
-\(
-z \equiv [v,\,p,\,S,\,a]^\top.
-\)
-The algorithm uses the exact discrete covariance
-\[
-\fitcol{
-\matg{Q}_{d,\text{axis}}(h)
-= \int_0^h \Phi_{\text{axis}}(t)\,
-    \mat{G}\,q_c\,\mat{G}^\top
-    \Phi_{\text{axis}}(t)^\top dt,
-\quad
-\mat{G} = [0,\,0,\,0,\,1]^\top,
-}
-\]
-implemented in two numerically stable branches.
+After evaluation, the covariance is symmetrized.  A scale-aware PSD check uses
+$\epsilon_Q=64\epsilon_{\mathrm{mach}}\max(1,\|Q\|_{\max})$.  If an LDL$^\top$
+factorization is nonnegative within this tolerance, the matrix is left
+unchanged.  Only when the check fails are negative eigenvalues clipped to zero.
+This conditional regularization addresses floating-point roundoff; it does not
+replace omitted analytical terms.
 
-\medskip
-\noindent\textbf{General closed form (\(|x|>x_0\))}
-For \(|x|>x_0\) with \(x_0 \approx 10^{-2}\) the algorithm uses the exact coefficient matrix
+\subsection{Three-dimensional assembly}
+For independent axes,
+\begin{equation}
+\matg{Q}_{LL}
+=\operatorname{assemble}_{\mathrm{group}}
+\left(Q_{\mathrm{axis}}(\sigma_x^2),
+Q_{\mathrm{axis}}(\sigma_y^2),
+Q_{\mathrm{axis}}(\sigma_z^2)\right).
+\end{equation}
+For a correlated stationary covariance
+$\matg{\Sigma}_{aw}^{\mathrm{stat}}$, first compute the scalar coefficient
+matrix $\mat{C}=Q_{\mathrm{axis}}(\sigma^2=1)$.  In group-first ordering, each
+$3\times3$ block is
+\begin{equation}
+[\matg{Q}_{LL}]_{ij}=C_{ij}\matg{\Sigma}_{aw}^{\mathrm{stat}},
+\qquad i,j\in\{v,p,S,a\},
+\label{eq:qll-correlated-assembly}
+\end{equation}
+which is equivalently
+$\matg{Q}_{LL}=\mat{C}\otimes\matg{\Sigma}_{aw}^{\mathrm{stat}}$ for this
+ordering.
+
+The accelerometer-bias block is
 \[
-\mathcal{K} \;=\; [\kappa_{ij}]_{i,j\in\{v,p,S,a\}},
-\]
-and constructs
-\[
-\matg{Q}_{d,\text{axis}}(h) = q_c\,\mathrm{sym}\,\mathcal{K},
+\Phi_{b_ab_a}=\Id,
 \qquad
-\mathrm{sym}(\mathcal{K}) \equiv \tfrac12(\mathcal{K}+\mathcal{K}^\top).
+\matg{Q}_{b_ab_a}=h\matg{Q}_{ba}.
 \]
-The method uses the following expressions:
-\[
-\fitcol{
-\begin{aligned}
-\kappa_{vv} &= \tfrac12\tau^3\bigl(-\alpha_2 + 4\alpha + 2x - 3\bigr),\\
-\kappa_{vp} &= \tfrac12\tau^4\bigl(\alpha_2 + 2\alpha(x-1) + x^2 - 2x + 1\bigr),\\
-\kappa_{vS} &= \tfrac16\tau^5\bigl(-3\alpha_2 + 3\alpha(x^2+4)
-                              + x^3 - 3x^2 + 6x - 9\bigr),\\
-\kappa_{va} &= \tfrac12\tau^2\bigl(\alpha_2 - 2\alpha + 1\bigr),\\[4pt]
-\kappa_{pp} &= \tau^5\Bigl(
-           -\tfrac12\alpha_2 - 2\alpha x
-           + \tfrac13 x^3 - x^2 + x + \tfrac12
-         \Bigr),\\
-\kappa_{pS} &= \tau^6\Bigl(
-           \tfrac12\alpha_2
-           + \tfrac12\alpha(-x^2 + 2x - 2)
-           + \tfrac18 x^4 - \tfrac12 x^3 + x^2 - x + \tfrac12
-         \Bigr),\\
-\kappa_{pa} &= \tfrac12\tau^3\bigl(-\alpha_2 - 2\alpha x + 1\bigr),\\[4pt]
-\kappa_{SS} &= \tau^7\Bigl(
-           -\tfrac12\alpha_2
-           + \alpha(x^2 + 2)
-           + \tfrac1{20}x^5 - \tfrac14 x^4 + \tfrac23 x^3
-           - x^2 + x - \tfrac32
-         \Bigr),\\
-\kappa_{Sa} &= \tfrac12\tau^4\bigl(\alpha_2 - \alpha(x^2+2) + 1\bigr),\\
-\kappa_{aa} &= \tfrac12\tau\bigl(1 - \alpha_2\bigr).
-\end{aligned}
-}
-\]
-
-\medskip
-\noindent\textbf{Small-\(x\) series (\(|x|\le x_0\))}
-For \(|x|\le x_0\), the implementation uses a
-Maclaurin expansion in \(h\) up to \(O(h^5)\).
-
-\iffalse
-Writing \(h^k/\tau^\ell\) explicitly, the nonzero entries are
-\[
-\fitcol{
-\begin{aligned}
-Q_{vv}
-&\approx \sigma^2\Big(
-    \tfrac{2}{3}\frac{h^3}{\tau}
-  - \tfrac{1}{2}\frac{h^4}{\tau^2}
-  + \tfrac{7}{30}\frac{h^5}{\tau^3}
-\Big),\\[2pt]
-Q_{vp}=Q_{pv}
-&\approx \sigma^2\Big(
-    \tfrac{1}{4}\frac{h^4}{\tau}
-  - \tfrac{1}{6}\frac{h^5}{\tau^2}
-\Big),\\[2pt]
-Q_{vS}=Q_{Sv}
-&\approx \sigma^2\Big(
-  \tfrac{1}{15}\frac{h^5}{\tau}
-\Big),\\[2pt]
-Q_{va}=Q_{av}
-&\approx \sigma^2\Big(
-    \frac{h^2}{\tau}
-  - \frac{h^3}{\tau^2}
-  + \tfrac{7}{12}\frac{h^4}{\tau^3}
-  - \tfrac{1}{4}\frac{h^5}{\tau^4}
-\Big),\\[2pt]
-Q_{pp}
-&\approx \sigma^2\Big(
-  \tfrac{1}{10}\frac{h^5}{\tau}
-\Big),\\[2pt]
-Q_{pa}=Q_{ap}
-&\approx \sigma^2\Big(
-    \tfrac{1}{3}\frac{h^3}{\tau}
-  - \tfrac{1}{3}\frac{h^4}{\tau^2}
-  + \tfrac{11}{60}\frac{h^5}{\tau^3}
-\Big),\\[2pt]
-Q_{Sa}=Q_{aS}
-&\approx \sigma^2\Big(
-    \tfrac{1}{12}\frac{h^4}{\tau}
-  - \tfrac{1}{12}\frac{h^5}{\tau^2}
-\Big),\\[2pt]
-Q_{aa}
-&\approx \sigma^2\Big(
-    2\frac{h}{\tau}
-  - 2\frac{h^2}{\tau^2}
-  + \tfrac{4}{3}\frac{h^3}{\tau^3}
-  - \tfrac{2}{3}\frac{h^4}{\tau^4}
-  + \tfrac{4}{15}\frac{h^5}{\tau^5}
-\Big).
-\end{aligned}
-}
-\]
-All omitted entries are of order \(O(h^6)\) or higher in \(h\) and are
-set to zero in the implementation. The matrix is then projected to the
-nearest PSD matrix (and symmetrized) to remove roundoff.
-\fi
-
-\medskip
-All other entries of \(\mathcal{K}\) follow by symmetry,
-\(\kappa_{ij}=\kappa_{ji}\). As in the small-\(x\) branch, \(\matg{Q}_{d,\text{axis}}\)
-is post-processed by a PSD projection and symmetrization.
-
-\medskip
-\noindent\textbf{Assembly of \(\matg{Q}_{\!LL}(h)\)}
-For uncorrelated axes with diagonal stationary covariance
-\(\Sigma_{\!a_w} = \mathrm{diag}(\sigma_x^2,\sigma_y^2,\sigma_z^2)\)
-the full linear-block covariance is the block-diagonal stacking
-\[
-\matg{Q}_{\!LL}(h)
-= \mathrm{blkdiag}\bigl(
-   \matg{Q}_{d,\text{axis}}(\sigma_x^2),\,
-   \matg{Q}_{d,\text{axis}}(\sigma_y^2),\,
-   \matg{Q}_{d,\text{axis}}(\sigma_z^2)
-\bigr).
-\]
-In the correlated case, the implementation uses a Kronecker product
-construction
-\(
-\matg{Q}_{\!LL} = \Sigma_{\!a_w}\otimes \matg{Q}_{d,\text{axis}}(\sigma^2{=}1)
-\),
-followed by a PSD projection.
-
-\paragraph{Accelerometer bias block}
-The accelerometer bias random walk contributes
-\[
-\Phi_{bb}(h)=\mat{I}_3,\qquad \matg{Q}_{bb}(h)=\matg{Q}_{ba}\,h.
-\]
-
-\paragraph{Analytic coefficients summary}
-In short, the discrete transition and covariance used by the method's algorithm are
-\[
-\begin{aligned}
-\matg{\Phi}(h) &=\mathrm{blkdiag}\big(\matg{\Phi}_{\!AA}(h),\,\matg{\Phi}_{\!LL}(h),\,\mat{I}_3\big),\qquad\\
-\matg{Q}_d(h) &=\mathrm{blkdiag}\big(\matg{Q}_{\!AA},\,\matg{Q}_{\!LL},\,\matg{Q}_{bb}\big),
-\end{aligned}
-\]
-with \(\Phi_{\text{axis}},\,\phi_{va},\phi_{pa},\phi_{Sa}\) and
-\(\matg{Q}_{d,\text{axis}}=q_c\,\mathrm{sym}\,\mathcal{K}\) as given above.
+The complete transition and process covariance are assembled blockwise while
+retaining all propagated cross-covariances in $\mat{P}$.

--- a/doc/kalman_ou_iii/w3d-analytic-coeff.tex-part
+++ b/doc/kalman_ou_iii/w3d-analytic-coeff.tex-part
@@ -125,46 +125,41 @@ K_{aa}&=\tfrac12\tau(1-\alpha^2).
 \end{align}
 
 \subsection{Complete small-step branch}
-For $|x|\le10^{-2}$, let $\lambda=1/\tau$.  To avoid cancellation, the
-implementation evaluates the complete symmetric covariance through ninth
-order where required:
-\begin{align}
-Q_{vv}/\sigma^2={}&\tfrac23h^3\lambda-\tfrac12h^4\lambda^2
-+\tfrac7{30}h^5\lambda^3-\tfrac1{12}h^6\lambda^4
-+\tfrac{31}{1260}h^7\lambda^5-\tfrac1{160}h^8\lambda^6
-+\tfrac{127}{90720}h^9\lambda^7,\\
-Q_{vp}/\sigma^2={}&\tfrac14h^4\lambda-\tfrac16h^5\lambda^2
-+\tfrac5{72}h^6\lambda^3-\tfrac1{45}h^7\lambda^4
-+\tfrac{17}{2880}h^8\lambda^5-\tfrac{41}{30240}h^9\lambda^6,\\
-Q_{vS}/\sigma^2={}&\tfrac1{15}h^5\lambda-\tfrac1{24}h^6\lambda^2
-+\tfrac{41}{2520}h^7\lambda^3-\tfrac7{1440}h^8\lambda^4
-+\tfrac{109}{90720}h^9\lambda^5,\\
-Q_{va}/\sigma^2={}&h^2\lambda-h^3\lambda^2+\tfrac7{12}h^4\lambda^3
--\tfrac14h^5\lambda^4+\tfrac{31}{360}h^6\lambda^5
--\tfrac1{40}h^7\lambda^6+\tfrac{127}{20160}h^8\lambda^7
--\tfrac{17}{12096}h^9\lambda^8,\\
-Q_{pp}/\sigma^2={}&\tfrac1{10}h^5\lambda-\tfrac1{18}h^6\lambda^2
-+\tfrac5{252}h^7\lambda^3-\tfrac1{180}h^8\lambda^4
-+\tfrac{17}{12960}h^9\lambda^5,\\
-Q_{pS}/\sigma^2={}&\tfrac1{36}h^6\lambda-\tfrac1{72}h^7\lambda^2
-+\tfrac{13}{2880}h^8\lambda^3-\tfrac1{864}h^9\lambda^4,\\
-Q_{pa}/\sigma^2={}&\tfrac13h^3\lambda-\tfrac13h^4\lambda^2
-+\tfrac{11}{60}h^5\lambda^3-\tfrac{13}{180}h^6\lambda^4
-+\tfrac{19}{840}h^7\lambda^5-\tfrac1{168}h^8\lambda^6
-+\tfrac{247}{181440}h^9\lambda^7,\\
-Q_{SS}/\sigma^2={}&\tfrac1{126}h^7\lambda-\tfrac1{288}h^8\lambda^2
-+\tfrac{13}{12960}h^9\lambda^3,\\
-Q_{Sa}/\sigma^2={}&\tfrac1{12}h^4\lambda-\tfrac1{12}h^5\lambda^2
-+\tfrac2{45}h^6\lambda^3-\tfrac1{60}h^7\lambda^4
-+\tfrac{11}{2240}h^8\lambda^5-\tfrac{73}{60480}h^9\lambda^6,\\
-Q_{aa}/\sigma^2={}&2h\lambda-2h^2\lambda^2+\tfrac43h^3\lambda^3
--\tfrac23h^4\lambda^4+\tfrac4{15}h^5\lambda^5
--\tfrac4{45}h^6\lambda^6+\tfrac8{315}h^7\lambda^7
--\tfrac2{315}h^8\lambda^8+\tfrac4{2835}h^9\lambda^9.
-\end{align}
-All remaining entries follow by symmetry.  The $[v,p,a]$ principal marginal is
-computed by the same OU-II routine and embedded into the OU-III matrix, making
-that common marginal identical by construction.
+For $|x|\le10^{-2}$, let $\lambda=1/\tau$ and associate the state order
+$[v,p,S,a]$ with integration indices
+\[
+(m_v,m_p,m_S,m_a)=(1,2,3,0).
+\]
+The impulse response from the scalar OU driving noise to state $i$ has the
+small-step expansion
+\begin{equation}
+g_i(t)=\sum_{r=0}^{\infty}
+\frac{(-\lambda)^r t^{r+m_i}}{(r+m_i)!}.
+\label{eq:ou-impulse-series}
+\end{equation}
+Substitution into
+$Q_{ij}=2\sigma^2\lambda\int_0^h g_i(t)g_j(t)\,dt$
+gives every covariance entry through ninth order in one expression:
+\begin{equation}
+\begin{aligned}
+Q_{ij}^{(9)}
+ &=2\sigma^2\lambda
+ \sum_{\substack{r,s\ge0\\d_{ijrs}\le9}}
+ \frac{(-\lambda)^{r+s}h^{d_{ijrs}}}
+ {(r+m_i)!(s+m_j)!\,d_{ijrs}},\\
+d_{ijrs}&=r+s+m_i+m_j+1,
+\qquad i,j\in\{v,p,S,a\}.
+\end{aligned}
+\label{eq:ou-small-step-compact}
+\end{equation}
+The matrix is completed by symmetry.  Equation~\eqref{eq:ou-small-step-compact}
+contains all terms retained by the implementation; for example, it produces the
+leading orders $Q_{aa}=2\sigma^2\lambda h+O(h^2)$,
+$Q_{va}=\sigma^2\lambda h^2+O(h^3)$, and
+$Q_{SS}=\sigma^2\lambda h^7/126+O(h^8)$.
+The $[v,p,a]$ principal marginal is computed by the same OU-II routine and
+embedded into the OU-III matrix, making that common marginal identical by
+construction.
 
 After evaluation, the covariance is symmetrized.  A scale-aware PSD check uses
 $\epsilon_Q=64\epsilon_{\mathrm{mach}}\max(1,\|Q\|_{\max})$.  If an LDL$^\top$

--- a/doc/kalman_ou_iii/w3d-init.tex-part
+++ b/doc/kalman_ou_iii/w3d-init.tex-part
@@ -2,51 +2,49 @@
 \section{Initialization and Reference Alignment}
 \label{sec:init_alignment}
 
-The startup procedure is designed to avoid using unobservable or poorly conditioned states too early, consistent with practical marine IMU initialization guidance \cite{Kuechler2011_HeaveAcceleration,Auestad2013_HeaveStrapdownIMU}.
-At boot, the filter first establishes a reliable
-gravity-based tilt frame, then lets the frequency/tuning logic collect enough
-data, and only later enables the full linear wave-displacement block and
-magnetometer yaw correction.
+The startup procedure avoids activating weakly observable navigation states
+before attitude and sea-state statistics are sufficiently stable
+\cite{Kuechler2011_HeaveAcceleration,Auestad2013_HeaveStrapdownIMU}.
 
-\subsection{Tilt-First Startup}
+\subsection{Tilt-first initialization}
+Before magnetic north is established, yaw is arbitrary.  Initial attitude is
+therefore obtained from accelerometer direction alone by aligning measured
+specific force with world down in NED.  This constrains roll and pitch but
+leaves rotation about world down unobservable.  A gravity bootstrap observer
+and hold-time gate are used instead of a single sample.
 
-Before magnetic north is known, yaw is arbitrary.  Therefore the initial
-attitude is obtained from the accelerometer only: the measured body-frame
-gravity direction is aligned with world down in the NED frame.  This fixes roll
-and pitch but intentionally leaves yaw unconstrained,
-\[
-\Rot(q_{bw,0})
-\left(
--\frac{\vct{a}_b}{\|\vct{a}_b\|}
-\right)
-=
-\begin{bmatrix}0\\0\\1\end{bmatrix}.
-\]
-A gravity-only bootstrap observer and slow acceleration gate are used so that
-this tilt lock is based on a stable estimate of down rather than on a single
-noisy or wave-contaminated sample.
+A hard attitude initialization re-seeds the attitude covariance and removes
+stale attitude cross-covariances.  In live operation, a large sustained tilt
+error may instead trigger a tilt-only re-lock that preserves the current yaw
+gauge.
 
-\subsection{Staged Enabling}
+\subsection{Staged enabling and covariance policy}
+Startup proceeds through Cold, TunerWarm, and Live stages.  During Cold and
+TunerWarm, the attitude MEKF and frequency tracker run, while the
+$[\vct{v},\vct{p},\vct{S},\vct{a}_w]$ block is disabled and accelerometer-bias
+learning may be frozen.  The tuner collects a dominant-frequency estimate and
+an acceleration-variance estimate, producing targets for
+$(\tau,\matg{\Sigma}_{aw}^{\mathrm{stat}},\mat{R}_S)$.
 
-After tilt initialization the system proceeds conservatively through startup
-stages.  In the early stage, the MEKF attitude update runs, but the extended
-linear block is disabled and accelerometer-bias learning may be frozen.  During
-the warm-up stage, the frequency tracker and sea-state tuner collect statistics
-for the dominant period, acceleration variance, and the corresponding
-$(\tau,\sigma_a,R_S)$ tuning targets.  Once these estimates are ready, the
-filter enters the live stage, enables the linear block if allowed by
-configuration, and applies the online OU and pseudo-measurement tuning.
+The transition into Live follows this order:
+\begin{enumerate}
+  \item apply the latest $\tau$ and stationary OU covariance to the process
+        model;
+  \item synchronize the posterior $a_w$ marginal with that stationary
+        covariance while preserving learned cross-covariances;
+  \item enable the linear navigation block;
+  \item apply the current integral pseudo-measurement covariance.
+\end{enumerate}
+Applying the tune before enabling the linear block avoids propagating one step
+with stale OU statistics.  The process-model setter alone never mutates the
+posterior covariance.  At initial construction, where no useful
+cross-covariances exist, a hard reset may additionally zero the $a_w$
+cross-covariances.
 
-The intent is to prevent the displacement states, acceleration bias, and drift
-regularization from being driven by transient startup data.
-
-\subsection{Magnetic Reference and Yaw Lock}
-
-Magnetometer updates are also delayed.
-The filter first waits for the startup delay and for a sufficiently stable gravity/tilt condition.
-Magnetometer samples are then accumulated in a gravity-only tilt frame to estimate the local
-magnetic field direction.
-
-Thus, the magnetometer is first used to establish a consistent magnetic reference, after which
-normal yaw updates can begin.
-
+\subsection{Magnetic reference and yaw lock}
+Magnetometer updates are delayed until tilt is sufficiently trustworthy.
+Samples are accumulated in a gravity-only tilt frame to estimate a consistent
+world magnetic reference without using the MEKF's initially arbitrary yaw.
+After the reference is accepted, a one-time yaw-gauge correction is applied and
+normal magnetometer updates begin.  Configuration may optionally require this
+magnetic lock before enabling the linear block.

--- a/doc/kalman_ou_iii/w3d-kalm-up.tex-part
+++ b/doc/kalman_ou_iii/w3d-kalm-up.tex-part
@@ -1,194 +1,105 @@
-\section{Measurement Update: Gain, Rank--3 Structure, and Block Algebra}
+\section{Measurement Update and MEKF Reset}
 \label{sec:meas-update-structure}
 
-\paragraph{From raw IMU streams to measurement vectors}
-At each IMU time step the hardware provides body-frame triads:
-gyroscope angular rate $\vct{\omega}_{\text{meas}}$, accelerometer specific force
-$\vct{f}_{\text{meas}}$, and magnetometer field $\vct{m}_{\text{meas}}$.
-After calibration (scale and axis mapping, hard/soft-iron correction, and fixed sensor offsets \cite{Rabault2022_OpenMetBuoy,Hope2025_SFY}),
-the signals enter the estimator as follows:
-\begin{itemize}\itemsep2pt
-\item $\vct{\omega}_{\text{meas}}$ is a \emph{propagation input}: it advances the nominal quaternion and drives the
-      attitude-error dynamics in the time update (it is not used as an EKF ``measurement'' in this work).
-\item $\vct{f}_{\text{meas}}$ is a rank--3 EKF measurement with $\vct{z}_{\text{acc}}=\vct{f}_{\text{meas}}$.
-\item $\vct{m}_{\text{meas}}$ is a rank--3 EKF measurement with $\vct{z}_{\text{mag}}=\vct{m}_{\text{meas}}$
-      when magnetometer updates are enabled/available.
-\item The drift-control channel is a rank--3 \emph{pseudo}-measurement $\vct{z}_S=\vct{0}$ on the integral state $\vct{S}$
-      (Sec.~\ref{sec:measurement_model}).
-\end{itemize}
-
-\paragraph{Gyroscope usage (time update)}
-The gyroscope does not enter the rank--3 correction formulas above because it is treated as a
-\emph{control/propagation} input. With gyro bias $\vct{b}_g$ and white noise $\vct{\eta}_g$,
+At each IMU step, the gyroscope propagates the nominal quaternion and process
+covariance.  Accelerometer, magnetometer, and integral-drift channels are
+rank--3 corrections.  For a measurement
 \[
-\vct{\omega}_{\text{meas}} = \vct{\omega}_{\text{true}} + \vct{b}_g + \vct{\eta}_g,
+\vct{z}=h(\vct{x})+\vct{\nu},
 \qquad
-\hat{\vct{\omega}} \;=\; \vct{\omega}_{\text{meas}} - \hat{\vct{b}}_g .
+\vct{\nu}\sim\mathcal{N}(0,\mat{R}),
+\qquad
+\mat{C}=\left.\frac{\partial h}{\partial\delta\vct{x}}\right|_{\hat{\vct{x}}^-},
 \]
-The nominal quaternion is advanced by $\hat{\vct{\omega}}$ via the discrete kinematics
-(e.g.\ $q^- = \exp_q\!\left(-\tfrac{1}{2}\hat{\vct{\omega}}\,h\right) \otimes q^+$), while the gyro noise and bias random walk
-enter the \emph{process} covariance $\mat{Q}_d$ of the attitude/bias block (Sec.~\ref{sec:block-Phi-Qd}).
-
-If an ``un-heeled'' effective body frame $B'$ is enabled, the measured triads are first mapped as
-$\vct{f}^{\,B'}_{\text{meas}}=\Rot_x(-\phi_h)\vct{f}^{\,B}_{\text{meas}}$ and
-$\vct{m}^{\,B'}_{\text{meas}}=\Rot_x(-\phi_h)\vct{m}^{\,B}_{\text{meas}}$; the attitude state is then interpreted as
-world$\to B'$. For notational simplicity we continue to write $\Rot_{wb}$ for the world$\to$(effective body) rotation
-used by the measurement models.
-
-Let the predicted pair be $(\hat{\vct{x}}^{-},\mat{P}^{-})$ and an $m$–dimensional measurement model
-\[
-\vct{z} \;=\; h(\vct{x}) + \vct{\nu},\qquad
-\vct{\nu}\sim\mathcal{N}(\vct{0},\mat{R}),\qquad
-\mat{C} \;\coloneqq\; \left.\frac{\partial h}{\partial \vct{x}}\right|_{\hat{\vct{x}}^{-}}.
-\]
-The EKF update is determined by the residual $\vct{r}=\vct{z}-h(\hat{\vct{x}}^{-})$,
-the innovation covariance
-\[
-\matg{\Lambda} \;=\; \mat{C}\,\mat{P}^{-}\,\mat{C}^\top + \mat{R} \;\in\; \mathbb{R}^{m\times m},
-\]
-the Kalman gain
-\[
-\mat{K} \;=\; \mat{P}^{-}\,\mat{C}^\top\,\matg{\Lambda}^{-1} \;\in\; \mathbb{R}^{N\times m},
-\]
-and the posterior
-\[
-\hat{\vct{x}}^{+} \;=\; \hat{\vct{x}}^{-} + \mat{K}\,\vct{r},\qquad
-\mat{P}^{+} \;=\; \mat{P}^{-} - \mat{K}\,\matg{\Lambda}\,\mat{K}^\top.
-\]
-For numerical robustness, the Joseph form
-\[
-\mat{P}^{+} \;=\; (\Id-\mat{K}\mat{C})\,\mat{P}^{-}\,(\Id-\mat{K}\mat{C})^\top
-      + \mat{K}\,\mat{R}\,\mat{K}^\top
-\]
-is algebraically equivalent and preserves $\mat{P}^{+}\succeq 0$ up to roundoff.
-
-\subsection*{Structural rank and block decomposition}
-In this work the measurement dimension is $m=3$ (vector triads), so the correction is intrinsically
-\emph{rank--3}. The state is ordered as
-\[
-\begin{aligned}
-\vct{x} &=\bigl[\vct{A}^\top,\vct{L}^\top,\vct{B}^\top\bigr]^\top,\quad
-\vct{A} =(\delta\vct{\theta},\vct{b}_g)\in\mathbb{R}^6,\;\\
-\vct{L} &=(\vct{v},\vct{p},\vct{S},\vct{a}_w)\in\mathbb{R}^{12},\;\quad
-\vct{B} =\vct{b}_a\in\mathbb{R}^3,
-\end{aligned}
-\]
-with prior covariance partitioned accordingly,
-\[
-\mat{P}^{-}=
-\begin{bmatrix}
-\mat{P}_{AA} & \mat{P}_{AL} & \mat{P}_{AB}\\
-\mat{P}_{LA} & \mat{P}_{LL} & \mat{P}_{LB}\\
-\mat{P}_{BA} & \mat{P}_{BL} & \mat{P}_{BB}
-\end{bmatrix}.
-\]
-Both magnetometer and accelerometer updates produce Jacobians $\mat{C}$ that are at most block-sparse over
-these three groups. The innovation covariance has the canonical form
+define
+\begin{align}
+\vct{r}&=\vct{z}-h(\hat{\vct{x}}^-),\\
+\matg{\Lambda}&=\mat{C}\mat{P}^-\mat{C}^{\top}+\mat{R},\\
+\mat{K}&=\mat{P}^-\mat{C}^{\top}\matg{\Lambda}^{-1}.
+\end{align}
+The additive state correction is
 \begin{equation}
-\begin{aligned}
-\matg{\Lambda} &= \mat{C}\,\mat{P}^{-}\,\mat{C}^\top + \mat{R} \\
-  &= \mat{C}_A \mat{P}_{AA} \mat{C}_A^\top
-   + \mat{C}_A \mat{P}_{AL} \mat{C}_L^\top
-   + \mat{C}_L \mat{P}_{LA} \mat{C}_A^\top \\
-  &\quad
-   + \mat{C}_L \mat{P}_{LL} \mat{C}_L^\top
-   + \mat{C}_B \mat{P}_{BB} \mat{C}_B^\top
-   + \text{(cross terms)} + \mat{R} .
-\end{aligned}
+\delta\hat{\vct{x}}^+=\delta\hat{\vct{x}}^-+\mat{K}\vct{r},
 \end{equation}
-and the cross-covariance factor
-\[
-\fitcol{
-\mat{P}\mat{C}^\top \;=\; \mat{P}^{-} \mat{C}^\top \;=\;
-\begin{bmatrix}
-\mat{P}_{AA} \mat{C}_A^\top + \mat{P}_{AL} \mat{C}_L^\top + \mat{P}_{AB} \mat{C}_B^\top\\
-\mat{P}_{LA} \mat{C}_A^\top + \mat{P}_{LL} \mat{C}_L^\top + \mat{P}_{LB} \mat{C}_B^\top\\
-\mat{P}_{BA} \mat{C}_A^\top + \mat{P}_{BL} \mat{C}_L^\top + \mat{P}_{BB} \mat{C}_B^\top
-\end{bmatrix}
-\;\in\; \mathbb{R}^{N\times 3}.
-}
-\]
-Hence the gain $\mat{K}$ is \emph{entirely determined} by a single $3\times 3$ solve:
-\[
-\mat{K} \;=\; (\mat{P}\mat{C}^\top)\,\matg{\Lambda}^{-1}.
-\]
-This characterization makes no algorithmic assumption: it is a direct algebraic consequence of the rank--3 measurement and the block partition of $\mat{P}^{-}$.
+and covariance is updated in Joseph form,
+\begin{equation}
+\mat{P}^+=(\Id-\mat{K}\mat{C})\mat{P}^-(\Id-\mat{K}\mat{C})^{\top}
++\mat{K}\mat{R}\mat{K}^{\top}.
+\label{eq:joseph-update}
+\end{equation}
 
-\paragraph{Magnetometer (attitude--only)}
-For a world-frame reference field $\vct{B}_w$ (in physical units), the measurement vector is
-$\vct{z}_{\text{mag}}=\vct{m}_{\text{meas}}$ and the model is
+\subsection{Rank--3 block structure}
+Partition the error state into attitude/gyro-bias, linear OU chain, and
+accelerometer-bias groups:
 \[
-\fitcol{
-\vct{z}_{\text{mag}} \;=\; \Rot_{wb}\,\vct{B}_w + \vct{\nu}_m,\qquad
-\mat{C}=\bigl[\,\mat{C}_A\ \ \mat{0}\ \ \mat{0}\,\bigr],\quad
-\mat{C}_A \;=\; -\Skew{\hat{v}_2}\in\mathbb{R}^{3\times 3}.
-}
+\delta\vct{x}=[\vct{A}^{\top},\vct{L}^{\top},\vct{B}^{\top}]^{\top},
 \]
-It follows that
+where $\vct{A}\in\mathbb{R}^6$,
+$\vct{L}=[\delta\vct{v},\delta\vct{p},\delta\vct{S},
+\delta\vct{a}_w]\in\mathbb{R}^{12}$, and
+$\vct{B}=\delta\vct{b}_a\in\mathbb{R}^3$.  Because every correction here has
+measurement dimension three, the gain is obtained from one $3\times3$ solve:
+\begin{equation}
+\mat{K}=(\mat{P}^-\mat{C}^{\top})\matg{\Lambda}^{-1}.
+\end{equation}
+All state groups may be corrected through cross-covariances even when a
+measurement Jacobian directly touches only one group.
+
+For the magnetometer,
 \[
-\fitcol{
-\matg{\Lambda} \;=\; \mat{C}_A \mat{P}_{AA} \mat{C}_A^\top + \mat{R}_{\text{mag}},\qquad
-\mat{P}\mat{C}^\top \;=\; \begin{bmatrix}
-\mat{P}_{AA} \mat{C}_A^\top\\[2pt]
-\mat{P}_{LA} \mat{C}_A^\top\\[2pt]
-\mat{P}_{BA} \mat{C}_A^\top
+\mat{C}_{\mathrm{mag}}
+=\begin{bmatrix}-\Skew{\hat{\vct{m}}_b}&0&0&0\end{bmatrix}.
+\]
+For the accelerometer,
+\[
+\mat{C}_{\mathrm{acc}}
+=\begin{bmatrix}
+-\Skew{\hat{\vct{f}}_{\mathrm{cog},b}}&0&0&0&0&\Rot_{wb}&\Id
 \end{bmatrix},
+\]
+with columns placed according to \eqref{eq:state-vector}.  For the integral
+pseudo-measurement, $\mat{C}_S$ selects the $\vct{S}$ block.
+
+\subsection{Quaternion injection}
+After an accepted correction, let
+$\delta\hat{\vct{\theta}}$ be the first three components of the additive error
+state.  The left-multiplicative injection is
+\begin{equation}
+q\leftarrow\exp_q\!\left(\tfrac12\delta\hat{\vct{\theta}}\right)\otimes q.
+\label{eq:quat-error-injection}
+\end{equation}
+This injection changes the local coordinates in which the attitude error and
+its cross-covariances are expressed.  Therefore simply setting
+$\delta\hat{\vct{\theta}}=0$ is not covariance-consistent.
+
+To first order, the reset Jacobian for the convention used here is
+\begin{equation}
+\mat{G}_{\theta}
+=\Id+\tfrac12\Skew{\delta\hat{\vct{\theta}}},
 \qquad
-\mat{K} \;=\; (\mat{P}\mat{C}^\top)\, \matg{\Lambda}^{-1}.
-}
-\]
-The posterior covariance then follows from the Joseph form, and the left--multiplicative attitude correction is applied to the quaternion, after which the attitude error subvector is reset.
+\mat{G}_{\mathrm{reset}}
+=\blkdiag(\mat{G}_{\theta},\Id_{N_X-3}).
+\label{eq:left-reset-jacobian}
+\end{equation}
+The covariance is transformed before clearing the local error:
+\begin{equation}
+\mat{P}^+
+\leftarrow
+\mat{G}_{\mathrm{reset}}\mat{P}^+
+\mat{G}_{\mathrm{reset}}^{\top},
+\qquad
+\delta\hat{\vct{\theta}}\leftarrow0.
+\label{eq:mekf-reset-covariance}
+\end{equation}
+The transformation applies to both the attitude marginal and every attitude
+cross-covariance.  It is required after accelerometer, magnetometer, position,
+velocity, and $S=0$ updates whenever those updates induce a nonzero attitude
+correction through direct sensitivity or learned cross-covariance.
 
-\paragraph{Accelerometer (attitude + latent $\vct{a}_w$ + bias $\vct{b}_a$)}
-For specific force in body coordinates, the measurement vector is $\vct{z}_{\text{acc}}=\vct{f}_{\text{meas}}$ and
-\[
-\fitcol{
-\vct{z}_{\text{acc}} \;=\; \Rot_{wb}\bigl(\vct{a}_w-\vct{g}\bigr) + \vct{b}_a + \vct{\nu}_a,
-}
-\]
-(optionally with a known lever-arm kinematic term added to the predicted measurement).
-The Jacobian touches three groups:
-\[
-\fitcol{
-\mat{C}=\bigl[\,\mat{C}_A\ \ \mat{C}_L\ \ \mat{C}_B\,\bigr],\quad
-\mat{C}_A = -\Skew{\hat{f}_b},\quad
-\mat{C}_L = \begin{bmatrix}\mat{0}_{3\times 9} & \Rot_{wb}\end{bmatrix},\quad
-\mat{C}_B = \mat{I}_3.
-}
-\]
-The rank--3 structure again yields
-\[
-\matg{\Lambda} \;=\; \mat{C}\,\mat{P}^{-}\,\mat{C}^\top + \mat{R}_{\text{acc}},\qquad
-\mat{K} \;=\; (\mat{P}\mat{C}^\top)\,\matg{\Lambda}^{-1},
-\]
-with $\mat{P}\mat{C}^\top$ assembled from the covariance blocks as above.
-\emph{This is precisely how the body-frame accelerometer residual updates the world-frame latent acceleration:}
-since $\partial h_{\text{acc}}/\partial \vct{a}_w = \Rot_{wb}$, the correction
-$\hat{\vct{x}}^{+}=\hat{\vct{x}}^{-}+\mat{K}\vct{r}$ contains a nonzero $\delta\vct{a}_w$ block,
-i.e.\ $\delta\vct{a}_w=(\mat{K}\vct{r})_{\vct{a}_w}$.
-
-\paragraph{Attitude}
-After each correction, the small-angle attitude increment
-$\delta\vct{\theta}$ is converted back into a unit quaternion
-via
-\[
-q \leftarrow \exp_q(\tfrac{1}{2}\delta\vct{\theta}) \otimes q,
-\qquad \delta\vct{\theta} \leftarrow \vct{0},
-\]
-closing the multiplicative EKF loop on~$SO(3)$.
-
-\subsection*{Numerical form and invariants}
-Because $\matg{\Lambda}\in\mathbb{R}^{3\times 3}$ is SPD whenever $\mat{R}\succ 0$,
-its factorization (LDL$^\top$ or Cholesky with a diagonal bump if needed) is well-posed. 
-The gain $\mat{K}$ is obtained by right-multiplying the $N\times 3$ cross-covariance
-$\mat{P}\mat{C}^\top$ with the $3\times 3$ inverse of $\matg{\Lambda}$. The posterior covariance
-satisfies the usual invariants:
-\begin{itemize}\itemsep2pt
-\item $\mat{P}^{+}$ is symmetric and (to numerical precision) PSD under the Joseph update.
-\item The left--multiplicative quaternion correction preserves unit norm and keeps the
-      linearization point consistent with the reset $\delta\vct{\theta}^{+}=0$.
-\end{itemize}
-This is precisely the form realized by the implementation: the block algebra expresses the method’s intrinsic
-structure rather than a procedural recipe, and the reduction to a single rank--3 solve is a direct consequence
-of the measurement dimension. The rank-3 structure substantially lowers computational cost enabling 
-real-time execution on resource-constrained MCU-class processors.
+\subsection{Numerical invariants}
+The innovation matrix is factored with an LDL$^{\top}$ solve and a small
+scale-dependent diagonal safeguard only when needed.  Equation
+\eqref{eq:joseph-update}, covariance symmetrization, and the reset
+\eqref{eq:mekf-reset-covariance} preserve the intended invariants to numerical
+precision: $\mat{P}=\mat{P}^{\top}$, $\mat{P}\succeq0$, unit quaternion norm,
+and a zero local attitude-error mean after injection.

--- a/doc/kalman_ou_iii/w3d-meas.tex-part
+++ b/doc/kalman_ou_iii/w3d-meas.tex-part
@@ -1,223 +1,99 @@
 \section{Measurement Model}
 \label{sec:measurement_model}
 
-The filter employs three complementary measurement channels:
-the accelerometer, the magnetometer, and a zero-valued
-pseudo-measurement on the integral displacement~$\vct{S}$.
-The gyroscope is treated as a propagation input for the attitude dynamics.
-Each measurement channel provides an independent correction pathway for attitude
-and translational drift.
+The filter uses accelerometer and magnetometer corrections together with a
+zero-valued pseudo-measurement on the integral displacement $\vct{S}$.  The
+gyroscope is a propagation input.
 
-\subsection{Accelerometer Model}
-
-The specific force measured in the body frame is modeled as
+\subsection{Accelerometer model}
+The body-frame specific-force measurement is
 \begin{equation}
+\vct{f}_b=\Rot_{wb}(\vct{a}_w-\vct{g}_w)+\vct{b}_a(T)+\vct{n}_a,
 \label{eq:acc-meas}
-\vct{f}_b
-= \Rot_{wb}\,(\vct{a}_w - \vct{g}_w)
-  + \vct{b}_a(T)
-  + \vct{n}_a,
 \end{equation}
-where
-\begin{itemize}
-  \item $\Rot_{wb}$ is the world-to-body rotation matrix
-        corresponding to quaternion~$q$,
-  \item $\vct{g}_w = [0,\,0,\,g]^\top$ is the gravity vector
-        in world coordinates ($g=9.80665~\mathrm{m/s^2}$),
-  \item $\vct{a}_w$ is the latent OU world acceleration,
-  \item $\vct{b}_a(T) = \vct{b}_{a0}
-        + \vct{k}_a\,(T - T_\mathrm{ref})$
-        represents the temperature-dependent accelerometer bias with measured IMU chip temperature $T$,
-  \item $\vct{n}_a \sim \mathcal{N}(\vct{0},\,\mat{R}_a)$
-        is white measurement noise.
-\end{itemize}
-
-The corresponding Jacobians, consistent with the
-left-multiplicative attitude convention, are
+where $\vct{g}_w=[0,0,g]^{\top}$ in NED,
+$\vct{n}_a\sim\mathcal{N}(0,\mat{R}_a)$, and
+\[
+\vct{b}_a(T)=\vct{b}_{a0}+\vct{k}_a(T-T_{\mathrm{ref}}).
+\]
+For the left-multiplicative convention,
 \begin{align}
-\frac{\partial \vct{f}_b}{\partial \vct{\theta}}
-  &= -\Skew{\hat{\vct{f}}_{\mathrm{cog},b}}, &
-\frac{\partial \vct{f}_b}{\partial \vct{a}_w}
-  &= \Rot_{wb}, &
-\frac{\partial \vct{f}_b}{\partial \vct{b}_a}
-  &= \mat{I}_3,
+\frac{\partial\vct{f}_b}{\partial\delta\vct{\theta}}
+&=-\Skew{\hat{\vct{f}}_{\mathrm{cog},b}},&
+\frac{\partial\vct{f}_b}{\partial\vct{a}_w}&=\Rot_{wb},&
+\frac{\partial\vct{f}_b}{\partial\vct{b}_a}&=\Id,
 \end{align}
 where
-\(
-\hat{\vct{f}}_{\mathrm{cog},b}
-=\Rot_{wb}\,(\hat{\vct{a}}_w-\vct{g}_w)
-\)
-is the predicted center-of-gravity specific force
-(excluding the lever-arm term).
+$\hat{\vct{f}}_{\mathrm{cog},b}=\Rot_{wb}(\hat{\vct{a}}_w-\vct{g}_w)$.
+Thus the accelerometer update couples attitude, latent world acceleration, and
+accelerometer bias through one rank--3 correction.
 
-The accelerometer update corrects both attitude and the OU acceleration
-state, maintaining the physical coupling between tilt, gravity alignment,
-and translational excitation.
-
-\iffalse
-\paragraph{Attitude-only / marginalized-acceleration mode.}
-When the linear navigation block is disabled (i.e., \(\vct{a}_w\) is not explicitly
-propagated as a state), the filter treats the latent excitation as an
-\emph{unmodeled input} and inflates the accelerometer innovation covariance
-by the stationary OU acceleration covariance:
+\subsection{Magnetometer model}
+With calibrated world reference $\vct{B}_w$,
 \begin{equation}
-\label{eq:acc-marginal-aw}
-\mat{S}_a
-\;\leftarrow\;
-\mat{S}_a
-+
-\Rot_{wb}\,\Sigma_{a_w}^{\mathrm{stat}}\,\Rot_{wb}^{\top},
-\end{equation}
-which is equivalent to marginalizing \(\vct{a}_w\) in the measurement update.
-\fi
-
-\subsection{Magnetometer Model}
-
-The predicted magnetic field in the body frame is
-\begin{equation}
+\vct{m}_b=\Rot_{wb}\vct{B}_w+\vct{n}_m,
+\qquad
+\vct{n}_m\sim\mathcal{N}(0,\mat{R}_m),
 \label{eq:mag-meas}
-\vct{m}_b = \Rot_{wb}\,\vct{B}_w + \vct{n}_m,
 \end{equation}
-where $\vct{B}_w$ is the calibrated magnetic reference vector
-expressed in world coordinates (usually defined by local
-declination~$D$ and inclination~$I$), and
-$\vct{n}_m \sim \mathcal{N}(\vct{0},\,\mat{R}_m)$
-is magnetometer noise.
-
-Linearization yields the attitude Jacobian using matrix skew operator
+and
 \begin{equation}
-\frac{\partial \vct{m}_b}{\partial \vct{\theta}}
-  = -\Skew{m_b}.
+\frac{\partial\vct{m}_b}{\partial\delta\vct{\theta}}
+=-\Skew{\hat{\vct{m}}_b}.
 \end{equation}
 
-\iffalse
-The predicted magnetic field in the body frame is
+\subsection{Integral pseudo-measurement}
+The drift-control channel is
 \begin{equation}
-\label{eq:mag-meas}
-\vct{m}_b
-=
-\Rot_{wb}\,\vct{B}_w
-+ \vct{b}_m
-+ \vct{n}_m,
-\end{equation}
-where $\vct{B}_w$ is the calibrated magnetic reference vector
-expressed in world coordinates (usually defined by local
-declination~$D$ and inclination~$I$), \(\vct{b}_m\) is an optional
-(estimated) magnetometer bias, and
-$\vct{n}_m \sim \mathcal{N}(\vct{0},\,\mat{R}_m)$
-is magnetometer noise.
-
-Linearization yields the attitude Jacobian using matrix skew operator
-\begin{equation}
-\frac{\partial \vct{m}_b}{\partial \vct{\theta}}
-  = -\Skew{\hat{\vct{m}}_b},
-\end{equation}
-and, when \(\vct{b}_m\) is estimated,
-\(
-\frac{\partial \vct{m}_b}{\partial \vct{b}_m}=\mat{I}_3.
-\)
-
-\paragraph{Implementation note.}
-For robustness when the reference polarity may be ambiguous, the implementation
-applies a dot-product sign check and flips the predicted vector if needed so that
-\(\hat{\vct{m}}_b^{\top}\vct{m}_b \ge 0\) prior to forming the innovation.
-\fi
-
-\subsection{Integral Pseudo-Measurement}
-
-To constrain long-term drift of the triple-integrated position
-state~$\vct{S}$, the filter applies a zero-valued
-pseudo-measurement:
-\begin{equation}
+\vct{z}_S=0=\vct{S}+\vct{n}_S,
+\qquad
+\vct{n}_S\sim\mathcal{N}(0,\mat{R}_S),
 \label{eq:zero-pseudo}
-\vct{z}_S = \vct{0}
-= \vct{S} + \vct{n}_S,
 \end{equation}
-with covariance $\mat{R}_S = \mathrm{diag}(\sigma_{Sx}^2,
-\sigma_{Sy}^2, \sigma_{Sz}^2)$.
-The corresponding measurement Jacobian is simply
+with
 \begin{equation}
-\frac{\partial \vct{z}_S}{\partial \vct{S}} = \mat{I}_3.
+\mat{R}_S=\diag(\sigma_{Sx}^2,\sigma_{Sy}^2,\sigma_{Sz}^2),
+\qquad
+\mat{H}_S=\begin{bmatrix}0&\cdots&\Id_{S}&\cdots&0\end{bmatrix}.
 \end{equation}
+The implementation API is parameterized by the standard-deviation vector
+$\vct{\sigma}_S$ and squares it internally to form $\mat{R}_S$.  Consequently,
+scalar adaptation laws denoted by $R_S$ elsewhere in the paper refer to a
+standard-deviation scale; the Kalman update always uses its squared covariance.
 
-This channel is not tied to a physical sensor: it provides a soft
-regularization that prevents uncontrolled growth of $\vct{S}$ while still
-allowing slow wave-induced motion. In the discrete-time implementation,
-repeated application of~\eqref{eq:zero-pseudo} turns the pure triple integral
-into a \emph{leaky} integral. In linear systems terms, the $S$-mode acquires a
-real negative eigenvalue whose magnitude depends on~$\mat{R}_S$: very
-low-frequency components of the integrated displacement are attenuated, so the
-pseudo-measurement acts as an \emph{effective high-pass} on the $S$-channel.
+This pseudo-measurement is a regularizer, not a physical observation.  Repeated
+application creates a soft leak in the augmented integration chain: smaller
+$\vct{\sigma}_S$ gives stronger low-frequency drift suppression, while larger
+values preserve slower motion at the cost of more drift.
 
-The choice of $\mat{R}_S$ is therefore critical:
-\begin{itemize}
-\item A small $\mat{R}_S$ yields a strong leak (large Kalman gain),
-      effectively pinning $\vct{S}\approx\vct{0}$ and pushing the
-      high-pass corner upward. This aggressively damps double-integral drift
-      but risks over-regularizing very long swell components.
-\item A large $\mat{R}_S$ yields a weak leak (small Kalman gain), so
-      $\vct{S}$ behaves closer to an ideal triple integral. Very slow drift
-      is less suppressed, but the filter exerts less artificial feedback on
-      long-period motion.
-\end{itemize}
-
-In this sense, $\mat{R}_S$ is a \emph{tuning parameter} rather than a
-physical noise level: it sets how strongly the filter treats the auxiliary
-state $\vct{S}$ as ``should be near zero'' versus ``free to wander''. Proper
-choice of $\mat{R}_S$ makes the augmented system effectively detectable:
-although $\vct{S}$ is not directly observable from real sensors, the
-pseudo-measurement provides an artificial observation that stabilizes the
-covariance and prevents drift of integrated displacement.
-
-\subsection{IMU Lever-Arm Model}
-
-In many installations the IMU is not located at the vessel's center of gravity
-but at a fixed lever arm $\vct{r}_b \in \mathbb{R}^3$ expressed in the
-body frame. The accelerometer then measures the specific force at the IMU
-location, which differs from the specific force at the center of gravity
-(CoG) by contributions due to angular motion.
-
-Let $\vct{\omega}_b$ denote the body-frame angular velocity from the
-gyroscope after bias correction, and let $\vct{\alpha}_b$ be an
-estimate of the angular acceleration, obtained by finite differences and
-optionally low-pass filtered. The specific force at the CoG in the body
-frame is
+\paragraph{Time-based cadence.}
+Let $T_S>0$ be the configured pseudo-update period and let $e_k$ be elapsed time
+since the previous application.  At each variable-duration IMU step $h_k$,
 \[
-\vct{f}_{\mathrm{cog},b}
-  = \Rot_{wb}\,(\vct{a}_w - \vct{g}_w),
+\tilde e_{k+1}=e_k+h_k.
 \]
-and the specific force at the IMU becomes
+If $\tilde e_{k+1}<T_S$, no pseudo-update is performed and
+$e_{k+1}=\tilde e_{k+1}$.  Otherwise the update is applied and
 \begin{equation}
+e_{k+1}=\tilde e_{k+1}\bmod T_S.
+\label{eq:pseudo-elapsed-scheduler}
+\end{equation}
+A floating-point tolerance is used at the boundary.  Defining cadence in
+seconds rather than as every $N$ samples makes the regularization rate invariant
+to the IMU sample rate; the same $T_S$ produces the same number of updates per
+unit time at 100, 200, or 400~Hz.
+
+\subsection{IMU lever-arm model}
+If the IMU is displaced from the center of gravity by known body-frame vector
+$\vct{r}_b$, the predicted specific force includes
+\begin{equation}
+\vct{f}_b=\vct{f}_{\mathrm{cog},b}
++\vct{\alpha}_b\times\vct{r}_b
++\vct{\omega}_b\times(\vct{\omega}_b\times\vct{r}_b)
++\vct{b}_a(T)+\vct{n}_a.
 \label{eq:acc-meas-lever}
-\vct{f}_b
-  = \vct{f}_{\mathrm{cog},b}
-    + \vct{\alpha}_b \times \vct{r}_b
-    + \vct{\omega}_b \times
-      \bigl(\vct{\omega}_b \times \vct{r}_b\bigr)
-    + \vct{b}_a(T)
-    + \vct{n}_a.
 \end{equation}
-
-The lever-arm term is purely kinematic and depends only on
-\((\vct{\omega}_b,\vct{\alpha}_b,\vct{r}_b)\), which are treated as known inputs
-rather than estimated states. In the implemented filter, this term is applied
-to the predicted measurement but is not included in the attitude Jacobian
-(i.e., second-order coupling of the lever-arm term through attitude uncertainty
-is neglected). Consequently, the measurement Jacobians with respect to the
-filter state remain identical to those in~\eqref{eq:acc-meas}, with
-\(\Skew{\hat{\vct{f}}_{\mathrm{cog},b}}\) computed from the CoG prediction:
-\begin{align}
-\frac{\partial \vct{f}_b}{\partial \vct{\theta}}
-  &= -\Skew{\hat{\vct{f}}_{\mathrm{cog},b}}, &
-\frac{\partial \vct{f}_b}{\partial \vct{a}_w}
-  &= \Rot_{wb}, &
-\frac{\partial \vct{f}_b}{\partial \vct{b}_a}
-  &= \mat{I}_3,
-\end{align}
-while
-\[
-\frac{\partial \vct{f}_b}{\partial \vct{x}_\text{other}} = \mat{0}
-\]
-for all remaining state components. Setting $\vct{r}_b = \vct{0}$
-recovers the CoG model~\eqref{eq:acc-meas} and disables the lever-arm
-correction.
+The angular-rate and angular-acceleration terms are treated as known inputs.
+The implementation does not include their second-order coupling through
+attitude uncertainty, so the state Jacobians remain those of
+\eqref{eq:acc-meas}.  Setting $\vct{r}_b=0$ disables the correction.

--- a/doc/kalman_ou_iii/w3d-proc-cont.tex-part
+++ b/doc/kalman_ou_iii/w3d-proc-cont.tex-part
@@ -1,195 +1,145 @@
 \section{Process Model (Continuous Time)}
 \label{sec:proc}
 
-We separate (i) the quaternion attitude subsystem used by the left--multiplicative
-EKF and (ii) the linear OU--driven kinematic chain. The former is propagated on
-the manifold (nominal quaternion); the latter is a vector LTI SDE in continuous time.
+We separate (i) the quaternion attitude subsystem used by the
+left-multiplicative MEKF and (ii) the linear OU-driven kinematic chain.  The
+nominal quaternion is propagated on the manifold, while the covariance is
+propagated for the additive error state of \eqref{eq:state-vector}.
 
-\subsection{Attitude subsystem (Q--MEKF nominal and error)}
-Let $\vct{\omega}_m$ be the measured gyro rate (body), $\vct{b}_g$ the gyro bias,
-and $\vct{n}_g$ gyro noise (white, zero–mean). The \emph{nominal} quaternion
-$q$ (world$\to$body) obeys
+\subsection{Attitude subsystem}
+Let $\vct{\omega}_m$ be measured body angular rate and $\vct{b}_g$ the nominal
+gyroscope bias.  The stored quaternion maps world to body and obeys
 \begin{equation}
-\begin{aligned}
-\dot{q} =& -\tfrac12\,\Omega\!\left(\vct{\omega}_m-\vct{b}_g\right)\,q,
-\qquad
-q \in \mathbb{H}_1,\qquad\\
-\Omega(\vct{\omega}) =&
+\dot q=-\tfrac12\,\Omega(\vct{\omega}_m-\vct{b}_g)q,
+\qquad q\in\Sph^3,
+\end{equation}
+with
+\[
+\Omega(\vct{\omega})=
 \begin{bmatrix}
-0 & -\vct{\omega}^\top\\[1ex]
-\vct{\omega} & -\Skew{\vct{\omega}}
-\end{bmatrix},
-\end{aligned}
-\end{equation}
-with unit–norm enforcement in implementation. The gyro bias follows a random walk
-\begin{equation}
-\fitcol{
-\dot{\vct{b}}_g = \vct{w}_{bg}, \qquad
-\vct{w}_{bg}\sim\mathcal N(\vct{0},\ \matg{Q}_{bg}),
-}
-\end{equation}
-where $\matg{Q}_{bg}$ is the continuous–time spectral density (per axis).
+0&-\vct{\omega}^{\top}\\
+\vct{\omega}&-\Skew{\vct{\omega}}
+\end{bmatrix}.
+\]
+The implementation renormalizes the quaternion after propagation and
+correction.
 
-For the left--multiplicative error state, we use a small rotation vector
-$\delta\vct{\theta}$ so that $q^+ = \exp(\tfrac12\,\delta\vct{\theta})\otimes q$.
-Linearizing the attitude error dynamics gives the standard Q--MEKF form \cite{Markley2003AttitudeError,TrawnyRoumeliotis2005_IndirectKF}
+Gyroscope bias follows
+\begin{equation}
+\dot{\vct{b}}_g=\vct{w}_{bg},
+\qquad
+\E[\vct{w}_{bg}(t)\vct{w}_{bg}^{\top}(s)]
+=\matg{Q}_{bg}\,\delta(t-s).
+\end{equation}
+For the left-multiplicative local error,
+$q^+=\exp_q(\tfrac12\delta\vct{\theta})\otimes q$, the first-order dynamics are
 \begin{equation}
 \dot{\delta\vct{\theta}}
-\;\approx\;
--\Skew{\vct{\omega}_m-\vct{b}_g}\,\delta\vct{\theta}
-\;+\;\delta\vct{b}_g
-\;-\;\vct{n}_g,
+=-\Skew{\hat{\vct{\omega}}}\,\delta\vct{\theta}
++\delta\vct{b}_g-\vct{n}_g,
 \qquad
-\vct{n}_g\sim\mathcal N(\vct{0},\ \matg{Q}_g),
+\hat{\vct{\omega}}=\vct{\omega}_m-\hat{\vct{b}}_g,
 \label{eq:att-error}
 \end{equation}
-where $\matg{Q}_g$ is the gyro white–noise spectral density.
+where
+\[
+\E[\vct{n}_g(t)\vct{n}_g^{\top}(s)]
+=\matg{Q}_g\,\delta(t-s).
+\]
+Thus $\matg{Q}_g$ is a continuous-time spectral-density matrix.  If a
+simulator specifies independent per-sample angular-rate noise with standard
+deviation $\vct{\sigma}_{g,\mathrm{samp}}$ at sample interval $h$, the
+corresponding density passed to the filter is
+\begin{equation}
+\vct{\sigma}_{g,\mathrm{dens}}
+=\vct{\sigma}_{g,\mathrm{samp}}\sqrt{h},
+\qquad
+\matg{Q}_g=\diag(\vct{\sigma}_{g,\mathrm{dens}}^2).
+\label{eq:gyro-density-conversion}
+\end{equation}
+This distinction prevents a sample-rate change from silently changing the
+attitude process covariance.
 
 \subsection{Linear kinematic chain with OU acceleration}
-Let $\vct{a}_w$ be the latent world–frame acceleration (NED). Along each axis
-the chain $\dot{\vct{v}}=\vct{a}_w$, $\dot{\vct{p}}=\vct{v}$,
-$\dot{\vct{S}}=\vct{p}$ is driven by a vector OU process
+The world-frame chain is
+\begin{equation}
+\dot{\vct{v}}=\vct{a}_w,
+\qquad
+\dot{\vct{p}}=\vct{v},
+\qquad
+\dot{\vct{S}}=\vct{p}.
+\end{equation}
+The latent acceleration is assigned the vector OU prior
 \begin{equation}
 \begin{aligned}
-\dot{\vct{a}}_w &= -\tfrac{1}{\tau}\,\vct{a}_w
-+ \sqrt{\tfrac{2}{\tau}}\;\mat{L}_a\,\vct{w}_a(t),\\
-\mat{L}_a \mat{L}_a^\top &= \matg{\Sigma}_{aw}, \qquad
-\text{$\vct{w}_a$ is standard white noise.}
+ d\vct{a}_w
+ &= -\tfrac1\tau\vct{a}_w\,dt
+    +\sqrt{\tfrac2\tau}\,\mat{L}_a\,d\vct{W}_a,\\
+ \mat{L}_a\mat{L}_a^{\top}
+ &=\matg{\Sigma}_{aw}^{\mathrm{stat}}.
 \end{aligned}
 \label{eq:ou-ct}
 \end{equation}
-Here $\tau>0$ is the correlation time and $\matg{\Sigma}_{aw}\succ0$ the stationary
-covariance (diagonal or correlated).
+Here $\tau>0$ is the correlation time and
+$\matg{\Sigma}_{aw}^{\mathrm{stat}}\succeq0$ is the stationary acceleration
+covariance.
 
-The sea wave-induced floating body acceleration is not OU; instead,
-\eqref{eq:ou-ct} is used as a low-order \emph{stationary Gauss--Markov prior} that captures \cite{Maybeck1979_StochasticModels,Jazwinski1970_Filtering}
-a key property for inertial drift control: the effective wave-driven acceleration is
-\emph{colored} with a finite correlation time on the order of the dominant wave time scale.
-The parameter $\tau$ sets this correlation time, while the stationary covariance
-$\matg{\Sigma}_{aw}$ sets the acceleration energy level; both can be tuned (or adapted
-online) from measured specific-force statistics. From an estimation standpoint, the OU
-prior is attractive because it is Markov (minimal state), mean-reverting with bounded
-variance, and admits closed-form discretization for $\matg{\Phi}(h)$ and $\matg{Q}_d(h)$.
+Ocean-wave acceleration is not asserted to be an OU process.  Equation
+\eqref{eq:ou-ct} is a low-order stationary Gauss--Markov prior
+\cite{Maybeck1979_StochasticModels,Jazwinski1970_Filtering}.  It is useful
+because it is Markov, mean-reverting, bounded in variance, and analytically
+discretizable.  For a scalar component with stationary variance $\sigma_a^2$,
+\[
+S_a(\omega)=\frac{2\sigma_a^2\tau}{1+\omega^2\tau^2}.
+\]
+This is a zero-centered first-order low-pass spectrum.  The empirical relation
+between $\tau$ and a tracked wave period is therefore a tuning rule for the
+prior, not a claim that the OU spectrum has a resonant peak at the wave
+frequency.
 
-In the frequency domain, each scalar OU component has PSD
-\(
-S_a(\omega)=\tfrac{2\sigma_a^2\tau}{1+\omega^2\tau^2}
-\),
-so relative to a white--acceleration model the OU dynamics act as a
-first--order low--pass filter on the driving noise, with corner frequency
-$\omega_c\approx 1/\tau$. This concentrates acceleration energy in a finite
-band around the dominant wave time scale and suppresses unrealistically fast
-(very high--frequency) components.
-
-We model the accelerometer bias as a (temperature--offset) random walk,
+Accelerometer bias follows
 \begin{equation}
-\dot{\vct{b}}_a = \vct{w}_{ba},\qquad
-\vct{w}_{ba}\sim\mathcal N(\vct{0},\ \matg{Q}_{ba}),
+\dot{\vct{b}}_a=\vct{w}_{ba},
+\qquad
+\E[\vct{w}_{ba}(t)\vct{w}_{ba}^{\top}(s)]
+=\matg{Q}_{ba}\,\delta(t-s),
 \label{eq:ba-rw}
 \end{equation}
-while its temperature dependence
-$\vct{b}_a(T)=\vct{b}_{a0}+\vct{k}_a(T-T_0)$
-enters the \emph{measurement} model, not the process.
+while the deterministic temperature term enters the measurement model.
 
-\subsection{Unified Continuous-Time LTI SDE (Attitude + Linear States)}
-\label{sec:lti-sde}
-
-Over each small sampling interval we assume the body angular velocity
-$\vct{\omega}_m-\vct{b}_g$ is constant. Under this standard Q--MEKF
-approximation, the small-angle attitude error $\delta\vct{\theta}$ evolves
-linearly, so both the attitude and the linear kinematic chains can be
-combined into a single continuous-time LTI stochastic differential
-equation with full error-state vector.
-
-\[
-\dot{\vct{x}}_{\rm err}
-= \mat{F}\,\vct{x}_{\rm err}
-+ \mat{L}\,\vct{w},
-\]
-
-where $\vct{w}$ collects all driving white noises
-$\vct{w}=[\,\vct{n}_g^\top,\ \vct{w}_{bg}^\top,\
-\vct{w}_a^\top,\ \vct{w}_{ba}^\top\,]^\top$.
-
-The continuous-time dynamics are linearized about the nominal trajectory
-and take the block structure
-\[
-\fitcol{
-\mat{F} =
-\begingroup\setlength\arraycolsep{4pt}
-\begin{bmatrix}
--\Skew{\vct{\omega}_m-\vct{b}_g} & +\Id & \mat{0} & \mat{0} & \mat{0} & \mat{0} & \mat{0}\\
-\mat{0} & \mat{0} & \mat{0} & \mat{0} & \mat{0} & \mat{0} & \mat{0}\\
-\mat{0} & \mat{0} & \mat{0} & \mat{0} & \mat{0} & \Id & \mat{0}\\
-\mat{0} & \mat{0} & \Id & \mat{0} & \mat{0} & \mat{0} & \mat{0}\\
-\mat{0} & \mat{0} & \mat{0} & \Id & \mat{0} & \mat{0} & \mat{0}\\
-\mat{0} & \mat{0} & \mat{0} & \mat{0} & \mat{0} & -\tfrac{1}{\tau}\Id & \mat{0}\\
-\mat{0} & \mat{0} & \mat{0} & \mat{0} & \mat{0} & \mat{0} & \mat{0}
-\end{bmatrix}
-\endgroup,
-}
-\]
-with each block $3\times3$ and block rows corresponding to
-$[\delta\vct{\theta},\,\vct{b}_g,\,\vct{v},\,\vct{p},\,\vct{S},\,\vct{a}_w,\,\vct{b}_a]$.
-
-The diffusion matrix $\mat{L}$ injects the independent process noises:
-\[
-\fitcol{
-\mat{L} =
-\begingroup\setlength\arraycolsep{4pt}
-\begin{bmatrix}
--\Id & \mat{0} & \mat{0} & \mat{0}\\
-\mat{0} & \Id & \mat{0} & \mat{0}\\
-\mat{0} & \mat{0} & \mat{0} & \mat{0}\\
-\mat{0} & \mat{0} & \mat{0} & \mat{0}\\
-\mat{0} & \mat{0} & \mat{0} & \mat{0}\\
-\mat{0} & \mat{0} & \sqrt{\tfrac{2}{\tau}}\,\mat{L}_a & \mat{0}\\
-\mat{0} & \mat{0} & \mat{0} & \Id
-\end{bmatrix}
-\endgroup,
-\\
-\qquad
-\mathbb E[\vct{w}\,\vct{w}^\top]
-= \mathrm{blkdiag}\!\left(
-\matg{Q}_g,\ \matg{Q}_{bg},\ \mat{I}_3,\ \matg{Q}_{ba}
-\right).
-}
-\]
-
-Hence the full continuous-time process model compactly reads
+\subsection{Unified local-error SDE}
+Over one sample interval, $\hat{\vct{\omega}}$ is treated as constant.  With
+block ordering
+$[\delta\vct{\theta},\delta\vct{b}_g,\delta\vct{v},
+\delta\vct{p},\delta\vct{S},\delta\vct{a}_w,\delta\vct{b}_a]$, the local error
+model is
 \begin{equation}
-\dot{\vct{x}}_{\rm err}(t)
-= \mat{F}\,\vct{x}_{\rm err}(t)
-+ \mat{L}\,\vct{w}(t),
-\qquad
-\matg{Q}_c = \mat{L}\,\mathbb E[\vct{w}\vct{w}^\top]\,\mat{L}^\top,
-\label{eq:full-sde}
+\dot{\delta\vct{x}}=\mat{F}\,\delta\vct{x}+\mat{L}\vct{w},
 \end{equation}
-where $\mat{F}$ and $\mat{L}$ are the Jacobian (linearized) dynamics and
-noise-input matrices, and $\matg{Q}_c$ is the
-continuous-time spectral density of the driving white noises.
+where
+\[
+\fitcol{
+\mat{F}=
+\begin{bmatrix}
+-\Skew{\hat{\vct{\omega}}}&+\Id&0&0&0&0&0\\
+0&0&0&0&0&0&0\\
+0&0&0&0&0&\Id&0\\
+0&0&\Id&0&0&0&0\\
+0&0&0&\Id&0&0&0\\
+0&0&0&0&0&-\tau^{-1}\Id&0\\
+0&0&0&0&0&0&0
+\end{bmatrix}.
+}
+\]
+The driving spectral density is assembled from $\matg{Q}_g$,
+$\matg{Q}_{bg}$, $2\matg{\Sigma}_{aw}^{\mathrm{stat}}/\tau$, and
+$\matg{Q}_{ba}$.
 
-Let $\mat{P}(t)$ be the error covariance. The \emph{propagation} (no measurement)
-obeys the continuous Lyapunov equation
+The covariance propagation satisfies
 \begin{equation}
-\dot{\mat{P}} \;=\; \mat{F}\,\mat{P} + \mat{P}\,\mat{F}^\top
-\;+\; \matg{Q}_c.
+\dot{\mat{P}}=\mat{F}\mat{P}+\mat{P}\mat{F}^{\top}+\matg{Q}_c,
 \label{eq:lyap-prop}
 \end{equation}
-If continuous-time measurements $\vct{z}=\mat{H}\,\delta\vct{x}+\vct{\eta}$
-with $\mathbb E[\vct{\eta}\vct{\eta}^\top]=\mat{R}$ are considered,
-the \emph{Kalman--Bucy Riccati} adds the information term
-\begin{equation}
-\dot{\mat{P}} \;=\; \mat{F}\,\mat{P} + \mat{P}\,\mat{F}^\top
-\;+\; \matg{Q}_c
-\;-\; \mat{P}\,\mat{H}^\top \mat{R}^{-1}\mat{H}\,\mat{P}.
-\label{eq:kbc}
-\end{equation}
-Equations \eqref{eq:lyap-prop}--\eqref{eq:kbc} are the continuous counterparts of
-the discrete Joseph-form covariance update used in implementation.
-
-This unified linear system provides the foundation for analytic
-discretization in the next section: the per-axis exponential of
-$\mat{F}$ yields the transition $\matg{\Phi}(h)$, and the corresponding
-integral gives the discrete process covariance $\matg{Q}_d(h)$ used in
-the Kalman time-update.
+which is discretized in the following sections.  Measurement updates use the
+Joseph form, followed by the MEKF reset transformation described in
+Sec.~\ref{sec:meas-update-structure}.

--- a/doc/kalman_ou_iii/w3d-state.tex-part
+++ b/doc/kalman_ou_iii/w3d-state.tex-part
@@ -1,57 +1,69 @@
 \section{State Definition}
 \label{sec:state}
 
-The extended state vector of our filter combines
-rotational attitude, linear kinematics, and stochastic acceleration subsystems within a
-single nonlinear estimator. It is defined as
+The estimator maintains a nominal quaternion separately from the additive
+navigation and bias states.  With the quaternion written as $q\in\Sph^3$, the
+nominal state is
+\begin{equation}
+\label{eq:nominal-state-vector}
+\vct{x}_{\mathrm{nom}} =
+\begin{bmatrix}
+q &
+\vct{b}_g^{\top} &
+\vct{v}^{\top} &
+\vct{p}^{\top} &
+\vct{S}^{\top} &
+\vct{a}_w^{\top} &
+\vct{b}_a^{\top}
+\end{bmatrix}^{\!\top}.
+\end{equation}
+The quaternion is propagated and corrected on $\Sph^3$; it is not updated by
+ordinary vector addition.
+
+The covariance is defined for the local error state
 \begin{equation}
 \label{eq:state-vector}
-\vct{x} =
+\delta\vct{x} =
 \begin{bmatrix}
-\delta\vct{\theta} &
-\vct{b}_g &
-\vct{v} &
-\vct{p} &
-\vct{S} &
-\vct{a}_w &
-\vct{b}_a
+\delta\vct{\theta}^{\top} &
+\delta\vct{b}_g^{\top} &
+\delta\vct{v}^{\top} &
+\delta\vct{p}^{\top} &
+\delta\vct{S}^{\top} &
+\delta\vct{a}_w^{\top} &
+\delta\vct{b}_a^{\top}
 \end{bmatrix}^{\!\top},
 \end{equation}
-where each subvector has the following physical meaning:
+where
 \begin{itemize}
-  \item $\delta\vct{\theta}\in\mathbb{R}^3$ --- small attitude-error
-        vector used in the multiplicative EKF formulation \cite{Shuster1993_AttitudeRepresentations,MarkleyCrassidis2014_Attitude}
-        (left-multiplicative quaternion correction).
-  \item $\vct{b}_g\in\mathbb{R}^3$ --- gyroscope bias, modeled as a
-        random-walk process.
-  \item $\vct{v}\in\mathbb{R}^3$ --- velocity in the world (NED) frame.
-  \item $\vct{p}\in\mathbb{R}^3$ --- position or displacement in the world frame.
-  \item $\vct{S}\in\mathbb{R}^3$ --- integral of displacement,
-        $\vct{S}(t)=\int_0^t\vct{p}(\tau)\,d\tau$, used to constrain
-        long-term drift by a zero pseudo-measurement.
-  \item $\vct{a}_w\in\mathbb{R}^3$ --- latent world-frame acceleration
-        following an Ornstein--Uhlenbeck (OU) process \cite{UhlenbeckOrnstein1930_OU},
-        \(
-           \dot{\vct{a}}_w = -\tfrac{1}{\tau_{a_w}}\vct{a}_w
-           + \vct{\eta}_{w}(t)
-        \),
-        representing correlated ocean-wave forcing.
-  \item $\vct{b}_a\in\mathbb{R}^3$ --- random-walk accelerometer bias with optional
-        temperature-dependent drift.
+  \item $\delta\vct{\theta}\in\mathbb{R}^3$ is the small
+        left-multiplicative attitude error used by the MEKF
+        \cite{Shuster1993_AttitudeRepresentations,MarkleyCrassidis2014_Attitude};
+  \item $\vct{b}_g\in\mathbb{R}^3$ is gyroscope bias, modeled as a random walk;
+  \item $\vct{v}\in\mathbb{R}^3$ is velocity in the world NED frame;
+  \item $\vct{p}\in\mathbb{R}^3$ is position or displacement in the world frame;
+  \item $\vct{S}\in\mathbb{R}^3$ is the integral of displacement,
+        $\vct{S}(t)=\int_0^t\vct{p}(s)\,ds$, used by the drift-control
+        pseudo-measurement;
+  \item $\vct{a}_w\in\mathbb{R}^3$ is latent world-frame acceleration with an
+        OU process prior;
+  \item $\vct{b}_a\in\mathbb{R}^3$ is accelerometer bias, modeled as a random
+        walk with an optional deterministic temperature correction.
 \end{itemize}
 
-The complete state dimension is
+With both bias states enabled, the additive error-state dimension is
 \[
-\fitcol{
-N_X =
-\underbrace{3}_{\delta\vct{\theta}} +
-\underbrace{3}_{\vct{b}_g} +
-\underbrace{3}_{\vct{v}} +
-\underbrace{3}_{\vct{p}} +
-\underbrace{3}_{\vct{S}} +
-\underbrace{3}_{\vct{a}_w} +
-\underbrace{3}_{\vct{b}_a}
-= 21,
-}
+N_X = 3+3+3+3+3+3+3=21.
 \]
-with both gyro and accelerometer bias.
+The stored covariance is
+$\mat{P}=\E[\delta\vct{x}\,\delta\vct{x}^{\top}]$.
+
+Two distinct acceleration covariances are used throughout the paper.  The
+matrix $\matg{\Sigma}_{aw}^{\mathrm{stat}}$ is a \emph{process-model
+parameter}: it is the stationary covariance of the OU prior and determines the
+discrete process covariance $\matg{Q}_d$.  In contrast,
+$\mat{P}_{a_wa_w}$ is the current posterior uncertainty of the estimated
+acceleration state.  Changing $\matg{\Sigma}_{aw}^{\mathrm{stat}}$ does not, by
+itself, overwrite $\mat{P}_{a_wa_w}$.  Hard initialization may reset the
+posterior block and its cross-covariances, whereas online retuning may replace
+only the $a_w$ marginal while preserving learned cross-covariances.


### PR DESCRIPTION
## Summary

Synchronize the OU-III article's mathematical description with the implementation merged in PR #188.

This is the first article-correction PR. It is intentionally limited to mathematical and algorithmic consistency; it does not change estimator code, simulation data, plots, reported scores, or the wave-direction method.

## Changes

- distinguish the nominal quaternion state from the 21-dimensional additive error state
- distinguish the stationary OU process covariance from the posterior `a_w` covariance
- document continuous gyro-noise density and the per-sample standard-deviation conversion
- replace the approximate attitude/gyro-bias transition with the implemented Rodrigues and integral coupling matrices
- correct the OU-III group-first state ordering and correlated-covariance Kronecker ordering
- replace the incomplete small-step covariance description with the complete series used by the shared OU implementation
- document OU-II/OU-III common-marginal parity and scale-aware conditional PSD regularization
- clarify pseudo-measurement standard deviation versus covariance notation
- document elapsed-time pseudo-update scheduling and sample-rate invariance
- add the left-multiplicative MEKF covariance reset after quaternion injection
- document the process-model setter, posterior synchronization, and tune-before-enable startup sequence
- explicitly describe OU acceleration as a Gauss-Markov prior rather than a resonant wave spectrum

## Scope deliberately deferred

- direction-estimator phase and travel-sense corrections
- regenerated simulation tables and PGF figures
- baseline and Monte Carlo validation
- title, abstract, contribution, hardware-validation, GPS, and conclusion restructuring

## Validation

- compiled the six revised LaTeX sections together in a standalone syntax harness with `pdflatex -halt-on-error`
- verified the branch differs from `main` only in the six intended `.tex-part` files
- formulas were synchronized against `src/kalman_ou_common/KalmanOUCoreMath.h`, the OU-III implementation, and the shared OU regression tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the filter’s quaternion-based state and local error representation.
  * Documented staged startup, tilt and magnetic reference initialization, and re-lock behavior.
  * Reworked measurement updates, MEKF resets, covariance handling, and numerical safeguards.
  * Added clearer descriptions of continuous-time and discrete process models, OU acceleration behavior, and covariance assembly.
  * Documented pseudo-measurement scheduling, accelerometer and magnetometer models, and lever-arm handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->