### PR TITLE
Protect proper-name capitalization in bibliography titles

### DIFF
--- a/doc/kalman_ou_iii/w3d.bib
+++ b/doc/kalman_ou_iii/w3d.bib
@@ -14,7 +14,7 @@
 
 @article{Sharkh2014MEF,
     author  = {Sharkh, Suleiman and Hendijanizadeh, Mehdi and Moshrefi-Torbati, M. and Abusara, Mohammad},
-    title   = {A Novel Kalman Filter Based Technique for Calculating the Time History of Vertical Displacement of a Boat from Measured Acceleration},
+    title   = {A Novel {Kalman} Filter Based Technique for Calculating the Time History of Vertical Displacement of a Boat from Measured Acceleration},
     journal = {Marine Engineering Frontiers (MEF)},
     volume  = {2},
     year    = {2014},
@@ -24,7 +24,7 @@
 
 @inproceedings{Ali2023DAFx,
     author    = {Ali, R. and {van Waterschoot}, T.},
-    title     = {A Frequency Tracker Based on a Kalman Filter Update of a Single Parameter Adaptive Notch Filter},
+    title     = {A Frequency Tracker Based on a {Kalman} Filter Update of a Single Parameter Adaptive Notch Filter},
     booktitle = {Proceedings of the 26th International Conference on Digital Audio Effects (DAFx23)},
     address   = {Copenhagen, Denmark},
     month     = sep,
@@ -34,7 +34,7 @@
 
 @article{Markley2003AttitudeError,
     author  = {Markley, F. Landis},
-    title   = {Attitude Error Representations for Kalman Filtering},
+    title   = {Attitude Error Representations for {Kalman} Filtering},
     journal = {Journal of Guidance, Control, and Dynamics},
     volume  = {26},
     number  = {2},
@@ -65,7 +65,7 @@
 
 @techreport{TrawnyRoumeliotis2005_IndirectKF,
     author      = {Trawny, Nikolas and Roumeliotis, Stergios I.},
-    title       = {Indirect Kalman Filter for 3D Attitude Estimation},
+    title       = {Indirect {Kalman} Filter for 3D Attitude Estimation},
     institution = {University of Minnesota, Multiple Autonomous Robotic Systems Laboratory},
     number      = {2005-002},
     year        = {2005}
@@ -73,7 +73,7 @@
 
 @misc{Sola2017_QuaternionESKF,
     author        = {Sol{\`a}, Joan},
-    title         = {Quaternion Kinematics for the Error-State Kalman Filter},
+    title         = {Quaternion Kinematics for the Error-State {Kalman} Filter},
     year          = {2017},
     eprint        = {1711.02508},
     archivePrefix = {arXiv},
@@ -132,7 +132,7 @@
 
 @article{UhlenbeckOrnstein1930_OU,
     author  = {Uhlenbeck, G. E. and Ornstein, L. S.},
-    title   = {On the Theory of the Brownian Motion},
+    title   = {On the Theory of the {Brownian} Motion},
     journal = {Physical Review},
     year    = {1930},
     volume  = {36},
@@ -143,7 +143,7 @@
 
 @article{Reis2023_DiscreteKalmanHeave,
     author  = {Reis, Joel and Batista, Pedro and Oliveira, Paulo and Silvestre, Carlos},
-    title   = {Discrete-Time Kalman Filter for Heave Motion Estimation},
+    title   = {Discrete-Time {Kalman} Filter for Heave Motion Estimation},
     journal = {Ocean Engineering},
     year    = {2023},
     volume  = {277},
@@ -173,7 +173,7 @@
 
 @article{Pascoal2009_KalmanDirectionalSpectrum,
     author  = {Pascoal, Ricardo and Guedes Soares, C.},
-    title   = {Kalman Filtering of Vessel Motions for Ocean Wave Directional Spectrum Estimation},
+    title   = {{Kalman} Filtering of Vessel Motions for Ocean Wave Directional Spectrum Estimation},
     journal = {Ocean Engineering},
     year    = {2009},
     volume  = {36},
@@ -238,7 +238,7 @@
 
 @article{Li2025_HeaveCKF,
     author  = {Li, Daoxi and Wang, Shuqing and Ning, Donghong},
-    title   = {Heave Motion Estimation Based on the Cubature Kalman Filter Combined with Fast Fourier Transform of Acceleration Autocorrelation},
+    title   = {Heave Motion Estimation Based on the Cubature {Kalman} Filter Combined with Fast {Fourier} Transform of Acceleration Autocorrelation},
     journal = {Ocean Engineering},
     year    = {2025},
     volume  = {336},
@@ -323,7 +323,7 @@
 
 @article{FossenPerez2009_KalmanShipsOffshoreRigs,
     author  = {Fossen, Thor I. and Perez, Tristan},
-    title   = {Kalman Filtering for Positioning and Heading Control of Ships and Offshore Rigs},
+    title   = {{Kalman} Filtering for Positioning and Heading Control of Ships and Offshore Rigs},
     journal = {IEEE Control Systems Magazine},
     year    = {2009},
     volume  = {29},


### PR DESCRIPTION
## What changed

- Protected `Kalman` in bibliography title fields so sentence-case bibliography styles preserve the eponym's capitalization.
- Protected `Brownian` and `Fourier` for the same reason.
- Left the cited titles and all bibliographic metadata otherwise unchanged.

## Why

The bibliography style lowercases unprotected words in title fields. These terms derive from proper names and should retain capitalization in the rendered references.

## Validation

- Compared the branch against the current `main`.
- Exactly one file is changed: `doc/kalman_ou_iii/w3d.bib`.
- The diff contains ten title-field capitalization protections and no code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved formatting of selected bibliography titles to preserve capitalization and rendering of technical terms in generated documentation.
  - No bibliographic entries or reference details were otherwise changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->