### PR TITLE
Clarify OU-III manuscript methodology and evidence scope

### DIFF
--- a/doc/kalman_ou_iii/kalman_ou-w3d.tex
+++ b/doc/kalman_ou_iii/kalman_ou-w3d.tex
@@ -124,7 +124,7 @@
 \DeclareMathOperator{\sgn}{sgn}
 \DeclareMathOperator{\blkdiag}{blkdiag}
 \DeclareMathOperator{\diag}{diag}
-\DeclareMathOperator{\sym}{sym}
+\DeclareMathOperator{\scomp}{scomp}
 \newcommand{\set}[1]{\mathcal{#1}}
 \newcommand{\R}{\mathbb{R}}
 \newcommand{\C}{\mathbb{C}}
@@ -176,17 +176,19 @@ error is $8.73\pm0.23\%$ of $H_s$ for OU--III and $8.98\pm0.24\%$ for OU--II;
 the paired difference is $-0.248$ percentage point (bootstrap 95\% interval
 $[-0.407,-0.116]$).  The sign changes by sea state, OU--III has larger 3D
 displacement error in all five scenarios, and online adaptation does not
-dominate fixed tuning during the transition.  The implementation remains
-suitable for real-time deployment with low-cost embedded IMUs.
+dominate fixed tuning during the transition.  The same source builds for an
+ESP32--S3 target and has been exercised with MEMS IMU input; quantitative
+timing, processor-load, and memory measurements are reserved for a separate
+embedded-performance study.
 \end{abstract}
 
 \begin{IEEEkeywords}
 extended Kalman filter, inertial navigation, IMU, marine Motion Reference Unit, MRU, Ornstein--Uhlenbeck process, Heave Reference System, HRS, heave sensor, wave height estimation, wave measurement buoy\end{IEEEkeywords}
 
 \input{w3d-intro.tex-part}
+\input{w3d-nomenclature.tex-part}
 \input{w3d-state.tex-part}
 \input{w3d-meas.tex-part}
-\input{w3d-wind-heel.tex-part}
 \input{w3d-proc-cont.tex-part}
 \input{w3d-lti-discrete.tex-part}
 \input{w3d-analytic-coeff.tex-part}
@@ -195,6 +197,10 @@ extended Kalman filter, inertial navigation, IMU, marine Motion Reference Unit, 
 \input{w3d-fus-methods.tex-part}
 \input{w3d-sim-charts.tex-part}
 \input{w3d-conclusion-summary.tex-part}
+
+\appendices
+\input{w3d-tracker-alternatives.tex-part}
+\input{w3d-wind-heel.tex-part}
 \input{w3d-gps-fusion.tex-part}
 \input{w3d-iss-stability.tex-part}
 

--- a/doc/kalman_ou_iii/kalman_ou_iii-charts.tex
+++ b/doc/kalman_ou_iii/kalman_ou_iii-charts.tex
@@ -73,38 +73,38 @@
 % PM Stokes
     \begin{figure}[H]\centering
     \resizebox{\textwidth}{!}{\input{w3d_ou3_pmstokes_low_tuner.pgf}}
-    \caption{Kalman 3D filter frequency and auto-tuner traces ( $f$, $T_p$, accel variance, $\tau$, $\sigma_a$, $R_S$ ) — PM Stokes, low $H_s$.}
+    \caption{Kalman 3D filter frequency and auto-tuner traces ($f$, $T_p$, acceleration variance, $\tau$, $\sigma_{aw}$, $r_S$) --- PM Stokes, low $H_s$.}
     \label{fig:w3d_ou3_pmstokes_low_tuner}
     \end{figure}
 
     \begin{figure}[H]\centering
     \resizebox{\textwidth}{!}{\input{w3d_ou3_pmstokes_medium_tuner.pgf}}
-    \caption{Kalman 3D filter frequency and auto-tuner traces ( $f$, $T_p$, accel variance, $\tau$, $\sigma_a$, $R_S$ ) — PM Stokes, medium $H_s$.}
+    \caption{Kalman 3D filter frequency and auto-tuner traces ($f$, $T_p$, acceleration variance, $\tau$, $\sigma_{aw}$, $r_S$) --- PM Stokes, medium $H_s$.}
     \label{fig:w3d_ou3_pmstokes_medium_tuner}
     \end{figure}
 
     \begin{figure}[H]\centering
     \resizebox{\textwidth}{!}{\input{w3d_ou3_pmstokes_high_tuner.pgf}}
-    \caption{Kalman 3D filter frequency and auto-tuner traces ( $f$, $T_p$, accel variance, $\tau$, $\sigma_a$, $R_S$ ) — PM Stokes, high $H_s$.}
+    \caption{Kalman 3D filter frequency and auto-tuner traces ($f$, $T_p$, acceleration variance, $\tau$, $\sigma_{aw}$, $r_S$) --- PM Stokes, high $H_s$.}
     \label{fig:w3d_ou3_pmstokes_high_tuner}
     \end{figure}
 
 % JONSWAP
     \begin{figure}[H]\centering
     \resizebox{\textwidth}{!}{\input{w3d_ou3_jonswap_low_tuner.pgf}}
-    \caption{Kalman 3D filter frequency and auto-tuner traces ( $f$, $T_p$, accel variance, $\tau$, $\sigma_a$, $R_S$ ) — JONSWAP, low $H_s$.}
+    \caption{Kalman 3D filter frequency and auto-tuner traces ($f$, $T_p$, acceleration variance, $\tau$, $\sigma_{aw}$, $r_S$) --- JONSWAP, low $H_s$.}
     \label{fig:w3d_ou3_jonswap_low_tuner}
     \end{figure}
 
     \begin{figure}[H]\centering
     \resizebox{\textwidth}{!}{\input{w3d_ou3_jonswap_medium_tuner.pgf}}
-    \caption{Kalman 3D filter frequency and auto-tuner traces ( $f$, $T_p$, accel variance, $\tau$, $\sigma_a$, $R_S$ ) — JONSWAP, medium $H_s$.}
+    \caption{Kalman 3D filter frequency and auto-tuner traces ($f$, $T_p$, acceleration variance, $\tau$, $\sigma_{aw}$, $r_S$) --- JONSWAP, medium $H_s$.}
     \label{fig:w3d_ou3_jonswap_medium_tuner}
     \end{figure}
 
     \begin{figure}[H]\centering
     \resizebox{\textwidth}{!}{\input{w3d_ou3_jonswap_high_tuner.pgf}}
-    \caption{Kalman 3D filter frequency and auto-tuner traces ( $f$, $T_p$, accel variance, $\tau$, $\sigma_a$, $R_S$ ) — JONSWAP, high $H_s$.}
+    \caption{Kalman 3D filter frequency and auto-tuner traces ($f$, $T_p$, acceleration variance, $\tau$, $\sigma_{aw}$, $r_S$) --- JONSWAP, high $H_s$.}
     \label{fig:w3d_ou3_jonswap_high_tuner}
     \end{figure}
 

--- a/doc/kalman_ou_iii/w3d-analytic-coeff.tex-part
+++ b/doc/kalman_ou_iii/w3d-analytic-coeff.tex-part
@@ -12,11 +12,11 @@ blocks without changing the state ordering.
 \subsection{Attitude and gyroscope-bias block}
 For constant $\hat{\vct{\omega}}$ over the step, define
 \[
-\mat{W}=\Skew{\hat{\vct{\omega}}},
-\qquad
-\mat{R}(t)=\exp(-\mat{W}t),
-\qquad
-\mat{B}(t)=\int_0^t\mat{R}(s)\,ds.
+\begin{aligned}
+\mat{W}&=\Skew{\hat{\vct{\omega}}},\\
+\mat{R}(t)&=\exp(-\mat{W}t),\\
+\mat{B}(t)&=\int_0^t\mat{R}(s)\,ds.
+\end{aligned}
 \]
 Then
 \begin{equation}
@@ -79,6 +79,11 @@ For $|x|<10^{-2}$, cancellation-sensitive coefficients are evaluated as
 \phi_{pa}&=\tau^2\left(\tfrac12x^2-\tfrac16x^3+\tfrac1{24}x^4\right),\\
 \phi_{Sa}&=\tau^3\left(\tfrac16x^3-\tfrac1{24}x^4+\tfrac1{120}x^5\right).
 \end{align}
+The reported simulations use $h=\SI{0.005}{s}$. Across the applied and fixed
+operating points recorded for the scored windows, the minimum correlation time
+is $\SI{0.944}{s}$, so $x\le 5.30\times10^{-3}$ and these recorded operating
+points use the small-step branch. The exact closed form remains necessary when
+the update cadence or admissible correlation-time range is changed.
 
 In group-first three-dimensional ordering
 $[\vct{v},\vct{p},\vct{S},\vct{a}_w]$, the transition is
@@ -106,21 +111,31 @@ q_c
 \label{eq:q-axis-integral}
 \end{equation}
 For $|x|>10^{-2}$, write
-$\matg{Q}_{d,\mathrm{axis}}=q_c\,\sym(\mat{K})$, where the upper-triangular
-coefficients in $[v,p,S,a]$ ordering are
+$\matg{Q}_{d,\mathrm{axis}}=q_c\,\scomp(\mat{U})$, where $\mat{U}$ stores the
+following upper-triangular coefficients in $[v,p,S,a]$ ordering:
+\begin{equation}
+[\scomp(\mat{U})]_{ij}=
+\begin{cases}
+U_{ij},&i\le j,\\
+U_{ji},&i>j.
+\end{cases}
+\label{eq:symmetric-completion}
+\end{equation}
+Thus $\scomp$ copies the upper triangle to the lower triangle; it is not the
+averaging operator $(\mat{U}+\mat{U}^{\top})/2$. The coefficients are
 \begin{align}
-K_{vv}&=\tfrac12\tau^3(-\alpha^2+4\alpha+2x-3),\\
-K_{vp}&=\tfrac12\tau^4(\alpha^2+2\alpha(x-1)+x^2-2x+1),\\
-K_{vS}&=\tfrac16\tau^5[-3\alpha^2+3\alpha(x^2+4)+x^3-3x^2+6x-9],\\
-K_{va}&=\tfrac12\tau^2(\alpha^2-2\alpha+1),\\
-K_{pp}&=\tau^5[-\tfrac12\alpha^2-2\alpha x+\tfrac13x^3-x^2+x+\tfrac12],\\
-K_{pS}&=\tau^6[\tfrac12\alpha^2+\tfrac12\alpha(-x^2+2x-2)
+U_{vv}&=\tfrac12\tau^3(-\alpha^2+4\alpha+2x-3),\\
+U_{vp}&=\tfrac12\tau^4(\alpha^2+2\alpha(x-1)+x^2-2x+1),\\
+U_{vS}&=\tfrac16\tau^5[-3\alpha^2+3\alpha(x^2+4)+x^3-3x^2+6x-9],\\
+U_{va}&=\tfrac12\tau^2(\alpha^2-2\alpha+1),\\
+U_{pp}&=\tau^5[-\tfrac12\alpha^2-2\alpha x+\tfrac13x^3-x^2+x+\tfrac12],\\
+U_{pS}&=\tau^6[\tfrac12\alpha^2+\tfrac12\alpha(-x^2+2x-2)
 +\tfrac18x^4-\tfrac12x^3+x^2-x+\tfrac12],\\
-K_{pa}&=\tfrac12\tau^3(-\alpha^2-2\alpha x+1),\\
-K_{SS}&=\tau^7[-\tfrac12\alpha^2+\alpha(x^2+2)+\tfrac1{20}x^5
+U_{pa}&=\tfrac12\tau^3(-\alpha^2-2\alpha x+1),\\
+U_{SS}&=\tau^7[-\tfrac12\alpha^2+\alpha(x^2+2)+\tfrac1{20}x^5
 -\tfrac14x^4+\tfrac23x^3-x^2+x-\tfrac32],\\
-K_{Sa}&=\tfrac12\tau^4[\alpha^2-\alpha(x^2+2)+1],\\
-K_{aa}&=\tfrac12\tau(1-\alpha^2).
+U_{Sa}&=\tfrac12\tau^4[\alpha^2-\alpha(x^2+2)+1],\\
+U_{aa}&=\tfrac12\tau(1-\alpha^2).
 \end{align}
 
 \subsection{Complete small-step branch}

--- a/doc/kalman_ou_iii/w3d-baseline-comparison.tex-part
+++ b/doc/kalman_ou_iii/w3d-baseline-comparison.tex-part
@@ -46,6 +46,41 @@ outputs of every method under the evaluated configuration. The comparison
 therefore addresses vertical wave reconstruction and tilt estimation rather
 than complete navigation capability or the respective theoretical guarantees.
 
+All baseline parameter files are committed and frozen before the comparison
+script is run. The script rebuilds the four executables, replays the records,
+and computes the table; it performs no parameter search and never uses
+reference errors to choose gains. No method is retuned per scenario. OU--II
+and OU--III use KalmANF and may adapt only from their sensor streams; PII uses
+its own committed PLL-based scheduler. The TVG--NLO gains belong to the stated
+no-GNSS/no-magnetometer adaptation of the published observer. Thus the protocol
+provides common records and a common scored-output intersection, but not
+identical aiding: the three author-developed methods may consume magnetometer
+updates, whereas yaw and horizontal outputs are excluded from the comparison.
+
+\begin{table}[t]
+\centering
+\caption{Frozen parameter and aiding policy for the deterministic baselines.}
+\label{tab:baseline-tuning-policy}
+\footnotesize
+\setlength{\tabcolsep}{3pt}
+\begin{tabular}{@{}>{\raggedright\arraybackslash}p{1.25cm}
+                    >{\raggedright\arraybackslash}p{2.55cm}
+                    >{\raggedright\arraybackslash}p{3.55cm}@{}}
+\toprule
+Method & Parameter policy & Aiding and scored-output policy \\
+\midrule
+OU--III & committed KalmANF/adaptation configuration; no scenario retuning
+& IMU and magnetometer available; common vertical and tilt outputs scored \\
+OU--II & committed predecessor configuration; no scenario retuning
+& same record and available aiding as OU--III; common outputs scored \\
+PII & committed PLL scheduler and fixed ranges
+& same record; only outputs shared by all methods scored \\
+TVG--NLO & fixed gains for the documented vertical-only adaptation
+& IMU only; no GNSS or magnetic aiding; yaw and horizontal motion unscored \\
+\bottomrule
+\end{tabular}
+\end{table}
+
 \IfFileExists{w3d-baseline-results-generated.tex-part}{%
   \input{w3d-baseline-results-generated.tex-part}%
 }{%

--- a/doc/kalman_ou_iii/w3d-conclusion-summary.tex-part
+++ b/doc/kalman_ou_iii/w3d-conclusion-summary.tex-part
@@ -28,10 +28,12 @@ operating point and adaptive parameters over the admissible set; it does not
 treat startup or reset logic and does not convert the simulation study into an
 unconditional EKF convergence claim.
 
-The results support embedded feasibility and drift-controlled wave-state
-reconstruction for the tested conditions, but they do not by themselves imply
+The results support drift-controlled wave-state reconstruction for the tested
+conditions, while the MCU exercise establishes only functional source
+portability. They do not by themselves imply
 universal performance across spectra, update cadences, vessel speeds, or sensor
-installations.  Future work should extend the paired ensembles and tuning
+installations, nor do they establish an embedded timing or memory margin.
+Future work should extend the paired ensembles and tuning
 ablations to additional spectra and update cadences, reduce the observed
 adaptation lag, and add quantitative timing and external-reference measurements
 on hardware.  The high trigger rate of the realization-specific historical

--- a/doc/kalman_ou_iii/w3d-fus-methods.tex-part
+++ b/doc/kalman_ou_iii/w3d-fus-methods.tex-part
@@ -2,108 +2,47 @@
 \section{Frequency Tracking from Vertical Specific Force}
 \label{sec:freq-tracking}
 
-To estimate parameters adaptively we need a stable, real-time estimate of the dominant frequency of acceleration from the IMU. Using the vertical specific force or vertical inertial acceleration, we form a scalar input $u(t)$ that drives one of three trackers. Each tracker outputs a raw frequency, which is then clamped and smoothed to produce a reliable $\bar f_k$ for downstream adaptation and direction estimation.
+Online tuning requires a stable estimate of the dominant acceleration
+frequency. All OU--III experiments in this paper use KalmANF
+\cite{Ali2023DAFx}; the implementation also compiles two alternative policies,
+documented separately in Appendix~\ref{app:tracker-alternatives}. Using the
+vertical specific force or vertical inertial acceleration, the selected tracker
+produces a raw frequency that is clamped and smoothed to give $\bar f_k$ for
+adaptation and direction estimation.
 
-\paragraph{Signal}
-Track frequency from a vertical acceleration-like signal. For normalized operation we use
+For normalized operation the scalar tracker input is
 \[
-u(t)=\frac{a_z(t)}{g}.
-\]
-Some trackers may instead use the up-positive inertial acceleration directly, with their RMS thresholds interpreted in physical acceleration units. Let
-\[
+u(t)=\frac{a_z(t)}{g},\qquad
 \omega=2\pi f,\qquad
-\phi(t)=\int_0^t \omega(\tau)\,d\tau .
+\phi(t)=\int_0^t \omega(s)\,ds .
 \]
 
 \subsection{\textsc{KalmANF}: Kalman-updated adaptive notch}
 
-KalmANF filter \cite{Ali2023DAFx} models the signal with a second-order notch parameterized by $a=2\cos\omega$. It treats $a$ as a slowly varying state and updates it via a scalar Kalman step driven by the instantaneous prediction error.
+KalmANF models the signal with a second-order notch parameterized by
+$\chi=2\cos\omega$. It treats $\chi$ as a slowly varying scalar state and
+updates it from the instantaneous prediction error.
 
-\paragraph{Method}
-Embed the notch with parameter $a\in(-2,2)$:
+Embed the notch with $\chi\in(-2,2)$:
 \begin{align}
-x_{k+1} &= \begin{bmatrix} 0 & 1 \\ -1 & a_k \end{bmatrix} x_k + \begin{bmatrix} 0 \\ 1 \end{bmatrix} u_k, \qquad
-y_k = \begin{bmatrix} 1 & 0 \end{bmatrix} x_k,\\
-a_{k+1} &= a_k + w_k, \quad w_k\sim\mathcal{N}(0,q_a).
+\vct{x}_{k+1} &= \begin{bmatrix}0&1\\-1&\chi_k\end{bmatrix}\vct{x}_k
+ + \begin{bmatrix}0\\1\end{bmatrix}u_k,
+&y_k&=\begin{bmatrix}1&0\end{bmatrix}\vct{x}_k,\\
+\chi_{k+1}&=\chi_k+w_k,
+&w_k&\sim\mathcal{N}(0,q_\chi).
 \end{align}
-Treat $a$ as a scalar state; run a Kalman correction on $a$ using the instantaneous prediction error $\varepsilon_k=u_k-y_k$:
+For $\varepsilon_k=u_k-y_k$, the scalar correction is
 \begin{align}
-\tilde a_k &= a_k, \quad P_k^- = P_{k-1}+q_a, \\
-K_k &= \frac{P_k^-\,\partial \varepsilon_k/\partial a}{(\partial \varepsilon_k/\partial a)^2 P_k^- + r}, \\
-a_k &\leftarrow \tilde a_k + K_k\,\varepsilon_k,\qquad
-P_k=(1-K_k\,\partial \varepsilon_k/\partial a)P_k^-,
+\widetilde\chi_k&=\chi_k,&p_{\chi,k}^-&=p_{\chi,k-1}+q_\chi,\\
+\kappa_k&=\frac{p_{\chi,k}^-\,\partial\varepsilon_k/\partial\chi}
+{(\partial\varepsilon_k/\partial\chi)^2p_{\chi,k}^-+r},\\
+\chi_k&\leftarrow\widetilde\chi_k+\kappa_k\varepsilon_k,&
+p_{\chi,k}&=(1-\kappa_k\,\partial\varepsilon_k/\partial\chi)p_{\chi,k}^-.
 \end{align}
-with $\partial \varepsilon_k/\partial a$ obtained from the standard state-sensitivity recursion. Frequency readout:
+The derivative follows the standard state-sensitivity recursion, and
 \[
-\hat\omega_k=\arccos\!\left(\tfrac{1}{2}\,\clip(a_k,-2,2)\right), \quad \hat f_k=\hat\omega_k/(2\pi).
-\]
-
-\subsection{Aranovskiy Frequency Tracker: nonlinear adaptive observer}
-
-Aranovskiy filter is based on the nonlinear sinusoidal frequency observer of Bobtsov--Nikolaev--Slita--Borgul--Aranovskiy \cite{Bobtsov2013182}. It uses a filtered copy of the input, an adaptive auxiliary state, and an algebraic frequency parameter.
-
-\paragraph{Method}
-The input is first passed through a first-order filter
-\[
-\dot x_1=-a x_1+b u .
-\]
-The nonlinear observer forms
-\[
-\varphi=\dot x_1(bu+a x_1)+x_1^2\theta ,
-\]
-and adapts an auxiliary state
-\[
-\dot\sigma=-k\varphi .
-\]
-The frequency-related parameter is updated algebraically:
-\[
-\theta = k b x_1 u+\sigma .
-\]
-The internal angular-frequency estimate is proportional to
-\[
-\Omega=\sqrt{|\theta|}.
-\]
-
-\subsection{PLL Frequency Tracker: prefiltered I/Q phase-locked loop}
-
-PLL filter is a control-style narrowband tracker. It removes slow drift and high-frequency noise, demodulates the signal against an internal oscillator, and adjusts oscillator frequency with a bounded PI loop.
-
-\paragraph{Method}
-The input is converted to a broad band-passed signal $b_k$ using a high-pass stage followed by a low-pass stage. The tracker then demodulates against the internal phase $\phi_k$:
-\[
-I_k \leftarrow \operatorname{LPF}\!\left\{b_k\cos\phi_k\right\},\qquad
-Q_k \leftarrow \operatorname{LPF}\!\left\{-b_k\sin\phi_k\right\}.
-\]
-The phase detector is
-\[
-e_{\phi,k}=\operatorname{atan2}(Q_k,I_k).
-\]
-A type-II PLL-style loop updates oscillator frequency and phase:
-\[
-\omega_{k+1}
-=
-\clip_{[\omega_{\min},\omega_{\max}]}
-\left(
-\omega_k + K_iG_ke_{\phi,k}\Delta t
-\right),
-\]
-\[
-\phi_{k+1}
-=
-\wrap_{(-\pi,\pi]}
-\left(
-\phi_k + (\omega_{k+1}+K_pG_ke_{\phi,k})\Delta t
-\right),
-\]
-where
-\[
-K_p=2\zeta\omega_n,\qquad
-K_i=\omega_n^2,\qquad
-\omega_n=2\pi B_L .
-\]
-Here $B_L$ is the configured loop bandwidth, $\zeta$ is the loop damping, and $G_k$ reduces adaptation when confidence is poor. The reported frequency is
-\[
-\hat f_k=\frac{\omega_k}{2\pi}.
+\hat\omega_k=\arccos\!\left(\tfrac12\clip(\chi_k,-2,2)\right),
+\qquad \hat f_k=\hat\omega_k/(2\pi).
 \]
 
 % =======================================================
@@ -167,15 +106,15 @@ $S_a^{(2)}(\omega)=\omega^4S_\eta^{(2)}(\omega)$ and
 
 \subsection{Normalization and spectral shape factor}
 
-Let $\sigma_a^2=\Var[a]$ and let $\tau$ be a characteristic time scale.  Write
+Let $\sigma_{aw}^2=\Var[a]$ and let $\tau$ be a characteristic time scale. Write
 the two-sided PSD for positive frequency as
 \begin{equation}
-S_a^{(2)}(\omega)=\sigma_a^2\tau\Phi(\omega\tau),
+S_a^{(2)}(\omega)=\sigma_{aw}^2\tau\psi_a(\omega\tau),
 \label{eq:Sa-normalized}
 \end{equation}
 with
 \[
-\frac{1}{\pi}\int_0^\infty\Phi(u)\,du=1.
+\frac{1}{\pi}\int_0^\infty\psi_a(u)\,du=1.
 \]
 The triple integral is not stationary for a model with nonzero spectral density
 at zero frequency.  We therefore make the low-frequency assumption explicit:
@@ -183,9 +122,9 @@ the scaling applies after the physical spectrum, preprocessing, or finite
 observation interval supplies an effective cutoff $\omega_{\min}>0$.  Then
 \begin{equation}
 \Var[S]
-=\sigma_a^2\tau^6
+=\sigma_{aw}^2\tau^6
 \left[\frac{1}{\pi}\int_{u_{\min}}^\infty
-\frac{\Phi(u)}{u^6}\,du\right],
+\frac{\psi_a(u)}{u^6}\,du\right],
 \qquad u_{\min}=\omega_{\min}\tau .
 \label{eq:varS-shape}
 \end{equation}
@@ -193,22 +132,22 @@ Define
 \begin{equation}
 c_{\mathrm{spec}}^2(u_{\min})
 :=\frac{1}{\pi}\int_{u_{\min}}^\infty
-\frac{\Phi(u)}{u^6}\,du,
+\frac{\psi_a(u)}{u^6}\,du,
 \label{eq:c-spec-def}
 \end{equation}
 so that
 \begin{equation}
 \sigma_S=\sqrt{\Var[S]}
-=c_{\mathrm{spec}}(u_{\min})\sigma_a\tau^3.
+=c_{\mathrm{spec}}(u_{\min})\sigma_{aw}\tau^3.
 \label{eq:sigmaS-scaling}
 \end{equation}
-The units are correct because $\sigma_a\tau^3$ has units $\mathrm{m\,s}$.
+The units are correct because $\sigma_{aw}\tau^3$ has units $\mathrm{m\,s}$.
 The coefficient depends strongly on spectral shape and on the effective
 low-frequency cutoff; it is not universal.
 
 For the two-sided OU surrogate
 \[
-\Phi_{\mathrm{OU}}(u)=\frac{2}{1+u^2}
+\psi_{a,\mathrm{OU}}(u)=\frac{2}{1+u^2}
 \]
 and $u_{\min}=1$, Eqs.~\eqref{eq:c-spec-def}--\eqref{eq:sigmaS-scaling} give
 $c_{\mathrm{spec}}\approx0.227$.  Under the equivalent one-sided convention,
@@ -219,15 +158,15 @@ physical variance.
 
 A physically scaled Gaussian design is
 \begin{equation}
-r_S(\sigma_a,\tau)
+r_S(\sigma_{aw},\tau)
 =k_i\sigma_S
-=k_i c_{\mathrm{spec}}(u_{\min})\sigma_a\tau^3,
+=k_i c_{\mathrm{spec}}(u_{\min})\sigma_{aw}\tau^3,
 \label{eq:Rs-from-sigmaS}
 \end{equation}
 where $k_i>0$ is dimensionless.  The selected spectral-shape and cutoff
 calibration are represented by a single coefficient $c_R$, giving
 \begin{equation}
-r_{S,\star}=c_R\sigma_{a,\star}\tau_\star^3.
+r_{S,\star}=c_R\sigma_{aw,\star}\tau_\star^3.
 \label{eq:Rs-sigmaa-tau3}
 \end{equation}
 This is an engineering normalization, not an exact sea-state invariance result.
@@ -241,7 +180,7 @@ require retuning $c_R$.
 \label{sec:adapt-impl}
 
 The adaptation law updates the OU time constant $\tau$, the OU stationary
-acceleration scale $\sigma_a$, and the integral pseudo-measurement
+acceleration scale $\sigma_{aw}$, and the integral pseudo-measurement
 standard-deviation scale $r_S$.
 
 \subsubsection{Vertical signal}
@@ -274,22 +213,22 @@ The adaptation targets are
 \begin{equation}
 \begin{aligned}
 \tau_\star&=c_\tau\frac{1}{2f_{\mathrm{tune}}},\\
-\sigma_{a,\star}&=c_\sigma
+\sigma_{aw,\star}&=c_\sigma
 \sqrt{\max(\widehat\sigma_{\mathrm{wave}}^2,\epsilon)},\\
-r_{S,\star}&=c_R\sigma_{a,\star}\tau_\star^3.
+r_{S,\star}&=c_R\sigma_{aw,\star}\tau_\star^3.
 \end{aligned}
 \label{eq:tuner-targets}
 \end{equation}
 
 \subsubsection{Smoothing}
-Applied $(\tau,\sigma_a)$ are EMA filtered with time constant $\tau_{\mathrm{adapt}}$:
+Applied $(\tau,\sigma_{aw})$ are EMA filtered with time constant $\tau_{\mathrm{adapt}}$:
 \begin{equation}
 \begin{aligned}
 \alpha&=1-e^{-\Delta t/\tau_{\mathrm{adapt}}},\\
 \tau_{\mathrm{appl}}&\leftarrow\tau_{\mathrm{appl}}
 +\alpha(\tau_\star-\tau_{\mathrm{appl}}),\\
-\sigma_{a,\mathrm{appl}}&\leftarrow\sigma_{a,\mathrm{appl}}
-+\alpha(\sigma_{a,\star}-\sigma_{a,\mathrm{appl}}).
+\sigma_{aw,\mathrm{appl}}&\leftarrow\sigma_{aw,\mathrm{appl}}
++\alpha(\sigma_{aw,\star}-\sigma_{aw,\mathrm{appl}}).
 \end{aligned}
 \label{eq:adapt-ewma}
 \end{equation}
@@ -307,8 +246,9 @@ r_{S,\mathrm{appl}}&\leftarrow r_{S,\mathrm{appl}}
 \subsubsection{Anisotropic parameterization}
 The OU stationary standard deviation is applied anisotropically,
 \[
-\Sigma_{a_w}^{1/2}=\diag(S_\sigma\sigma_{a,\mathrm{appl}},
-S_\sigma\sigma_{a,\mathrm{appl}},\sigma_{a,\mathrm{appl}}),
+(\matg{\Sigma}_{aw}^{\mathrm{stat}})^{1/2}
+=\diag(S_\sigma\sigma_{aw,\mathrm{appl}},
+S_\sigma\sigma_{aw,\mathrm{appl}},\sigma_{aw,\mathrm{appl}}),
 \]
 and the integral pseudo-measurement standard-deviation vector is
 \[
@@ -323,6 +263,53 @@ Its componentwise square defines the covariance,
 \mat{R}_S=\diag\!\left(\vct{r}_S\odot\vct{r}_S\right),
 \end{equation}
 consistent with the measurement model in Sec.~\ref{sec:measurement_model}.
+
+\subsection{Implementation bounds and validity gates}
+
+Table~\ref{tab:implementation-gates} records the defaults used by the reported
+OU--III implementation. They are saturation and validity safeguards rather
+than quantities estimated from the reference trajectory; public configuration
+setters can override the tunable bounds. The $r_S$ limits apply to the
+standard-deviation scale, not to the covariance $\mat{R}_S$.
+
+\begin{table*}[t]
+\caption{Principal implementation defaults used in the reported experiments.}
+\label{tab:implementation-gates}
+\centering
+\footnotesize
+\begin{tabular}{@{}>{\raggedright\arraybackslash}p{0.28\textwidth}
+                    >{\raggedright\arraybackslash}p{0.18\textwidth}
+                    >{\raggedright\arraybackslash}p{0.28\textwidth}
+                    >{\raggedright\arraybackslash}p{0.18\textwidth}@{}}
+\toprule
+Bound or gate & Default & Bound or gate & Default \\
+\midrule
+IMU period $h$ & \SI{0.005}{s}
+& tracker band $[f_{\min},f_{\max}]$ & $[0.2,6.0]$ Hz \\
+OU time scale $[\tau_{\min},\tau_{\max}]$
+& $[0.02,3.0]$ s
+& stationary scale ceiling $\sigma_{aw,\max}$ & \SI{6.0}{\meter\per\second\squared} \\
+acceleration noise floor $\sigma_{\mathrm{nf}}$
+& \SI{0.12}{m.s^{-2}}
+& integral scale $[r_{S,\min},r_{S,\max}]$ & $[0.4,35]$ m\,s \\
+adaptation cadence / time constant
+& $0.1/1.8$ s
+& $r_S$ smoothing time & $5\tau_\star$ \\
+online-tuning warmup / magnetometer delay
+& $5/7$ s
+& frequency smoothing (fast/slow) & $3.5/10$ s \\
+horizontal OU / $r_S$ scale
+& $S_\sigma=1.87$, $\rho_{xy}=0.36$
+& tilt reset (threshold/hold/cooldown) & $70^\circ/0.35/3$ s \\
+direction-axis validity (amplitude/confidence/linearity)
+& $0.08/20/0.25$
+& sense coherence on/off & $0.20/0.12$ \\
+sense absolute RMS gates (horizontal/vertical slope)
+& $0.01\,\mathrm{m\,s^{-2}}/0.01\,\mathrm{m\,s^{-3}}$
+& KalmANF policy for reported OU results & enabled \\
+\bottomrule
+\end{tabular}
+\end{table*}
 
 % =======================================================
 \input{w3d-direction-methods.tex-part}

--- a/doc/kalman_ou_iii/w3d-gps-fusion.tex-part
+++ b/doc/kalman_ou_iii/w3d-gps-fusion.tex-part
@@ -1,4 +1,3 @@
-\appendices
 \section{Optional GNSS Fusion Extension}
 \label{sec:gps_fusion}
 

--- a/doc/kalman_ou_iii/w3d-intro.tex-part
+++ b/doc/kalman_ou_iii/w3d-intro.tex-part
@@ -7,17 +7,17 @@ augmented with an Ornstein--Uhlenbeck (OU) process model for latent
 acceleration. The filter is designed for marine inertial sensing and
 wave-kinematics reconstruction. The proposed framework unifies
 attitude estimation, 3D kinematics, and stochastic excitation
-modeling into a single, analytically tractable structure suitable for
-real-time embedded estimation.
+modeling into a single, analytically tractable structure intended for
+resource-constrained embedded estimation.
 
 Most wave measurement systems derive parameters by chaining separate motion estimation
 and spectral analysis stages, a process prone to bias and delay.
 Our approach instead uses a unified 21-state Kalman filter that
-directly incorporates wave kinematics. Two central novelties are the integration
-of an OU prior for latent world acceleration into the quaternion MEKF and an
-adaptive tuning law that jointly adjusts the OU time scale, stationary
-acceleration scale, and integral-state regularization from observed sea-state
-statistics. Together with a real-time directional estimator, these elements
+directly incorporates wave kinematics. The architectural contributions are the
+integration of a first-order Gauss--Markov acceleration prior into the
+quaternion MEKF and an adaptive tuning law that jointly adjusts the prior time
+scale, stationary acceleration scale, and integral-state regularization from
+observed sea-state statistics. Together with an online directional estimator, these elements
 address colored excitation and MEMS errors in an efficient, embedded-friendly
 framework. Appendix~\ref{app:iss-stability} supplies a sufficient-condition
 uniform local input-to-state stability analysis for the core estimator and its
@@ -37,13 +37,20 @@ cumulative wave kinematics in the world frame.
 \subsection*{Stochastic Forcing and the OU Acceleration Model}
 
 The latent world acceleration $\bm{a}_w$ is modeled with an
-Ornstein--Uhlenbeck (OU) prior \cite{UhlenbeckOrnstein1930_OU} characterized by a stationary variance
-$\Sigma_{aw}$ and a correlation time constant $\tau_{aw}$, referred to hereafter as $\tau$.
+Ornstein--Uhlenbeck (OU) prior
+\cite{UhlenbeckOrnstein1930_OU,Singer1970_ManeuverModel} characterized by a stationary variance
+$\matg{\Sigma}_{aw}^{\mathrm{stat}}$ and a correlation time constant
+$\tau_{aw}$, referred to hereafter as $\tau$.
 The OU prior is a low-order Gauss--Markov model for broadband, temporally
 correlated excitation with bounded variance; it is not asserted to be the
-physical ocean-wave spectrum. The novel contribution is its integration as the
-latent acceleration prior within the coupled quaternion and translational
-estimator, enabling analytically tractable colored-excitation modeling. For
+physical ocean-wave spectrum. In each scalar axis this is the continuous
+first-order Gauss--Markov acceleration model used in the Singer tracking
+family, with $\alpha=1/\tau$ and the diffusion chosen to give the prescribed
+stationary covariance \cite{Singer1970_ManeuverModel}. We do not claim the OU
+or Singer process itself as new. The contribution is its use as a latent 3D
+world-acceleration prior inside a coupled left-MEKF, $v$--$p$--$S$ chain,
+analytic discretization, adaptive pseudo-constraint, and embedded
+implementation. For
 Lagrangian sensors following surface motion, this prior improves low-frequency
 stability without sacrificing responsiveness to swell-band motion.
 
@@ -57,7 +64,7 @@ kinematics of the Q-MEKF. IMU measurements provide specific force and
 angular rate observations, while a pseudo-measurement of the integral of
 displacement serves as a long-term constraint to suppress drift. The
 pseudo-measurement standard-deviation scale $r_S$, whose square forms the
-covariance $R_S$, is a crucial design parameter: smaller values tighten the
+covariance $\mat{R}_S$, is a crucial design parameter: smaller values tighten the
 constraint but risk biasing slow wave components, while larger values relax
 drift control.
 
@@ -79,14 +86,16 @@ different vertical and lateral dynamics.
 
 A fixed-parameter Kalman filter performs optimally only under a
 particular sea-state regime, determined by its assumed correlation time
-$\tau$ and stationary acceleration variance $\Sigma_{aw}$.
+$\tau$ and stationary acceleration variance
+$\matg{\Sigma}_{aw}^{\mathrm{stat}}$.
 Different wave spectra exhibit distinct dominant frequencies and energy
-levels. To maintain performance across conditions, we introduce a novel online
+levels. To maintain performance across conditions, we use an online
 adaptation law that continuously estimates and tunes these parameters together
-with the integral-state regularization scale. Three alternative embedded
-frequency trackers are supported: the \textit{KalmANF adaptive notch filter},
-\textit{PLL (Phase-Locked Loop)} filter, and the \textit{Aranovskiy frequency
-estimator}. The dominant frequency provides an updated correlation time
+with the integral-state regularization scale. All OU--III results reported in
+this paper use the \textit{KalmANF adaptive notch filter}; two compiled
+alternative tracker policies are documented in
+Appendix~\ref{app:tracker-alternatives} but are not evaluated as OU--III
+ablations. The dominant frequency provides an updated correlation time
 $\tau$, while the stationary acceleration scale $\sigma_{aw}$ is estimated
 in the time domain. The pseudo-measurement standard-deviation scale is adapted
 through the spectrally motivated law
@@ -95,7 +104,7 @@ r_S \propto \sigma_{aw}\tau^3,
 \]
 which couples displacement drift suppression to the estimated strength and
 time scale of stochastic excitation. This joint adaptation of the OU prior and
-integral-state constraint is a principal novelty of the proposed method. The
+integral-state constraint is a principal architectural contribution. The
 normalization is approximate and assumes a fixed pseudo-update cadence and a
 bounded family of spectral shapes and effective low-frequency cutoffs.
 
@@ -109,22 +118,22 @@ assessed via RMS displacement errors relative to the true wave elevation. The
 OU-based Q-MEKF achieves drift-suppressed reconstruction of three-dimensional
 surface motion.
 
-Not all numerical coefficient values are reproduced in this article; for
-reproducibility, the complete coefficient set, tuning constants, and simulation
-configuration are freely accessible in the source code published in the
-Bareboat Necessities GitHub project.
+The principal runtime bounds, gates, and time constants are tabulated in
+Sec.~\ref{sec:adapt-impl}. The complete coefficient set, fixed baseline
+configurations, seed manifest, and simulation configuration are versioned with
+the source and result bundle in the Bareboat Necessities GitHub project.
 
 \subsection{Main Contributions}
 
 The main contributions of this work are:
 \begin{itemize}
-  \item A novel integration of an OU-driven latent world-acceleration prior into
-        a 21-state quaternion MEKF for coupled marine attitude and wave-motion
+  \item A 21-state quaternion MEKF architecture that couples an OU-driven
+        latent world-acceleration prior to marine attitude and wave-motion
         estimation.
   \item Closed-form discrete-time transition and covariance matrices for
         the OU process and linear kinematic chain, with numerically stable
         small-step series expansions.
-  \item A novel adaptive tuning law that jointly updates $\tau$,
+  \item An adaptive tuning law that jointly updates $\tau$,
         $\sigma_{aw}$, and the integral pseudo-measurement scale from dominant
         frequency and time-domain variance estimates.
   \item A sufficient-condition proof of uniform local ISS for the adaptive core,
@@ -135,6 +144,7 @@ The main contributions of this work are:
         and two earlier author-developed observer architectures, including an
         OU--II ablation that isolates the incremental effect of the OU--III
         translational state structure.
-  \item Empirical validation on simulated directional sea spectra,
-        demonstrating drift suppression and physical fidelity.
+  \item A versioned ten-seed paired validation on stationary and transitioning
+        directional sea spectra, including confidence intervals, negative
+        results, and the limits of the observed OU--III advantage.
 \end{itemize}

--- a/doc/kalman_ou_iii/w3d-iss-stability.tex-part
+++ b/doc/kalman_ou_iii/w3d-iss-stability.tex-part
@@ -34,7 +34,7 @@ Collect the applied adaptive parameters into
 \begin{equation}
 \vct\vartheta_k=
 \begin{bmatrix}
-\tau_k & \sigma_{a,k} & r_{S,k}
+\tau_k & \sigma_{aw,k} & r_{S,k}
 \end{bmatrix}^{\!\top}.
 \label{eq:iss-adaptive-vector}
 \end{equation}

--- a/doc/kalman_ou_iii/w3d-lti-discrete.tex-part
+++ b/doc/kalman_ou_iii/w3d-lti-discrete.tex-part
@@ -21,7 +21,7 @@ Over a small step $h>0$, the exact discrete transition of the mean is
   \;=\;
   \underbrace{e^{\mat{F} h}}_{\displaystyle \matg{\Phi}(h)}\,\delta\vct{x}(t)
   \;+\;
-  \int_{0}^{h} e^{\mat{F} (h-\tau)}\,\mat{L}\,\vct{w}_c(t{+}\tau)\,d\tau.
+  \int_{0}^{h} e^{\mat{F} (h-s)}\,\mat{L}\,\vct{w}_c(t{+}s)\,ds.
 \end{equation}
 The matrix exponential is defined by the absolutely convergent series
 $e^{\mat{F} h}=\sum_{k=0}^{\infty}\frac{(\mat{F} h)^k}{k!}$.
@@ -35,8 +35,8 @@ From the stochastic variation-of-constants formula,
 \matg{Q}_d(h)
 \;=\;
 \int_{0}^{h}
-  e^{\mat{F} \tau}\,\mat{L}\,\matg{Q}_c\,\mat{L}^\top\,
-  e^{\mat{F}^\top \tau}\,d\tau.
+  e^{\mat{F} s}\,\mat{L}\,\matg{Q}_c\,\mat{L}^\top\,
+  e^{\mat{F}^\top s}\,ds.
 \label{eq:Qd-integral}
 \end{equation}
 

--- a/doc/kalman_ou_iii/w3d-meas.tex-part
+++ b/doc/kalman_ou_iii/w3d-meas.tex-part
@@ -104,3 +104,7 @@ The angular-rate and angular-acceleration terms are treated as known inputs.
 Their second-order coupling through attitude uncertainty is neglected, so the
 state Jacobians remain those of \eqref{eq:acc-meas}.  Setting $\vct{r}_b=0$
 disables the correction.
+
+The optional steady-heel frame transform is documented in
+Appendix~\ref{sec:heel}. It is outside the evaluated configuration and is
+disabled for all results in this paper.

--- a/doc/kalman_ou_iii/w3d-nomenclature.tex-part
+++ b/doc/kalman_ou_iii/w3d-nomenclature.tex-part
@@ -1,0 +1,41 @@
+\section{Nomenclature and Conventions}
+\label{sec:nomenclature}
+
+Table~\ref{tab:nomenclature} collects the symbols that recur across the
+attitude, translational, and adaptation models. Bold lower- and upper-case
+symbols denote vectors and matrices, respectively; a hat denotes an estimate.
+
+\begin{table*}[t]
+\caption{Principal notation and disambiguation of similarly named quantities.}
+\label{tab:nomenclature}
+\centering
+\footnotesize
+\setlength{\tabcolsep}{3pt}
+\begin{tabular}{@{}>{\raggedright\arraybackslash}p{0.15\textwidth}
+                    >{\raggedright\arraybackslash}p{0.33\textwidth}
+                    >{\raggedright\arraybackslash}p{0.15\textwidth}
+                    >{\raggedright\arraybackslash}p{0.31\textwidth}@{}}
+\toprule
+Symbol & Meaning & Symbol & Meaning \\
+\midrule
+$q,\ \mat{R}_{wb}$ & world-to-body quaternion and rotation matrix
+& $\delta\vct{\theta}$ & left-multiplicative local attitude error \\
+$h,\ \tau$ & sample interval and OU correlation time
+& $\vct{v},\vct{p},\vct{S}$ & velocity, oscillatory displacement, and its integral \\
+$\vct{a}_w$ & latent world-frame acceleration
+& $\vct{b}_g,\vct{b}_a$ & gyroscope and accelerometer biases \\
+$\matg{\Sigma}_{aw}^{\mathrm{stat}}$ & prescribed stationary covariance of the OU acceleration prior
+& $\mat{P}_{a_wa_w}$ & posterior covariance block for the estimated acceleration state \\
+$\sigma_{aw}$ & scalar stationary standard-deviation scale used for the OU prior
+& $\sigma_{a,\mathrm{white}}$ & accelerometer white-noise standard deviation \\
+$r_S,\ \mat{R}_S$ & integral-channel standard-deviation scale and covariance, with $\mat{R}_S=\diag(\vct r_S\odot\vct r_S)$
+& $\matg{Q}_c,\ \matg{Q}_d$ & continuous spectral-density and discrete process-covariance matrices \\
+$\matg{\Phi}$ & discrete state-transition matrix
+& $\mat{C},\ \mat{K}$ & measurement Jacobian and Kalman gain \\
+$\scomp(\mat{U})$ & symmetric completion of an upper-triangular coefficient array; defined in Sec.~\ref{sec:block-Phi-Qd}
+& $f_{\mathrm{tune}},\ \tau_{\mathrm{adapt}}$ & smoothed tracker frequency and adaptation time constant \\
+$(\cdot)_\star,\ (\cdot)_{\mathrm{appl}}$ & target and applied adaptive values
+& $\clip(\cdot),\ \wrap(\cdot)$ & saturation and phase-wrapping operators \\
+\bottomrule
+\end{tabular}
+\end{table*}

--- a/doc/kalman_ou_iii/w3d-proc-cont.tex-part
+++ b/doc/kalman_ou_iii/w3d-proc-cont.tex-part
@@ -83,13 +83,17 @@ Here $\tau>0$ is the correlation time and
 $\matg{\Sigma}_{aw}^{\mathrm{stat}}\succeq0$ is the stationary acceleration
 covariance.
 
-Ocean-wave acceleration is not asserted to be an OU process.  Equation
+Ocean-wave acceleration is not asserted to be an OU process. Equation
 \eqref{eq:ou-ct} is a low-order stationary Gauss--Markov prior
-\cite{Maybeck1979_StochasticModels,Jazwinski1970_Filtering}.  It is useful
-because it is Markov, mean-reverting, bounded in variance, and analytically
-discretizable.  For a scalar component with stationary variance $\sigma_a^2$,
+\cite{Maybeck1979_StochasticModels,Jazwinski1970_Filtering}. For each scalar
+axis it belongs to the Singer first-order acceleration-model family under the
+identification $\alpha=1/\tau$; here the diffusion is parameterized directly by
+the desired stationary covariance
+\cite{Singer1970_ManeuverModel}. It is useful because it is Markov,
+mean-reverting, bounded in variance, and analytically discretizable. For a
+scalar component with stationary variance $\sigma_{aw}^2$,
 \[
-S_a(\omega)=\frac{2\sigma_a^2\tau}{1+\omega^2\tau^2}.
+S_{a_w}(\omega)=\frac{2\sigma_{aw}^2\tau}{1+\omega^2\tau^2}.
 \]
 This is a zero-centered first-order low-pass spectrum.  The empirical relation
 between $\tau$ and a tracked wave period is therefore a tuning rule for the

--- a/doc/kalman_ou_iii/w3d-sim-charts.tex-part
+++ b/doc/kalman_ou_iii/w3d-sim-charts.tex-part
@@ -84,7 +84,7 @@ in physical units (e.g.\ $\mu$T). This provides both estimator inputs and ground
     Misalignment bound & $\le \SI{1}{\degree}$ & rotation in $\mat{M}_{\mathrm{mis}}$ \\
     \midrule
     \multicolumn{3}{@{}l}{\emph{Filter initialization (measurement noise std)}} \\
-    $\sigma_a$ init & $2.8\,\sigma_{a,\mathrm{white}}$ & per-axis \\
+    $\sigma_{a,\mathrm{meas}}$ init & $2.8\,\sigma_{a,\mathrm{white}}$ & per-axis \\
     $\sigma_g$ init & $2.0\,\sigma_{g,\mathrm{white}}$ & per-axis \\
     $\sigma_m$ init & $1.2\,\sigma_{m,\mathrm{white}}$ & per-axis \\
     \bottomrule
@@ -179,7 +179,7 @@ validation protocol instead uses the final \SI{900}{s} of each \SI{1200}{s}
 run as its primary score, thereby excluding startup while retaining a long
 steady-state record.  The runner reports per-axis and 3D displacement RMS,
 roll/pitch/yaw RMS, bias errors, and diagnostic tuning variables
-$(f,\tau,\sigma_a,R_S)$.
+$(f,\tau,\sigma_{aw},r_S)$.
 
 \paragraph{Paired Monte Carlo and adaptation ablations}
 Ten predeclared repetitions independently vary wave phase, IMU noise and random
@@ -240,10 +240,10 @@ summaries, paired effects, and manifest are retained with the source tree.
     JONSWAP   & 4.00 & 0.297 & 7.4 & 0.60 & 1.36 & 1.59 & 26.1  & 96.8/0.5/2.7 \\
     JONSWAP   & 8.50 & 0.453 & 5.3 & 1.37 & 0.54 & 1.06 & -22.1 & 94.8/0.9/4.3 \\
     \addlinespace
-    PM+Stokes & 0.27 & 0.020 & 7.6 & 0.37 & 0.12 & 1.94 & 30.4  & 99.6/0.0/0.4 \\
-    PM+Stokes & 1.50 & 0.063 & 4.2 & 0.18 & 0.17 & 2.10 & -26.9 & 94.0/1.2/4.7 \\
-    PM+Stokes & 4.00 & 0.262 & 6.6 & 0.19 & 0.39 & 2.10 & 29.6  & 98.6/0.1/1.3 \\
-    PM+Stokes & 8.50 & 0.537 & 6.3 & 1.00 & 0.56 & 2.21 & -24.1 & 96.5/1.2/2.3 \\
+    PM--Stokes & 0.27 & 0.020 & 7.6 & 0.37 & 0.12 & 1.94 & 30.4  & 99.6/0.0/0.4 \\
+    PM--Stokes & 1.50 & 0.063 & 4.2 & 0.18 & 0.17 & 2.10 & -26.9 & 94.0/1.2/4.7 \\
+    PM--Stokes & 4.00 & 0.262 & 6.6 & 0.19 & 0.39 & 2.10 & 29.6  & 98.6/0.1/1.3 \\
+    PM--Stokes & 8.50 & 0.537 & 6.3 & 1.00 & 0.56 & 2.21 & -24.1 & 96.5/1.2/2.3 \\
     \bottomrule
   \end{tabular}
   \vspace{1pt}
@@ -262,22 +262,22 @@ implemented in modern idiomatic C++ with the embedded-friendly Eigen linear alge
 
 \input{w3d-baseline-comparison.tex-part}
 
-\section{Real-Hardware Validation Platform}
+\section{Embedded Implementation Platform}
 \label{sec:real-hardware-platform}
 
-To verify that the proposed estimator is suitable for embedded marine
-deployment, the implementation was also run on real hardware using an
+As a functional portability exercise, the implementation was run on an
 M5Stack AtomS3R development module based on the ESP32-S3 microcontroller.
 This platform provides a compact, low-power target representative of the
 resource-constrained devices for which the filter is intended.
 
-The purpose of the hardware validation is not to replace the controlled
+The purpose of this exercise is not to replace the controlled
 simulation study of Sec.~\ref{sec:sim-and-eval}, where ground-truth wave
-kinematics are available, but to confirm the practical real-time properties
-of the implementation: stable execution on an MCU-class processor, fixed-rate
-IMU sampling, bounded memory use, sensor calibration handling, and end-to-end
-operation of the attitude, acceleration, frequency-tracking, and wave-state
-estimation pipeline.
+kinematics are available. It confirms that the source builds for the target and
+that calibrated MEMS samples can traverse the initialization, attitude,
+acceleration, frequency-tracking, and wave-state pipeline. This study did not
+instrument update latency, worst-case execution time, processor utilization,
+RAM, flash, or sustained deadline margin; it therefore does not establish a
+quantitative real-time-performance claim.
 
 \begin{figure}[!t]\centering
   \includesvg[
@@ -285,7 +285,7 @@ estimation pipeline.
     inkscapelatex=false
   ]{AtomS3R_device}
   \caption{M5Stack AtomS3R device based on the ESP32-S3 MCU, used as the
-  embedded real-hardware validation target.}
+  embedded implementation target.}
   \label{fig:atoms3r_device}
 \end{figure}
 
@@ -304,13 +304,13 @@ bias, axis alignment, and magnetometer hard-/soft-iron effects. The calibrated
 sensor triads are transformed into the body-frame convention used by the
 filter. 
 
-The real-hardware tests therefore validate three implementation-level claims:
-(i) the proposed OU-driven Q-MEKF can execute in real time on an ESP32-S3-class
-microcontroller, (ii) the staged initialization and calibration pipeline is
-compatible with real MEMS IMU data, and (iii) the adaptive tuning logic remains
-numerically stable outside the idealized simulation environment. Quantitative
-wave-kinematics accuracy is evaluated separately in simulation, where exact
-reference displacement, velocity, acceleration, and attitude are available.
+This exercise supports source-level portability and end-to-end functional
+integration with real MEMS input. It does not quantify embedded resource use or
+wave-reconstruction accuracy on hardware. Those require the timing, memory,
+power, sustained-rate, and external-reference measurements reserved for the
+embedded-performance phase. Quantitative wave-kinematics accuracy in the
+present paper is evaluated only in simulation, where exact reference
+displacement, velocity, acceleration, and attitude are available.
 
 \section{Conclusion and Future Work}
 \label{sec:future-work}

--- a/doc/kalman_ou_iii/w3d-tracker-alternatives.tex-part
+++ b/doc/kalman_ou_iii/w3d-tracker-alternatives.tex-part
@@ -1,0 +1,53 @@
+\section{Alternative Compiled Frequency-Tracker Policies}
+\label{app:tracker-alternatives}
+
+The OU--III results and adaptation claims in this paper use KalmANF exclusively.
+The following policies are maintained as selectable implementation options but
+were not evaluated as OU--III tracker ablations, so no relative-performance
+claim is made. The PII baseline in Sec.~\ref{sec:observer-comparison} uses its
+own committed PLL configuration and is not evidence for substituting that PLL
+inside OU--III.
+
+\subsection{Aranovskiy nonlinear adaptive observer}
+
+The observer follows the sinusoidal frequency estimator of
+Bobtsov--Nikolaev--Slita--Borgul--Aranovskiy \cite{Bobtsov2013182}. A filtered
+copy of input $u$ obeys
+\[
+\dot x_f=-c_fx_f+b_fu.
+\]
+It forms
+\[
+\varphi_f=\dot x_f(b_fu+c_fx_f)+x_f^2\theta_f,
+\qquad \dot\varsigma=-k_f\varphi_f,
+\]
+and updates the algebraic frequency parameter as
+\[
+\theta_f=k_fb_fx_fu+\varsigma,
+\qquad \widehat\Omega_f\propto\sqrt{|\theta_f|}.
+\]
+The subscripts distinguish these tracker states and gains from acceleration,
+attitude, and Kalman-gain symbols in the main estimator.
+
+\subsection{Prefiltered I/Q phase-locked loop}
+
+The PLL policy band-passes the input to $b_k$, demodulates it against internal
+phase $\phi_k$, and low-pass filters the in-phase and quadrature components:
+\[
+\begin{aligned}
+I_k&\leftarrow\operatorname{LPF}\{b_k\cos\phi_k\},\\
+Q_k&\leftarrow\operatorname{LPF}\{-b_k\sin\phi_k\},\\
+e_{\phi,k}&=\operatorname{atan2}(Q_k,I_k).
+\end{aligned}
+\]
+A bounded type-II loop then applies
+\begin{align}
+\omega_{k+1}&=\clip_{[\omega_{\min},\omega_{\max}]}
+\left(\omega_k+k_i^{\mathrm{PLL}}G_ke_{\phi,k}\Delta t\right),\\
+\phi_{k+1}&=\wrap_{(-\pi,\pi]}
+\left(\phi_k+[\omega_{k+1}+k_p^{\mathrm{PLL}}G_ke_{\phi,k}]\Delta t\right),
+\end{align}
+where $k_p^{\mathrm{PLL}}=2\zeta\omega_n$,
+$k_i^{\mathrm{PLL}}=\omega_n^2$, and $\omega_n=2\pi B_L$. The confidence
+factor $G_k$ reduces adaptation when the input is weak, and the readout is
+$\hat f_k=\omega_k/(2\pi)$.

--- a/doc/kalman_ou_iii/w3d-wind-heel.tex-part
+++ b/doc/kalman_ou_iii/w3d-wind-heel.tex-part
@@ -1,5 +1,11 @@
-\subsection{Steady Wind-Heel Correction}
+\section{Optional Steady Wind-Heel Transform}
 \label{sec:heel}
+
+This transform is an implementation option, not an evaluated contribution.
+It was disabled in every deterministic simulation, ten-seed Monte Carlo run,
+and hardware exercise reported here. Consequently, the present evidence makes
+no performance claim for heel correction; the derivation is retained only to
+document the frame convention used when the option is enabled.
 
 For a sailing vessel the hull experiences a slowly varying \emph{steady wind heel},
 well-approximated as a rotation about the physical body $x$-axis. If unmodeled, this

--- a/doc/kalman_ou_iii/w3d.bib
+++ b/doc/kalman_ou_iii/w3d.bib
@@ -341,3 +341,15 @@
     pages     = {174--178},
     doi       = {10.1109/OCEANS.1998.725750}
 }
+
+@article{Singer1970_ManeuverModel,
+    author  = {Singer, Robert A.},
+    title   = {Estimating Optimal Tracking Filter Performance for Manned Maneuvering Targets},
+    journal = {IEEE Transactions on Aerospace and Electronic Systems},
+    year    = {1970},
+    volume  = {AES-6},
+    number  = {4},
+    pages   = {473--483},
+    month   = jul,
+    doi     = {10.1109/TAES.1970.310128}
+}

--- a/tests/validation/test_ou_validation.py
+++ b/tests/validation/test_ou_validation.py
@@ -274,5 +274,78 @@ class CommittedFullResultsTests(unittest.TestCase):
         )
 
 
+class ManuscriptMethodologyTests(unittest.TestCase):
+    DOC = REPO_ROOT / "doc" / "kalman_ou_iii"
+
+    @classmethod
+    def read(cls, name):
+        return (cls.DOC / name).read_text(encoding="utf-8")
+
+    def test_singer_relationship_and_contribution_wording(self):
+        intro = self.read("w3d-intro.tex-part")
+        bibliography = self.read("w3d.bib")
+        self.assertIn("Singer1970_ManeuverModel", intro)
+        self.assertIn("We do not claim the OU", intro)
+        self.assertIn("doi     = {10.1109/TAES.1970.310128}", bibliography)
+        self.assertNotIn("novel", intro.lower())
+
+    def test_nomenclature_is_included_and_disambiguates_covariances(self):
+        manuscript = self.read("kalman_ou-w3d.tex")
+        nomenclature = self.read("w3d-nomenclature.tex-part")
+        self.assertIn("\\input{w3d-nomenclature.tex-part}", manuscript)
+        self.assertIn("\\Sigma}_{aw}^{\\mathrm{stat}}", nomenclature)
+        self.assertIn("\\mat{P}_{a_wa_w}", nomenclature)
+        self.assertIn("Kalman gain", nomenclature)
+
+    def test_analytic_completion_and_small_step_regime_are_explicit(self):
+        analytic = self.read("w3d-analytic-coeff.tex-part")
+        lti = self.read("w3d-lti-discrete.tex-part")
+        manuscript = self.read("kalman_ou-w3d.tex")
+        self.assertIn("\\scomp(\\mat{U})", analytic)
+        self.assertIn("it is not the\naveraging operator", analytic)
+        self.assertNotIn("\\sym", manuscript + analytic)
+        self.assertIn("5.30\\times10^{-3}", analytic)
+        self.assertIn("h-s", lti)
+        self.assertNotIn("h-\\tau", lti)
+
+    def test_tracker_and_heel_material_are_scoped_as_unevaluated_appendices(self):
+        manuscript = self.read("kalman_ou-w3d.tex")
+        fusion = self.read("w3d-fus-methods.tex-part")
+        trackers = self.read("w3d-tracker-alternatives.tex-part")
+        heel = self.read("w3d-wind-heel.tex-part")
+        appendix_sources = "".join(
+            self.read(name)
+            for name in (
+                "w3d-tracker-alternatives.tex-part",
+                "w3d-wind-heel.tex-part",
+                "w3d-gps-fusion.tex-part",
+                "w3d-iss-stability.tex-part",
+            )
+        )
+        self.assertLess(
+            manuscript.index("\\appendices"),
+            manuscript.index("\\input{w3d-tracker-alternatives.tex-part}"),
+        )
+        self.assertEqual(manuscript.count("\\appendices"), 1)
+        self.assertNotIn("\\appendices", appendix_sources)
+        self.assertNotIn("Aranovskiy Frequency Tracker", fusion)
+        self.assertIn("not evaluated as OU--III tracker ablations", trackers)
+        self.assertIn("disabled in every deterministic simulation", heel)
+
+    def test_baseline_fairness_thresholds_and_hardware_limits_are_recorded(self):
+        baseline = self.read("w3d-baseline-comparison.tex-part")
+        fusion = self.read("w3d-fus-methods.tex-part")
+        simulation = self.read("w3d-sim-charts.tex-part")
+        self.assertIn("frozen before the comparison", baseline)
+        self.assertIn("performs no parameter search", baseline)
+        self.assertIn("never uses\nreference errors to choose gains", baseline)
+        self.assertIn("tab:baseline-tuning-policy", baseline)
+        self.assertIn("tab:implementation-gates", fusion)
+        for value in ("[0.2,6.0]", "[0.02,3.0]", "[0.4,35]", "70^\\circ"):
+            self.assertIn(value, fusion)
+        self.assertIn("did not\ninstrument update latency", simulation)
+        self.assertIn("does not establish a\nquantitative real-time-performance claim", simulation)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- cite Singer and state explicitly that the OU/Singer process itself is not the contribution
- focus the contribution claims on the coupled 21-state architecture, analytic discretization, adaptive pseudo-constraint, and embedded integration
- add a nomenclature table and remove notation collisions across prior/posterior covariance, spectral shape, coefficient arrays, tuning scales, and integration variables
- define the upper-triangle symmetric-completion operator and document that the reported operating points use the small-step covariance branch
- document frozen baseline tuning and aiding policy plus the implementation bounds, validity gates, and timing constants used in the reported experiments
- keep KalmANF in the main method; move unevaluated tracker alternatives and heel compensation to scoped appendices
- preserve the ISS contribution while stating its local, conditional scope
- replace unsupported real-time/resource claims with the narrower, demonstrated MCU source-portability claim
- add manuscript regression checks, including a guard against restarting appendix lettering

## Verification

- full repository build and runtime suite: `make all EIGEN_DIR=/tmp/eigen-3.4.0`
- validation/manuscript tests: 14/14 passed
- article rebuilt successfully as a 19-page PDF with no overfull boxes
- visually inspected the full PDF, with focused checks on the nomenclature, implementation defaults, baseline policy, tracker/heel appendices, GNSS appendix, and ISS appendix

## Scope

This is the single Phase 1 methodology/presentation PR. It does not add the later sensitivity/failure-case study or embedded timing, CPU, RAM, flash, power, and sustained-rate measurements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified OU-III versus OU-II error results, validation scope, baseline comparisons, and embedded-platform limitations.
  * Added nomenclature, reproducibility details, implementation thresholds, and Singer-model context.
  * Documented KalmANF as the evaluated tracker and added appendices for alternative trackers and optional wind/heel transforms.
  * Standardized mathematical notation, chart captions, terminology, and citations.

* **Tests**
  * Added checks for methodology, nomenclature, analytical details, appendix scope, baseline fairness, and hardware-performance disclosures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->