### PR TITLE
Narrow the claim to what the ablation supports, and stop resting it on one interval

### DIFF
--- a/doc/kalman_ou_iii/kalman_ou-w3d.tex
+++ b/doc/kalman_ou_iii/kalman_ou-w3d.tex
@@ -142,7 +142,7 @@
 \emergencystretch=2em
 \allowdisplaybreaks
 
-\title{OU-Driven Quaternion MEKF for Marine INS and Wave-State Estimation (draft)}
+\title{OU-Driven Quaternion MEKF with Adaptive Integral Regularization for Marine Wave-State Estimation (draft)}
 \author{%
     \IEEEauthorblockN{Mikhail S. Grushinskiy}
     \IEEEauthorblockA{Independent Researcher, USA, Fair Lawn\\
@@ -176,6 +176,14 @@
 \providecommand{\OUValidationTravelWrong}{--}
 \providecommand{\OUValidationTravelUnresolved}{--}
 \providecommand{\OUValidationTravelAbsError}{--}
+\providecommand{\OUValidationNormalizedTLow}{--}
+\providecommand{\OUValidationNormalizedTHigh}{--}
+\providecommand{\OUValidationNormalizedTStatistic}{--}
+\providecommand{\OUValidationNormalizedTP}{--}
+\providecommand{\OUValidationNormalizedSignNegative}{--}
+\providecommand{\OUValidationNormalizedSignP}{--}
+\providecommand{\OUValidationNormalizedRandomizationP}{--}
+\providecommand{\OUValidationNormalizedRandomizationPatterns}{--}
 
 \maketitle
 
@@ -185,8 +193,9 @@ attitude to a linear kinematic chain for velocity, oscillatory displacement,
 and the integral of displacement. World-frame acceleration is assigned an
 Ornstein--Uhlenbeck prior with stationary variance and finite temporal
 correlation. Gyroscope and accelerometer biases are modeled explicitly. To
-suppress integration drift, an anisotropic zero pseudo-measurement is applied
-to the integral state. We derive the continuous model, analytic OU-chain
+suppress integration drift, a zero pseudo-measurement is applied
+to the integral state; its covariance may be made anisotropic, although every
+configuration evaluated here is isotropic. We derive the continuous model, analytic OU-chain
 discretization, numerically stable small-step covariance formulas, and explicit
 accelerometer and magnetometer Jacobians. A lightweight estimator obtains the
 horizontal wave-propagation axis and apparent travel sense from leveled
@@ -196,12 +205,18 @@ pseudo-measurement covariance. The cubic scaling with correlation time is a
 physically motivated engineering normalization for fixed update cadence and a
 bounded family of spectra. A ten-seed paired study scores the final
 \SI{900}{s} of four stationary JONSWAP seas, four PM--Stokes seas, and a
-controlled transition.  Over the stationary JONSWAP seas, the prespecified
+controlled transition.  Over the stationary JONSWAP seas, the declared
 primary endpoint, the seed-wise mean normalized vertical-displacement RMS
 error is $4.98\pm0.25\%$ of $H_s$ for OU--III and $6.68\pm0.29\%$ for OU--II
 (mean $\pm$ sample standard deviation over the ten seed triplets); the paired
 difference is $-1.697$ percentage point (percentile-bootstrap 95\% interval
-$[-1.781,-1.623]$).  The PM--Stokes ensemble, reported separately rather than
+$[-1.781,-1.623]$, Student-$t$ interval $[-1.794,-1.601]$, all ten seed-level
+differences negative, exact sign and paired sign-flip tests both at their
+$n=10$ floor of $p=0.002$).  These are four readings of the same ten paired
+differences and establish repeatability within the simulator, not
+generalization beyond it: they carry no uncertainty for the simulation model,
+sensor-model misspecification, spectral family, vessel geometry, or update
+cadence.  The PM--Stokes ensemble, reported separately rather than
 pooled, reproduces the vertical advantage.  Both filters estimate the operating
 point in the wave band rather than from a frequency tracked on acceleration,
 whose apparent frequency barely moves as the sea grows; tuning only the

--- a/doc/kalman_ou_iii/w3d-baseline-comparison.tex-part
+++ b/doc/kalman_ou_iii/w3d-baseline-comparison.tex-part
@@ -123,6 +123,26 @@ continuity with the earlier deterministic protocol; the inferential statement
 about the two OU filters is the ten-seed \SI{900}{s} study below, and the two
 should not be quoted interchangeably.
 
+\paragraph{What the benchmark set does not contain}
+It is worth being direct about the shape of that gap, because it bounds how
+the paper's strongest number should be read. The only comparison carried out
+under the inferential protocol -- ten paired seeds, \SI{900}{s} windows,
+matched tuning band -- is against OU--II, an architecture developed by the same
+author. That is a legitimate and, done this way, a fairly demanding ablation:
+it isolates the additional integral-displacement state and its regularization
+while holding the tuning band, the seeds, and the covariance policy fixed. It
+is not an independent state-of-the-art benchmark, and no amount of pairing
+makes it one. The external observer here is evaluated outside that protocol
+and stripped of the GNSS and heading aiding it was designed around, and the
+comparison set contains no conventional frequency-domain double-integration
+heave estimator of the kind used in operational buoy processing, which would
+be the natural non-model-based reference. Establishing where this filter sits
+against published practice, rather than against its own predecessor, requires
+at least one current published heave estimator and one spectral-domain
+baseline re-implemented under the same ten-seed protocol. That work is not in
+this paper, and the vertical result should be read as an architectural
+comparison until it is.
+
 \IfFileExists{w3d_multi_observer_jonswap_medium.pgf}{%
   \begin{figure}[!t]
     \centering
@@ -248,7 +268,7 @@ for OU--II, a paired difference of $\OUValidationPMStokesDifference$ percentage
 point
 ($[\OUValidationPMStokesDifferenceLow,\OUValidationPMStokesDifferenceHigh]$,
 $n=\OUValidationPMStokesPairs$).  Because PM--Stokes adds third-order bound
-harmonics, it is a separate prespecified ensemble and is not pooled into the
+harmonics, it is a separate declared ensemble and is not pooled into the
 primary aggregate; it extends the vertical result to a second spectral family
 rather than enlarging the confirmatory sample.
 

--- a/doc/kalman_ou_iii/w3d-conclusion-summary.tex-part
+++ b/doc/kalman_ou_iii/w3d-conclusion-summary.tex-part
@@ -10,7 +10,14 @@ $H_s$, versus
 $\OUValidationOUIINormalizedMean\pm\OUValidationOUIINormalizedStd\%$ for
 OU--II.  Their paired difference is $\OUValidationNormalizedDifference$
 percentage point (bootstrap 95\% interval
-$[\OUValidationNormalizedDifferenceLow,\OUValidationNormalizedDifferenceHigh]$).
+$[\OUValidationNormalizedDifferenceLow,\OUValidationNormalizedDifferenceHigh]$,
+Student-$t$ interval
+$[\OUValidationNormalizedTLow,\OUValidationNormalizedTHigh]$, with all
+$\OUValidationNormalizedSignNegative$ seed-level differences in the same
+direction).  Those are four constructions on ten paired numbers, and they
+establish that the difference is stable across realizations of this simulator
+rather than that it would survive a change of simulator, sensor model, or
+sea (Sec.~\ref{par:companion-inference}).
 Both filters take that operating point from the same wave-band zero-crossing
 period, so the comparison isolates the additional integral-displacement state
 rather than the spectral band the two were tuned from; in earlier revisions
@@ -76,8 +83,22 @@ conditions, while the MCU exercise establishes only functional source
 portability. They do not by themselves imply
 universal performance across spectra, update cadences, vessel speeds, or sensor
 installations, nor do they establish an embedded timing or memory margin.
+Two gaps bound the work most sharply, and neither is closed here. The only
+comparison run under the inferential protocol is against the author's own
+predecessor architecture, so the paper establishes an architectural increment
+and not a position against published practice; closing that needs a current
+published heave estimator and a conventional frequency-domain
+double-integration baseline re-implemented under the same ten-seed protocol.
+And no result is validated against an external physical displacement
+reference, so this remains a simulation and implementation study rather than a
+characterized measurement instrument; closing that needs a motion platform,
+wave tank, or instrumented deployment scored against optical, GNSS, or
+commercial-MRU truth.
 Future work should extend the paired ensembles to parameter interactions,
-additional spectra, and update cadences; reduce the estimation jitter that
+additional spectra, and update cadences; independently vary wave height,
+period, directional spreading, heading, sensor grade, and update rate rather
+than moving them in the four linked pairs used here, and hold out sea states
+not used to fit the coefficients; reduce the estimation jitter that
 costs accuracy where a well-matched frozen point exists; replace the
 crossfade with a continuously evolving spectrum so that adaptation rate can be
 isolated from the composition of the scoring window; and add quantitative

--- a/doc/kalman_ou_iii/w3d-intro.tex-part
+++ b/doc/kalman_ou_iii/w3d-intro.tex-part
@@ -15,13 +15,22 @@ and spectral analysis stages, a process prone to bias and delay.
 Our approach instead uses a unified 21-state Kalman filter that
 directly incorporates wave kinematics. The architectural contributions are the
 integration of a first-order Gauss--Markov acceleration prior into the
-quaternion MEKF and an adaptive tuning law that jointly adjusts the prior time
-scale, stationary acceleration scale, and integral-state regularization from
-observed sea-state statistics. Together with an online directional estimator, these elements
+quaternion MEKF, an explicit integral-of-displacement state, and a
+wave-band-driven adaptive law for the regularization scale $r_S$ that
+constrains it. The tuning law is written to adjust the prior time scale, the
+stationary acceleration scale, and $r_S$ together, but the demonstrated
+vertical benefit is attributable to the $r_S$ channel: a $2\times2$ channel
+ablation (Sec.~\ref{par:channel-ablation}) shows that letting $r_S$ adapt while
+$\tau$ and $\sigma_{aw}$ stay frozen reproduces essentially the whole adaptive
+result, whereas the converse recovers none of it. The supported claim is
+therefore about adaptive integral-state regularization, not about the necessity
+of joint three-parameter OU adaptation, and the paper is written around that
+narrower claim. Together with an online directional estimator, these elements
 address colored excitation and MEMS errors in an efficient, embedded-friendly
-framework. Appendix~\ref{app:iss-stability} supplies a sufficient-condition
-uniform local input-to-state stability analysis for the core estimator and its
-continuous adaptation, excluding startup and reset logic.
+framework. Appendix~\ref{app:iss-stability} supplies a conditional
+sufficient-condition uniform local input-to-state stability analysis for the
+core estimator and its continuous adaptation, excluding startup and reset
+logic; it is not an unconditional convergence result for the filter.
 
 \subsection*{From Standard Q-MEKF to Extended Kinematics}
 
@@ -104,8 +113,13 @@ through the spectrally motivated law
 r_S \propto \sigma_{aw}\tau^3,
 \]
 which couples displacement drift suppression to the estimated strength and
