### PR TITLE
Correct OU-MEKF paper math, notation, and organization

### DIFF
--- a/doc/kalman_ou_iii/kalman_ou-w3d.tex
+++ b/doc/kalman_ou_iii/kalman_ou-w3d.tex
@@ -1,18 +1,15 @@
 \documentclass[conference]{IEEEtran}
 
-% Core packages
 \usepackage{iftex}
 \ifPDFTeX
 \usepackage[utf8]{inputenc}
 \usepackage[T1]{fontenc}
 \fi
-
 \usepackage{amsthm}
 \usepackage{amsmath, bm}
-\usepackage{newtxtext,newtxmath} % Times-like text + math (IEEE-style)
+\usepackage{newtxtext,newtxmath}
 \usepackage{textcomp}
-
-\interdisplaylinepenalty=2500 % allow page breaks in multiline equations
+\interdisplaylinepenalty=2500
 \usepackage{pgf}
 \usepackage{pgfplots}
 \usepackage{xcolor}
@@ -20,56 +17,38 @@
 \usepackage{mathrsfs}
 \usepackage{graphicx}
 \usepackage{svg}
-\usepackage{placeins} % for \FloatBarrier
+\usepackage{placeins}
 \usepackage{array, booktabs, makecell, adjustbox}
 \usepackage{mathtools}
 \usepackage{nccmath, relsize}
 \usepackage{enumitem}
-
-\usepackage{balance} % balance final page columns
-\usepackage{flafter} % figures/tables won’t appear before they’re definedap
+\usepackage{balance}
+\usepackage{flafter}
 \usepackage{siunitx}
-\usepackage[final]{microtype}   % better spacing/hyphenation
+\usepackage[final]{microtype}
 \usepackage{etoolbox}
 
