### PR TITLE
Add reproducibility note for published coefficient values

### DIFF
--- a/doc/kalman_ou_iii/w3d-intro.tex-part
+++ b/doc/kalman_ou_iii/w3d-intro.tex-part
@@ -107,6 +107,11 @@ assessed via RMS displacement errors relative to the true wave elevation. The
 OU-based Q-MEKF achieves drift-suppressed reconstruction of three-dimensional
 surface motion.
 
+Not all numerical coefficient values are reproduced in this article; for
+reproducibility, the complete coefficient set, tuning constants, and simulation
+configuration are freely accessible in the source code published in the
+Bareboat Necessities GitHub project.
+
 \subsection{Main Contributions}
 
 The main contributions of this work are:


### PR DESCRIPTION
## What changed

- Added a manuscript statement clarifying that not every numerical coefficient is reproduced in the article.
- States that the complete coefficient set, tuning constants, and simulation configuration are freely accessible in the published Bareboat Necessities GitHub source code.

## Why

This makes the reproducibility path explicit for readers while keeping the article focused on the mathematical formulation and principal evaluation parameters.

## Scope

- Documentation/manuscript text only.
- No estimator code, tests, or simulation results are changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a reproducibility note clarifying that some numerical coefficients are not included in the article.
  * Directed readers to the Bareboat Necessities GitHub project for complete coefficients, tuning constants, and simulation configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->