-time scale of stochastic excitation. This joint adaptation of the OU prior and
-integral-state constraint is a principal architectural contribution. The
+time scale of stochastic excitation. This law, driven by a period estimated in
+the wave band, is the principal architectural contribution, and the channel
+ablation of Sec.~\ref{par:channel-ablation} is what locates the measured
+benefit in it rather than in the OU parameters it is derived from. The two
+readings are consistent: $\tau$'s material role in this filter is setting
+$r_S\propto\tau^{3}$ rather than shaping the OU process covariance, which the
+accelerometer already observes closely. The
 normalization is approximate and assumes a fixed pseudo-update cadence and a
 bounded family of spectral shapes and effective low-frequency cutoffs.
 
@@ -134,11 +148,19 @@ The main contributions of this work are:
   \item Closed-form discrete-time transition and covariance matrices for
         the OU process and linear kinematic chain, with numerically stable
         small-step series expansions.
-  \item An adaptive tuning law that jointly updates $\tau$,
-        $\sigma_{aw}$, and the integral pseudo-measurement scale from dominant
-        frequency and time-domain variance estimates.
-  \item A sufficient-condition proof of uniform local ISS for the adaptive core,
-        with bounded parameter increments treated explicitly as an input.
+  \item An adaptive law for the integral pseudo-measurement scale,
+        $r_S\propto\sigma_{aw}\tau^{3}$, driven by a period estimated in the
+        wave band, together with the $2\times2$ ablation that isolates it as
+        the channel carrying the measured vertical benefit. The same law
+        updates $\tau$ and $\sigma_{aw}$ online, but the evidence here supports
+        adaptive integral-state regularization rather than joint
+        three-parameter OU adaptation, which costs a little accuracy where a
+        well-matched frozen operating point already exists.
+  \item A conditional sufficient-condition proof of uniform \emph{local} ISS for
+        the adaptive core, with bounded parameter increments treated explicitly
+        as an input. It certifies a declared finite envelope under frozen-point
+        Schur stability, uniform Lyapunov bounds, and slow metric variation;
+        it is not an unconditional EKF convergence claim.
   \item A formulation independent of hydrodynamic equations, relying instead on
         oscillatory kinematics with slowly varying spectra and high-rate inertial measurements.
   \item A reproducible paired comparison against a published nonlinear observer
@@ -147,6 +169,20 @@ The main contributions of this work are:
         translational state structure by tuning both filters from the same
         wave-band period.
   \item A versioned ten-seed paired validation on stationary and transitioning
-        directional sea spectra, including confidence intervals, negative
-        results, and the limits of the observed OU--III advantage.
+        directional sea spectra, including intervals from four separate
+        constructions on the declared primary endpoint, negative results, and
+        the limits of the observed OU--III advantage.
 \end{itemize}
+
+The scope of the claim deserves stating once, plainly, at the outset. The
+displacement state $\vct{p}$ is oscillatory wave-induced motion, not a global
+navigation position; absolute positioning is an optional extension kept in
+Appendix~\ref{sec:gps_fusion}. The measured advantage over the matched OU--II
+architecture is a \emph{vertical} one: OU--III has higher total 3D displacement
+error in \OUValidationThreeDHigherCount{} of the
+\OUValidationThreeDScenarios{} principal scenarios, because the vertical gain
+is largely paid for in the horizontal channels
+(Sec.~\ref{sec:observer-comparison}). And every quantitative result below comes
+from simulation. The embedded exercise establishes source portability, not a
+timing or memory margin, and no result here is validated against an external
+physical displacement reference.

--- a/doc/kalman_ou_iii/w3d-ou-robustness.tex-part
+++ b/doc/kalman_ou_iii/w3d-ou-robustness.tex-part
@@ -1,7 +1,7 @@
 \subsubsection{Sensitivity and degradation-case study}
 \label{sec:ou-robustness}
 
-The confirmatory comparison above is complemented by a prespecified
+The confirmatory comparison above is complemented by a declared
 OU--III robustness study using the same ten paired wave-realization, IMU-noise, and
 initialization seed triplets.  At the nominal $H_s=\SI{1.5}{m}$ sea, the
 frozen operating point is perturbed by the multipliers $0.5$, $0.75$, $1.0$,

--- a/doc/kalman_ou_iii/w3d-ou-validation-macros-generated.tex-part
+++ b/doc/kalman_ou_iii/w3d-ou-validation-macros-generated.tex-part
@@ -77,6 +77,14 @@
 \providecommand{\OUValidationNormalizedDifferenceHigh}{-1.623}
 \providecommand{\OUValidationNormalizedDz}{-12.58}
 \providecommand{\OUValidationNormalizedGz}{-11.50}
+\providecommand{\OUValidationNormalizedTLow}{-1.794}
+\providecommand{\OUValidationNormalizedTHigh}{-1.601}
+\providecommand{\OUValidationNormalizedTStatistic}{-39.78}
+\providecommand{\OUValidationNormalizedTP}{<\!10^{-4}}
+\providecommand{\OUValidationNormalizedSignNegative}{10}
+\providecommand{\OUValidationNormalizedSignP}{0.002}
+\providecommand{\OUValidationNormalizedRandomizationP}{0.002}
+\providecommand{\OUValidationNormalizedRandomizationPatterns}{1{,}024}
 \providecommand{\OUValidationLegacyGatePasses}{148}
 \providecommand{\OUValidationLegacyGateFailures}{692}
 \providecommand{\OUValidationBootstrapResamples}{10{,}000}

--- a/doc/kalman_ou_iii/w3d-ou-validation-results-generated.tex-part
+++ b/doc/kalman_ou_iii/w3d-ou-validation-results-generated.tex-part
@@ -130,7 +130,7 @@
 
 \begin{table*}[t]
   \centering
-  \caption{Ten-seed paired OU-family comparison on the PM--Stokes seas, scored over the same final \SI{900}{s} window and the same seed triplets as the JONSWAP ensemble. PM--Stokes carries third-order bound harmonics that JONSWAP does not, so it is reported as a separate prespecified ensemble and is not pooled into the primary aggregate.}
+  \caption{Ten-seed paired OU-family comparison on the PM--Stokes seas, scored over the same final \SI{900}{s} window and the same seed triplets as the JONSWAP ensemble. PM--Stokes carries third-order bound harmonics that JONSWAP does not, so it is reported as a separate declared ensemble and is not pooled into the primary aggregate.}
   \label{tab:ou_mc_pmstokes}
   \footnotesize
   \setlength{\tabcolsep}{4.0pt}

--- a/doc/kalman_ou_iii/w3d-sim-charts.tex-part
+++ b/doc/kalman_ou_iii/w3d-sim-charts.tex-part
@@ -196,9 +196,13 @@ redistributing finite-record boundary leakage between incompatible derivative
 channels.
 
 \paragraph{Inference, and what it does and does not license}
-The prespecified primary endpoint is the seed-level mean normalized
+The declared primary endpoint is the seed-level mean normalized
 vertical-displacement RMS error over the four stationary JONSWAP seas, compared
-between OU--III and OU--II at matched seeds.  Everything else reported here --
+between OU--III and OU--II at matched seeds.  It is recorded as
+\texttt{primary\_endpoint} in the versioned protocol block of the result
+bundle, which is what makes the declaration checkable rather than asserted;
+the word \emph{declared} is used in preference to \emph{preregistered}, since
+the study carries no external timestamp.  Everything else reported here --
 per-scenario contrasts, the adaptation and channel ablations, the covariance
 control, the PM--Stokes ensemble, the transition intervals, and the direction
 metrics -- is descriptive.
@@ -224,6 +228,43 @@ $d_z$ is both large and imprecisely estimated; the raw paired difference in
 percentage points and its bootstrap interval are the primary statement of
 effect magnitude throughout.
 
