### PR TITLE
Polish manuscript implementation language and references

### DIFF
--- a/doc/kalman_ou_iii/w3d-analytic-coeff.tex-part
+++ b/doc/kalman_ou_iii/w3d-analytic-coeff.tex-part
@@ -1,14 +1,13 @@
 \section{Discrete Transition and Process Covariance}
 \label{sec:block-Phi-Qd}
 
-Let $h>0$ be the sample interval.  The implementation preserves the group-first
-state ordering
+The estimator preserves the group-first state ordering
 \[
 [\delta\vct{\theta},\vct{b}_g,\vct{v},\vct{p},\vct{S},\vct{a}_w,\vct{b}_a]
 \]
 used in Sec.~\ref{sec:state}.  Axis-wise formulas are derived in the compact
 ordering $[v,p,S,a]$, then assembled into the group-first three-dimensional
-blocks without permuting the public state.
+blocks without permuting the state.
 
 \subsection{Attitude and gyroscope-bias block}
 For constant $\hat{\vct{\omega}}$ over the step, define
@@ -50,8 +49,8 @@ The structured process covariance is
  &=\left(\int_0^h\mat{B}(s)\,ds\right)\matg{Q}_{bg},\\
 \matg{Q}_{bb}&=h\matg{Q}_{bg}.
 \end{align}
-The first integral is exact for isotropic $\matg{Q}_g$; the implementation uses
-Simpson quadrature for anisotropic matrices and for the bias-driven integral.
+The first integral is exact for isotropic $\matg{Q}_g$; Simpson quadrature is
+used for anisotropic matrices and for the bias-driven integral.
 
 \subsection{OU-driven linear transition}
 For one axis, let
@@ -153,11 +152,11 @@ d_{ijrs}&=r+s+m_i+m_j+1,
 \label{eq:ou-small-step-compact}
 \end{equation}
 The matrix is completed by symmetry.  Equation~\eqref{eq:ou-small-step-compact}
-contains all terms retained by the implementation; for example, it produces the
-leading orders $Q_{aa}=2\sigma^2\lambda h+O(h^2)$,
+contains all terms retained in the ninth-order expansion; for example, it
+produces the leading orders $Q_{aa}=2\sigma^2\lambda h+O(h^2)$,
 $Q_{va}=\sigma^2\lambda h^2+O(h^3)$, and
 $Q_{SS}=\sigma^2\lambda h^7/126+O(h^8)$.
-The $[v,p,a]$ principal marginal is computed by the same OU-II routine and
+The $[v,p,a]$ principal marginal is computed by the same OU-II formulation and
 embedded into the OU-III matrix, making that common marginal identical by
 construction.
 

--- a/doc/kalman_ou_iii/w3d-gps-fusion.tex-part
+++ b/doc/kalman_ou_iii/w3d-gps-fusion.tex-part
@@ -6,10 +6,10 @@ The core wave estimator uses $\vct{p}\in\R^3$ for the oscillatory displacement
 of the tracked vessel or buoy reference point.  This is not an unbounded global
 position state.  When GNSS is fused, introduce a separate local-tangent-plane
 position state $\vct{r}_{\mathrm{nav}}^{\mathcal W}\in\R^3$ for absolute
-navigation relative to a chosen geodetic origin.  The implementation currently
-provides generic position and velocity pseudo-update functions; an application
-that combines wave displacement with absolute navigation should keep these two
-quantities separate and define the measured reference point explicitly.
+navigation relative to a chosen geodetic origin.  Generic position and
+velocity pseudo-updates are available; an application that combines wave
+displacement with absolute navigation should keep these two quantities
+separate and define the measured reference point explicitly.
 
 \subsection{Local frame and measurement preprocessing}
 \label{sec:gps_ned_short}
@@ -84,5 +84,5 @@ During aggressive maneuvers, the antenna also experiences
 \Bigr).
 \end{equation}
 GNSS updates are asynchronous, typically at 1--10~Hz.  A production fusion
-implementation should timestamp-align or delay-compensate the measurements;
-simply inflating $\mat{R}_{r}$ and $\mat{R}_{v}$ is only an approximation.
+system should timestamp-align or delay-compensate the measurements; simply
+inflating $\mat{R}_{r}$ and $\mat{R}_{v}$ is only an approximation.

