### PR TITLE
Let the robustness bundle be restated instead of re-run

### DIFF
--- a/docs/ou-robustness.md
+++ b/docs/ou-robustness.md
@@ -83,6 +83,36 @@ lists, `--duration-sec`, `--window-sec`, `--bootstrap-resamples`, and
 `0.5`, `1.0`, and `1.5`; intermediate scales may be added or removed.
 Smoke mode is an integration check and is not inferential evidence.
 
+### Restating a committed bundle
+
+The manifest pins `tools/ou_validation.py` because this study imports it: the
+seed broadcasting, the simulator invocation, and the bootstrap and paired-effect
+machinery all live there. An edit over there therefore strands the bundle's
+source pin even when it changes nothing this study measures, and the replays are
+far too expensive to re-run for that. Recompute the derived files from the
+archived rows instead:
+
+```bash
+python3 tools/ou_robustness.py \
+  --restat-from reports/results/ou_robustness/ou_robustness.json \
+  --bootstrap-resamples 10000 \
+  --output-dir reports/results/ou_robustness
+```
+
+This reads `raw_runs` back out of the bundle and rewrites the summaries, paired
+effects, publication table, bundle, and manifest with the statistics of the
+current source. Restating the committed bundle unchanged reproduces those files
+byte for byte, which `tests/validation/test_ou_robustness.py` asserts. It cannot
+invent rows: whatever ensemble the source bundle scored is the ensemble the
+restated bundle reports.
+
+The two SVG figures are carried rather than redrawn -- Matplotlib's SVG output
+is not a function of the rows alone -- and the manifest keeps covering them by
+re-hashing what is on disk. Any source whose hash moved between the archived run
+and the restat is recorded under `sources_moved_since_rows`, since the rows are
+carried and not re-run: if a moved file is one the simulator goes through, the
+study needs a `--mode full` regeneration and no restat will substitute for it.
+
 ## Outputs
 
 The versioned full result bundle under `reports/results/ou_robustness/` contains:

--- a/reports/results/ou_robustness/ou_robustness.json
+++ b/reports/results/ou_robustness/ou_robustness.json
@@ -10893,6 +10893,7 @@
     "mode": "full",
     "pairing": "identical wave-realization, IMU-noise, and initialization seeds",
     "r_s_semantics": "standard deviation; R_S = diag(r_S^2)",