+\paragraph{Four constructions on the primary endpoint}
+\label{par:companion-inference}%
+A percentile bootstrap at $n=10$ resamples ten numbers, and its interval is
+narrow because the pairing is strong rather than because the ensemble is large.
+The confirmatory endpoint is therefore reported under four constructions on the
+same ten paired differences: the percentile bootstrap of the paired mean, a
+Student-$t$ interval on those differences, an exact sign test, and an exact
+paired randomization (sign-flip) test enumerated over all
+$\OUValidationNormalizedRandomizationPatterns$ sign patterns.  The Student-$t$
+interval is $[\OUValidationNormalizedTLow,\OUValidationNormalizedTHigh]$
+percentage points ($t=\OUValidationNormalizedTStatistic$,
+$p=\OUValidationNormalizedTP$), slightly wider than the bootstrap interval, as
+a small-sample $t$ interval should be.
+$\OUValidationNormalizedSignNegative$ of the
+$\OUValidationStationaryPairs$ seed-level differences favour OU--III, giving
+$p=\OUValidationNormalizedSignP$ by the sign test and
+$p=\OUValidationNormalizedRandomizationP$ by the randomization test.  Both
+exact p-values sit at the floor $2^{-(n-1)}$ that $n=10$ imposes: with ten
+pairs no exact paired test can report anything smaller, whichever direction the
+data take, and that floor is a property of the design rather than a measure of
+the evidence.  These are four readings of one ensemble, not four
+experiments, and they agree only about repeatability inside this simulator.
+
+What none of them contains is uncertainty from the simulation model itself,
+sensor-model misspecification, the choice of spectral family, the coefficient
+values, vessel geometry, update cadence, real hardware vibration, or
+environmental disturbance.  Those enter the result as fixed choices, not as
+sampled variation, so an interval this narrow should be read as \emph{the
+algorithmic difference is stable across realizations of this simulator}, and
+not as a bound on the difference a field deployment would see.  Thirty to fifty
+seed triplets would estimate the seed-level variance itself more stably; ten
+establishes the sign and the approximate magnitude, which is what the primary
+claim rests on.  The statistics are recomputed from the archived rows by
+\texttt{tools/ou\_validation.py -{}-restat-from}, so a reader can reproduce every
+interval in this section, or substitute a different construction, without
+re-running a single simulator replay.
+
 \paragraph{Adaptation-channel ablation}
 \label{par:channel-ablation}%
 Comparing Adaptive with FixedNominal moves three parameters at once, and the
@@ -246,7 +287,7 @@ is defined for OU--III only.
 The four PM--Stokes seas of Table~\ref{tab:scenarios} are scored over the same
 window, seed triplets, and primary modes as the JONSWAP ensemble.  PM--Stokes
 carries third-order bound harmonics that JONSWAP does not, so it is reported as
-a separate prespecified ensemble and is \emph{not} pooled into the primary
+a separate declared ensemble and is \emph{not} pooled into the primary
 aggregate; pooling would silently redefine the confirmatory comparison.
 Direction is scored against the generator azimuth carried by each record.
 Because the propagation axis is defined modulo \SI{180}{\degree}, the reported

--- a/docs/ou-validation.md
+++ b/docs/ou-validation.md
@@ -1,6 +1,6 @@
 # Paired OU-II/OU-III validation
 
-`tools/ou_validation.py` implements the statistically powered validation path for
+`tools/ou_validation.py` implements the paired inferential validation path for
 the two OU filter families. It does not replace the executable regression gates:
 the simulators still calculate and enforce their historical trailing 60-second
 thresholds. The full experiment separately scores the trailing 900 seconds of each
@@ -116,7 +116,7 @@ make fetch-sim-data
 python3 tools/ou_validation.py --mode smoke
 ```
 
-Run the preregistered full defaults:
+Run the declared full defaults:
 
 ```bash
 python3 tools/ou_validation.py --mode full
@@ -145,6 +145,32 @@ lifetime. It uploads the result as an artifact rather than committing it: a
 regenerated bundle has to be read against the manuscript before it replaces the
 committed one.
 
+### Restating a bundle without re-simulating
+
+The replays are the expensive half of this study and are fully determined by
+their seed triplets, so a change to how the rows are *summarized* does not
+require re-running them:
+
+```bash
+python3 tools/ou_validation.py \
+  --restat-from reports/results/ou_validation/ou_validation.json \
+  --output-dir reports/results/ou_validation
+```
+
+This reads `raw_runs` back out of the bundle and rewrites every derived file --
+summaries, paired effects, LaTeX tables, generated macros, bundle, and manifest
+-- with the statistics of the current source. Restating the committed bundle
+unchanged reproduces its derived files byte for byte, which
+`tests/validation/test_ou_validation.py` asserts; that is what makes it safe to
+use for adding or changing an interval construction. It cannot invent rows:
+whatever ensemble the source bundle scored is the ensemble the restated bundle
+reports, so widening the seed set still requires a `--mode full` run.
+
+Protocol fields that describe what was *run* (seeds, durations, transition
+bounds) are carried over untouched. Fields that describe how the rows are
+summarized are taken from the current source, so a restated bundle cannot
+disagree with the manuscript generated beside it.
+
 ## Outputs and interpretation
 
 The output directory contains:
@@ -155,6 +181,14 @@ The output directory contains:
   interval, and bootstrap 95% interval;
 - `ou_validation_paired_effects.csv`: paired mean differences, bootstrap intervals,
   Cohen's $d_z$, and small-sample-corrected Hedges' $g_z$;
+- the `stationary_normalized_aggregate` block of the bundle and manifest, which
+  carries the declared primary endpoint under four constructions on the same
+  paired differences: the percentile bootstrap, a Student-t interval, an exact
+  sign test, and an exact paired randomization (sign-flip) test enumerated over
+  all $2^n$ sign patterns. Descriptive contrasts keep the bootstrap alone; four
+  p-values on every one of them would enlarge the family of tests without
+  adding evidence. At $n=10$ both exact tests bottom out at $2^{-9}=0.002$
+  regardless of the data, so that floor is a property of the design;
 - `ou_validation.json`: protocol, calibration points, raw observations, and all
   statistics;
 - `ou_validation_manifest.json`: command, versions, Git state, source-file hashes,
@@ -174,9 +208,12 @@ zero is inconclusive at that interval level. Effect sizes should be interpreted
 with their paired sample count and interval, not in isolation.
 
 Across the four stationary JONSWAP seas, the within-seed mean normalized
-vertical RMS is 5.08% of $H_s$ for OU-III and 6.66% for OU-II. The paired
-difference is -1.581 percentage points with a bootstrap 95% interval of
-[-1.695, -1.451]. OU-III is lower vertically in every stationary sea and during
+vertical RMS is 4.98% of $H_s$ for OU-III and 6.68% for OU-II. The paired
+difference is -1.697 percentage points with a bootstrap 95% interval of
+[-1.781, -1.623], a Student-t interval of [-1.794, -1.601], and all ten
+seed-level differences negative (exact sign and paired sign-flip tests both at
+$p=0.002$, the smallest two-sided p-value ten pairs can produce). OU-III is
+lower vertically in every stationary sea and during
 the transition, and has higher 3D displacement RMS in four of the five
 scenarios. In the fifth, the $H_s=8.5$ m sea, it is lower with an interval
 excluding zero; that is a scenario-specific exception, not a general

--- a/reports/results/ou_validation/ou_validation.json
+++ b/reports/results/ou_validation/ou_validation.json
@@ -35268,8 +35268,10 @@
       "FixedNominal",
       "FixedOracle"
     ],
-    "pmstokes_pooling": "PM-Stokes is a separate prespecified ensemble and is not pooled into the primary JONSWAP aggregate",
+    "pmstokes_pooling": "PM-Stokes is a separate declared ensemble and is not pooled into the primary JONSWAP aggregate",
     "primary_endpoint": "seed-level mean normalized vertical displacement RMS error over the four stationary JONSWAP seas, OU-III Adaptive minus OU-II Adaptive",
+    "primary_endpoint_inference": "the confirmatory endpoint carries four companion statements on the same paired seed-level differences: the percentile bootstrap interval, a Student-t interval, an exact sign test, and an exact paired randomization (sign-flip) test enumerated over all 2^n sign patterns.  They are companions, not independent confirmations: all four read the same n paired differences, and none of them widens the ensemble.",
+    "restated_from": "reports/results/ou_validation/ou_validation.json",
     "score_window_sec": 900.0,
     "seed_triplets": [
       {
@@ -83376,7 +83378,20 @@
       "hedges_gz": -11.495508292945399,
       "mean_paired_difference": -1.69746297025,
       "n_pairs": 10,
-      "std_paired_difference": 0.13494564561456326
+      "randomization_exact": true,
+      "randomization_p_value": 0.001953125,
+      "randomization_patterns": 1024,
+      "sign_negative": 10,
+      "sign_p_value": 0.001953125,
+      "sign_positive": 0,
+      "sign_zero": 0,
+      "standard_error": 0.04267356004639324,
+      "std_paired_difference": 0.13494564561456326,
+      "t_ci95_high": -1.6009286707289523,
+      "t_ci95_low": -1.7939972697710476,
+      "t_critical_value": 2.2621571627982036,
+      "t_p_value": 1.9953566001015164e-11,
+      "t_statistic": -39.777861711199535
     }
   },
   "summary": [

--- a/reports/results/ou_validation/ou_validation_macros.tex
+++ b/reports/results/ou_validation/ou_validation_macros.tex
@@ -77,6 +77,14 @@
 \providecommand{\OUValidationNormalizedDifferenceHigh}{-1.623}
 \providecommand{\OUValidationNormalizedDz}{-12.58}
 \providecommand{\OUValidationNormalizedGz}{-11.50}
+\providecommand{\OUValidationNormalizedTLow}{-1.794}
+\providecommand{\OUValidationNormalizedTHigh}{-1.601}
+\providecommand{\OUValidationNormalizedTStatistic}{-39.78}
+\providecommand{\OUValidationNormalizedTP}{<\!10^{-4}}
+\providecommand{\OUValidationNormalizedSignNegative}{10}
+\providecommand{\OUValidationNormalizedSignP}{0.002}
+\providecommand{\OUValidationNormalizedRandomizationP}{0.002}
+\providecommand{\OUValidationNormalizedRandomizationPatterns}{1{,}024}
 \providecommand{\OUValidationLegacyGatePasses}{148}
 \providecommand{\OUValidationLegacyGateFailures}{692}
 \providecommand{\OUValidationBootstrapResamples}{10{,}000}

--- a/reports/results/ou_validation/ou_validation_manifest.json
+++ b/reports/results/ou_validation/ou_validation_manifest.json
@@ -1,14 +1,9 @@
 {
   "command": [
-    "/usr/bin/python3",
+    "/tmp/claude-0/-home-user-ocean-imu/bdfdb9f1-a6cc-5b65-9e2e-f8d5d296bfb3/scratchpad/venv/bin/python",
     "tools/ou_validation.py",
-    "--mode",
-    "full",
-    "--bootstrap-resamples",
-    "10000",
-    "--combine-shards",
-    "--shard-dir",
-    "shards",
+    "--restat-from",
+    "reports/results/ou_validation/ou_validation.json",
     "--output-dir",
     "reports/results/ou_validation"
   ],
@@ -144,11 +139,11 @@
       }
     }
   },