--- a/doc/kalman_ou_iii/w3d-kalm-up.tex-part
+++ b/doc/kalman_ou_iii/w3d-kalm-up.tex-part
@@ -61,10 +61,9 @@ with columns placed according to \eqref{eq:state-vector}.  For the integral
 pseudo-measurement, $\mat{C}_S$ selects the $\vct{S}$ block.
 
 \subsection{Nominal-state injection and quaternion reset}
-After an accepted correction, the implementation first adds the complete
-Kalman correction to the stored additive state vector.  Equivalently, writing
-$\delta\hat{\vct{x}}^+$ in the ordering of \eqref{eq:state-vector}, the nominal
-additive states are injected as
+After an accepted correction, the complete Kalman correction is first added to
+the nominal additive state vector.  Writing $\delta\hat{\vct{x}}^+$ in the
+ordering of \eqref{eq:state-vector}, the nominal additive states are injected as
 \begin{align}
 \hat{\vct{b}}_g &\leftarrow \hat{\vct{b}}_g+\delta\hat{\vct{b}}_g,&
 \hat{\vct{v}} &\leftarrow \hat{\vct{v}}+\delta\hat{\vct{v}},\\
@@ -75,8 +74,7 @@ additive states are injected as
 \label{eq:additive-state-injection}
 \end{align}
 The optional bias terms are omitted when the corresponding state is disabled.
-This matches the C++ implementation, where the full vector update is applied
-before the quaternion correction.
+The full additive-state injection precedes the quaternion correction.
 
 Let $\delta\hat{\vct{\theta}}$ be the first three components of the corrected
 error state.  The left-multiplicative quaternion injection is

--- a/doc/kalman_ou_iii/w3d-lti-discrete.tex-part
+++ b/doc/kalman_ou_iii/w3d-lti-discrete.tex-part
@@ -33,7 +33,7 @@ Let $\matg{Q}_d(h)$ denote the process noise accrued over $[t,t{+}h]$.
 From the stochastic variation-of-constants formula,
 \begin{equation}
 \matg{Q}_d(h)
-\;=\;
+  \;=\;
 \int_{0}^{h}
   e^{\mat{F} \tau}\,\mat{L}\,\matg{Q}_c\,\mat{L}^\top\,
   e^{\mat{F}^\top \tau}\,d\tau.
@@ -47,8 +47,8 @@ Given $(\hat{\vct{x}}_k,\mat{P}_k)$ at $t_k$, the prediction to $t_{k+1}=t_k{+}h
 \mat{P}_{k+1|k} &= \matg{\Phi}(h)\,\mat{P}_k\,\matg{\Phi}(h)^\top \;+\; \matg{Q}_d(h).
 \end{align}
 These equations are the discrete counterparts of the continuous covariance
-flow for the local-error SDE defined in Sec.~\ref{sec:process_model}.  In the
-implementation, the OU-driven kinematic transition and process covariance are
+flow for the local-error SDE defined in Sec.~\ref{sec:proc}.  For the proposed
+estimator, the OU-driven kinematic transition and process covariance are
 computed analytically, including the small-step series branch.  The
 attitude/gyro-bias transition is structured and exact for constant angular
 rate, while anisotropic attitude-noise and bias-driven covariance integrals use

--- a/doc/kalman_ou_iii/w3d-proc-cont.tex-part
+++ b/doc/kalman_ou_iii/w3d-proc-cont.tex-part
@@ -21,8 +21,7 @@ with
 \vct{\omega}&-\Skew{\vct{\omega}}
 \end{bmatrix}.
 \]
-The implementation renormalizes the quaternion after propagation and
-correction.
+The quaternion is renormalized after propagation and correction.
 
 Gyroscope bias follows
 \begin{equation}


### PR DESCRIPTION
## Summary

- replace remaining C++/implementation-specific wording in the OU-III manuscript with algorithmic or mathematical descriptions
- remove the explicit statement that the MEKF update matches the C++ implementation
- clarify the covariance small-step truncation language
- revise the optional GNSS extension to describe estimator capabilities rather than software functions
- fix the unresolved process-model section reference that rendered as `Sec. ??`

## Root cause

The manuscript mixed research-paper language with source-code documentation, and `w3d-lti-discrete.tex-part` referenced the nonexistent label `sec:process_model` instead of the defined label `sec:proc`.

## Validation

- compared the branch against `main`; five manuscript source files are changed
- verified that the corrected section label exists in `w3d-proc-cont.tex-part`
- no estimator source code or numerical results were changed

A local LaTeX build was not available in this environment, so CI should perform the final compile/reference check.