### PR TITLE
Resolve the simulator path before running it from its own directory

### DIFF
--- a/tools/ou_sim_table.py
+++ b/tools/ou_sim_table.py
@@ -64,6 +64,12 @@ PATTERNS = {
 
 def run_record(binary: Path, record: Path) -> dict[str, Any]:
     """Replay one record and pull the last-60 s block out of the output."""
+    # The child runs with cwd=binary.parent, so a relative binary path -- what
+    # the CI step passes -- would be resolved against that directory instead of
+    # ours and fail to exec.  Resolve both ends before crossing the boundary.
+    binary = binary.resolve()
+    record = record.resolve()
+
     env = dict(os.environ)
     env["W3D_WRITE_TIMESERIES"] = "0"
     # Every record has to be scored, including any that trip a historical gate;


### PR DESCRIPTION
The CI step passes --binary as a repo-root-relative path, and run_record
launches the simulator with cwd set to the binary's parent.  The existence
check in main() therefore passed while the exec did not: the child's argv[0]
was re-resolved against tests/kalman_ou_iii/ rather than the repo root, so
the run died with FileNotFoundError on
'tests/kalman_ou_iii/kalman_ou_iii-sim' before the first record scored.

Resolve both the binary and the record to absolute paths before handing
them to the subprocess.  The record was already resolved by the caller;
doing it here as well keeps the function correct on its own terms rather
than relying on where it happens to be called from.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012zqhMARn97mSsLdXKmCVsF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed simulator runs using relative paths when the working directory changes.
  * Simulator binaries and input records are now resolved correctly before execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->