-% Vectors and matrices: bold italic (IEEE-style)
-\DeclareRobustCommand{\vct}[1]{\bm{#1}}  % vectors (Latin & Greek)
-\DeclareRobustCommand{\mat}[1]{\bm{#1}}  % matrices (LATIN)
-\DeclareRobustCommand{\matg}[1]{\bm{#1}} % matrices (GREEK)
-
-% === Spaces / groups (quaternions, rotations) ===
-\newcommand{\Quat}{\mathbb{H}}        % all quaternions
-\newcommand{\Sph}{\mathbb{S}}         % spheres; unit quats live in \Sph^3
-\newcommand{\SO}{\mathrm{SO}}         % rotation group
-\newcommand{\SE}{\mathrm{SE}}         % rigid motions
-
-% === Quaternion variables ===
-% Quaternion as a 4-vector: bold italic (consistent with \vct)
+\DeclareRobustCommand{\vct}[1]{\bm{#1}}
+\DeclareRobustCommand{\mat}[1]{\bm{#1}}
+\DeclareRobustCommand{\matg}[1]{\bm{#1}}
+\newcommand{\Quat}{\mathbb{H}}
+\newcommand{\Sph}{\mathbb{S}}
+\newcommand{\SO}{\mathrm{SO}}
+\newcommand{\SE}{\mathrm{SE}}
 \newcommand{\quat}[1]{\vct{#1}}
-
-% Rotation matrices / operators (leave \mathbf{R} for Kalman measurement noise)
 \newcommand{\Rot}{\bm{\mathcal{R}}}
-
-% Optional helpers (use only if you like the notation)
-\newcommand{\qconj}[1]{\overline{#1}} % quaternion conjugate
-\newcommand{\qreal}[1]{\operatorname{Re}\! \left(#1\right)} % real part
-\newcommand{\qimag}[1]{\operatorname{Im}\! \left(#1\right)} % imaginary/vector part
+\newcommand{\qconj}[1]{\overline{#1}}
+\newcommand{\qreal}[1]{\operatorname{Re}\! \left(#1\right)}
+\newcommand{\qimag}[1]{\operatorname{Im}\! \left(#1\right)}
 
 \usepackage{cite}
 \usepackage[breaklinks=true,hidelinks]{hyperref}
 \usepackage{bookmark}
 \usepackage[nameinlink,capitalise,noabbrev]{cleveref}
 
-\sisetup{
-    detect-weight = true,
-    detect-family = true,
-    per-mode = symbol,
-}
+\sisetup{detect-weight=true,detect-family=true,per-mode=symbol}
+\setlist[description]{font=\footnotesize\bfseries,labelsep=0.6em,leftmargin=1.8em}
 
-% Description labels small & bold
-\setlist[description]{font=\footnotesize\bfseries, labelsep=0.6em, leftmargin=1.8em}
-
-% Make math/siunitx safe in PDF bookmarks
 \pdfstringdefDisableCommands{%
     \def\SI#1#2{#1 #2}%
     \def\bm#1{#1}%
@@ -77,7 +56,7 @@
     \def\Id{I}%
     \def\pct#1{#1\%}%
     \def\circ{deg}%
-    \def\degree{deg}% siunitx \degree if it leaks into bookmarks
+    \def\degree{deg}%
     \def\propto{∝}%
     \def\sigma{sigma}%
     \def\tau{tau}%
@@ -96,8 +75,6 @@
 
 \AtBeginEnvironment{equation}{\small}
 \AtBeginEnvironment{align}{\small}
-
-% Needed by PGF outputs that reference \mathdefault
 \providecommand{\mathdefault}[1]{#1}
 
 \setcounter{topnumber}{5}
@@ -107,22 +84,18 @@
 \renewcommand{\textfraction}{0.05}
 \renewcommand{\floatpagefraction}{0.9}
 \renewcommand{\dblfloatpagefraction}{0.9}
-
-% For including PGF
 \newcommand{\IncludePGF}[1]{\resizebox{\linewidth}{!}{\input{#1}}}
 
-% Unicode punctuation mappings (pdfLaTeX only)
 \ifPDFTeX
-\DeclareUnicodeCharacter{2013}{\textendash}        % –
-\DeclareUnicodeCharacter{2014}{\textemdash}        % —
-\DeclareUnicodeCharacter{2018}{\textquoteleft}     % ‘
-\DeclareUnicodeCharacter{2019}{\textquoteright}    % ’
-\DeclareUnicodeCharacter{201C}{\textquotedblleft}  % “
-\DeclareUnicodeCharacter{201D}{\textquotedblright} % ”
-\DeclareUnicodeCharacter{2212}{\textminus}         % − (math minus)
+\DeclareUnicodeCharacter{2013}{\textendash}
+\DeclareUnicodeCharacter{2014}{\textemdash}
+\DeclareUnicodeCharacter{2018}{\textquoteleft}
+\DeclareUnicodeCharacter{2019}{\textquoteright}
+\DeclareUnicodeCharacter{201C}{\textquotedblleft}
+\DeclareUnicodeCharacter{201D}{\textquotedblright}
+\DeclareUnicodeCharacter{2212}{\textminus}
 \fi
 
-% Make math macros harmless in PDF bookmarks
 \pdfstringdefDisableCommands{%
     \def\vct#1{#1}%
     \def\mat#1{#1}%
@@ -130,30 +103,21 @@
     \def\I{I}%
 }
 
-% Theorems: small header/body
-\newtheoremstyle{bodysmall}
-{3pt}{3pt}{\normalfont\small}{0pt}{\bfseries\small}{.}{0.5em}{}
+\newtheoremstyle{bodysmall}{3pt}{3pt}{\normalfont\small}{0pt}{\bfseries\small}{.}{0.5em}{}
 \theoremstyle{bodysmall}
 \newtheorem{lemma}{Lemma}
 \newtheorem{theorem}{Theorem}
 \newtheorem*{theorem*}{Theorem}
-
 \theoremstyle{remark}
 \newtheorem{remark}{Remark}
 
-% Shortcuts
 \newcommand{\Skew}[1]{\left[#1\right]_\times}
 \newcommand{\Id}{\mat{I}}
 \newcommand{\pct}[1]{#1\%}
 \newcommand{\meanstd}[2]{#1 \pm #2}
-% or
-% \newcommand{\meanstd}[2]{#1\,{\scriptsize$\pm$}\,#2}
 \newcommand{\ci}[2]{#1\,(\,#2\,\text{CI}\,)}
-
-% Itô integral
 \newcommand{\Ito}{\mathrm{It\hat{o}}}
 \newcommand{\ItoInt}[2]{\int_0^{#1} #2\, dW_s^{\Ito}}
-
 \DeclareMathOperator{\proj}{\mathcal{P}}
 \DeclareMathOperator{\clip}{clip}
 \DeclareMathOperator{\wrap}{wrap}
@@ -161,98 +125,80 @@
 \DeclareMathOperator{\blkdiag}{blkdiag}
 \DeclareMathOperator{\diag}{diag}
 \DeclareMathOperator{\sym}{sym}
-
-% === Sets and spaces ===
-\newcommand{\set}[1]{\mathcal{#1}}  % generic set, e.g. \set{X}
-\newcommand{\R}{\mathbb{R}}         % real numbers
-\newcommand{\C}{\mathbb{C}}         % complex numbers
-\newcommand{\N}{\mathbb{N}}         % natural numbers
-\newcommand{\Z}{\mathbb{Z}}         % integers
-
-% === Probability / statistics ===
-\newcommand{\E}{\mathbb{E}}         % expectation
-\DeclareMathOperator{\Var}{Var}     % variance
-\DeclareMathOperator{\Cov}{Cov}     % covariance
-
-% Text subscript helper (labels, not variables)
+\newcommand{\set}[1]{\mathcal{#1}}
+\newcommand{\R}{\mathbb{R}}
+\newcommand{\C}{\mathbb{C}}
+\newcommand{\N}{\mathbb{N}}
+\newcommand{\Z}{\mathbb{Z}}
+\newcommand{\E}{\mathbb{E}}
+\DeclareMathOperator{\Var}{Var}
+\DeclareMathOperator{\Cov}{Cov}
 \newcommand{\ts}[1]{\text{#1}}
-
-% Two-column helper (no layout change)
-\newcommand{\fitcol}[1]{%
-    \adjustbox{max width=\columnwidth}{\ensuremath{\displaystyle #1}}%
-}
+\newcommand{\fitcol}[1]{\adjustbox{max width=\columnwidth}{\ensuremath{\displaystyle #1}}}
 
 \makeatletter
-\@ifpackageloaded{cite}{%
-    \renewcommand{\citepunct}{,\penalty\citepunctpenalty\,}%
-    \renewcommand{\citedash}{--}%
-}{}
+\@ifpackageloaded{cite}{\renewcommand{\citepunct}{,\penalty\citepunctpenalty\,}\renewcommand{\citedash}{--}}{}
 \makeatother
-
-% Allow multi-line displays to break across columns
 \emergencystretch=2em
 \allowdisplaybreaks
 
-% Title & authors (IEEEtran conference style)
-\title{OU-Driven Quaternion MEKF for Marine INS and Wave-State Estimation 
-(draft)}
-
+\title{OU-Driven Quaternion MEKF for Marine INS and Wave-State Estimation (draft)}
 \author{%
     \IEEEauthorblockN{Mikhail S. Grushinskiy}
     \IEEEauthorblockA{Independent Researcher, USA, Fair Lawn\\
     Bareboat Necessities GitHub Project\\
     Email: mgrouch@users.github.com}%
 }
-
 \pgfplotsset{compat=1.18}
 
 \begin{document}
-    \maketitle
+\maketitle
 
-    \begin{abstract}
-        We present a detailed mathematical development of a quaternion multiplicative EKF for ocean-wave motion that couples attitude to an extended
-        linear kinematic chain for velocity, displacement, and the integral of displacement. World-frame acceleration is modeled as
-        an Ornstein–Uhlenbeck (OU) process, giving stationary variance and realistic temporal correlation. Gyroscope bias is modeled as a random walk;
-        accelerometer bias includes random-walk and temperature-dependent drift. To suppress double-integration drift, we add an anisotropic
-        pseudo-measurement on the integral state. We derive continuous- and discrete-time models with Rodrigues/analytic discretizations and
-        provide explicit Jacobians for accelerometer and magnetometer updates. A lightweight Kalman filter estimates horizontal wave direction
-        using the tracked carrier frequency. We also outline practical tuning and a novel adaptive law that scales the pseudo-measurement
-        variance with the OU parameters, enabling stable behavior across sea states. The approach targets embedded, low-cost IMU deployments, enabling accurate, real-time heave and wave direction estimation for dynamic positioning, unmanned vehicles, maritime safety, and oceanographic studies.
-    \end{abstract}
+\begin{abstract}
+We present a quaternion multiplicative EKF for ocean-wave motion that couples
+attitude to a linear kinematic chain for velocity, oscillatory displacement,
+and the integral of displacement. World-frame acceleration is assigned an
+Ornstein--Uhlenbeck prior with stationary variance and finite temporal
+correlation. Gyroscope and accelerometer biases are modeled explicitly. To
+suppress integration drift, an anisotropic zero pseudo-measurement is applied
+to the integral state. We derive the continuous model, analytic OU-chain
+discretization, numerically stable small-step covariance formulas, and explicit
+accelerometer and magnetometer Jacobians. A lightweight estimator obtains the
+horizontal wave-propagation axis and apparent travel sense from leveled
+acceleration. Online adaptation tunes the OU time scale, stationary acceleration
+scale, and the standard-deviation scale whose square forms the integral
+pseudo-measurement covariance. The cubic scaling with correlation time is a
+physically motivated engineering normalization for fixed update cadence and a
+bounded family of spectra, rather than an exact universal invariance claim. The
+implementation targets real-time low-cost embedded IMU deployments.
+\end{abstract}
 
-    \begin{IEEEkeywords}
-        extended Kalman filter, inertial navigation, IMU, marine Motion Reference Unit, MRU, Ornstein--Uhlenbeck process, Heave Reference System, HRS, heave sensor,
-        wave height estimation, wave measurement buoy
-    \end{IEEEkeywords}
+\begin{IEEEkeywords}
+extended Kalman filter, inertial navigation, IMU, marine Motion Reference Unit, MRU, Ornstein--Uhlenbeck process, Heave Reference System, HRS, heave sensor, wave height estimation, wave measurement buoy\end{IEEEkeywords}
 
-% === CORE SECTIONS ===
-    \input{w3d-intro.tex-part}
-    \input{w3d-state.tex-part}
-    \input{w3d-meas.tex-part}
-    \input{w3d-wind-heel.tex-part}
-    \input{w3d-proc-cont.tex-part}
-    \input{w3d-lti-discrete.tex-part}
-    \input{w3d-analytic-coeff.tex-part}
-    \input{w3d-kalm-up.tex-part}
-    \input{w3d-init.tex-part}
-    \input{w3d-fus-methods.tex-part}
-    \input{w3d-sim-charts.tex-part}
-    \input{w3d-gps-fusion.tex-part}
+\input{w3d-intro.tex-part}
+\input{w3d-state.tex-part}
+\input{w3d-meas.tex-part}
+\input{w3d-wind-heel.tex-part}
+\input{w3d-proc-cont.tex-part}
+\input{w3d-lti-discrete.tex-part}
+\input{w3d-analytic-coeff.tex-part}
+\input{w3d-kalm-up.tex-part}
+\input{w3d-init.tex-part}
+\input{w3d-fus-methods.tex-part}
+\input{w3d-sim-charts.tex-part}
+\input{w3d-conclusion-summary.tex-part}
+\input{w3d-gps-fusion.tex-part}
 
-    \FloatBarrier
+\FloatBarrier
+\section*{Acknowledgments}
+This work was prepared with the supervised assistance of artificial intelligence tools, including ChatGPT, Claude and DeepSeek, which were employed to aid in code generation, mathematical drafting, and editorial preparation. All conceptual development, validation of results, and final revisions were conducted independently by the author.
 
-    \section*{Acknowledgments}
-    This work was prepared with the supervised assistance of artificial intelligence tools, including ChatGPT, Claude and DeepSeek, which were employed to aid in code generation, mathematical drafting, and editorial preparation. All conceptual development, validation of results, and final revisions were conducted independently by the author.
-
-    \section*{Disclosure Statement}
-    The author declares no conflicts of interest and received no funding for this research.
+\section*{Disclosure Statement}
+The author declares no conflicts of interest and received no funding for this research.
 
 \nocite{Kalman1960_Filtering,Jazwinski1970_Filtering,Maybeck1979_StochasticModels,Markley2003AttitudeError,UhlenbeckOrnstein1930_OU}
-%\nocite{*}
-    \bibliographystyle{IEEEtran}
-    \bibliography{w3d}
-
-% Balance final page columns (optional, IEEE-style)
-    \balance
-
+\bibliographystyle{IEEEtran}
+\bibliography{w3d}
+\balance
 \end{document}

--- a/doc/kalman_ou_iii/w3d-conclusion-summary.tex-part
+++ b/doc/kalman_ou_iii/w3d-conclusion-summary.tex-part
@@ -1,0 +1,20 @@
+
+The present study establishes the complete estimator recursion and verifies it
+under the simulation protocol of Sec.~\ref{sec:sim-and-eval}. Across the tested
+JONSWAP and PM--Stokes cases, the reported vertical-displacement RMS errors
+remain within the ranges listed in Table~\ref{tab:sim_results_rms_dir_basic},
+while the attitude and direction pipelines remain operational under the stated
+multi-rate sensor and error models. The exact OU-chain transition, small-step
+covariance branch, full MEKF reset, and adaptive pseudo-measurement scaling are
+implemented in the same C++ code exercised by the simulations and embedded
+builds.
+
+The results support embedded feasibility and drift-controlled wave-state
+reconstruction for the tested conditions, but they do not by themselves imply
+universal performance across spectra, update cadences, vessel speeds, or sensor
+installations. Future work should therefore add Monte Carlo ensembles, direct
+baseline and ablation comparisons, controlled sea-state transitions, and
+quantitative timing and external-reference measurements on hardware. Optional
+absolute-navigation fusion is kept separate in Appendix~\ref{sec:gps_fusion}
+so that the oscillatory displacement state $\vct{p}$ is not conflated with a
+local or global navigation position.

--- a/doc/kalman_ou_iii/w3d-fus-methods.tex-part
+++ b/doc/kalman_ou_iii/w3d-fus-methods.tex-part
@@ -49,15 +49,12 @@ The input is first passed through a first-order filter
 \]
 The nonlinear observer forms
 \[
-\varphi
-=
-\dot x_1(bu+a x_1)+x_1^2\theta ,
+\varphi=\dot x_1(bu+a x_1)+x_1^2\theta ,
 \]
 and adapts an auxiliary state
 \[
-\dot\sigma=-k\varphi
-\].
-
+\dot\sigma=-k\varphi .
+\]
 The frequency-related parameter is updated algebraically:
 \[
 \theta = k b x_1 u+\sigma .
@@ -81,7 +78,6 @@ The phase detector is
 \[
 e_{\phi,k}=\operatorname{atan2}(Q_k,I_k).
 \]
-
 A type-II PLL-style loop updates oscillator frequency and phase:
 \[
 \omega_{k+1}
@@ -105,314 +101,226 @@ K_p=2\zeta\omega_n,\qquad
 K_i=\omega_n^2,\qquad
 \omega_n=2\pi B_L .
 \]
-Here $B_L$ is the configured loop bandwidth, $\zeta$ is the loop damping, and $G_k$ reduces adaptation when confidence is poor.
-
-The reported frequency is
+Here $B_L$ is the configured loop bandwidth, $\zeta$ is the loop damping, and $G_k$ reduces adaptation when confidence is poor. The reported frequency is
 \[
-\hat f_k=\frac{\omega_k}{2\pi},
-\]. 
-
-\iffalse
-\subsection{Zero-crossing baseline with hysteresis}
-
-Use debounced threshold crossings to estimate period directly; smooth to reduce jitter.
-
-\paragraph{Method}
-Times of upcrossings of $u$ through band $[-h,+h]$ (debounced by $T_{\mathrm{deb}}$). Period estimate
-\(
-\hat T_k=(1-\alpha_T)\hat T_{k-1}+\alpha_T (t_k-t_{k-1}), \quad \hat f_k=1/\hat T_k.
-\)
-
-Clamp $\hat f_k \in [f_{\min}, f_{\max}]$, then apply a short EMA:
-\(
-\bar f_k=(1-\alpha_s)\bar f_{k-1}+\alpha_s \hat f_k.
-\)
-\fi
+\hat f_k=\frac{\omega_k}{2\pi}.
+\]
 
 % =======================================================
 \section{Variance-Informed Online Adaptation}
 \label{sec:adaptation}
 
-
 \subsection{Spectral scaling and pseudo-measurement on $S$}
 \label{sec:spectral-Rs}
 \label{app:rs-scaling}
 
-The pseudo-measurement on the triple-integral state
+The pseudo-measurement on the triple-integral state is written using a scalar
+standard-deviation scale $r_S$,
 \[
-y_S = 0 = S + n_S,\qquad n_S \sim \mathcal{N}(0,R_S^2)
+y_S=0=S+n_S,\qquad n_S\sim\mathcal{N}(0,r_S^2).
 \]
-is not a physical sensor but a regularizer. Its design should reflect the
-\emph{natural} fluctuations of $S$ under a given sea state, so that $R_S$
-scales with the sea state in a physically consistent and, ideally,
-sea-state–invariant way.
-
-The key steps are:
-\begin{enumerate}\itemsep2pt
-\item Express the variance of $S$ in terms of the vertical-acceleration
-spectrum.
-\item Show that, for a broad class of spectra, the standard deviation
-$\sigma_S$ of $S$ scales as
-\[
-\sigma_S \sim c_{\text{spec}}\;\sigma_a\,\tau^3,
-\]
-where $c_{\text{spec}}$ is a dimensionless \emph{spectral shape factor}.
-\item Choose the pseudo-measurement noise $R_S$ proportional to this physical
-scale $\sigma_S$. This makes the pseudo-measurement effectively
-\emph{sea-state invariant}.
-\end{enumerate}
+For the three-axis implementation, the corresponding vector $\vct{r}_S$ is
+squared componentwise to form the covariance $\mat{R}_S$, as defined in
+\eqref{eq:RS-from-rS}.  The channel is a regularizer, not a physical sensor.
+The purpose of the scaling argument below is to choose $r_S$ on the same
+physical scale as the natural fluctuations of $S$ within a stated family of
+wave spectra and a fixed pseudo-update cadence.
 
 \subsection{Variance of $S$ from the acceleration spectrum}
 
 Let $a(t)$ denote vertical acceleration and let
 \[
-\dot v = a,\qquad \dot p = v,\qquad \dot S = p,
+\dot v=a,\qquad \dot p=v,\qquad \dot S=p,
 \]
-so that $S$ is the triple time-integral of $a$. In the frequency domain, the
-transfer function from $a$ to $S$ is
+so that $S$ is the triple time-integral of $a$.  In the frequency domain,
 \[
-H_S(j\omega) = \frac{1}{(j\omega)^3},\qquad
-\big|H_S(j\omega)\big|^2 = \frac{1}{\omega^6}.
+H_S(j\omega)=\frac{1}{(j\omega)^3},\qquad
+|H_S(j\omega)|^2=\frac{1}{\omega^6}.
 \]
-If $a(t)$ is stationary with one-sided PSD $S_a(\omega)$, standard linear
-systems theory gives
+We use a two-sided angular-frequency PSD $S_a^{(2)}(\omega)$ with convention
 \[
-\mathrm{Var}[S]
-= \frac{1}{2\pi}\int_{-\infty}^{\infty}
- S_a(\omega)\,\big|H_S(j\omega)\big|^2\,d\omega
-= \frac{1}{\pi}\int_0^\infty \frac{S_a(\omega)}{\omega^6}\,d\omega.
+\Var[a]=\frac{1}{2\pi}\int_{-\infty}^{\infty}S_a^{(2)}(\omega)\,d\omega .
 \]
+For a real process the PSD is even, and therefore
+\begin{equation}
+\Var[S]
+=\frac{1}{2\pi}\int_{-\infty}^{\infty}
+\frac{S_a^{(2)}(\omega)}{\omega^6}\,d\omega
+=\frac{1}{\pi}\int_0^{\infty}
+\frac{S_a^{(2)}(\omega)}{\omega^6}\,d\omega .
+\label{eq:varS-two-sided}
+\end{equation}
+Equivalently, with the one-sided PSD $S_a^{(1)}(\omega)=2S_a^{(2)}(\omega)$ for
+$\omega>0$,
+\[
+\Var[S]=\frac{1}{2\pi}\int_0^{\infty}
+\frac{S_a^{(1)}(\omega)}{\omega^6}\,d\omega .
+\]
+This explicit convention removes the previous factor-of-two ambiguity.
 
-For linear deep-water waves, displacement $\eta$ and acceleration $a$ are
-related by $a(\omega)=-(j\omega)^2\eta(\omega)$, so
-$S_a(\omega)=\omega^4 S_\eta(\omega)$ and
+For linear deep-water waves, displacement $\eta$ and acceleration satisfy
+$a(\omega)=-(j\omega)^2\eta(\omega)$, so
+$S_a^{(2)}(\omega)=\omega^4S_\eta^{(2)}(\omega)$ and
 \[
-\mathrm{Var}[S]
-= \frac{1}{\pi}\int_0^\infty \frac{\omega^4 S_\eta(\omega)}{\omega^6}\,d\omega
-= \frac{1}{\pi}\int_0^\infty \frac{S_\eta(\omega)}{\omega^2}\,d\omega.
+\Var[S]=\frac{1}{\pi}\int_0^{\infty}
+\frac{S_\eta^{(2)}(\omega)}{\omega^2}\,d\omega .
 \]
-Either representation (in terms of $S_a$ or $S_\eta$) leads to the same scaling
-law once the spectrum is parameterized.
 
 \subsection{Normalization and spectral shape factor}
 
-We now separate \emph{scale} from \emph{shape}. Let $\sigma_a^2$ denote the
-variance of vertical acceleration and let $\tau$ be a characteristic time
-scale of the sea state (e.g.\ the OU correlation time or a quantity
-proportional to the peak period). We write the acceleration spectrum in the
-normalized form
+Let $\sigma_a^2=\Var[a]$ and let $\tau$ be a characteristic time scale.  Write
+the two-sided PSD for positive frequency as
 \begin{equation}
+S_a^{(2)}(\omega)=\sigma_a^2\tau\Phi(\omega\tau),
 \label{eq:Sa-normalized}
-S_a(\omega)
-= \sigma_a^2\,\tau\,\Phi(\omega\tau),
 \end{equation}
-where $\Phi(u)$ is a dimensionless shape function and the prefactor is chosen
-so that
+with
 \[
-\frac{1}{\pi}\int_0^\infty \Phi(u)\,du = 1
-\quad\Longleftrightarrow\quad
-\frac{1}{\pi}\int_0^\infty S_a(\omega)\,d\omega = \sigma_a^2.
+\frac{1}{\pi}\int_0^\infty\Phi(u)\,du=1.
 \]
-
-In practice, any realistic spectrum has negligible energy below some
-effective nonzero frequency $\omega_{\min}>0$. We model this by
-\[
-\mathrm{Var}[S]
-= \frac{1}{\pi}\int_{\omega_{\min}}^\infty \frac{S_a(\omega)}{\omega^6}\,d\omega.
-\]
-Substituting \eqref{eq:Sa-normalized} and changing variables $u=\omega\tau$,
-$d\omega=du/\tau$, we obtain
+The triple integral is not stationary for a model with nonzero spectral density
+at zero frequency.  We therefore make the low-frequency assumption explicit:
+the scaling applies after the physical spectrum, preprocessing, or finite
+observation interval supplies an effective cutoff $\omega_{\min}>0$.  Then
 \begin{equation}
+\Var[S]
+=\sigma_a^2\tau^6
+\left[\frac{1}{\pi}\int_{u_{\min}}^\infty
+\frac{\Phi(u)}{u^6}\,du\right],
+\qquad u_{\min}=\omega_{\min}\tau .
 \label{eq:varS-shape}
-\fitcol{
-\mathrm{Var}[S]
-= \sigma_a^2\tau^6\,
-\Bigg[\frac{1}{\pi}\int_{u_{\min}}^\infty \frac{\Phi(u)}{u^6}\,du\Bigg],
-}
 \end{equation}
-where $u_{\min}:=\omega_{\min}\tau$ is a (dimensionless) low-frequency cutoff
-in normalized coordinates.
-
-This motivates the definition
+Define
 \begin{equation}
+c_{\mathrm{spec}}^2(u_{\min})
+:=\frac{1}{\pi}\int_{u_{\min}}^\infty
+\frac{\Phi(u)}{u^6}\,du,
 \label{eq:c-spec-def}
-c_{\mathrm{spec}}^{2}(u_{\min})
-:= \frac{1}{\pi}\int_{u_{\min}}^\infty \frac{\Phi(u)}{u^6}\,du,
 \end{equation}
 so that
 \begin{equation}
+\sigma_S=\sqrt{\Var[S]}
+=c_{\mathrm{spec}}(u_{\min})\sigma_a\tau^3.
 \label{eq:sigmaS-scaling}
-\sigma_S(\sigma_a,\tau)
-:= \sqrt{\mathrm{Var}[S]}
-= c_{\text{spec}}(u_{\min})\,\sigma_a\,\tau^3.
 \end{equation}
-The factor $c_{\text{spec}}$ is \emph{dimensionless} and encodes only the
-spectral shape (and the choice of effective low-frequency cutoff), while
-$\sigma_a$ and $\tau$ carry the physical scale.
+The units are correct because $\sigma_a\tau^3$ has units $\mathrm{m\,s}$.
+The coefficient depends strongly on spectral shape and on the effective
+low-frequency cutoff; it is not universal.
 
-\begin{remark}[Dimensional consistency]
-$\sigma_a$ has units $\mathrm{m/s^2}$ and $\tau$ has units $\mathrm{s}$, so
-$\sigma_a\tau^3$ has units $\mathrm{m\cdot s}$, the same units as the
-triple-integral state $S$ (since $S$ integrates displacement $p$ once more in
-time). Thus \eqref{eq:sigmaS-scaling} is dimensionally correct, and
-$c_{\text{spec}}$ is a pure number.
-\end{remark}
-
-\paragraph{Narrowband vs.\ broadband spectra}
-For a given $(\sigma_a,\tau)$, the value of $c_{\text{spec}}$ depends mainly on
-how much spectral mass lies near the low frequencies emphasized by the
-$1/u^6$ weight in \eqref{eq:c-spec-def}:
-\begin{itemize}[itemsep=1pt,topsep=1pt,leftmargin=*]
-\item A \emph{narrowband} spectrum (e.g.\ an idealized very sharp JONSWAP)
-concentrates variance near a single normalized frequency $u\approx 1$ and
-yields a relatively large $c_{\text{spec}}$.
-\item A more \emph{broadband} spectrum (e.g.\ Pierson--Moskowitz or a
-low-$\gamma$ JONSWAP) spreads energy across higher normalized frequencies.
-Because of the $1/u^6$ factor, this reduces $c_{\text{spec}}$ even though
-$\sigma_a$ and $\tau$ are kept fixed.
-\end{itemize}
-In particular, $c_{\text{spec}}$ is much more sensitive to spectral
-\emph{shape} (narrowness, bandwidth, tail behavior) than to overall energy
-($\sigma_a^2$) or peak period ($\tau$), which have already been factored out
-in \eqref{eq:sigmaS-scaling}.
-
-As a concrete example, for an OU surrogate with
-$\Phi_{\mathrm{OU}}(u)=2/(1+u^2)$ and a modest cutoff $u_{\min}\approx 1$, the
-integral \eqref{eq:c-spec-def} gives $c_{\text{spec}}\approx 0.16$.
-
-\subsection{From physical $\sigma_S$ to pseudo-measurement $R_S$}
-
-The pseudo-measurement
+For the two-sided OU surrogate
 \[
-y_S = 0 = S + n_S,\qquad n_S \sim \mathcal{N}(0,R_S^2)
+\Phi_{\mathrm{OU}}(u)=\frac{2}{1+u^2}
 \]
-encodes a prior belief that $S$ fluctuates around zero with some expected
-spread. The spectral result \eqref{eq:sigmaS-scaling} provides exactly that
-spread: the \emph{physical} standard deviation $\sigma_S(\sigma_a,\tau)$
-generated by the sea state described by $(\sigma_a,\tau)$ and by the chosen
-spectral shape.
+and $u_{\min}=1$, Eqs.~\eqref{eq:c-spec-def}--\eqref{eq:sigmaS-scaling} give
+$c_{\mathrm{spec}}\approx0.227$.  Under the equivalent one-sided convention,
+the PSD and normalization both change consistently and produce the same
+physical variance.
 
-A natural Gaussian design is therefore
+\subsection{Practical pseudo-measurement scale}
+
+A physically scaled Gaussian design is
 \begin{equation}
+r_S(\sigma_a,\tau)
+=k_i\sigma_S
+=k_i c_{\mathrm{spec}}(u_{\min})\sigma_a\tau^3,
 \label{eq:Rs-from-sigmaS}
-R_S(\sigma_a,\tau)
-= k_i\,\sigma_S(\sigma_a,\tau)
-= k_i\,c_{\text{spec}}(u_{\min})\,\sigma_a\,\tau^3,
 \end{equation}
-with $k_i>0$ a dimensionless “comfort factor.” Values $k_i\approx 1$ make the
-pseudo-measurement noise comparable to the natural spread of $S$, $k_i>1$ are
-more conservative, and $k_i<1$ are more aggressive.
-
-Absorbing the (unknown but bounded) shape factor $c_{\text{spec}}$ into
-$k_i$ leads to the practical adaptation law used in the filter:
+where $k_i>0$ is dimensionless.  The implementation absorbs the selected
+spectral-shape and cutoff calibration into a single coefficient $c_R$ and uses
 \begin{equation}
+r_{S,\star}=c_R\sigma_{a,\star}\tau_\star^3.
 \label{eq:Rs-sigmaa-tau3}
-R_S(\sigma_a,\tau)
-= k_i\,\sigma_a\,\tau^3,
 \end{equation}
-where $k_i$ is now understood as a \emph{spectral design coefficient}. It is
-chosen large enough to cover the expected range of realistic spectra (OU,
-Pierson--Moskowitz, JONSWAP with typical $\gamma$) and reasonable effective
-low-frequency cutoffs $u_{\min}$.
-
-\begin{remark}[Sea-state invariance]
-Under \eqref{eq:sigmaS-scaling} and \eqref{eq:Rs-from-sigmaS}, the ratio
-\[
-\frac{\sigma_S^2(\sigma_a,\tau)}{R_S^2(\sigma_a,\tau)}
-= \Big(\frac{c_{\text{spec}}(u_{\min})}{k_i}\Big)^2
-\]
-is a pure number independent of $(\sigma_a,\tau)$. In other words, $S$ is
-always measured in units of its physically expected spread for that sea
-state. This makes the pseudo-measurement \emph{sea-state invariant}: a calm
-sea and a steep sea produce innovation statistics of the same order once
-normalized by $R_S$, and the qualitative effect of the pseudo-measurement on
-the filter does not depend on wave height or period, only on the choice of
-$k_i$ and on spectral shape.
-\end{remark}
+This is an engineering normalization, not an exact sea-state invariance result.
+For a fixed pseudo-update period $T_S$ and a bounded family of spectral shapes
+and cutoffs, it keeps the regularizer on approximately comparable physical
+scales as wave amplitude and period change.  Changing $T_S$, spectral bandwidth,
+or low-frequency contamination changes the effective regularization and may
+require retuning $c_R$.
 
 \subsection{Online Adaptation Implementation}
 \label{sec:adapt-impl}
 
-The implementation adapts three MEKF parameters online:
-the OU time constant $\tau$, the OU stationary acceleration scale $\sigma_a$,
-and the integral pseudo-measurement level $R_S$.
+The implementation adapts the OU time constant $\tau$, the OU stationary
+acceleration scale $\sigma_a$, and the integral pseudo-measurement
+standard-deviation scale $r_S$.
 
 \subsubsection{Vertical signal}
-Let $a_{z,\text{inert}}=a_z+g$ denote vertical inertial acceleration in the body/NED convention.
-We use the up-positive signal
+Let $a_{z,\mathrm{inert}}=a_z+g$ denote vertical inertial acceleration in the body/NED convention. We use the up-positive signal
 \[
-a_{\uparrow}:=-a_{z,\text{inert}}.
+a_{\uparrow}:=-a_{z,\mathrm{inert}}.
 \]
 
 \subsubsection{Frequency and period-tied variance horizon}
-A dominant frequency estimate $f$ is tracked from $a_{\uparrow}$ (by a frequency tracker),
-then clamped and smoothed to an internal tuning frequency $f_{\text{tune}}\in[f_{\min},f_{\max}]$.
-To make the acceleration scale adapt with comparable responsiveness across chop and swell,
-the variance of $a_{\uparrow}$ is estimated over a \emph{fixed number of periods}:
+A dominant frequency estimate $f$ is tracked from $a_{\uparrow}$, then clamped and smoothed to $f_{\mathrm{tune}}\in[f_{\min},f_{\max}]$.  The variance is estimated over a fixed number of periods:
 \begin{equation}
 \begin{aligned}
-T_{\text{eff}} = \frac{1}{f_{\text{tune}}}, \qquad
-\tau_{\text{var}} &=
-\clip\!\Big(
-K_{\text{periods}}\,T_{\text{eff}},
-\ \tau_{\text{var,min}},
-\ \tau_{\text{var,max}}
-\Big),\\
-\alpha_{\text{var}} &= 1 - e^{-\Delta t/\tau_{\text{var}}}.
+T_{\mathrm{eff}}&=\frac{1}{f_{\mathrm{tune}}},\\
+\tau_{\mathrm{var}}&=\clip\!\left(K_{\mathrm{periods}}T_{\mathrm{eff}},
+\tau_{\mathrm{var,min}},\tau_{\mathrm{var,max}}\right),\\
+\alpha_{\mathrm{var}}&=1-e^{-\Delta t/\tau_{\mathrm{var}}}.
 \end{aligned}
 \end{equation}
-Using $\alpha_{\text{var}}$, the tuner maintains an online estimate $\widehat{\sigma}^2_{\text{tot}}\approx\mathrm{Var}[a_{\uparrow}]$.
+Using $\alpha_{\mathrm{var}}$, the tuner maintains
+$\widehat\sigma_{\mathrm{tot}}^2\approx\Var[a_{\uparrow}]$.
 
 \subsubsection{Noise-floor subtraction}
-A configured acceleration noise floor $\sigma_{\text{nf}}$ is subtracted in variance:
 \[
-\widehat{\sigma}^2_{\text{wave}}
-=\max\{0,\ \widehat{\sigma}^2_{\text{tot}}-\sigma_{\text{nf}}^2\}.
+\widehat\sigma_{\mathrm{wave}}^2
+=\max\{0,\widehat\sigma_{\mathrm{tot}}^2-\sigma_{\mathrm{nf}}^2\}.
 \]
 
-\subsubsection{Targets (half-period scaling)}
-Targets follow the half-period rule and the cubic $R_S$ scaling:
-\begin{equation}\label{eq:tuner-targets}
+\subsubsection{Targets}
+The code uses
+\begin{equation}
 \begin{aligned}
-\tau_\star &= c_{\tau}\,\frac{1}{2f_{\text{tune}}},\qquad
-\sigma_{a,\star} = c_{\sigma}\,\sqrt{\max\!\bigl(\widehat{\sigma}^2_{\text{wave}},\epsilon\bigr)},\\
-R_{S,\star} &= c_R\,\sigma_{a,\star}\,\tau_\star^3.
+\tau_\star&=c_\tau\frac{1}{2f_{\mathrm{tune}}},\\
+\sigma_{a,\star}&=c_\sigma
+\sqrt{\max(\widehat\sigma_{\mathrm{wave}}^2,\epsilon)},\\
+r_{S,\star}&=c_R\sigma_{a,\star}\tau_\star^3.
 \end{aligned}
+\label{eq:tuner-targets}
 \end{equation}
 
 \subsubsection{Smoothing}
-Applied $(\tau,\sigma_a)$ are EMA filtered toward their targets with a fixed adaptation time constant
-$\tau_{\text{adapt}}$:
-\begin{equation}\label{eq:adapt-ewma}
+Applied $(\tau,\sigma_a)$ are EMA filtered with time constant $\tau_{\mathrm{adapt}}$:
+\begin{equation}
 \begin{aligned}
-\alpha &= 1 - e^{-\Delta t/\tau_{\text{adapt}}},\qquad
-\tau_{\text{appl}} \leftarrow \tau_{\text{appl}} + \alpha\bigl(\tau_\star - \tau_{\text{appl}}\bigr),\\
-\sigma_{a,\text{appl}} &\leftarrow \sigma_{a,\text{appl}}
-  + \alpha\bigl(\sigma_{a,\star} - \sigma_{a,\text{appl}}\bigr).
+\alpha&=1-e^{-\Delta t/\tau_{\mathrm{adapt}}},\\
+\tau_{\mathrm{appl}}&\leftarrow\tau_{\mathrm{appl}}
++\alpha(\tau_\star-\tau_{\mathrm{appl}}),\\
+\sigma_{a,\mathrm{appl}}&\leftarrow\sigma_{a,\mathrm{appl}}
++\alpha(\sigma_{a,\star}-\sigma_{a,\mathrm{appl}}).
 \end{aligned}
+\label{eq:adapt-ewma}
+\end{equation}
+The pseudo-measurement standard-deviation scale uses
+\begin{equation}
+\begin{aligned}
+\tau_{r_S}&=m_{r_S}\tau_\star,\qquad
+\alpha_{r_S}=1-e^{-\Delta t/\tau_{r_S}},\\
+r_{S,\mathrm{appl}}&\leftarrow r_{S,\mathrm{appl}}
++\alpha_{r_S}(r_{S,\star}-r_{S,\mathrm{appl}}).
+\end{aligned}
+\label{eq:adapt-RS}
 \end{equation}
 
-In contrast, $R_S$ is EMA-smoothed with a time constant proportional to the current wave time scale:
-\begin{equation}\label{eq:adapt-RS}
-\begin{aligned}
-\tau_{R_S} &= m_{R_S}\,\tau_\star,\qquad
-\alpha_{R_S} = 1 - e^{-\Delta t/\tau_{R_S}},\\
-R_{S,\text{appl}} &\leftarrow R_{S,\text{appl}}
- + \alpha_{R_S}\bigl(R_{S,\star} - R_{S,\text{appl}}\bigr).
-\end{aligned}
-\end{equation}
-
-Thus $R_S$ responds faster for short-period seas and more slowly for long-period swell.
-
-\subsubsection{Anisotropy}
-When applied to the MEKF, the OU stationary standard deviation is set anisotropically,
+\subsubsection{Anisotropy and implementation API}
+The OU stationary standard deviation is applied anisotropically,
 \[
-\Sigma_{a_w}^{1/2}=\diag(S_{\sigma}\sigma_{a,\text{appl}},\ S_{\sigma}\sigma_{a,\text{appl}},\ \sigma_{a,\text{appl}}),
+\Sigma_{a_w}^{1/2}=\diag(S_\sigma\sigma_{a,\mathrm{appl}},
+S_\sigma\sigma_{a,\mathrm{appl}},\sigma_{a,\mathrm{appl}}),
 \]
-and the $S$ pseudo-measurement uses anisotropic noise
+and the vector passed to \texttt{set\_RS\_noise()} is
 \[
-\mat{R}_S=\diag(\rho_{xy}R_{S,\text{appl}},\ \rho_{xy}R_{S,\text{appl}},\ R_{S,\text{appl}}).
+\vct{r}_S=\begin{bmatrix}
+\rho_{xy}r_{S,\mathrm{appl}}&
+\rho_{xy}r_{S,\mathrm{appl}}&
+r_{S,\mathrm{appl}}
+\end{bmatrix}^{\top}.
 \]
+The setter squares these entries to obtain $\mat{R}_S$, exactly matching the
+measurement model in Sec.~\ref{sec:measurement_model}.
 
 % =======================================================
 \input{w3d-direction-methods.tex-part}

--- a/doc/kalman_ou_iii/w3d-gps-fusion.tex-part
+++ b/doc/kalman_ou_iii/w3d-gps-fusion.tex-part
@@ -1,88 +1,88 @@
-\subsection{GPS Fusion}
+\appendices
+\section{Optional GNSS Fusion Extension}
 \label{sec:gps_fusion}
 
-The filter already maintains world-frame navigation states
-$\bm v\in\R^3$ and $\bm p\in\R^3$, so GNSS/GPS can be fused as a
-low-rate absolute reference to control long-term drift, a common strategy in integrated navigation filters \cite{Jazwinski1970_Filtering,Maybeck1979_StochasticModels}.
+The core wave estimator uses $\vct{p}\in\R^3$ for the oscillatory displacement
+of the tracked vessel or buoy reference point.  This is not an unbounded global
+position state.  When GNSS is fused, introduce a separate local-tangent-plane
+position state $\vct{r}_{\mathrm{nav}}^{\mathcal W}\in\R^3$ for absolute
+navigation relative to a chosen geodetic origin.  The implementation currently
+provides generic position and velocity pseudo-update functions; an application
+that combines wave displacement with absolute navigation should keep these two
+quantities separate and define the measured reference point explicitly.
 
-\subsubsection{Local frame and measurement preprocessing}
+\subsection{Local frame and measurement preprocessing}
 \label{sec:gps_ned_short}
 
-Assume a local-level world frame $\mathcal{W}$ with NED axes. A GNSS fix is typically given in
-geodetic coordinates (latitude, longitude, altitude). Convert to a local tangent-plane
-displacement about an origin $\mathrm{LLA}_0$ (e.g., the first accepted fix):
+Assume a local-level world frame $\mathcal{W}$ with NED axes. A GNSS fix is
+typically given in geodetic coordinates. Convert it to a local tangent-plane
+position about an origin $\mathrm{LLA}_0$:
 \begin{equation}
-\bm z_p^{\mathcal{W}} = \mathrm{LLAtoNED}(\mathrm{LLA}_{\text{gps}};\ \mathrm{LLA}_0),
+\vct{z}_{r}^{\mathcal{W}}
+= \mathrm{LLAtoNED}(\mathrm{LLA}_{\mathrm{gps}};\ \mathrm{LLA}_0),
 \qquad
-\bm n_p \sim \mathcal{N}(\bm 0,\bm R_p).
+\vct{n}_{r}\sim\mathcal{N}(\vct{0},\mat{R}_{r}).
 \end{equation}
-If GNSS velocity is available (Doppler or receiver solution), treat it as
+If GNSS velocity is available, treat it as
 \begin{equation}
-\bm z_v^{\mathcal{W}} = \bm v_{\text{gps}}^{\mathcal{W}},
+\vct{z}_{v}^{\mathcal{W}}=\vct{v}_{\mathrm{gps}}^{\mathcal{W}},
 \qquad
-\bm n_v \sim \mathcal{N}(\bm 0,\bm R_v).
+\vct{n}_{v}\sim\mathcal{N}(\vct{0},\mat{R}_{v}).
 \end{equation}
-A convenient parameterization is $\bm R_p=\diag(\sigma_N^2,\sigma_E^2,\sigma_D^2)$ and
-$\bm R_v=\diag(\sigma_{vN}^2,\sigma_{vE}^2,\sigma_{vD}^2)$, typically with
+A convenient parameterization is
+$\mat{R}_{r}=\diag(\sigma_N^2,\sigma_E^2,\sigma_D^2)$ and
+$\mat{R}_{v}=\diag(\sigma_{vN}^2,\sigma_{vE}^2,\sigma_{vD}^2)$, typically with
 $\sigma_D>\sigma_N\approx\sigma_E$.
 
-\subsubsection{Lever-arm model (antenna not at the reference point)}
+\subsection{Lever-arm model}
 \label{sec:gps_leverarm_short}
 
-Let the GNSS antenna be displaced from the filter reference point by a known lever arm
-$\bm r_{\text{gps}}^{\mathcal{B}}$ expressed in the body frame. With $\Rot_{bw}$ mapping body to
-world, the generic kinematics are
+Let the GNSS antenna be displaced from the navigation reference point by a
+known body-frame lever arm $\vct{r}_{\mathrm{gps}}^{\mathcal B}$. With
+$\Rot_{bw}$ mapping body to world, the antenna kinematics are
 \begin{align}
-\bm p_{\text{gps}}^{\mathcal{W}}
-&= \bm p^{\mathcal{W}} + \Rot_{bw}\,\bm r_{\text{gps}}^{\mathcal{B}},
-\label{eq:gps_p_lever_short}
-\\
-\bm v_{\text{gps}}^{\mathcal{W}}
-&= \bm v^{\mathcal{W}} + \Rot_{bw}\big(\bm\omega^{\mathcal{B}}\times \bm r_{\text{gps}}^{\mathcal{B}}\big),
-\label{eq:gps_v_lever_short}
+\vct{r}_{\mathrm{gps}}^{\mathcal W}
+&=\vct{r}_{\mathrm{nav}}^{\mathcal W}
+ +\Rot_{bw}\vct{r}_{\mathrm{gps}}^{\mathcal B},\\
+\vct{v}_{\mathrm{gps}}^{\mathcal W}
+&=\vct{v}_{\mathrm{nav}}^{\mathcal W}
+ +\Rot_{bw}\bigl(\vct{\omega}^{\mathcal B}\times
+ \vct{r}_{\mathrm{gps}}^{\mathcal B}\bigr),
 \end{align}
-where $\bm\omega^{\mathcal{B}}$ is the body angular rate (ideally bias-corrected).
-
-These models are used as measurement predictions for position and velocity updates:
-\begin{equation}
-\bm z_p = \hat{\bm p} + \hat{\Rot}_{bw}\bm r_{\text{gps}}^{\mathcal{B}} + \bm n_p,
+where $\vct{\omega}^{\mathcal B}$ is ideally bias-corrected.
+The corresponding measurement predictions are
+\begin{align}
+\vct{z}_{r}
+&=\hat{\vct{r}}_{\mathrm{nav}}
+ +\hat{\Rot}_{bw}\vct{r}_{\mathrm{gps}}^{\mathcal B}+\vct{n}_{r},\\
+\vct{z}_{v}
+&=\hat{\vct{v}}_{\mathrm{nav}}
+ +\hat{\Rot}_{bw}(\vct{\omega}^{\mathcal B}\times
+ \vct{r}_{\mathrm{gps}}^{\mathcal B})+\vct{n}_{v}.
+\end{align}
+For the paper's left-multiplicative world-to-body convention,
+\begin{align}
+\frac{\partial}{\partial\delta\vct{\theta}}
+\left(\hat{\Rot}_{bw}\vct{r}_{\mathrm{gps}}^{\mathcal B}\right)
+&\approx \hat{\Rot}_{bw}\Skew{\vct{r}_{\mathrm{gps}}^{\mathcal B}},\\
+\frac{\partial}{\partial\delta\vct{\theta}}
+\left(\hat{\Rot}_{bw}\vct{u}\right)
+&\approx \hat{\Rot}_{bw}\Skew{\vct{u}},
 \qquad
-\bm z_v = \hat{\bm v} + \hat{\Rot}_{bw}(\bm\omega^{\mathcal{B}}\times \bm r_{\text{gps}}^{\mathcal{B}}) + \bm n_v.
-\end{equation}
-For the left-multiplicative world-to-body attitude convention used in this paper,
-linearizing the lever-arm term gives the attitude Jacobians
-\begin{align}
-\frac{\partial}{\partial\,\delta\bm\theta}\!\left(\hat{\Rot}_{bw}\bm r_{\text{gps}}^{\mathcal{B}}\right)
-&\approx \hat{\Rot}_{bw}\Skew{\bm r_{\text{gps}}^{\mathcal{B}}}, \label{eq:dRr_dth}\\
-\frac{\partial}{\partial\,\delta\bm\theta}\!\left(\hat{\Rot}_{bw}\bm u\right)
-&\approx \hat{\Rot}_{bw}\Skew{\bm u}, \qquad
-\bm u \triangleq \bm\omega^{\mathcal{B}}\times\bm r_{\text{gps}}^{\mathcal{B}}.
-\label{eq:dRu_dth}
+\vct{u}:=\vct{\omega}^{\mathcal B}\times\vct{r}_{\mathrm{gps}}^{\mathcal B}.
 \end{align}
 
-\subsubsection{Centripetal acceleration during maneuvers}
-\label{sec:gps_centripetal_short}
-
-During aggressive boat maneuvers or with a long lever arm, the antenna experiences additional
-\emph{relative} acceleration due to rotation:
+\subsection{Rotational acceleration and timestamp alignment}
+During aggressive maneuvers, the antenna also experiences
 \begin{equation}
-\bm a_{\text{gps}}^{\mathcal{W}}
-=
-\bm a^{\mathcal{W}}
-+
-\Rot_{bw}\Big(
-\bm\alpha^{\mathcal{B}}\times \bm r_{\text{gps}}^{\mathcal{B}}
-+
-\bm\omega^{\mathcal{B}}\times(\bm\omega^{\mathcal{B}}\times \bm r_{\text{gps}}^{\mathcal{B}})
-\Big),
+\vct{a}_{\mathrm{gps}}^{\mathcal W}
+=\vct{a}_{\mathrm{nav}}^{\mathcal W}
++\Rot_{bw}\Bigl(
+\vct{\alpha}^{\mathcal B}\times\vct{r}_{\mathrm{gps}}^{\mathcal B}
++\vct{\omega}^{\mathcal B}\times
+ (\vct{\omega}^{\mathcal B}\times\vct{r}_{\mathrm{gps}}^{\mathcal B})
+\Bigr).
 \end{equation}
-where $\bm\omega\times(\bm\omega\times\bm r)$ is the centripetal term and
-$\bm\alpha^{\mathcal{B}}$ is the angular acceleration. Even when only position/velocity are fused,
-these terms explain why lever-arm compensation matters most under high $\|\bm\omega\|$ and large
-$\|\bm r_{\text{gps}}\|$.
-
-\subsubsection{Timestamp alignment}
-\label{sec:gps_time_short}
-
-GNSS updates are asynchronous (typically 1--10~Hz) relative to the IMU.
-The exact timestamp alignment is usually unavailable, for best results inflate $\bm R_p,\bm R_v$ to absorb timing uncertainty.
+GNSS updates are asynchronous, typically at 1--10~Hz.  A production fusion
+implementation should timestamp-align or delay-compensate the measurements;
+simply inflating $\mat{R}_{r}$ and $\mat{R}_{v}$ is only an approximation.

--- a/doc/kalman_ou_iii/w3d-intro.tex-part
+++ b/doc/kalman_ou_iii/w3d-intro.tex-part
@@ -10,13 +10,13 @@ attitude estimation, 3D kinematics, and stochastic excitation
 modeling into a single, analytically tractable structure suitable for
 real-time implementation.
 
-Most wave measurement systems derive parameters by chaining separate motion estimation 
-and spectral analysis stages, a process prone to bias and delay. 
-Our approach instead uses a unified 21-state Kalman filter that 
-directly incorporates wave kinematics. By modeling wave acceleration 
-as an Ornstein-Uhlenbeck process and combining it with adaptive drift control 
-and a real-time directional estimator, we address key challenges like colored 
-excitation and MEMS errors in an efficient, embedded-friendly framework.
+Most wave measurement systems derive parameters by chaining separate motion estimation
+and spectral analysis stages, a process prone to bias and delay.
+Our approach instead uses a unified 21-state Kalman filter that
+directly incorporates wave kinematics. By modeling wave acceleration
+with an Ornstein--Uhlenbeck prior and combining it with adaptive drift control
+and a real-time directional estimator, we address colored excitation and MEMS
+errors in an efficient, embedded-friendly framework.
 
 \subsection*{From Standard Q-MEKF to Extended Kinematics}
 
@@ -24,82 +24,80 @@ We start from a standard Q-MEKF \cite{Markley2003AttitudeError,TrawnyRoumeliotis
 gyroscope bias using a left-multiplicative quaternion error
 representation. To enable full wave motion estimation, the state vector
 is augmented to include additional translational quantities:
-world-frame acceleration, velocity, displacement, and the integral of
-displacement in three dimensions, together with accelerometer bias.
-This augmentation allows the estimator to directly reconstruct both
-instantaneous and cumulative kinematic quantities in the world frame.
+world-frame acceleration, velocity, oscillatory displacement, and the integral of
+oscillatory displacement in three dimensions, together with accelerometer bias.
+This augmentation allows the estimator to reconstruct instantaneous and
+cumulative wave kinematics in the world frame.
 
 \subsection*{Stochastic Forcing and the OU Acceleration Model}
 
-The latent world acceleration \(\bm{a}_w\) is modeled as an
-Ornstein--Uhlenbeck (OU) process \cite{UhlenbeckOrnstein1930_OU} characterized by a stationary variance
-\(\Sigma_{aw}\) and a correlation time constant \(\tau_{aw}\) referred hereafter \(\tau\). This choice
-captures the nature of ocean-wave excitation: broadband, temporally correlated but with bounded variance.
-For Lagrangian sensors following surface motion, this leads to
-substantially improved low-frequency stability without sacrificing
-responsiveness to swell-band motion.
+The latent world acceleration \(\bm{a}_w\) is modeled with an
+Ornstein--Uhlenbeck (OU) prior \cite{UhlenbeckOrnstein1930_OU} characterized by a stationary variance
+\(\Sigma_{aw}\) and a correlation time constant \(\tau_{aw}\), referred to hereafter as \(\tau\).
+The OU prior is a low-order Gauss--Markov model for broadband, temporally
+correlated excitation with bounded variance; it is not asserted to be the
+physical ocean-wave spectrum. For Lagrangian sensors following surface motion,
+this prior improves low-frequency stability without sacrificing responsiveness
+to swell-band motion.
 
 \subsection*{Continuous-Time Model Formulation}
 
 The continuous-time model is organized into three independent linear
-chains, one for each axis, linking acceleration, velocity, displacement,
-and integral of displacement. These linear chains are coupled to the
+chains, one for each axis, linking acceleration, velocity, oscillatory displacement,
+and integral of oscillatory displacement. These linear chains are coupled to the
 quaternion attitude subsystem through the standard small-angle error
 kinematics of the Q-MEKF. IMU measurements provide specific force and
 angular rate observations, while a pseudo-measurement of the integral of
 displacement serves as a long-term constraint to suppress drift. The
-pseudo-measurement covariance \(R_S\) becomes a crucial design
-parameter: smaller values tighten the constraint but risk biasing slow
-wave components, while larger values relax drift control.
+pseudo-measurement standard-deviation scale \(r_S\), whose square forms the
+covariance \(R_S\), is a crucial design parameter: smaller values tighten the
+constraint but risk biasing slow wave components, while larger values relax
+drift control.
 
 \subsection*{Discrete-Time Analytic Derivation}
 
 Having established the continuous-time system, we derive the discrete
 transition and process-noise covariance matrices required for Kalman
-recursion. The discretization of the OU-driven linear subsystem is
-performed analytically by integrating the exponential kernel of the OU
-correlation function, yielding closed-form expressions for both the
-transition matrix \(\Phi(h,\tau)\) and the discrete process-noise matrix
-\(Q_d(h,\tau)\). For small \(x = h/\tau\), we construct high-order
-Maclaurin series to prevent numerical floating-point cancellation and preserve
-stability in the limit of small time steps. The derivation exploits the
-block sparsity of the continuous Jacobian to obtain efficient
-expressions and simplify matrix exponentials. The pseudo-measurement weighting
-\(R_S\) can be made anisotropic to reflect different vertical and
-lateral dynamics.
+recursion. The OU-driven linear subsystem is discretized analytically by
+integrating the exponential kernel of the OU correlation function, yielding
+closed-form expressions for its transition matrix \(\Phi(h,\tau)\) and
+discrete process-noise matrix \(Q_d(h,\tau)\). For small \(x=h/\tau\),
+high-order Maclaurin series prevent floating-point cancellation and preserve
+stability. The attitude/gyro-bias transition is also structured analytically;
+some anisotropic attitude covariance integrals are evaluated by Simpson
+quadrature, matching the implementation. The pseudo-measurement weighting can
+be anisotropic to reflect different vertical and lateral dynamics.
 
 \subsection*{Adaptive Parameter Estimation}
 
 A fixed-parameter Kalman filter performs optimally only under a
 particular sea-state regime, determined by its assumed correlation time
 \(\tau\) and stationary acceleration variance \(\Sigma_{aw}\).
-Different wave spectra, however, exhibit distinct dominant frequencies
-and energy levels. To maintain performance across conditions, we
-introduce an online adaptation mechanism that continuously estimates and
-tunes these parameters. Three alternative embedded frequency trackers
-are supported: the \textit{KalmANF adaptive notch filter}, \textit{PLL (Phase-Locked Loop)} filter,
-and the \textit{Aranovskiy frequency estimator}. The dominant frequency inferred from
-these modules provides an updated correlation time \(\tau\), while the
-stationary variance \(\sigma_{aw}^2\) is estimated directly in the time
-domain. The pseudo-measurement noise \(R_S\) is then adapted through a spectrally
-motivated regularization law,
+Different wave spectra exhibit distinct dominant frequencies and energy
+levels. To maintain performance across conditions, we introduce an online
+adaptation mechanism that continuously estimates and tunes these parameters.
+Three alternative embedded frequency trackers are supported: the
+\textit{KalmANF adaptive notch filter}, \textit{PLL (Phase-Locked Loop)} filter,
+and the \textit{Aranovskiy frequency estimator}. The dominant frequency
+provides an updated correlation time \(\tau\), while the stationary acceleration
+scale \(\sigma_{aw}\) is estimated in the time domain. The pseudo-measurement
+standard-deviation scale is adapted through the spectrally motivated law
 \[
-R_S \propto \sigma_{aw} \tau^3,
+r_S \propto \sigma_{aw}\tau^3,
 \]
-which links displacement drift suppression to the stochastic excitation
-strength. Without online adaptation the integration drift produces heave errors 
-that exceed practical tolerances.
+which links displacement drift suppression to stochastic excitation strength.
+The normalization is approximate and assumes a fixed pseudo-update cadence and
+a bounded family of spectral shapes and effective low-frequency cutoffs.
 
 \subsection*{Validation}
 
-The complete filter is validated using synthetic data generated
-from directional JONSWAP and Pierson--Moskowitz wave spectra with
-second-order Stokes corrections. The simulated IMU represents a
-surface-following (Lagrangian) buoy subject to realistic measurement
-noise. Performance is assessed via RMS displacement errors relative to
-the true wave elevation. The OU-based Q-MEKF achieves
-drift-suppressed yet dynamically faithful reconstruction of
-three-dimensional surface motion.
+The complete filter is validated using synthetic data generated from
+directional JONSWAP spectra and Pierson--Moskowitz seas augmented by the
+nonlinear Stokes harmonics implemented by the repository wave generator. The
+simulated IMU represents a surface-following (Lagrangian) buoy subject to
+realistic measurement noise. Performance is assessed via RMS displacement
+errors relative to the true wave elevation. The OU-based Q-MEKF achieves
+drift-suppressed reconstruction of three-dimensional surface motion.
 
 \subsection{Main Contributions}
 
@@ -109,15 +107,13 @@ The main contributions of this work are:
         latent OU-driven acceleration, integral drift suppression, and
         left-multiplicative quaternion error dynamics.
   \item Closed-form discrete-time transition and covariance matrices for
-        the OU process and linear kinematic chain, with numerically
-        stable small-step series expansions.
+        the OU process and linear kinematic chain, with numerically stable
+        small-step series expansions.
   \item A unified parameter-adaptive mechanism that continuously tunes
-        \(\tau\), \(\sigma_{aw}\), and \(R_S\) based on frequency
-        tracking and time-domain variance estimation.
+        \(\tau\), \(\sigma_{aw}\), and the pseudo-measurement standard-deviation
+        scale based on frequency tracking and time-domain variance estimation.
   \item A formulation independent of hydrodynamic equations, relying instead on
-        oscillatory kinematics with slowly varying spectra and
-        high-rate inertial data measurements.
+        oscillatory kinematics with slowly varying spectra and high-rate inertial measurements.
   \item Empirical validation on simulated directional sea spectra,
-        demonstrating accurate drift suppression and physical fidelity.
+        demonstrating drift suppression and physical fidelity.
 \end{itemize}
-

--- a/doc/kalman_ou_iii/w3d-kalm-up.tex-part
+++ b/doc/kalman_ou_iii/w3d-kalm-up.tex-part
@@ -17,7 +17,7 @@ define
 \matg{\Lambda}&=\mat{C}\mat{P}^-\mat{C}^{\top}+\mat{R},\\
 \mat{K}&=\mat{P}^-\mat{C}^{\top}\matg{\Lambda}^{-1}.
 \end{align}
-The additive state correction is
+The additive error-state correction is
 \begin{equation}
 \delta\hat{\vct{x}}^+=\delta\hat{\vct{x}}^-+\mat{K}\vct{r},
 \end{equation}
@@ -60,10 +60,26 @@ For the accelerometer,
 with columns placed according to \eqref{eq:state-vector}.  For the integral
 pseudo-measurement, $\mat{C}_S$ selects the $\vct{S}$ block.
 
-\subsection{Quaternion injection}
-After an accepted correction, let
-$\delta\hat{\vct{\theta}}$ be the first three components of the additive error
-state.  The left-multiplicative injection is
+\subsection{Nominal-state injection and quaternion reset}
+After an accepted correction, the implementation first adds the complete
+Kalman correction to the stored additive state vector.  Equivalently, writing
+$\delta\hat{\vct{x}}^+$ in the ordering of \eqref{eq:state-vector}, the nominal
+additive states are injected as
+\begin{align}
+\hat{\vct{b}}_g &\leftarrow \hat{\vct{b}}_g+\delta\hat{\vct{b}}_g,&
+\hat{\vct{v}} &\leftarrow \hat{\vct{v}}+\delta\hat{\vct{v}},\\
+\hat{\vct{p}} &\leftarrow \hat{\vct{p}}+\delta\hat{\vct{p}},&
+\hat{\vct{S}} &\leftarrow \hat{\vct{S}}+\delta\hat{\vct{S}},\\
+\hat{\vct{a}}_w &\leftarrow \hat{\vct{a}}_w+\delta\hat{\vct{a}}_w,&
+\hat{\vct{b}}_a &\leftarrow \hat{\vct{b}}_a+\delta\hat{\vct{b}}_a.
+\label{eq:additive-state-injection}
+\end{align}
+The optional bias terms are omitted when the corresponding state is disabled.
+This matches the C++ implementation, where the full vector update is applied
+before the quaternion correction.
+
+Let $\delta\hat{\vct{\theta}}$ be the first three components of the corrected
+error state.  The left-multiplicative quaternion injection is
 \begin{equation}
 q\leftarrow\exp_q\!\left(\tfrac12\delta\hat{\vct{\theta}}\right)\otimes q.
 \label{eq:quat-error-injection}
@@ -81,7 +97,7 @@ To first order, the reset Jacobian for the convention used here is
 =\blkdiag(\mat{G}_{\theta},\Id_{N_X-3}).
 \label{eq:left-reset-jacobian}
 \end{equation}
-The covariance is transformed before clearing the local error:
+The covariance is transformed before clearing the local attitude coordinates:
 \begin{equation}
 \mat{P}^+
 \leftarrow
@@ -91,6 +107,11 @@ The covariance is transformed before clearing the local error:
 \delta\hat{\vct{\theta}}\leftarrow0.
 \label{eq:mekf-reset-covariance}
 \end{equation}
+The non-attitude entries of the stored vector now contain the injected nominal
+additive states, while the first three entries are reset to zero.  Thus the
+post-update representation is a nominal quaternion plus additive navigation
+and bias states, with a zero-mean local attitude error.
+
 The transformation applies to both the attitude marginal and every attitude
 cross-covariance.  It is required after accelerometer, magnetometer, position,
 velocity, and $S=0$ updates whenever those updates induce a nonzero attitude

--- a/doc/kalman_ou_iii/w3d-lti-discrete.tex-part
+++ b/doc/kalman_ou_iii/w3d-lti-discrete.tex-part
@@ -1,7 +1,7 @@
 \subsection{Discretization of a generic LTI SDE over step \texorpdfstring{$h$}{h}}
 \label{sec:lti-disc}
 
-Consider a linear time–invariant SDE
+Consider a linear time--invariant SDE
 \begin{equation}
 \fitcol{
 \dot{\delta\vct{x}}(t)
@@ -11,7 +11,7 @@ Consider a linear time–invariant SDE
   = \matg{Q}_c\,\delta(t{-}s),
 }
 \end{equation}
-with Jacobian (linearized) dynamics matrix $\mat{F}$, noise–input matrix $\mat{L}$,
+with Jacobian (linearized) dynamics matrix $\mat{F}$, noise--input matrix $\mat{L}$,
 and continuous spectral density $\matg{Q}_c$.
 
 \paragraph{State transition via the matrix exponential}
@@ -46,7 +46,10 @@ Given $(\hat{\vct{x}}_k,\mat{P}_k)$ at $t_k$, the prediction to $t_{k+1}=t_k{+}h
 \hat{\vct{x}}_{k+1|k} &= \matg{\Phi}(h)\,\hat{\vct{x}}_k,\\
 \mat{P}_{k+1|k} &= \matg{\Phi}(h)\,\mat{P}_k\,\matg{\Phi}(h)^\top \;+\; \matg{Q}_d(h).
 \end{align}
-These equations are the discrete counterparts of the continuous Lyapunov/Riccati
-flow with $\mat{F}$ and $\mat{L}$ the Jacobian dynamics and noise–input matrices
-defined in \S\ref{sec:lti-sde}. In our implementation, $\matg{\Phi}$ and $\matg{Q}_d$
-are computed analytically for the OU–driven kinematic blocks.
+These equations are the discrete counterparts of the continuous covariance
+flow for the local-error SDE defined in Sec.~\ref{sec:process_model}.  In the
+implementation, the OU-driven kinematic transition and process covariance are
+computed analytically, including the small-step series branch.  The
+attitude/gyro-bias transition is structured and exact for constant angular
+rate, while anisotropic attitude-noise and bias-driven covariance integrals use
+Simpson quadrature as described in Sec.~\ref{sec:discrete_model}.

--- a/doc/kalman_ou_iii/w3d-lti-discrete.tex-part
+++ b/doc/kalman_ou_iii/w3d-lti-discrete.tex-part
@@ -52,4 +52,4 @@ implementation, the OU-driven kinematic transition and process covariance are
 computed analytically, including the small-step series branch.  The
 attitude/gyro-bias transition is structured and exact for constant angular
 rate, while anisotropic attitude-noise and bias-driven covariance integrals use
-Simpson quadrature as described in Sec.~\ref{sec:discrete_model}.
+Simpson quadrature, as stated in the following attitude-block derivation.

--- a/doc/kalman_ou_iii/w3d-meas.tex-part
+++ b/doc/kalman_ou_iii/w3d-meas.tex-part
@@ -52,18 +52,23 @@ The drift-control channel is
 \end{equation}
 with
 \begin{equation}
-\mat{R}_S=\diag(\sigma_{Sx}^2,\sigma_{Sy}^2,\sigma_{Sz}^2),
+\vct{r}_S:=
+\begin{bmatrix}r_{Sx}&r_{Sy}&r_{Sz}\end{bmatrix}^{\top},
+\qquad
+\mat{R}_S=\diag(r_{Sx}^2,r_{Sy}^2,r_{Sz}^2),
 \qquad
 \mat{H}_S=\begin{bmatrix}0&\cdots&\Id_{S}&\cdots&0\end{bmatrix}.
+\label{eq:RS-from-rS}
 \end{equation}
-The implementation API is parameterized by the standard-deviation vector
-$\vct{\sigma}_S$ and squares it internally to form $\mat{R}_S$.  Consequently,
-scalar adaptation laws denoted by $R_S$ elsewhere in the paper refer to a
-standard-deviation scale; the Kalman update always uses its squared covariance.
+Here $\vct{r}_S$ is the per-axis pseudo-measurement standard-deviation
+vector, in units of $\mathrm{m\,s}$, whereas $\mat{R}_S$ is the covariance
+used by the Kalman update.  This notation matches the implementation:
+\texttt{set\_RS\_noise()} accepts $\vct{r}_S$ and squares its components,
+while \texttt{set\_RS\_noise\_matrix()} accepts a covariance matrix directly.
 
 This pseudo-measurement is a regularizer, not a physical observation.  Repeated
 application creates a soft leak in the augmented integration chain: smaller
-$\vct{\sigma}_S$ gives stronger low-frequency drift suppression, while larger
+$\vct{r}_S$ gives stronger low-frequency drift suppression, while larger
 values preserve slower motion at the cost of more drift.
 
 \paragraph{Time-based cadence.}
@@ -81,7 +86,9 @@ e_{k+1}=\tilde e_{k+1}\bmod T_S.
 A floating-point tolerance is used at the boundary.  Defining cadence in
 seconds rather than as every $N$ samples makes the regularization rate invariant
 to the IMU sample rate; the same $T_S$ produces the same number of updates per
-unit time at 100, 200, or 400~Hz.
+unit time at 100, 200, or 400~Hz.  The effective regularization strength still
+depends on both $\vct{r}_S$ and $T_S$, so comparisons of tuning laws assume a
+fixed pseudo-update cadence unless stated otherwise.
 
 \subsection{IMU lever-arm model}
 If the IMU is displaced from the center of gravity by known body-frame vector

--- a/doc/kalman_ou_iii/w3d-meas.tex-part
+++ b/doc/kalman_ou_iii/w3d-meas.tex-part
@@ -51,15 +51,17 @@ The drift-control channel is
 \label{eq:zero-pseudo}
 \end{equation}
 with
-\begin{equation}
-\vct{r}_S:=
-\begin{bmatrix}r_{Sx}&r_{Sy}&r_{Sz}\end{bmatrix}^{\top},
-\qquad
-\mat{R}_S=\diag(r_{Sx}^2,r_{Sy}^2,r_{Sz}^2),
-\qquad
-\mat{H}_S=\begin{bmatrix}0&\cdots&\Id_{S}&\cdots&0\end{bmatrix}.
-\label{eq:RS-from-rS}
-\end{equation}
+\begin{align}
+\vct{r}_S
+&:=\begin{bmatrix}r_{Sx}&r_{Sy}&r_{Sz}\end{bmatrix}^{\top},
+\label{eq:rS-vector}\\
+\mat{R}_S
+&:=\diag\!\left(r_{Sx}^2,r_{Sy}^2,r_{Sz}^2\right),
+\label{eq:RS-from-rS}\\
+\mat{H}_S
+&:=\begin{bmatrix}0&\cdots&\Id_S&\cdots&0\end{bmatrix}.
+\label{eq:HS-selector}
+\end{align}
 Here $\vct{r}_S$ is the per-axis pseudo-measurement standard-deviation
 vector, in units of $\mathrm{m\,s}$, whereas $\mat{R}_S$ is the covariance
 used by the Kalman update.  This notation matches the implementation:


### PR DESCRIPTION
## Summary

Corrects the LaTeX sources for review issues 1–4 and presentation items 1–4 without changing any tables or figures.

### Mathematical and notation corrections
- makes the PSD convention explicitly two-sided (with the equivalent one-sided formula) and corrects the OU example from `c_spec ≈ 0.16` to `c_spec ≈ 0.227` for `u_min = 1`;
- narrows the sea-state-invariance claim to an approximate engineering normalization for a fixed pseudo-update cadence and bounded spectral family;
- separates pseudo-measurement standard deviation `r_S` / vector `r_S` from covariance matrix `R_S`, matching `set_RS_noise()` and `set_RS_noise_matrix()` in the C++ implementation;
- documents full additive-state injection followed by quaternion injection and MEKF covariance reset, matching the implementation’s `xext += K r` then quaternion correction.

### Presentation corrections
- removes the unresolved section reference and qualifies which covariance terms use Simpson quadrature;
- aligns validation wording with the repository wave generator rather than mixing second- and third-order Stokes terminology;
- adds a results-focused conclusion summary;
- moves optional GNSS material to an appendix and distinguishes oscillatory displacement `p` from absolute local navigation position `r_nav`.

### Scope
- no changes to simulation result tables or figures;
- no merge requested; this draft PR is for author review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the estimator documentation to clarify modeling, discretization, covariance handling, and numerical stability.
  * Expanded guidance for adaptive pseudo-measurement tuning, cadence effects, and spectral assumptions.
  * Clarified the measurement-update reset sequence and post-update state representation.
  * Reworked optional GNSS guidance to separate navigation position from oscillatory displacement and emphasize timestamp alignment.
  * Added conclusions covering validation results, embedded feasibility, limitations, and future work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->