### PR TITLE
Remove remaining implementation-oriented manuscript language

### DIFF
--- a/doc/kalman_ou_iii/kalman_ou-w3d.tex
+++ b/doc/kalman_ou_iii/kalman_ou-w3d.tex
@@ -170,7 +170,7 @@ scale, and the standard-deviation scale whose square forms the integral
 pseudo-measurement covariance. The cubic scaling with correlation time is a
 physically motivated engineering normalization for fixed update cadence and a
 bounded family of spectra, rather than an exact universal invariance claim. The
-implementation targets real-time low-cost embedded IMU deployments.
+method is suitable for real-time deployment with low-cost embedded IMUs.
 \end{abstract}
 
 \begin{IEEEkeywords}

--- a/doc/kalman_ou_iii/w3d-conclusion-summary.tex-part
+++ b/doc/kalman_ou_iii/w3d-conclusion-summary.tex-part
@@ -4,10 +4,9 @@ under the simulation protocol of Sec.~\ref{sec:sim-and-eval}. Across the tested
 JONSWAP and PM--Stokes cases, the reported vertical-displacement RMS errors
 remain within the ranges listed in Table~\ref{tab:sim_results_rms_dir_basic},
 while the attitude and direction pipelines remain operational under the stated
-multi-rate sensor and error models. The exact OU-chain transition, small-step
-covariance branch, full MEKF reset, and adaptive pseudo-measurement scaling are
-implemented in the same C++ code exercised by the simulations and embedded
-builds.
+multi-rate sensor and error models. The simulations and embedded builds exercise
+the same estimator recursion, including the exact OU-chain transition, small-step
+covariance branch, full MEKF reset, and adaptive pseudo-measurement scaling.
 
 The results support embedded feasibility and drift-controlled wave-state
 reconstruction for the tested conditions, but they do not by themselves imply

--- a/doc/kalman_ou_iii/w3d-direction-methods.tex-part
+++ b/doc/kalman_ou_iii/w3d-direction-methods.tex-part
@@ -94,19 +94,19 @@ L_k=\frac{\lambda_{1,k}-\lambda_{2,k}}
 \label{eq:dir-amplitude-linearity}
 \end{equation}
 Linearly polarized motion has $L_k\simeq1$; circular or equally spread motion
-has $L_k\simeq0$ and is rejected. The implementation combines covariance and
+has $L_k\simeq0$ and is rejected. Confidence combines covariance and
 linearity as
 \begin{equation}
 c_k=\frac{L_k}{\operatorname{tr}(\mat{P}_k)+\epsilon_P},
 \label{eq:dir-confidence}
 \end{equation}
-and requires amplitude, confidence, and linearity gates before exposing a
-current axis. Axial smoothing is performed on
+and amplitude, confidence, and linearity gates must all be satisfied before a
+current axis is reported. Axial smoothing is performed on
 $[\cos 2\theta_k,\sin 2\theta_k]^\top$, avoiding artificial $180^\circ$ jumps.
 Let $\mat{P}_{C,k}$ and $\mat{P}_{S,k}$ be the cosine- and sine-quadrature
 $2\times2$ covariance blocks and let
 $\vct{t}_k=[-\widehat d_{S,k},\widehat d_{F,k}]^\top$ be tangent to the axis.
-The implemented first-order angular uncertainty is
+A first-order angular-uncertainty approximation is
 \begin{equation}
 \sigma_{\theta,k}^2
 \approx

--- a/doc/kalman_ou_iii/w3d-fus-methods.tex-part
+++ b/doc/kalman_ou_iii/w3d-fus-methods.tex-part
@@ -119,8 +119,8 @@ standard-deviation scale $r_S$,
 \[
 y_S=0=S+n_S,\qquad n_S\sim\mathcal{N}(0,r_S^2).
 \]
-For the three-axis implementation, the corresponding vector $\vct{r}_S$ is
-squared componentwise to form the covariance $\mat{R}_S$, as defined in
+For three-axis operation, the corresponding vector $\vct{r}_S$ is squared
+componentwise to form the covariance $\mat{R}_S$, as defined in
 \eqref{eq:RS-from-rS}.  The channel is a regularizer, not a physical sensor.
 The purpose of the scaling argument below is to choose $r_S$ on the same
 physical scale as the natural fluctuations of $S$ within a stated family of
@@ -225,8 +225,8 @@ r_S(\sigma_a,\tau)
 =k_i c_{\mathrm{spec}}(u_{\min})\sigma_a\tau^3,
 \label{eq:Rs-from-sigmaS}
 \end{equation}