-  "git_branch": "claude/github-actions-attitude-errors-yddwr7",
-  "git_commit": "8dc66110f8ea5bfece1a093789c09446816aea0f",
-  "git_diff_stat": "reports/results/ou_validation/ou_validation.json   | 1524 ++++++++---------\n .../ou_validation/ou_validation_attitude.svg       |  603 ++++---\n .../ou_validation/ou_validation_covsync.svg        |  679 ++++----\n .../ou_validation/ou_validation_displacement.svg   |  605 ++++---\n .../ou_validation/ou_validation_paired_effects.csv |  112 +-\n .../results/ou_validation/ou_validation_raw.csv    |   10 +-\n .../ou_validation/ou_validation_summary.csv        |  112 +-\n .../ou_validation/ou_validation_transition.csv     | 1772 ++++++++++----------\n .../ou_validation/ou_validation_transition.svg     |  239 ++-\n .../ou_validation/ou_validation_vertical.svg       |  605 ++++---\n 10 files changed, 3128 insertions(+), 3133 deletions(-)",
-  "numpy": "1.26.4",
-  "platform": "Linux-6.17.0-1020-azure-x86_64-with-glibc2.39",
+  "git_branch": "claude/paper-review-improvements-ka43fy",
+  "git_commit": "6f4f1495f08d7588dfe0b52a8066b33d6a3b824f",
+  "git_diff_stat": "doc/kalman_ou_iii/kalman_ou-w3d.tex                |  25 +-\n doc/kalman_ou_iii/w3d-baseline-comparison.tex-part |  22 +-\n doc/kalman_ou_iii/w3d-conclusion-summary.tex-part  |  25 +-\n doc/kalman_ou_iii/w3d-intro.tex-part               |  65 ++-\n doc/kalman_ou_iii/w3d-ou-robustness.tex-part       |   2 +-\n .../w3d-ou-validation-macros-generated.tex-part    |   8 +\n .../w3d-ou-validation-results-generated.tex-part   |   2 +-\n doc/kalman_ou_iii/w3d-sim-charts.tex-part          |  47 ++-\n docs/ou-validation.md                              |  47 ++-\n reports/results/ou_validation/ou_validation.json   |  19 +-\n .../results/ou_validation/ou_validation_macros.tex |   8 +\n .../ou_validation/ou_validation_publication.tex    |   2 +-\n tests/validation/test_ou_validation.py             | 258 ++++++++++++\n tools/ou_validation.py                             | 447 ++++++++++++++++++++-\n 14 files changed, 936 insertions(+), 41 deletions(-)",
+  "numpy": "2.4.6",
+  "platform": "Linux-6.18.5-fc-v18-x86_64-with-glibc2.39",
   "protocol": {
     "adaptation_modes": [
       "Adaptive",
@@ -184,8 +179,10 @@
       "FixedNominal",
       "FixedOracle"
     ],
-    "pmstokes_pooling": "PM-Stokes is a separate prespecified ensemble and is not pooled into the primary JONSWAP aggregate",
+    "pmstokes_pooling": "PM-Stokes is a separate declared ensemble and is not pooled into the primary JONSWAP aggregate",
     "primary_endpoint": "seed-level mean normalized vertical displacement RMS error over the four stationary JONSWAP seas, OU-III Adaptive minus OU-II Adaptive",
+    "primary_endpoint_inference": "the confirmatory endpoint carries four companion statements on the same paired seed-level differences: the percentile bootstrap interval, a Student-t interval, an exact sign test, and an exact paired randomization (sign-flip) test enumerated over all 2^n sign patterns.  They are companions, not independent confirmations: all four read the same n paired differences, and none of them widens the ensemble.",
+    "restated_from": "reports/results/ou_validation/ou_validation.json",
     "score_window_sec": 900.0,
     "seed_triplets": [
       {
@@ -268,11 +265,12 @@
     },
     "wave_phase_method": "common random phase on the 0.02-1.60 Hz world-velocity and Euler spectra; displacement and acceleration analytically derived from velocity; body IMU and quaternion reconstructed"
   },
-  "python": "3.12.3 (main, Jun 19 2026, 12:46:00) [GCC 13.3.0]",
+  "python": "3.11.15 (main, Mar  3 2026, 09:26:23) [GCC 13.3.0]",
+  "restated_from": "reports/results/ou_validation/ou_validation.json",
   "result_files": {
     "ou_validation.json": {
-      "bytes": 4662858,
-      "sha256": "8fb2cadaeca952fbdb8d310e6d994378027790e8f62de4ac3742ca41ec78bc38"
+      "bytes": 4663856,
+      "sha256": "786998b4e8d2d619bbe3c7f8ba7cff4466a813c06982eb2fd2439568932c3f80"
     },
     "ou_validation_attitude.svg": {
       "bytes": 81519,
@@ -287,16 +285,16 @@
       "sha256": "9a76d42fda076eff5ad9a7fb5e1937bb81464e861a5fbed26cda09ef9194b577"
     },
     "ou_validation_macros.tex": {
-      "bytes": 10250,
-      "sha256": "931d51c35d6d466ac11afe709a38acb15cd3ec07be8da95bdddd19cd7083815d"
+      "bytes": 10714,
+      "sha256": "76eb8db8fbc744e5f8d121f3ba8e18566bbd8af69cba35292a0195aa03b69372"
     },
     "ou_validation_paired_effects.csv": {
       "bytes": 621768,
       "sha256": "c9f9ee4d0e8bd2f71edac07750aa35663150732acea62d902aafaf924fa54956"
     },
     "ou_validation_publication.tex": {
-      "bytes": 12655,
-      "sha256": "24d1aeba551d0aad6732ed1ae801fa47057e39c71db2f25f7ec5368319af58fe"
+      "bytes": 12651,
+      "sha256": "834f86d58a800b1d162cfdb270669e6ba166cf8d755f3603fb95751c2f50faa1"
     },
     "ou_validation_raw.csv": {
       "bytes": 559547,
@@ -383,7 +381,20 @@
       "hedges_gz": -11.495508292945399,
       "mean_paired_difference": -1.69746297025,
       "n_pairs": 10,
-      "std_paired_difference": 0.13494564561456326
+      "randomization_exact": true,
+      "randomization_p_value": 0.001953125,
+      "randomization_patterns": 1024,
+      "sign_negative": 10,
+      "sign_p_value": 0.001953125,
+      "sign_positive": 0,
+      "sign_zero": 0,
+      "standard_error": 0.04267356004639324,
+      "std_paired_difference": 0.13494564561456326,
+      "t_ci95_high": -1.6009286707289523,
+      "t_ci95_low": -1.7939972697710476,
+      "t_critical_value": 2.2621571627982036,
+      "t_p_value": 1.9953566001015164e-11,
+      "t_statistic": -39.777861711199535
     }
   },
   "transition_diagnostic": {

--- a/reports/results/ou_validation/ou_validation_publication.tex
+++ b/reports/results/ou_validation/ou_validation_publication.tex
@@ -130,7 +130,7 @@
 
 \begin{table*}[t]
   \centering
-  \caption{Ten-seed paired OU-family comparison on the PM--Stokes seas, scored over the same final \SI{900}{s} window and the same seed triplets as the JONSWAP ensemble. PM--Stokes carries third-order bound harmonics that JONSWAP does not, so it is reported as a separate prespecified ensemble and is not pooled into the primary aggregate.}
+  \caption{Ten-seed paired OU-family comparison on the PM--Stokes seas, scored over the same final \SI{900}{s} window and the same seed triplets as the JONSWAP ensemble. PM--Stokes carries third-order bound harmonics that JONSWAP does not, so it is reported as a separate declared ensemble and is not pooled into the primary aggregate.}
   \label{tab:ou_mc_pmstokes}
   \footnotesize
   \setlength{\tabcolsep}{4.0pt}

--- a/tests/validation/test_ou_validation.py
+++ b/tests/validation/test_ou_validation.py
@@ -1,5 +1,7 @@
+import contextlib
 import csv
 import hashlib
+import io
 import json
 import math
 import os
@@ -726,11 +728,227 @@ class CommittedFullResultsTests(unittest.TestCase):
         # confidence interval, and the interval must name its construction.
         self.assertIn("sample standard deviation", abstract)
         self.assertIn("percentile-bootstrap", abstract)
+
+        # The bootstrap interval is one construction on ten paired numbers.
+        # The abstract has to carry its companions and the honest reading of
+        # what ten seeds buy, or the narrow interval reads as generality.
+        self.assertIn(
+            "$["
+            f"{difference['t_ci95_low']:.3f},"
+            f"{difference['t_ci95_high']:.3f}"
+            "]$",
+            abstract,
+        )
+        flat = " ".join(abstract.split())
+        self.assertIn("Student-$t$ interval", flat)
+        self.assertIn("sign-flip", flat)
+        self.assertIn(
+            "establish repeatability within the simulator, not "
+            "generalization beyond it",
+            flat,
+        )
+
+        # The evaluated R_S is isotropic, so the abstract may not describe the
+        # applied pseudo-measurement as anisotropic without that qualifier.
+        self.assertNotIn("an anisotropic zero pseudo-measurement", flat)
+        self.assertIn("may be made anisotropic", flat)
+
+        # "Prespecified" claims a timestamp this study does not carry.
+        self.assertNotIn("prespecified", flat)
+        self.assertIn("declared primary endpoint", flat)
         # The negative three-dimensional result and the channel ablation both
         # bound the contribution, so neither may be left to the body text.
         self.assertIn("full-3D displacement error", abstract)
         self.assertIn("channel ablation", abstract)
         self.assertIn("tolerance", abstract)
+
+
+class PairedInferenceTests(unittest.TestCase):
+    """The companion inference on the confirmatory endpoint.
+
+    The Student-t machinery is written out in the tool rather than imported,
+    because the validation workflow installs NumPy and nothing else, so it is
+    checked against published table values here.
+    """
+
+    def test_student_t_quantiles_match_published_tables(self):
+        for degrees_of_freedom, expected in (
+            (1, 12.7062), (5, 2.570582), (9, 2.262157),
+            (29, 2.045230), (100, 1.983972),
+        ):
+            self.assertAlmostEqual(
+                validation.student_t_quantile(0.975, degrees_of_freedom),
+                expected,
+                places=5,
+                msg=f"df={degrees_of_freedom}",
+            )
+        # Symmetry, and the degenerate arguments the caller can produce.
+        self.assertAlmostEqual(
+            validation.student_t_quantile(0.025, 9),
+            -validation.student_t_quantile(0.975, 9),
+        )
+        self.assertEqual(validation.student_t_quantile(0.5, 9), 0.0)
+        self.assertTrue(math.isnan(validation.student_t_quantile(0.975, 0)))
+
+    def test_student_t_tail_probabilities_match_published_tables(self):
+        self.assertAlmostEqual(
+            validation.student_t_two_sided_p(2.262157, 9), 0.05, places=6
+        )
+        self.assertAlmostEqual(
+            validation.student_t_two_sided_p(3.0, 10), 0.013343655, places=8
+        )
+        self.assertEqual(validation.student_t_two_sided_p(0.0, 9), 1.0)
+        # Monotone decreasing in |t|, which is what makes the bisection above
+        # a valid inverse.
+        tails = [
+            validation.student_t_two_sided_p(t, 9)
+            for t in (0.5, 1.0, 2.0, 4.0, 8.0)
+        ]
+        self.assertEqual(tails, sorted(tails, reverse=True))
+
+    def test_exact_tests_are_exact_and_bottom_out_where_n_says_they_must(self):
+        rng = np.random.default_rng(7)
+        # Ten differences that all favour one arm: both exact tests must land
+        # on 2^-(n-1), the smallest two-sided p-value ten pairs can produce.
+        one_sided = np.array([-1.0, -1.1, -0.9, -1.4, -0.7,
+                              -1.2, -0.8, -1.3, -1.0, -0.95])
+        result = validation.paired_inference(one_sided, rng)
+        self.assertEqual(result["sign_negative"], 10)
+        self.assertEqual(result["sign_positive"], 0)
+        self.assertTrue(result["randomization_exact"])
+        self.assertEqual(result["randomization_patterns"], 1024)
+        floor = 2.0 ** -(one_sided.size - 1)
+        self.assertAlmostEqual(result["sign_p_value"], floor)
+        self.assertAlmostEqual(result["randomization_p_value"], floor)
+
+        # A balanced sample must not be called significant by either test.
+        balanced = np.array([1.0, -1.0, 0.9, -0.9, 1.1,
+                             -1.1, 0.8, -0.8, 1.2, -1.2])
+        neutral = validation.paired_inference(balanced, rng)
+        self.assertEqual(neutral["sign_negative"], 5)
+        self.assertGreater(neutral["sign_p_value"], 0.5)
+        self.assertGreater(neutral["randomization_p_value"], 0.5)
+
+        # The t interval must be centred on the paired mean and must contain
+        # the bootstrap interval's centre.
+        self.assertAlmostEqual(
+            0.5 * (result["t_ci95_low"] + result["t_ci95_high"]),
+            float(np.mean(one_sided)),
+        )
+
+        # Too few pairs to say anything: no interval, no test, no crash.
+        self.assertEqual(
+            validation.paired_inference(np.array([1.0]), rng), {"n_pairs": 1}
+        )
+
+    def test_the_committed_primary_endpoint_agrees_across_constructions(self):
+        with (
+            REPO_ROOT / "reports" / "results" / "ou_validation"
+            / "ou_validation_manifest.json"
+        ).open(encoding="utf-8") as stream:
+            difference = json.load(stream)[
+                "stationary_normalized_aggregate"
+            ]["OU_III_minus_OU_II"]
+
+        # Every construction has to point the same way, and the t interval --
+        # which makes a distributional assumption the bootstrap does not --
+        # has to be the wider of the two.  If these ever disagree, the
+        # confirmatory claim is resting on the choice of interval method.
+        self.assertLess(difference["mean_paired_difference"], 0.0)
+        self.assertLess(difference["bootstrap_ci95_high"], 0.0)
+        self.assertLess(difference["t_ci95_high"], 0.0)
+        self.assertLessEqual(
+            difference["t_ci95_low"], difference["bootstrap_ci95_low"]
+        )
+        self.assertGreaterEqual(
+            difference["t_ci95_high"], difference["bootstrap_ci95_high"]
+        )
+        self.assertLess(difference["sign_p_value"], 0.05)
+        self.assertLess(difference["randomization_p_value"], 0.05)
+        self.assertTrue(difference["randomization_exact"])
+        self.assertEqual(
+            difference["sign_negative"] + difference["sign_positive"]
+            + difference["sign_zero"],
+            difference["n_pairs"],
+        )
+
+
+class RestatTests(unittest.TestCase):
+    """`--restat-from` has to restate a bundle, not quietly rewrite it.
+
+    The simulator replays are the expensive half of this study, so the tables
+    and intervals are recomputed from the archived rows.  That is only sound
+    if a restat of the committed bundle reproduces the committed derived files
+    byte for byte, which is what this checks.
+    """
+
+    RESULTS = REPO_ROOT / "reports" / "results" / "ou_validation"
+
+    def test_restating_the_committed_bundle_reproduces_its_derived_files(self):
+        source = self.RESULTS / "ou_validation.json"
+        if not source.exists():  # pragma: no cover - smoke checkouts
+            self.skipTest("no committed validation bundle")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp)
+            with contextlib.redirect_stdout(io.StringIO()):
+                validation.restat_bundle(
+                    source,
+                    output,
+                    bootstrap_resamples=10_000,
+                    stats_seed=20260317,
+                )
+            for name in (
+                "ou_validation_raw.csv",
+                "ou_validation_summary.csv",
+                "ou_validation_paired_effects.csv",
+                "ou_validation_table.tex",
+                "ou_validation_publication.tex",
+                "ou_validation_macros.tex",
+                "ou_validation_tuning_points.tex",
+            ):
+                self.assertEqual(
+                    (output / name).read_bytes(),
+                    (self.RESULTS / name).read_bytes(),
+                    name,
+                )
+
+            restated = json.loads(
+                (output / "ou_validation.json").read_text(encoding="utf-8")
+            )
+            committed = json.loads(source.read_text(encoding="utf-8"))
+            # Same rows, and the restat must say what it restated.
+            self.assertEqual(restated["raw_runs"], committed["raw_runs"])
+            self.assertIn("restated_from", restated["protocol"])
+
+    def test_a_restat_keeps_covering_the_files_it_did_not_rewrite(self):
+        """A restat rewrites the tables; the figures stay as the run left them.
+
+        The manifest is the bundle's inventory, so dropping the files a restat
+        happens not to touch would quietly shrink what the hash check covers.
+        """
+        manifest = json.loads(
+            (self.RESULTS / "ou_validation_manifest.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        covered = set(manifest["result_files"])
+        for name in (
+            "ou_validation_vertical.svg",
+            "ou_validation_transition.svg",
+            "ou_validation_transition.csv",
+            "ou_validation_displacement.svg",
+        ):
+            self.assertIn(name, covered, name)
+        self.assertIn("source_files", manifest)
+
+    def test_a_restat_cannot_manufacture_an_ensemble(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            empty = Path(tmp) / "empty.json"
+            empty.write_text(json.dumps({"raw_runs": []}), encoding="utf-8")
+            with contextlib.redirect_stdout(io.StringIO()):
+                with self.assertRaises(ValueError):
+                    validation.restat_bundle(empty, Path(tmp), 100, 1)
 
 
 class ManuscriptMethodologyTests(unittest.TestCase):
@@ -844,6 +1062,38 @@ class ManuscriptMethodologyTests(unittest.TestCase):
         self.assertIn("not an interval estimate for the mean", protocol)
         self.assertIn("deliberately secondary", protocol)
         self.assertIn("primary statement of effect size", results)
+
+        # The confirmatory endpoint may not rest on one small-sample interval
+        # construction, and the narrowness of that interval may not be left to
+        # read as generality.  Both the companion constructions and the list of
+        # what the ensemble does not sample have to be present.
+        companion = self.paragraph(protocol, "Four constructions on the")
+        for macro in (
+            "OUValidationNormalizedTLow",
+            "OUValidationNormalizedTHigh",
+            "OUValidationNormalizedSignP",
+            "OUValidationNormalizedRandomizationP",
+            "OUValidationNormalizedRandomizationPatterns",
+        ):
+            self.assertIn(macro, companion)
+        self.assertIn("floor", companion)
+        self.assertIn("property of the design", companion)
+        self.assertIn("sensor-model misspecification", companion)
+        self.assertIn("update cadence", companion)
+        self.assertIn("restat-from", companion.replace("\\_", "_"))
+
+        # "Prespecified" is only defensible with an external timestamp, which
+        # this study does not have.
+        self.assertNotIn("prespecified", protocol + results + robustness)
+
+        # The only comparison run under the inferential protocol is against
+        # the author's own predecessor.  That has to be named as the limit it
+        # is, in the section that reports the number, rather than left for a
+        # reader to infer from the authorship of the baseline.
+        gap = self.paragraph(results, "What the benchmark set does not contain")
+        self.assertIn("not an independent state-of-the-art benchmark", gap)
+        self.assertIn("frequency-domain double-integration", gap)
+        self.assertIn("same ten-seed protocol", gap)
 
         # Wave energy scales with Hs^2, so 1.5 m against 0.27 m or 8.5 m is a
         # factor of about 31, not two orders of magnitude.
@@ -970,6 +1220,39 @@ class ManuscriptMethodologyTests(unittest.TestCase):
         self.assertIn("We do not claim the OU", intro)
         self.assertIn("doi     = {10.1109/TAES.1970.310128}", bibliography)
         self.assertNotIn("novel", intro.lower())
+
+    def test_the_contribution_is_framed_at_the_width_of_the_evidence(self):
+        """The introduction has to claim what the ablation actually supports.
+
+        The channel ablation attributes the vertical benefit to the adaptive
+        integral regularization, not to joint three-parameter OU adaptation,
+        and OU--III is worse in total 3D displacement in four of five
+        scenarios.  An introduction that leads with "jointly adjusts tau,
+        sigma_aw and r_S" and a title promising an INS therefore both claim
+        more than the results section delivers.
+        """
+        intro = self.read_flat("w3d-intro.tex-part")
+        manuscript = self.read("kalman_ou-w3d.tex")
+        title = re.search(r"\\title\{(.+?)\}", manuscript).group(1)
+
+        self.assertIn("Adaptive Integral Regularization", title)
+        self.assertIn("Wave-State Estimation", title)
+        # p is oscillatory displacement, and absolute navigation is an
+        # optional appendix, so the title may not promise an INS.
+        self.assertNotIn("INS", title)
+
+        self.assertIn("not about the necessity of joint three-parameter", intro)
+        self.assertIn("par:channel-ablation", intro)
+        # The 3D negative result and the absence of physical validation belong
+        # in the introduction, not only in the results and the conclusion.
+        self.assertIn("higher total 3D displacement error", intro)
+        self.assertIn("not a global navigation position", intro)
+        self.assertIn("comes from simulation", intro)
+
+        # The ISS appendix is a conditional local result and has to be
+        # described that way where it is claimed as a contribution.
+        self.assertIn("conditional sufficient-condition", intro)
+        self.assertIn("not an unconditional EKF convergence claim", intro)
 
     def test_nomenclature_is_included_and_disambiguates_covariances(self):
         manuscript = self.read("kalman_ou-w3d.tex")

--- a/tools/ou_validation.py
+++ b/tools/ou_validation.py
@@ -44,6 +44,18 @@ TRANSITION_METHOD = (
     "stationary records, with exact first- and second-derivative cross terms; "
     "not a continuously evolving JONSWAP spectrum"
 )
+PMSTOKES_POOLING = (
+    "PM-Stokes is a separate declared ensemble and is not pooled into the "
+    "primary JONSWAP aggregate"
+)
+PRIMARY_ENDPOINT_INFERENCE = (
+    "the confirmatory endpoint carries four companion statements on the same "
+    "paired seed-level differences: the percentile bootstrap interval, a "
+    "Student-t interval, an exact sign test, and an exact paired "
+    "randomization (sign-flip) test enumerated over all 2^n sign patterns.  "
+    "They are companions, not independent confirmations: all four read the "
+    "same n paired differences, and none of them widens the ensemble."
+)
 
 # Adaptation modes.  The three primary modes all run the deployed covariance
 # policy and vary only whether the OU operating point adapts online.  The two
@@ -736,6 +748,229 @@ def _finite_values(rows: Sequence[Mapping[str, Any]], metric: str) -> np.ndarray
     return values[np.isfinite(values)]
 
 
+def _regularized_incomplete_beta(a: float, b: float, x: float) -> float:
+    """I_x(a,b) by the Lentz continued fraction, to double precision.
+
+    Written out rather than imported so that the inference the manuscript
+    quotes depends only on NumPy, which is what the validation workflow
+    installs.  Only the Student-t tail needs it.
+    """
+
+    if not 0.0 <= x <= 1.0:
+        raise ValueError("regularized incomplete beta requires 0 <= x <= 1")
+    if x in (0.0, 1.0):
+        return x
+    # The continued fraction converges rapidly only on one side of the
+    # symmetry point; reflect onto that side when necessary.
+    if x > (a + 1.0) / (a + b + 2.0):
+        return 1.0 - _regularized_incomplete_beta(b, a, 1.0 - x)
+
+    log_front = (
+        math.lgamma(a + b)
+        - math.lgamma(a)
+        - math.lgamma(b)
+        + a * math.log(x)
+        + b * math.log1p(-x)
+    )
+
+    tiny = 1e-300
+    c = 1.0
+    d = 1.0 - (a + b) * x / (a + 1.0)
+    if abs(d) < tiny:
+        d = tiny
+    d = 1.0 / d
+    fraction = d
+    for iteration in range(1, 300):
+        even = 2 * iteration
+        numerator = (
+            iteration * (b - iteration) * x / ((a + even - 1.0) * (a + even))
+        )
+        d = 1.0 + numerator * d
+        if abs(d) < tiny:
+            d = tiny
+        c = 1.0 + numerator / c
+        if abs(c) < tiny:
+            c = tiny
+        d = 1.0 / d
+        fraction *= d * c
+
+        numerator = (
+            -(a + iteration) * (a + b + iteration) * x
+            / ((a + even) * (a + even + 1.0))
+        )
+        d = 1.0 + numerator * d
+        if abs(d) < tiny:
+            d = tiny
+        c = 1.0 + numerator / c
+        if abs(c) < tiny:
+            c = tiny
+        d = 1.0 / d
+        delta = d * c
+        fraction *= delta
+        if abs(delta - 1.0) < 1e-15:
+            break
+    return math.exp(log_front) * fraction / a
+
+
+def student_t_two_sided_p(t_statistic: float, degrees_of_freedom: int) -> float:
+    """Two-sided Student-t tail probability."""
+
+    if degrees_of_freedom < 1 or not math.isfinite(t_statistic):
+        return math.nan
+    if t_statistic == 0.0:
+        return 1.0
+    x = degrees_of_freedom / (degrees_of_freedom + t_statistic * t_statistic)
+    return float(
+        min(1.0, _regularized_incomplete_beta(0.5 * degrees_of_freedom, 0.5, x))
+    )
+
+
+def student_t_quantile(probability: float, degrees_of_freedom: int) -> float:
+    """Inverse Student-t CDF by bisection on the two-sided tail."""
+
+    if degrees_of_freedom < 1 or not 0.0 < probability < 1.0:
+        return math.nan
+    if probability == 0.5:
+        return 0.0
+    upper_tail = 1.0 - probability if probability > 0.5 else probability
+    target = 2.0 * upper_tail
+    low, high = 0.0, 1.0
+    while student_t_two_sided_p(high, degrees_of_freedom) > target:
+        high *= 2.0
+        if high > 1e12:
+            break
+    for _ in range(200):
+        middle = 0.5 * (low + high)
+        if student_t_two_sided_p(middle, degrees_of_freedom) > target:
+            low = middle
+        else:
+            high = middle
+    quantile = 0.5 * (low + high)
+    return quantile if probability > 0.5 else -quantile
+
+
+# The exhaustive sign-flip enumeration materializes a 2^n x n sign matrix, so
+# its cost doubles with every added pair: n = 18 is about 37 MB and n = 22 is
+# about 740 MB.  Past the bound the test is taken by Monte Carlo instead.  The
+# study runs at n = 10, well under it, so its randomization p-value is exact.
+MAX_EXACT_SIGN_FLIP_PAIRS = 18
+SIGN_FLIP_RESAMPLES = 200_000
+
+
+def paired_inference(
+    differences: np.ndarray, rng: np.random.Generator
+) -> dict[str, Any]:
+    """Complementary inference for one paired contrast.
+
+    The percentile bootstrap of the paired mean is the study's interval, but
+    with ten pairs it is a small-sample interval whose coverage is not
+    guaranteed.  Three companions are reported alongside it:
+
+      * a Student-t interval on the paired differences, which is exact under
+        normality and is the conventional small-sample choice; and
+      * two assumption-light exact tests -- the sign test, which uses only the
+        direction of each difference, and the paired randomization
+        (sign-flip) test, which is exact under the sharp null of exchangeable
+        signs and is enumerated in full at this sample size.
+
+    Agreement across the four is the actual claim: no single one of them turns
+    ten seeds into a large sample.
+    """
+
+    finite = np.asarray(differences, dtype=np.float64)
+    finite = finite[np.isfinite(finite)]
+    n = int(finite.size)
+    result: dict[str, Any] = {"n_pairs": n}
+    if n < 2:
+        return result
+
+    mean = float(np.mean(finite))
+    std = float(np.std(finite, ddof=1))
+    standard_error = std / math.sqrt(n)
+    degrees_of_freedom = n - 1
+    critical = student_t_quantile(0.975, degrees_of_freedom)
+    t_statistic = mean / standard_error if standard_error > 0.0 else math.inf
+    result.update(
+        {
+            "t_ci95_low": mean - critical * standard_error,
+            "t_ci95_high": mean + critical * standard_error,
+            "t_statistic": t_statistic,
+            "t_p_value": student_t_two_sided_p(t_statistic, degrees_of_freedom),
+            "t_critical_value": critical,
+            "standard_error": standard_error,
+        }
+    )
+
+    # Exact sign test.  Ties are conservatively counted against the observed
+    # direction rather than discarded.
+    negative = int(np.sum(finite < 0.0))
+    positive = int(np.sum(finite > 0.0))
+    zero = n - negative - positive
+    extreme = min(negative, positive) + zero
+    sign_p = min(
+        1.0,
+        2.0
+        * sum(math.comb(n, k) for k in range(0, extreme + 1))
+        / float(2**n),
+    )
+    result.update(
+        {
+            "sign_negative": negative,
+            "sign_positive": positive,
+            "sign_zero": zero,
+            "sign_p_value": sign_p,
+        }
+    )
+
+    # Paired randomization test on the mean, under the sharp null that each
+    # difference is equally likely to have carried either sign.
+    observed = abs(mean)
+    if n <= MAX_EXACT_SIGN_FLIP_PAIRS:
+        signs = 1.0 - 2.0 * (
+            (np.arange(2**n, dtype=np.int64)[:, None] >> np.arange(n)) & 1
+        ).astype(np.float64)
+        means = np.abs(signs @ finite) / n
+        count = int(np.sum(means >= observed - 1e-15))
+        result.update(
+            {
+                "randomization_p_value": count / float(2**n),
+                "randomization_exact": True,
+                "randomization_patterns": int(2**n),
+            }
+        )
+    else:
+        draws = rng.integers(0, 2, size=(SIGN_FLIP_RESAMPLES, n)) * 2.0 - 1.0
+        means = np.abs(draws @ finite) / n
+        count = int(np.sum(means >= observed - 1e-15))
+        result.update(
+            {
+                # +1/+1 keeps the Monte Carlo p-value strictly positive, which
+                # is the standard correction for an estimated permutation tail.
+                "randomization_p_value": (count + 1) / float(SIGN_FLIP_RESAMPLES + 1),
+                "randomization_exact": False,
+                "randomization_patterns": int(SIGN_FLIP_RESAMPLES),
+            }
+        )
+    return result
+
+
+def _latex_p_value(value: float) -> str:
+    """Format a p-value as math-mode *content*, without delimiters.
+
+    The manuscript quotes these inside expressions such as `$p=\\macro$`, so a
+    macro carrying its own `$` would close that expression and typeset the
+    rest as text.  `<` is likewise emitted bare, which is correct in math mode
+    and wrong in text mode -- these macros are only ever used in math mode.
+    """
+
+    if not math.isfinite(value):
+        return r"\text{--}"
+    if value < 1e-4:
+        return r"<\!10^{-4}"
+    digits = f"{value:.5f}" if value < 1e-3 else f"{value:.4f}"
+    return digits.rstrip("0").rstrip(".")
+
+
 def _bootstrap_mean_ci(
     values: np.ndarray, resamples: int, rng: np.random.Generator
 ) -> tuple[float, float]:
@@ -1272,6 +1507,11 @@ def stationary_normalized_aggregate(
         "bootstrap_ci95_high": bootstrap_high,
         "cohen_dz": cohen_dz,
         "hedges_gz": correction * cohen_dz,
+        # Companions to the percentile bootstrap on the confirmatory endpoint
+        # only.  Every other contrast in the study is descriptive, and giving
+        # each of those four p-values as well would enlarge the family of
+        # tests without adding evidence.
+        **paired_inference(differences, rng),
     }
     return result
 
@@ -1442,6 +1682,18 @@ def write_publication_table(
         rf"\providecommand{{\OUValidationNormalizedDifferenceHigh}}{{{difference['bootstrap_ci95_high']:+.3f}}}",
         rf"\providecommand{{\OUValidationNormalizedDz}}{{{difference['cohen_dz']:+.2f}}}",
         rf"\providecommand{{\OUValidationNormalizedGz}}{{{difference['hedges_gz']:+.2f}}}",
+        # Companion inference on the confirmatory endpoint, so the primary
+        # claim does not rest on a single small-sample interval method.
+        rf"\providecommand{{\OUValidationNormalizedTLow}}{{{difference['t_ci95_low']:+.3f}}}",
+        rf"\providecommand{{\OUValidationNormalizedTHigh}}{{{difference['t_ci95_high']:+.3f}}}",
+        rf"\providecommand{{\OUValidationNormalizedTStatistic}}{{{difference['t_statistic']:+.2f}}}",
+        rf"\providecommand{{\OUValidationNormalizedTP}}{{{_latex_p_value(difference['t_p_value'])}}}",
+        rf"\providecommand{{\OUValidationNormalizedSignNegative}}{{{difference['sign_negative']}}}",
+        rf"\providecommand{{\OUValidationNormalizedSignP}}{{{_latex_p_value(difference['sign_p_value'])}}}",
+        rf"\providecommand{{\OUValidationNormalizedRandomizationP}}"
+        rf"{{{_latex_p_value(difference['randomization_p_value'])}}}",
+        rf"\providecommand{{\OUValidationNormalizedRandomizationPatterns}}"
+        rf"{{{difference['randomization_patterns']:,}}}".replace(",", r"{,}"),
         rf"\providecommand{{\OUValidationLegacyGatePasses}}{{{gate_passes}}}",
         rf"\providecommand{{\OUValidationLegacyGateFailures}}{{{len(rows) - gate_passes}}}",
         # Interval construction, so the manuscript states the method rather
@@ -1918,7 +2170,7 @@ def _pmstokes_table(
         r"",
         r"\begin{table*}[t]",
         r"  \centering",
-        r"  \caption{Ten-seed paired OU-family comparison on the PM--Stokes seas, scored over the same final \SI{900}{s} window and the same seed triplets as the JONSWAP ensemble. PM--Stokes carries third-order bound harmonics that JONSWAP does not, so it is reported as a separate prespecified ensemble and is not pooled into the primary aggregate.}",
+        r"  \caption{Ten-seed paired OU-family comparison on the PM--Stokes seas, scored over the same final \SI{900}{s} window and the same seed triplets as the JONSWAP ensemble. PM--Stokes carries third-order bound harmonics that JONSWAP does not, so it is reported as a separate declared ensemble and is not pooled into the primary aggregate.}",
         r"  \label{tab:ou_mc_pmstokes}",
         r"  \footnotesize",
         r"  \setlength{\tabcolsep}{4.0pt}",
@@ -2495,6 +2747,179 @@ def _copy_duration(path: Path, destination: Path, duration_sec: float) -> tuple[
     return columns, data
 
 
+NONSTATIONARY_ENDPOINT_NAME = "nonstationary_endpoint_H4_0_Tp11_4"
+
+
+def restat_bundle(
+    source: Path,
+    output_dir: Path,
+    bootstrap_resamples: int,
+    stats_seed: int,
+) -> int:
+    """Recompute every statistic and table from an archived bundle's rows.
+
+    The simulator replays are the expensive half of this study and are fully
+    determined by their seed triplets, so a change to how the rows are
+    *summarized* should not require re-running them.  This path reads
+    `raw_runs` back out of a committed bundle and rewrites the derived files
+    exactly as the run that produced it would have, with the statistics of the
+    current source.  It cannot invent rows: whatever ensemble the source
+    bundle scored is the ensemble the restated bundle reports.
+    """
+
+    with source.open(encoding="utf-8") as stream:
+        bundle = json.load(stream)
+    raw_rows = [dict(row) for row in bundle["raw_runs"]]
+    if not raw_rows:
+        raise ValueError(f"{source} carries no raw runs to restate")
+
+    # The bundle JSON is written with sorted keys, so the rows come back
+    # alphabetical.  Column order is not information, but a restated bundle
+    # that reshuffles 66 columns is impossible to diff against the run it
+    # restates, so the archived CSV header is used to put them back.
+    archived_csv = source.parent / "ou_validation_raw.csv"
+    if archived_csv.exists():
+        with archived_csv.open(encoding="utf-8", newline="") as stream:
+            header = next(csv.reader(stream), [])
+        if header:
+            raw_rows = [
+                {
+                    **{key: row[key] for key in header if key in row},
+                    **{key: value for key, value in row.items() if key not in header},
+                }
+                for row in raw_rows
+            ]
+
+    tuning_points: dict[str, dict[str, TuningPoint]] = {
+        family: {
+            name: TuningPoint(**{key: point.get(key) for key in (
+                "tau_s", "sigma_a_mps2", "R_p0_std_m", "R_v0_std_mps", "RS_ms"
+            )})
+            for name, point in points.items()
+        }
+        for family, points in bundle.get("fixed_tuning_points", {}).items()
+    }
+    calibrated_names = {
+        name for points in tuning_points.values() for name in points
+    }
+    scored_scenarios = {str(row["scenario"]) for row in raw_rows}
+    # FixedNominal is calibrated from one record that is also scored as a
+    # stationary scenario; the endpoint is calibrated but never scored.
+    nominal_candidates = sorted(
+        name for name in calibrated_names
+        if name in scored_scenarios and "H1_500" in name
+    )
+    nominal_name = nominal_candidates[0] if nominal_candidates else ""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    summary = summarize_rows(raw_rows, bootstrap_resamples, stats_seed)
+    effects = paired_effect_rows(raw_rows, bootstrap_resamples, stats_seed)
+    normalized_aggregate = stationary_normalized_aggregate(
+        raw_rows, bootstrap_resamples, stats_seed
+    )
+
+    raw_path = output_dir / "ou_validation_raw.csv"
+    summary_path = output_dir / "ou_validation_summary.csv"
+    effects_path = output_dir / "ou_validation_paired_effects.csv"
+    json_path = output_dir / "ou_validation.json"
+    tex_path = output_dir / "ou_validation_table.tex"
+    publication_tex_path = output_dir / "ou_validation_publication.tex"
+    publication_macros_path = output_dir / "ou_validation_macros.tex"
+    tuning_tex_path = output_dir / "ou_validation_tuning_points.tex"
+    manifest_path = output_dir / "ou_validation_manifest.json"
+
+    write_csv(raw_path, raw_rows)
+    write_csv(summary_path, summary)
+    write_csv(effects_path, effects)
+    write_latex_table(tex_path, summary)
+    write_publication_table(
+        publication_tex_path,
+        raw_rows,
+        summary,
+        effects,
+        bootstrap_resamples,
+        stats_seed,
+        macros_path=publication_macros_path,
+    )
+    if tuning_points:
+        write_tuning_points_table(
+            tuning_tex_path, tuning_points, nominal_name, NONSTATIONARY_ENDPOINT_NAME
+        )
+
+    # Fields that describe what was *run* are carried over untouched -- the
+    # restated bundle scored exactly the ensemble the source did.  Fields that
+    # describe how the rows are summarized or how the study words its own
+    # design come from this file, so that a restated bundle cannot disagree
+    # with the manuscript generated beside it.
+    protocol = dict(bundle.get("protocol", {}))
+    protocol["bootstrap_resamples"] = bootstrap_resamples
+    protocol["stats_seed"] = stats_seed
+    protocol["primary_endpoint_inference"] = PRIMARY_ENDPOINT_INFERENCE
+    protocol["pmstokes_pooling"] = PMSTOKES_POOLING
+    protocol["restated_from"] = str(
+        source.relative_to(REPO_ROOT) if source.is_relative_to(REPO_ROOT) else source
+    )
+    write_json(
+        json_path,
+        {
+            "protocol": protocol,
+            "fixed_tuning_points": bundle.get("fixed_tuning_points", {}),
+            "raw_runs": raw_rows,
+            "summary": summary,
+            "paired_effects": effects,
+            "stationary_normalized_aggregate": normalized_aggregate,
+            "transition_diagnostic": bundle.get("transition_diagnostic"),
+        },
+    )
+
+    result_paths = [
+        raw_path, summary_path, effects_path, json_path, tex_path,
+        publication_tex_path, publication_macros_path,
+    ]
+    if tuning_points:
+        result_paths.append(tuning_tex_path)
+    manifest = dict(json.loads(manifest_path.read_text(encoding="utf-8")))    \
+        if manifest_path.exists() else {}
+    # A restat rewrites some of the bundle's files and leaves others (the
+    # figures, the transition series) exactly as the run produced them.  The
+    # manifest has to keep covering all of them, so the carried entries are
+    # re-hashed from disk rather than trusted or dropped.
+    result_files = {
+        name: {"sha256": sha256_file(path), "bytes": path.stat().st_size}
+        for name, path in (
+            (name, output_dir / name)
+            for name in manifest.get("result_files", {})
+        )
+        if path.is_file()
+    }
+    result_files.update(
+        {
+            path.name: {"sha256": sha256_file(path), "bytes": path.stat().st_size}
+            for path in result_paths
+        }
+    )
+    manifest.update(
+        {
+            "git_commit": git_output("rev-parse", "HEAD"),
+            "git_branch": git_output("branch", "--show-current"),
+            "git_diff_stat": git_output("diff", "--stat"),
+            "python": sys.version,
+            "platform": platform.platform(),
+            "numpy": np.__version__,
+            "command": [sys.executable, *sys.argv],
+            "protocol": protocol,
+            "restated_from": protocol["restated_from"],
+            "result_files": result_files,
+            "stationary_normalized_aggregate": normalized_aggregate,
+        }
+    )
+    write_json(manifest_path, manifest)
+
+    for path in (*result_paths, manifest_path):
+        print(f"Wrote {path}")
+    return 0
+
+
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--mode", choices=("smoke", "full"), default="smoke")
@@ -2576,6 +3001,13 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         help="skip simulation, read every shard file, and write the bundle "
         "the unsharded run would have written",
     )
+    parser.add_argument(
+        "--restat-from",
+        type=Path,
+        help="skip simulation entirely and recompute the summaries, paired "
+        "effects, tables, macros, and bundle from the raw runs archived in an "
+        "existing ou_validation.json",
+    )
     parser.add_argument("--eigen-dir")
     parser.add_argument("--skip-build", action="store_true")
     parser.add_argument("--no-plots", action="store_true")
@@ -2587,6 +3019,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     args.data_dir = args.data_dir.resolve()
     args.output_dir = args.output_dir.resolve()
     args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.restat_from is not None:
+        return restat_bundle(
+            args.restat_from.resolve(),
+            args.output_dir,
+            args.bootstrap_resamples,
+            args.stats_seed,
+        )
 
     families = ("OU_II", "OU_III") if args.families == "both" else (args.families,)
     allowed_modes = tuple(MODE_SETTINGS)
@@ -3097,11 +3537,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             "the four stationary JONSWAP seas, OU-III Adaptive minus OU-II "
             "Adaptive"
         ),
+        "primary_endpoint_inference": PRIMARY_ENDPOINT_INFERENCE,
         "pmstokes_modes": list(pmstokes_modes),
-        "pmstokes_pooling": (
-            "PM-Stokes is a separate prespecified ensemble and is not pooled "
-            "into the primary JONSWAP aggregate"
-        ),
+        "pmstokes_pooling": PMSTOKES_POOLING,
         "transition_segments_sec": {
             name: [start, stop] for name, start, stop in transition_segments
         },


### PR DESCRIPTION
The reviewer's central point is that the paper claims a joint three-parameter
adaptation and a marine INS, while its own channel ablation attributes the
vertical benefit to r_S alone and its own 3D table puts OU-III behind in four
of five scenarios.  The title, the introduction, and the contribution list now
say what the evidence says: an OU-driven quaternion MEKF with an integral
displacement state and wave-band-driven adaptive integral regularization,
evaluated for vertical wave reconstruction.  The scope paragraph that closes
the introduction states the three limits once, up front -- p is oscillatory
displacement and not a navigation position, the 3D result is negative, and
every number is simulated.

The confirmatory endpoint no longer rests on a single small-sample interval.
The same ten paired differences now also carry a Student-t interval
([-1.794,-1.601] against the bootstrap's [-1.781,-1.623], correctly wider), an
exact sign test, and an exact paired randomization test enumerated over all
1024 sign patterns.  All four agree, and the section says plainly that both
exact p-values are sitting on the 2^-(n-1) floor that ten pairs impose, that
four readings of one ensemble are not four experiments, and what the intervals
contain no uncertainty for.  The Student-t machinery is written out against
NumPy alone, since that is what the workflow installs, and is checked against
published table values.

Recomputing statistics used to mean re-running 840 twenty-minute replays.
`--restat-from` reads the archived rows back out of a committed bundle and
rewrites every derived file; restating the committed bundle reproduces its
derived files byte for byte, which the tests assert.  That is how this change
updated the numbers without a regeneration run, and it is also a reproducibility
result in its own right.

Also: the abstract said the applied pseudo-measurement is anisotropic, but
R_S_xy_factor_ is 1 in every evaluated configuration, so it now says the
covariance may be made anisotropic; "prespecified" becomes "declared"
throughout, since the endpoint is recorded in the versioned protocol but
carries no external timestamp; the ISS contribution is labelled conditional and
local where it is claimed; the benchmark gap and the missing physical
validation are named as the two limits that bound the work; and the stale
5.08/6.66/-1.581 figures in docs/ou-validation.md are corrected to the
committed bundle.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019w2E38KN8p6F7i1YQaaG11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Student’s *t*, exact sign, and paired sign-flip randomization analyses for validation results.
  * Added the ability to regenerate reports and summaries from archived results without rerunning simulations.
* **Documentation**
  * Clarified adaptive integral regularization, validation methods, benchmark limitations, and the scope of conclusions.
  * Documented revised JONSWAP results, confidence intervals, and per-seed comparisons.
* **Tests**
  * Expanded coverage for statistical calculations, reproducibility, result consistency, and report regeneration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->