### PR TITLE
Strengthen comparison interpretation and manuscript summary

### DIFF
--- a/doc/kalman_ou_iii/kalman_ou-w3d.tex
+++ b/doc/kalman_ou_iii/kalman_ou-w3d.tex
@@ -169,8 +169,12 @@ acceleration. Online adaptation tunes the OU time scale, stationary acceleration
 scale, and the standard-deviation scale whose square forms the integral
 pseudo-measurement covariance. The cubic scaling with correlation time is a
 physically motivated engineering normalization for fixed update cadence and a
-bounded family of spectra. The
-method is suitable for real-time deployment with low-cost embedded IMUs.
+bounded family of spectra. Across eight paired JONSWAP and PM--Stokes cases,
+the proposed OU--III estimator achieved a mean vertical-displacement RMS error
+of 6.6\% of significant wave height, compared with 8.2\% for OU--II, 12.3\%
+for an adaptive PII observer, and 15.0\% for an adapted published nonlinear
+observer. The method is suitable for real-time deployment with low-cost
+embedded IMUs.
 \end{abstract}
 
 \begin{IEEEkeywords}

--- a/doc/kalman_ou_iii/w3d-baseline-comparison.tex-part
+++ b/doc/kalman_ou_iii/w3d-baseline-comparison.tex-part
@@ -73,8 +73,8 @@ OU--II. The reduction from OU--II to OU--III is most visible in the moderate
 and large sea states, supporting the additional integral-displacement state as
 the principal source of the improved vertical reconstruction. By contrast,
 the mean roll and pitch errors of OU--II and OU--III differ by only
-0.01\,degree in each axis, so the measured benefit is primarily translational
-rather than an improvement in attitude estimation.
+\SI{0.01}{\degree} in each axis, so the measured benefit is primarily
+translational rather than an improvement in attitude estimation.
 
 \IfFileExists{w3d_multi_observer_jonswap_medium.pgf}{%
   \begin{figure}[!t]

--- a/doc/kalman_ou_iii/w3d-baseline-comparison.tex-part
+++ b/doc/kalman_ou_iii/w3d-baseline-comparison.tex-part
@@ -64,6 +64,18 @@ than complete navigation capability or the respective theoretical guarantees.
   \end{table}
 }
 