-where $k_i>0$ is dimensionless.  The implementation absorbs the selected
-spectral-shape and cutoff calibration into a single coefficient $c_R$ and uses
+where $k_i>0$ is dimensionless.  The selected spectral-shape and cutoff
+calibration are represented by a single coefficient $c_R$, giving
 \begin{equation}
 r_{S,\star}=c_R\sigma_{a,\star}\tau_\star^3.
 \label{eq:Rs-sigmaa-tau3}
@@ -238,10 +238,10 @@ scales as wave amplitude and period change.  Changing $T_S$, spectral bandwidth,
 or low-frequency contamination changes the effective regularization and may
 require retuning $c_R$.
 
-\subsection{Online Adaptation Implementation}
+\subsection{Online Adaptation}
 \label{sec:adapt-impl}
 
-The implementation adapts the OU time constant $\tau$, the OU stationary
+The adaptation law updates the OU time constant $\tau$, the OU stationary
 acceleration scale $\sigma_a$, and the integral pseudo-measurement
 standard-deviation scale $r_S$.
 
@@ -271,7 +271,7 @@ $\widehat\sigma_{\mathrm{tot}}^2\approx\Var[a_{\uparrow}]$.
 \]
 
 \subsubsection{Targets}
-The code uses
+The adaptation targets are
 \begin{equation}
 \begin{aligned}
 \tau_\star&=c_\tau\frac{1}{2f_{\mathrm{tune}}},\\
@@ -305,13 +305,13 @@ r_{S,\mathrm{appl}}&\leftarrow r_{S,\mathrm{appl}}
 \label{eq:adapt-RS}
 \end{equation}
 
-\subsubsection{Anisotropy and implementation API}
+\subsubsection{Anisotropic parameterization}
 The OU stationary standard deviation is applied anisotropically,
 \[
 \Sigma_{a_w}^{1/2}=\diag(S_\sigma\sigma_{a,\mathrm{appl}},
 S_\sigma\sigma_{a,\mathrm{appl}},\sigma_{a,\mathrm{appl}}),
 \]
-and the vector passed to \texttt{set\_RS\_noise()} is
+and the integral pseudo-measurement standard-deviation vector is
 \[
 \vct{r}_S=\begin{bmatrix}
 \rho_{xy}r_{S,\mathrm{appl}}&
@@ -319,8 +319,11 @@ and the vector passed to \texttt{set\_RS\_noise()} is
 r_{S,\mathrm{appl}}
 \end{bmatrix}^{\top}.
 \]
-The setter squares these entries to obtain $\mat{R}_S$, exactly matching the
-measurement model in Sec.~\ref{sec:measurement_model}.
+Its componentwise square defines the covariance,
+\begin{equation}
+\mat{R}_S=\diag\!\left(\vct{r}_S\odot\vct{r}_S\right),
+\end{equation}
+consistent with the measurement model in Sec.~\ref{sec:measurement_model}.
 
 % =======================================================
 \input{w3d-direction-methods.tex-part}


### PR DESCRIPTION
## What changed

- Replaced the final implementation-oriented sentence in the abstract with a method-focused embedded-deployment statement.
- Renamed `Online Adaptation Implementation` to `Online Adaptation`.
- Replaced phrases such as `The implementation adapts` and `The code uses` with direct descriptions of the adaptation law.
- Renamed `Anisotropy and implementation API` to `Anisotropic parameterization`.
- Removed the literal `set_RS_noise()` API reference and defined the covariance directly as the componentwise square of the standard-deviation vector.
- Reworded direction-confidence and angular-uncertainty statements to describe the estimator rather than its implementation.
- Replaced the C++-specific conclusion statement with a reproducibility statement that the simulations and embedded builds exercise the same estimator recursion.

## Why

The mathematical and algorithmic sections should describe the estimator directly rather than read as source-code documentation. Implementation-specific wording remains appropriate in dedicated hardware and reproducibility discussion, but not in the core derivation.

## Validation

- Compared against current `main`: four manuscript source files changed.
- No C++ source or simulation results were changed.
- The existing equation labels and section labels were retained.
- A local LaTeX build was not available in this environment; CI should run the repository's normal document checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified real-time deployment suitability for low-cost embedded IMUs.
  * Improved explanations of estimator behavior across simulations and embedded builds.
  * Clarified propagation-axis quality gates, confidence criteria, and uncertainty approximations.
  * Updated variance-informed adaptation documentation, including covariance scaling and anisotropic parameterization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->