### PR TITLE
Guard OU phi_pa coefficient at small-step boundary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,4 +37,5 @@ add_executable(imu_calibrate-test "${OCEAN_IMU_TESTS_DIR}/imu_calibrate/imu_cali
 add_executable(kalman_ou_ii-sim "${OCEAN_IMU_TESTS_DIR}/kalman_ou_ii/kalman_ou_ii-sim.cpp" ${W3D_SIM_COMMON})
 add_executable(kalman_ou_iii-sim "${OCEAN_IMU_TESTS_DIR}/kalman_ou_iii/kalman_ou_iii-sim.cpp" ${W3D_SIM_COMMON})
 add_executable(kalman_ou_common-test "${OCEAN_IMU_TESTS_DIR}/kalman_ou_iii/kalman_ou_common-test.cpp")
+add_executable(phi_coeff_boundary-test "${OCEAN_IMU_TESTS_DIR}/kalman_ou_iii/phi_coeff_boundary-test.cpp")
 add_executable(pii_observer-adaptive "${OCEAN_IMU_TESTS_DIR}/pii_observer/pii_observer-adaptive.cpp" ${W3D_SIM_COMMON})

--- a/tests/kalman_ou_iii/phi_coeff_boundary-test.cpp
+++ b/tests/kalman_ou_iii/phi_coeff_boundary-test.cpp
@@ -1,0 +1,84 @@
+#define EIGEN_NON_ARDUINO
+
+#include "kalman_ou_common/KalmanOUCoreMath.h"
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+
+namespace detail = ocean_imu::kalman::ou_detail;
+
+namespace {
+
+using T = double;
+
+bool check_close(T actual, T expected, T tolerance, const char* message) {
+    if (std::abs(actual - expected) <= tolerance) return true;
+    std::cerr << message << ": actual=" << actual
+              << " expected=" << expected
+              << " tolerance=" << tolerance << '\n';
+    return false;
+}
+
+T phi_pa_exact(T x, T tau) {
+    return tau * tau * (x + std::expm1(-x));
+}
+
+T phi_Sa_exact(T x, T tau) {
+    return tau * tau * tau * (T(0.5) * x * x - x - std::expm1(-x));
+}
+
+bool test_phi_coefficients_at_branch_boundary() {
+    constexpr T threshold = T(1e-2);
+    constexpr T tau = T(2.3);
+    constexpr T relative_offset = T(1e-9);
+
+    const T x_below = threshold * (T(1) - relative_offset);
+    const T x_at = threshold;
+    const T x_above = threshold * (T(1) + relative_offset);
+
+    const auto below = detail::safe_phi_A_coeffs(tau * x_below, tau);
+    const auto at = detail::safe_phi_A_coeffs(tau * x_at, tau);
+    const auto above = detail::safe_phi_A_coeffs(tau * x_above, tau);
+
+    const T scale_pa = std::max(T(1), std::abs(phi_pa_exact(threshold, tau)));
+    const T scale_Sa = std::max(T(1), std::abs(phi_Sa_exact(threshold, tau)));
+
+    // Below the threshold the polynomial branch must approximate the exact
+    // expressions through its retained order. At and above the threshold the
+    // exact expm1 branch is used.
+    if (!check_close(below.phi_pa, phi_pa_exact(x_below, tau),
+                     T(1e-11) * scale_pa,
+                     "phi_pa small-x branch mismatch")) return false;
+    if (!check_close(below.phi_Sa, phi_Sa_exact(x_below, tau),
+                     T(1e-13) * scale_Sa,
+                     "phi_Sa small-x branch mismatch")) return false;
+    if (!check_close(at.phi_pa, phi_pa_exact(x_at, tau),
+                     T(1e-15) * scale_pa,
+                     "phi_pa exact branch mismatch at threshold")) return false;
+    if (!check_close(at.phi_Sa, phi_Sa_exact(x_at, tau),
+                     T(1e-15) * scale_Sa,
+                     "phi_Sa exact branch mismatch at threshold")) return false;
+    if (!check_close(above.phi_pa, phi_pa_exact(x_above, tau),
+                     T(1e-15) * scale_pa,
+                     "phi_pa exact branch mismatch above threshold")) return false;
+    if (!check_close(above.phi_Sa, phi_Sa_exact(x_above, tau),
+                     T(1e-15) * scale_Sa,
+                     "phi_Sa exact branch mismatch above threshold")) return false;
+
+    // Guard against the manuscript typo that inserted a spurious factor 1/2
+    // in tau^2 * (x + expm1(-x)).
+    const T erroneous_half_factor = T(0.5) * phi_pa_exact(x_at, tau);
+    if (std::abs(at.phi_pa - erroneous_half_factor) <= T(0.1) * std::abs(at.phi_pa)) {
+        std::cerr << "phi_pa regressed to the erroneous half-factor formula\n";
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace
+
+int main() {
+    return test_phi_coefficients_at_branch_boundary() ? 0 : 1;
+}


### PR DESCRIPTION
## What changed

- Added a dedicated regression test for the OU transition coefficients at the `|x| = 1e-2` branch threshold.
- Verifies `phi_pa = tau^2 * (x + expm1(-x))` against an independent exact reference.
- Verifies the retained small-`x` polynomial for both `phi_pa` and `phi_Sa` immediately below the threshold.
- Checks the exact branch at and above the threshold.
- Includes an explicit guard against the erroneous extra factor `1/2` in `phi_pa`.
- Registers the test as a CMake target.

## Important note

The current `main` source already contains the corrected Eq. (40) expression and the implementation already uses the correct coefficient. The uploaded version 33 PDF was therefore built from an older manuscript revision. This PR adds the requested regression protection so the exact and small-step branches cannot silently diverge in future changes.

## Validation

- Branch is based on current `main`.
- Only the new test and its CMake target are changed.
- No estimator behavior or simulation results are modified.
- CI should compile and execute the new `phi_coeff_boundary-test` target through the repository's normal test workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated coverage for numerical coefficient calculations near a branch threshold.
  * Validates results below, at, and above the threshold against precise reference formulas.
  * Includes regression checks for previously incorrect boundary behavior.
  * Added the new test to the project’s build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->