+Across the eight paired cases, OU--III attains the lowest mean normalized
+vertical-displacement RMS error: 6.6\% of $H_s$, compared with 8.2\% for
+OU--II, 12.3\% for the adaptive PII observer, and 15.0\% for the adapted
+TVG--NLO. OU--III gives the lowest error in seven cases; in the remaining
+smallest JONSWAP case, its 9.7\% result is within 0.1 percentage point of
+OU--II. The reduction from OU--II to OU--III is most visible in the moderate
+and large sea states, supporting the additional integral-displacement state as
+the principal source of the improved vertical reconstruction. By contrast,
+the mean roll and pitch errors of OU--II and OU--III differ by only
+0.01\,degree in each axis, so the measured benefit is primarily translational
+rather than an improvement in attitude estimation.
+
 \IfFileExists{w3d_multi_observer_jonswap_medium.pgf}{%
   \begin{figure}[!t]
     \centering

--- a/doc/kalman_ou_iii/w3d-conclusion-summary.tex-part
+++ b/doc/kalman_ou_iii/w3d-conclusion-summary.tex-part
@@ -5,12 +5,18 @@ JONSWAP and PM--Stokes cases, the reported vertical-displacement RMS errors
 remain within the ranges listed in Table~\ref{tab:sim_results_rms_dir_basic},
 while the attitude and direction pipelines remain operational under the stated
 multi-rate sensor and error models. The paired comparison in
-Sec.~\ref{sec:nlo-baseline-comparison} additionally evaluates vertical
-reconstruction against an adapted time-varying-gain nonlinear observer using
-the same reference and inertial records. The simulations and embedded builds
-exercise the same estimator recursion, including the exact OU-chain transition,
-small-step covariance branch, full MEKF reset, and adaptive
-pseudo-measurement scaling.
+Sec.~\ref{sec:observer-comparison} evaluates OU--III against the OU--II
+predecessor, the adaptive PII observer, and an adapted published TVG--NLO using
+the same reference and inertial records. Across all eight paired cases, the
+mean normalized vertical-displacement RMS error is 6.6\% of $H_s$ for OU--III,
+compared with 8.2\% for OU--II, 12.3\% for adaptive PII, and 15.0\% for
+TVG--NLO. OU--III gives the lowest error in seven cases and is within 0.1
+percentage point of OU--II in the remaining smallest JONSWAP case. The nearly
+identical mean roll and pitch errors of OU--II and OU--III indicate that the
+observed improvement is primarily in vertical reconstruction rather than
+attitude estimation. The simulations and embedded builds exercise the same
+estimator recursion, including the exact OU-chain transition, small-step
+covariance branch, full MEKF reset, and adaptive pseudo-measurement scaling.
 
 Appendix~\ref{app:iss-stability} complements the empirical results with a
 sufficient-condition proof of uniform local input-to-state stability for the

--- a/doc/kalman_ou_iii/w3d-intro.tex-part
+++ b/doc/kalman_ou_iii/w3d-intro.tex-part
@@ -131,6 +131,10 @@ The main contributions of this work are:
         with bounded parameter increments treated explicitly as an input.
   \item A formulation independent of hydrodynamic equations, relying instead on
         oscillatory kinematics with slowly varying spectra and high-rate inertial measurements.
+  \item A reproducible paired comparison against a published nonlinear observer
+        and two earlier author-developed observer architectures, including an
+        OU--II ablation that isolates the incremental effect of the OU--III
+        translational state structure.
   \item Empirical validation on simulated directional sea spectra,
         demonstrating drift suppression and physical fidelity.
 \end{itemize}

--- a/plots/kalman_ou_iii/draw_plots.sh
+++ b/plots/kalman_ou_iii/draw_plots.sh
@@ -55,13 +55,15 @@ from pathlib import Path
 
 sim_path = Path("../../doc/kalman_ou_iii/w3d-sim-charts.tex-part")
 source = sim_path.read_text(encoding="utf-8")
+# Use one manuscript name for the nonlinear Pierson--Moskowitz cases.
+source = source.replace("PM+Stokes", "PM--Stokes")
 include = r"\input{w3d-baseline-comparison.tex-part}"
 anchor = r"\section{Real-Hardware Validation Platform}"
 if include not in source:
     if source.count(anchor) != 1:
         raise RuntimeError("hardware-section insertion anchor not found exactly once")
     source = source.replace(anchor, include + "\n\n" + anchor, 1)
-    sim_path.write_text(source, encoding="utf-8")
+sim_path.write_text(source, encoding="utf-8")
 
 main_path = Path("../../doc/kalman_ou_iii/kalman_ou-w3d.tex")
 main = main_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Addresses the requested manuscript-review findings after the four-method observer comparison was added.

## Changes

- fixes the unresolved comparison-section reference by pointing the conclusion to `sec:observer-comparison`;
- updates the conclusion to summarize all four methods and the aggregate numerical results;
- adds an interpretation paragraph explaining that OU-III has the best mean vertical reconstruction, wins seven of eight cases, is effectively tied in the smallest JONSWAP case, and primarily improves translation rather than attitude;
- adds the reproducible external-baseline and internal-ablation study to the main contributions;
- adds the aggregate four-method result to the abstract;
- standardizes the rendered manuscript terminology to `PM--Stokes` rather than mixing `PM+Stokes` and `PM--Stokes`.

## Quantitative wording

The manuscript now reports the generated aggregate values directly:

- OU-III: 6.6% of Hs;
- OU-II: 8.2%;
- adaptive PII: 12.3%;
- adapted TVG-NLO: 15.0%.

It also states that OU-III has the lowest error in seven cases and is within 0.1 percentage point of OU-II in the remaining case.

No estimator equations, implementation behavior, simulation inputs, or generated results are changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added quantitative validation results for OU–III across eight paired wave scenarios.
  * Reported improved vertical-displacement accuracy compared with OU–II, adaptive PII, and TVG–NLO baselines.
  * Clarified that improvements primarily affect vertical reconstruction, while roll and pitch performance remains comparable.
  * Expanded the contribution summary with reproducible observer comparisons and ablation results.
  * Improved plot generation compatibility with alternate direction-column names and standardized labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->