+    "restated_from": "reports/results/ou_robustness/ou_robustness.json",
     "score_window_sec": 900.0,
     "seed_triplets": [
       {

--- a/reports/results/ou_robustness/ou_robustness_manifest.json
+++ b/reports/results/ou_robustness/ou_robustness_manifest.json
@@ -1,22 +1,17 @@
 {
   "command": [
-    "/usr/bin/python3",
+    "/usr/local/bin/python3",
     "tools/ou_robustness.py",
-    "--mode",
-    "full",
-    "--sensitivity-scales",
-    "0.5,0.75,1.0,1.25,1.5",
+    "--restat-from",
+    "reports/results/ou_robustness/ou_robustness.json",
     "--bootstrap-resamples",
     "10000",
-    "--combine-shards",
-    "--shard-dir",
-    "shards",
     "--output-dir",
     "reports/results/ou_robustness"
   ],
-  "git_branch": "claude/github-actions-attitude-errors-yddwr7",
-  "git_commit": "8dc66110f8ea5bfece1a093789c09446816aea0f",
-  "git_diff_stat": "",
+  "git_branch": "claude/github-action-ou-validation-3ee785",
+  "git_commit": "7a31e622c5bc0adf2ad077fc0609aa7df96443b4",
+  "git_diff_stat": "reports/results/ou_robustness/ou_robustness.json | 1 +\n 1 file changed, 1 insertion(+)",
   "matplotlib": "3.6.3",
   "nominal_tuning_point": {
     "RS_ms": 3.408071216442874,
@@ -25,8 +20,8 @@
     "sigma_a_mps2": 0.941857219,
     "tau_s": 2.17847133
   },
-  "numpy": "1.26.4",
-  "platform": "Linux-6.17.0-1020-azure-x86_64-with-glibc2.39",
+  "numpy": "2.4.6",
+  "platform": "Linux-6.18.5-fc-v18-x86_64-with-glibc2.39",
   "protocol": {
     "bootstrap_resamples": 10000,
     "duration_sec": 1200.0,
@@ -37,6 +32,7 @@
     "mode": "full",
     "pairing": "identical wave-realization, IMU-noise, and initialization seeds",
     "r_s_semantics": "standard deviation; R_S = diag(r_S^2)",
+    "restated_from": "reports/results/ou_robustness/ou_robustness.json",
     "score_window_sec": 900.0,
     "seed_triplets": [
       {
@@ -121,11 +117,12 @@
     "transition_method": "C2 quintic crossfade between two independently phase-randomized stationary records, with exact first- and second-derivative cross terms; not a continuously evolving JONSWAP spectrum",
     "wave_phase_method": "common random phase on the 0.02-1.60 Hz world-velocity and Euler spectra; displacement and acceleration analytically derived from velocity; body IMU and quaternion reconstructed"
   },
-  "python": "3.12.3 (main, Jun 19 2026, 12:46:00) [GCC 13.3.0]",
+  "python": "3.11.15 (main, Mar  3 2026, 09:26:23) [GCC 13.3.0]",
+  "restated_from": "reports/results/ou_robustness/ou_robustness.json",
   "result_files": {
     "ou_robustness.json": {
-      "bytes": 1421552,
-      "sha256": "18d6f5d68fe8adbcc3a0ed14ce7f299687c5384976fde788b134a947b1a74513"
+      "bytes": 1421625,
+      "sha256": "7e73032b63133afc16876d3f7b351b221fe405e5b6ec0fbea908b4a9daa71fe6"
     },
     "ou_robustness_paired_effects.csv": {
       "bytes": 142493,
@@ -173,6 +170,16 @@
       "bytes": 20049,
       "sha256": "794d9a41eb4b25aee130812263d951edce8e5cc47739212f312bd91b16235f7e"
     },
+    "tools/ou_robustness.py": {
+      "bytes": 53362,
+      "sha256": "fda56a95e66ee2ff11126bfa919c4571c2c2327089d6d122bd68bb8277cf4a70"
+    },
+    "tools/ou_validation.py": {
+      "bytes": 147900,
+      "sha256": "30119e19c80ee0c51cbb95299a21cf0e41f79b6a64b90b4c5fc49bd0df65cbdd"
+    }
+  },
+  "sources_moved_since_rows": {
     "tools/ou_robustness.py": {
       "bytes": 44950,
       "sha256": "86429f492fe0f5dc1bd5165d9c06c64b09d28fa08df8015768d8731a35b21e2f"

--- a/tests/validation/test_ou_robustness.py
+++ b/tests/validation/test_ou_robustness.py
@@ -1,5 +1,7 @@
+import contextlib
 import csv
 import hashlib
+import io
 import json
 import math
 import sys
@@ -231,6 +233,111 @@ class ShardMergeTests(unittest.TestCase):
         self.assertEqual(merged[0]["dir_axis_error_deg"], float("inf"))
         self.assertEqual(merged[0]["disp_z_pct_hs"], 4.25)
         self.assertEqual(merged[0]["mode"], "Adaptive")
+
+
+class RestatTests(unittest.TestCase):
+    """`--restat-from` has to restate a bundle, not quietly rewrite it.
+
+    The replays are the expensive half of this study, and this study borrows
+    its statistics from ``ou_validation.py``, so an edit over there strands the
+    bundle's source pin without changing a single number.  Recomputing the
+    tables from the archived rows is the honest way out of that, but only if a
+    restat of the committed bundle reproduces the committed derived files byte
+    for byte, which is what this checks.
+    """
+
+    RESULTS = REPO_ROOT / "reports" / "results" / "ou_robustness"
+
+    def test_restating_the_committed_bundle_reproduces_its_derived_files(self):
+        source = self.RESULTS / "ou_robustness.json"
+        if not source.exists():  # pragma: no cover - smoke checkouts
+            self.skipTest("no committed robustness bundle")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp)
+            with contextlib.redirect_stdout(io.StringIO()):
+                robustness.restat_bundle(
+                    source,
+                    output,
+                    bootstrap_resamples=10_000,
+                    stats_seed=20260329,
+                )
+            for name in (
+                "ou_robustness_raw.csv",
+                "ou_robustness_summary.csv",
+                "ou_robustness_paired_effects.csv",
+                "ou_robustness_publication.tex",
+            ):
+                self.assertEqual(
+                    (output / name).read_bytes(),
+                    (self.RESULTS / name).read_bytes(),
+                    name,
+                )
+
+            restated = json.loads(
+                (output / "ou_robustness.json").read_text(encoding="utf-8")
+            )
+            committed = json.loads(source.read_text(encoding="utf-8"))
+            # Same rows, same operating point, and the restat must say what it
+            # restated.
+            self.assertEqual(restated["raw_runs"], committed["raw_runs"])
+            self.assertEqual(
+                restated["nominal_tuning_point"], committed["nominal_tuning_point"]
+            )
+            self.assertIn("restated_from", restated["protocol"])
+
+    def test_a_restat_keeps_covering_the_files_it_did_not_rewrite(self):
+        """A restat rewrites the tables; the figures stay as the run left them.
+
+        Matplotlib's SVG output is not a function of the rows alone, so the
+        figures are carried rather than redrawn.  The manifest is the bundle's
+        inventory, and dropping the files a restat happens not to touch would
+        quietly shrink what the hash check covers.
+        """
+        manifest = json.loads(
+            (self.RESULTS / "ou_robustness_manifest.json").read_text(encoding="utf-8")
+        )
+        covered = set(manifest["result_files"])
+        for name in (
+            "ou_robustness_sensitivity.svg",
+            "ou_robustness_stress.svg",
+        ):
+            self.assertIn(name, covered, name)
+        # The code sources are pinned by whichever path wrote the manifest, so
+        # a restat must not be a way to lose them.
+        pinned = set(manifest["source_files"])
+        for path in robustness.CODE_SOURCE_PATHS:
+            self.assertIn(str(path.relative_to(REPO_ROOT)), pinned)
+
+    def test_a_restat_records_the_sources_that_moved_under_it(self):
+        """The rows come from the earlier run; the tables come from this tree.
+
+        When those two disagree about a source file the manifest has to say so,
+        because a moved simulator source means the replays are stale and no
+        amount of restating fixes that.
+        """
+        previous = {
+            "tools/ou_validation.py": {"sha256": "0" * 64, "bytes": 1},
+            "plots/kalman_ou_ii/absent.csv": {"sha256": "1" * 64, "bytes": 2},
+        }
+        restated, moved = robustness._restated_source_files(previous)
+        # Present and changed: re-pinned, and reported as moved.
+        self.assertEqual(set(moved), {"tools/ou_validation.py"})
+        self.assertEqual(moved["tools/ou_validation.py"], previous["tools/ou_validation.py"])
+        self.assertNotEqual(restated["tools/ou_validation.py"]["sha256"], "0" * 64)
+        # Absent from the checkout: carried across, never dropped.
+        self.assertEqual(
+            restated["plots/kalman_ou_ii/absent.csv"],
+            previous["plots/kalman_ou_ii/absent.csv"],
+        )
+
+    def test_a_restat_cannot_manufacture_an_ensemble(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            empty = Path(tmp) / "empty.json"
+            empty.write_text(json.dumps({"raw_runs": []}), encoding="utf-8")
+            with contextlib.redirect_stdout(io.StringIO()):
+                with self.assertRaises(ValueError):
+                    robustness.restat_bundle(empty, Path(tmp), 100, 1)
 
 
 class CommittedRobustnessResultsTests(unittest.TestCase):

--- a/tools/ou_robustness.py
+++ b/tools/ou_robustness.py
@@ -11,6 +11,7 @@ by wave-realization, IMU-noise, and initialization seed.
 from __future__ import annotations
 
 import argparse
+import csv
 import json
 import math
 import os
@@ -55,6 +56,19 @@ LOW_STRESS_HS_M = 0.05
 TAU_BOUNDS_S = (0.02, 12.0)
 SIGMA_AW_BOUNDS_MPS2 = (1e-9, 6.0)
 R_S_BOUNDS_MS = (0.4, 400.0)
+# The code that decides what this study measures: the two tools, and the
+# simulator sources the replays go through.  ``ou_validation.py`` is in the
+# list because this module imports it -- the seed broadcasting, the simulator
+# invocation, and the bootstrap and paired-effect machinery all live there.
+# The manifest pins them by hash, so a run and its bundle cannot drift apart
+# silently.  Declared once because the restat path has to pin the same set the
+# run does.
+CODE_SOURCE_PATHS = (
+    Path(__file__).resolve(),
+    REPO_ROOT / "tools" / "ou_validation.py",
+    REPO_ROOT / "src" / "util" / "W3dSimCommon.cpp",
+    REPO_ROOT / "tests" / "kalman_ou_iii" / "kalman_ou_iii-sim.cpp",
+)
 
 
 @dataclass(frozen=True)
@@ -699,6 +713,184 @@ def read_shards(shard_dir: Path) -> list[dict[str, Any]]:
     return core.read_shards(shard_dir, SHARD_PREFIX, ordered=True)
 
 
+def _restated_source_files(
+    previous: Mapping[str, Mapping[str, Any]],
+) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
+    """Re-pin the sources a restat runs under, and report what moved.
+
+    The wave records are versioned release inputs and are not in the checkout,
+    so an entry whose file is absent is carried across unchanged rather than
+    dropped -- a restat must not shrink what the manifest covers.  Everything
+    present is hashed from disk, including the code sources, which is the point:
+    the restat's derived files really were produced by the tree as it stands.
+
+    The rows, though, were produced by the tree as it stood *then*.  Any source
+    whose hash moved between the two is returned separately so the manifest can
+    say so, because a moved simulator source means the replays are stale and a
+    restat cannot fix that.
+    """
+
+    restated: dict[str, dict[str, Any]] = {}
+    moved: dict[str, dict[str, Any]] = {}
+    names = {
+        *previous,
+        *(str(path.relative_to(REPO_ROOT)) for path in CODE_SOURCE_PATHS),
+    }
+    for name in sorted(names):
+        path = REPO_ROOT / name
+        recorded = dict(previous.get(name, {}))
+        if not path.is_file():
+            if recorded:
+                restated[name] = recorded
+            continue
+        entry = {"sha256": core.sha256_file(path), "bytes": path.stat().st_size}
+        restated[name] = entry
+        if recorded and recorded.get("sha256") != entry["sha256"]:
+            moved[name] = recorded
+    return restated, moved
+
+
+def restat_bundle(
+    source: Path,
+    output_dir: Path,
+    bootstrap_resamples: int,
+    stats_seed: int,
+) -> int:
+    """Recompute the summaries, effects, and table from an archived bundle's rows.
+
+    The simulator replays are the expensive half of this study -- the full run
+    is some 310 twenty-minute replays -- and each one is fixed by its seed
+    triplet and tuning point.  A change to how the rows are *summarized*, or to
+    a part of ``ou_validation.py`` this study only borrows helpers from, should
+    therefore not cost a regeneration.  This path reads ``raw_runs`` back out of
+    a committed bundle and rewrites the derived files with the statistics of the
+    current source.  It cannot invent rows: whatever ensemble the source bundle
+    scored is the ensemble the restated bundle reports.
+
+    The figures are deliberately not rewritten.  They are not a function of the
+    rows alone -- Matplotlib's SVG output moves between versions -- so they stay
+    as the run left them and the manifest keeps covering them by re-hashing what
+    is on disk.
+    """
+
+    with source.open(encoding="utf-8") as stream:
+        bundle = json.load(stream)
+    rows = [dict(row) for row in bundle["raw_runs"]]
+    if not rows:
+        raise ValueError(f"{source} carries no raw runs to restate")
+
+    # The bundle JSON is written with sorted keys, so the rows come back
+    # alphabetical.  Column order is not information, but a restated bundle
+    # that reshuffles the columns is impossible to diff against the run it
+    # restates, so the archived CSV header is used to put them back.
+    archived_csv = source.parent / "ou_robustness_raw.csv"
+    if archived_csv.exists():
+        with archived_csv.open(encoding="utf-8", newline="") as stream:
+            header = next(csv.reader(stream), [])
+        if header:
+            rows = [
+                {
+                    **{key: row[key] for key in header if key in row},
+                    **{key: value for key, value in row.items() if key not in header},
+                }
+                for row in rows
+            ]
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    summary = summarize_rows(rows, bootstrap_resamples, stats_seed)
+    effects = paired_effect_rows(rows, bootstrap_resamples, stats_seed)
+
+    raw_path = output_dir / "ou_robustness_raw.csv"
+    summary_path = output_dir / "ou_robustness_summary.csv"
+    effects_path = output_dir / "ou_robustness_paired_effects.csv"
+    json_path = output_dir / "ou_robustness.json"
+    publication_path = output_dir / "ou_robustness_publication.tex"
+    manifest_path = output_dir / "ou_robustness_manifest.json"
+
+    core.write_csv(raw_path, rows)
+    core.write_csv(summary_path, summary)
+    core.write_csv(effects_path, effects)
+    write_publication_table(publication_path, summary, effects)
+
+    # Fields that describe what was *run* are carried over untouched -- the
+    # restated bundle scored exactly the ensemble the source did.  Fields that
+    # describe how the rows are summarized come from this run.
+    protocol = dict(bundle.get("protocol", {}))
+    protocol["bootstrap_resamples"] = bootstrap_resamples
+    protocol["stats_seed"] = stats_seed
+    protocol["restated_from"] = str(
+        source.relative_to(REPO_ROOT) if source.is_relative_to(REPO_ROOT) else source
+    )
+    core.write_json(
+        json_path,
+        {
+            "protocol": protocol,
+            "nominal_tuning_point": bundle.get("nominal_tuning_point"),
+            "raw_runs": rows,
+            "summary": summary,
+            "paired_effects": effects,
+        },
+    )
+
+    result_paths = [raw_path, summary_path, effects_path, json_path, publication_path]
+    manifest = (
+        json.loads(manifest_path.read_text(encoding="utf-8"))
+        if manifest_path.exists()
+        else {}
+    )
+    # The manifest is the bundle's inventory. The files a restat does not
+    # rewrite -- the two figures -- have to stay covered, so the carried
+    # entries are re-hashed from disk rather than trusted or dropped.
+    result_files = {
+        name: {"sha256": core.sha256_file(path), "bytes": path.stat().st_size}
+        for name, path in (
+            (name, output_dir / name) for name in manifest.get("result_files", {})
+        )
+        if path.is_file()
+    }
+    result_files.update(
+        {
+            path.name: {"sha256": core.sha256_file(path), "bytes": path.stat().st_size}
+            for path in result_paths
+        }
+    )
+    source_files, moved = _restated_source_files(manifest.get("source_files", {}))
+    manifest.update(
+        {
+            "git_commit": core.git_output("rev-parse", "HEAD"),
+            "git_branch": core.git_output("branch", "--show-current"),
+            "git_diff_stat": core.git_output("diff", "--stat"),
+            "python": sys.version,
+            "platform": platform.platform(),
+            "numpy": np.__version__,
+            "command": [sys.executable, *sys.argv],
+            "protocol": protocol,
+            "restated_from": protocol["restated_from"],
+            "source_files": source_files,
+            "result_files": result_files,
+        }
+    )
+    # Only ever present after a restat, and only for sources that actually
+    # moved: the pin above is what the tables were computed under, and this is
+    # what the replays were run under.
+    if moved:
+        manifest["sources_moved_since_rows"] = moved
+    else:
+        manifest.pop("sources_moved_since_rows", None)
+
+    core.write_json(manifest_path, manifest)
+
+    for name in moved:
+        print(
+            f"Note: {name} has changed since the archived rows were produced. "
+            "The rows are carried, not re-run; regenerate the study if that "
+            "file decides what the simulator does."
+        )
+    for path in (*result_paths, manifest_path):
+        print(f"Wrote {path}")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--mode", choices=("smoke", "full"), default="smoke")
@@ -752,6 +944,13 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="skip simulation, read every shard file, and write the bundle "
         "the unsharded run would have written",
+    )
+    parser.add_argument(
+        "--restat-from",
+        type=Path,
+        help="skip simulation entirely and recompute the summaries, paired "
+        "effects, table, and bundle from the raw runs archived in an existing "
+        "ou_robustness.json",
     )
     parser.add_argument("--eigen-dir")
     parser.add_argument("--skip-build", action="store_true")
@@ -931,6 +1130,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     args.output_dir = args.output_dir.resolve()
     args.output_dir.mkdir(parents=True, exist_ok=True)
 
+    if args.restat_from is not None:
+        return restat_bundle(
+            args.restat_from.resolve(),
+            args.output_dir,
+            args.bootstrap_resamples,
+            args.stats_seed,
+        )
+
     duration_sec = args.duration_sec or (180.0 if args.mode == "smoke" else 1200.0)
     window_sec = args.window_sec or (120.0 if args.mode == "smoke" else 900.0)
     if not duration_sec > window_sec > 0.0:
@@ -1089,10 +1296,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         nominal_input,
         low_input,
         endpoint_input,
-        Path(__file__).resolve(),
-        REPO_ROOT / "tools" / "ou_validation.py",
-        REPO_ROOT / "src" / "util" / "W3dSimCommon.cpp",
-        REPO_ROOT / "tests" / "kalman_ou_iii" / "kalman_ou_iii-sim.cpp",
+        *CODE_SOURCE_PATHS,
     ]
     manifest = {
         "git_commit": core.git_output("rev-parse", "HEAD"),


### PR DESCRIPTION
The ou-validation gate has now gone red twice for the same reason, and neither
time was the evidence wrong. The robustness manifest pins tools/ou_validation.py
by hash -- correctly, because this study imports it for seed broadcasting, the
simulator invocation, and the bootstrap and paired-effect machinery -- so any
edit over there strands the pin. The last one was 21dcf5f, which added Student-t
and exact sign/randomization inference and a --restat-from path to the
validation study. None of it is in the surface ou_robustness.py borrows, and
none of it moves a robustness number, but the recorded hash no longer matched
the file and the committed-bundle test failed on it.

The only remedies available were a multi-hour regeneration of 310 twenty-minute
replays, or hand-editing a hash in a manifest whose whole purpose is to not be
hand-edited. So ou_robustness.py gets the same --restat-from path
ou_validation.py already has: the archived raw_runs are read back out of the
bundle and the summaries, paired effects, publication table, bundle, and
manifest are rewritten with the statistics of the current source. Restating the
committed bundle reproduces its derived files byte for byte, which the tests
assert, and it cannot invent rows -- whatever ensemble the source scored is the
ensemble the restated bundle reports.

Two things the validation restat did not have to deal with:

The figures are carried, not redrawn. Matplotlib's SVG output is not a function
of the rows alone and moves between versions, so a restat that redrew them would
report a difference that is not in the evidence. The manifest keeps covering
them by re-hashing what is on disk.

The rows come from the earlier run and the tables from the current tree, so the
two can disagree about a source file. Every source whose hash moved between them
is recorded under sources_moved_since_rows and printed at the end of the run.
That keeps the restat from being a way to quietly bless stale replays: if a
moved file is one the simulator goes through, the study needs a regeneration and
this path will not substitute for it.

The source list is now declared once as CODE_SOURCE_PATHS so the run and the
restat cannot pin different sets, and a source missing from the checkout -- the
wave records, which are versioned release inputs -- is carried across rather
than dropped, so a restat can never shrink what the manifest covers.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014WE7Lwt7shVYy7rY3Uo8Zj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for restating archived robustness-study results and regenerating derived outputs.
  - Added command-line options for restoring results from a previous report.
  - Added tracking for source files changed since the archived run.
  - Added reproducibility metadata, including environment details and file checksums.

- **Documentation**
  - Documented the restatement workflow, regenerated artifacts, reproducibility guarantees, ensemble limitations, and preserved figures.

- **Tests**
  - Added validation for byte-for-byte regeneration, manifest coverage, source movement tracking, and empty-ensemble rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->