### PR TITLE
Fix obsolete ISS wording in conclusion

### DIFF
--- a/doc/kalman_ou_iii/w3d-conclusion-summary.tex-part
+++ b/doc/kalman_ou_iii/w3d-conclusion-summary.tex-part
@@ -11,9 +11,11 @@ covariance branch, full MEKF reset, and adaptive pseudo-measurement scaling.
 Appendix~\ref{app:iss-stability} complements the empirical results with a
 sufficient-condition proof of uniform local input-to-state stability for the
 core predict--correct recursion and its bounded-rate adaptation. The proof is
-conditional on a common contraction certificate over the admissible tuning and
-motion set; it does not treat startup or reset logic and does not convert the
-simulation study into an unconditional EKF convergence claim.
+conditional on frozen-point Schur stability, uniform bounds on the
+parameter-dependent Lyapunov family, and sufficiently slow variation of the
+operating point and adaptive parameters over the admissible set; it does not
+treat startup or reset logic and does not convert the simulation study into an
+unconditional EKF convergence claim.
 
 The results support embedded feasibility and drift-controlled wave-state
 reconstruction for the tested conditions, but they do not by themselves imply


### PR DESCRIPTION
## Summary

Updates the conclusion to match the final Appendix B stability theorem.

The obsolete reference to a common contraction certificate is replaced with the actual conditions used by the proof:

- frozen-point Schur stability;
- uniform bounds on the parameter-dependent Lyapunov family;
- sufficiently slow variation of the operating point and adaptive parameters.

No estimator, simulation, or theorem implementation code is changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the stability conditions in the conclusion appendix.
  * Specified requirements involving frozen-point stability, bounded Lyapunov behavior, and sufficiently gradual parameter variation.
  * Retained the existing exclusions for startup/reset behavior and unconditional EKF convergence claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->