### PR TITLE
Score the PII and TVG-NLO baselines on the same 900 s window

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ TEST_DIRS := \
 	$(REPO_ROOT)/tests/imu_calibrate \
 	$(REPO_ROOT)/tests/kalman_ou_ii \
 	$(REPO_ROOT)/tests/kalman_ou_iii \
+	$(REPO_ROOT)/tests/nlo \
 	$(REPO_ROOT)/tests/pii_observer \
 	$(REPO_ROOT)/tests/spectrum \
 	$(REPO_ROOT)/tests/validation \

--- a/doc/kalman_ou_iii/w3d-baseline-comparison.tex-part
+++ b/doc/kalman_ou_iii/w3d-baseline-comparison.tex-part
@@ -52,7 +52,11 @@ two were tuned from.
 
 The deterministic comparison evaluates all four methods from the same
 timestamped synthetic reference records, inertial sample stream, sensor-error
-realizations, \SI{20}{min} duration, and final \SI{900}{s} scoring window. Raw vertical-displacement RMS
+realizations, \SI{20}{min} duration, and final \SI{900}{s} scoring window. That
+window is also the one each of the four simulators applies to its own
+executable regression gate, so the thresholds committed alongside the code
+describe the same stretch of the replay as the table below rather than a
+shorter one. Raw vertical-displacement RMS
 error is the primary metric; normalized vertical error, roll RMS, and pitch RMS
 are secondary metrics. Direction, travel sense, horizontal displacement, and
 yaw are excluded from the common comparison because they are not observable

--- a/doc/kalman_ou_iii/w3d-sim-charts.tex-part
+++ b/doc/kalman_ou_iii/w3d-sim-charts.tex-part
@@ -174,10 +174,14 @@ hard-iron bias and slow drift, and $\vct{w}_m$ is per-sample white noise.
 
 \paragraph{Scoring window}
 The deterministic regression gates, Table~\ref{tab:sim_results_rms_dir_basic},
-and the ensemble validation protocol all score the same trailing window
+the four-method comparison of Sec.~\ref{sec:observer-comparison}, and the
+ensemble validation protocol all score the same trailing window
 $T_{\mathrm{RMS}}=900$~s, the final \SI{900}{s} of each \SI{1200}{s}
 run, thereby excluding startup while retaining a long
-steady-state record.  The runner reports per-axis and 3D displacement RMS,
+steady-state record.  This holds for the regression gates of all four
+simulators in the comparison, not only the two OU families, so no reported
+number rests on a shorter window than any other.  The runner reports per-axis
+and 3D displacement RMS,
 roll/pitch/yaw RMS, bias errors, wave-direction accuracy against the generator
 azimuth, and diagnostic tuning variables $(f,\tau,\sigma_{aw},r_S)$.  For the
 non-stationary case it additionally scores three disjoint intervals inside the

--- a/doc/pii_observer/pii_observer-model.tex
+++ b/doc/pii_observer/pii_observer-model.tex
@@ -615,16 +615,24 @@
 
     \subsection{Quality Gates Used in the Example}
 
-    The simulation code checks the last \SI{60}{s} of each run and applies quality
-    gates:
+    The simulation code checks the last \SI{900}{s} of each \SI{1200}{s} run and
+    applies quality gates:
     \begin{itemize}[leftmargin=1.4em]
-        \item Z RMS \(< 17.9\%\) of \(H_s\) for JONSWAP cases,
-        \item Z RMS \(< 16.0\%\) of \(H_s\) for PM-Stokes cases,
-        \item yaw RMS \(< 5.06^\circ\) when magnetometer is used.
+        \item Z RMS \(< 15.8\%\) of \(H_s\) for JONSWAP cases,
+        \item Z RMS \(< 16.6\%\) of \(H_s\) for PM-Stokes cases,
+        \item yaw RMS \(< 10.9^\circ\) when magnetometer is used.
     \end{itemize}
 
     These are not part of the observer itself, but they are useful context for the
     intended tuning regime in the supplied simulation.
+
+    The window is the one the OU-II/OU-III simulators gate on and the one the
+    four-method comparison of the OU-III manuscript scores, so this observer is
+    described over the same stretch of the replay as the estimators it is
+    compared against. Each threshold is a regression sentinel for the
+    deterministic realization -- the worst value this observer currently produces
+    across the eight scored records plus about half a percent -- rather than an
+    acceptance criterion.
 
     \begin{table}[t]
         \centering

--- a/tests/nlo/nlo-sim.cpp
+++ b/tests/nlo/nlo-sim.cpp
@@ -25,10 +25,25 @@ using Eigen::Vector3f;
 
 bool add_noise = true;
 
+// The scored trailing window.  It is the window the OU-II and OU-III
+// simulators gate on and the one the four-method deterministic comparison
+// scores, so every method that comparison reports describes the same stretch
+// of the 20-minute replay rather than windows an order of magnitude apart.
+static constexpr float RMS_WINDOW_SEC = 900.0f;
+static constexpr int RMS_WINDOW_SEC_LABEL = static_cast<int>(RMS_WINDOW_SEC);
+
+// Regression sentinels for the deterministic single-realization protocol, not
+// targets.  Each is the worst value the current observer produces across the
+// scored records plus about half a percent, rounded up to the next tenth, the
+// same rule the OU simulators use.
+//
+// Re-derived for the 900 s scoring window: a sentinel fitted to the previous
+// 60 s window is not a sentinel for this one, it is just a number the observer
+// passes by a wide margin.
 static constexpr W3dFailureLimits FAIL_LIMITS{
-    .err_limit_percent_z_jonswap   = 21.5f,
-    .err_limit_percent_z_pmstokes  = 22.0f,
-    .err_limit_yaw_deg             = 8.0f,
+    .err_limit_percent_z_jonswap   = 19.8f,   // worst 19.61 (jonswap H8.5)
+    .err_limit_percent_z_pmstokes  = 22.7f,   // worst 22.54 (pmstokes H8.5)
+    .err_limit_yaw_deg             = 8.0f,    // yaw is free here and is not gated
     .err_limit_percent_3d_jonswap  = 9999.0f,
     .err_limit_percent_3d_pmstokes = 9999.0f,
     .acc_z_bias_percent            = 9999.0f,
@@ -215,7 +230,6 @@ static std::vector<float> finite_tail_values(const std::vector<float>& v,
 static void print_tvg_nlo_vertical_summary(const TvgNloSimulationRunResult& result,
                                            float dt)
 {
-    constexpr float RMS_WINDOW_SEC = 60.0f;
     const int N_last = static_cast<int>(RMS_WINDOW_SEC / dt);
     if (result.errs_z.size() <= static_cast<size_t>(N_last)) return;
 
@@ -256,7 +270,8 @@ static void print_tvg_nlo_vertical_summary(const TvgNloSimulationRunResult& resu
 
     const auto& d = result.final_snapshot.tvg;
 
-    std::cout << "=== Last 60 s TimeVarGain NLO VVR-only summary for "
+    std::cout << "=== Last " << RMS_WINDOW_SEC_LABEL
+              << " s TimeVarGain NLO VVR-only summary for "
               << result.output_name << " ===\n";
 
     std::cout << "Z RMS raw (m): " << z_rms << "\n";
@@ -315,9 +330,16 @@ static void print_tvg_nlo_vertical_summary(const TvgNloSimulationRunResult& resu
 static void fail_if_tvg_nlo_vertical_gates_breached(const TvgNloSimulationRunResult& result,
                                                     float dt)
 {
-    constexpr float RMS_WINDOW_SEC = 60.0f;
     const int N_last = static_cast<int>(RMS_WINDOW_SEC / dt);
-    if (result.errs_z.size() <= static_cast<size_t>(N_last)) return;
+    // A partial window is not the scored window, so a record shorter than it is
+    // left ungated rather than scored against sentinels fitted to the full one.
+    // Said out loud, because the silence otherwise reads as a pass.
+    if (result.errs_z.size() <= static_cast<size_t>(N_last)) {
+        std::cout << "QUALITY_GATE: SKIPPED REASON=record_shorter_than_"
+                  << RMS_WINDOW_SEC_LABEL << "s_window RECORD="
+                  << result.output_name << "\n";
+        return;
+    }
 
     const size_t start = result.errs_z.size() - N_last;
 

--- a/tests/pii_observer/pii_observer-adaptive.cpp
+++ b/tests/pii_observer/pii_observer-adaptive.cpp
@@ -28,10 +28,25 @@ using Eigen::Quaternionf;
 
 bool add_noise = true;
 
+// The scored trailing window.  It is the window the OU-II and OU-III
+// simulators gate on and the one the four-method deterministic comparison
+// scores, so every method that comparison reports describes the same stretch
+// of the 20-minute replay rather than windows an order of magnitude apart.
+static constexpr float RMS_WINDOW_SEC = 900.0f;
+static constexpr int RMS_WINDOW_SEC_LABEL = static_cast<int>(RMS_WINDOW_SEC);
+
+// Regression sentinels for the deterministic single-realization protocol, not
+// targets.  Each is the worst value the current observer produces across the
+// scored records plus about half a percent, rounded up to the next tenth, the
+// same rule the OU simulators use.
+//
+// Re-derived for the 900 s scoring window: a sentinel fitted to the previous
+// 60 s window is not a sentinel for this one, it is just a number the observer
+// passes by a wide margin.
 static constexpr W3dFailureLimits FAIL_LIMITS{
-    .err_limit_percent_z_jonswap = 15.5f,
-    .err_limit_percent_z_pmstokes = 15.5f,
-    .err_limit_yaw_deg = 8.5f,
+    .err_limit_percent_z_jonswap = 15.8f,   // worst 15.71 (jonswap H0.27)
+    .err_limit_percent_z_pmstokes = 16.6f,  // worst 16.42 (pmstokes H0.27)
+    .err_limit_yaw_deg = 10.9f,             // worst 10.78 (pmstokes H8.5)
 };
 
 class FusionAdapterAdaptivePIIMahony final : public IW3dFusionAdapter {
@@ -359,7 +374,6 @@ private:
 
 static void print_vertical_only_summary(const W3dSimulationRunResult& result, float dt)
 {
-    constexpr float RMS_WINDOW_SEC = 60.0f;
     const int N_last = static_cast<int>(RMS_WINDOW_SEC / dt);
     if (result.errs_z.size() <= static_cast<size_t>(N_last)) return;
 
@@ -378,7 +392,8 @@ static void print_vertical_only_summary(const W3dSimulationRunResult& result, fl
 
     std::vector<float> vf(result.freq_hist.begin() + start, result.freq_hist.end());
 
-    std::cout << "=== Last 60 s VERTICAL-ONLY summary for " << result.output_name << " ===\n";
+    std::cout << "=== Last " << RMS_WINDOW_SEC_LABEL << " s VERTICAL-ONLY summary for "
+              << result.output_name << " ===\n";
     std::cout << "Z RMS (m): " << z_rms << "\n";
     std::cout << "Z RMS (%Hs): " << z_pct << "% (Hs=" << result.wave_params.height << ")\n";
     std::cout << "Angles RMS (deg): Roll=" << rms_roll.rms()
@@ -404,9 +419,16 @@ static void print_vertical_only_summary(const W3dSimulationRunResult& result, fl
 
 static void fail_if_vertical_quality_gates_breached(const W3dSimulationRunResult& result, float dt)
 {
-    constexpr float RMS_WINDOW_SEC = 60.0f;
     const int N_last = static_cast<int>(RMS_WINDOW_SEC / dt);
-    if (result.errs_z.size() <= static_cast<size_t>(N_last)) return;
+    // A partial window is not the scored window, so a record shorter than it is
+    // left ungated rather than scored against sentinels fitted to the full one.
+    // Said out loud, because the silence otherwise reads as a pass.
+    if (result.errs_z.size() <= static_cast<size_t>(N_last)) {
+        std::cout << "QUALITY_GATE: SKIPPED REASON=record_shorter_than_"
+                  << RMS_WINDOW_SEC_LABEL << "s_window RECORD="
+                  << result.output_name << "\n";
+        return;
+    }
 
     const size_t start = result.errs_z.size() - N_last;
 


### PR DESCRIPTION
The four-method comparison in the OU-III manuscript is computed in Python over
the trailing 900 s of each 20-minute replay, and the OU-II/OU-III simulators
gate themselves on that same window. The PII and TVG-NLO simulators still
summarized and gated the trailing 60 s, so the two external legs of that
comparison carried committed thresholds describing a stretch of the run an
order of magnitude shorter than the table they appear in.

- tests/pii_observer/pii_observer-adaptive.cpp and tests/nlo/nlo-sim.cpp: one
  file-scope RMS_WINDOW_SEC of 900 s replaces the two local 60 s constants in
  each, with the summary headers derived from it. A record shorter than the
  window is still left ungated, but now says so, the way the OU simulators do,
  because silence otherwise reads as a pass.
- Re-derived both FAIL_LIMITS blocks over the 900 s window by the rule the OU
  blocks state (worst scored value plus about half a percent, rounded up to the
  next tenth). PII: 15.5/15.5/8.5 -> 15.8/16.6/10.9. TVG-NLO: 21.5/22.0 ->
  19.8/22.7 de-meaned Z. Limits fitted to the 60 s window were no longer
  sentinels. All eight scored records pass on both simulators.
- Makefile: tests/nlo joins TEST_DIRS, so `make all` builds and runs the NLO
  gate and `make fetch-sim-data` unpacks the records it needs. It was reachable
  only from the CI matrix before.
- Manuscript: the scoring-window paragraph and the comparison protocol now
  state that all four simulators gate on the window the comparison scores. The
  PII observer document's quality-gate section was still quoting a 60 s window
  and three thresholds no version of the code has used; it now carries the
  900 s window and the current numbers.

The comparison table itself is unchanged: it always applied its window in
Python, so the aggregate stands at OU-III 4.5%, OU-II 6.5%, PII 11.9% and
TVG-NLO 14.5% of Hs. Verified by rerunning all four simulators from the same
records and regenerating the table, which reproduces those values exactly.

Verified: both simulators pass every gate on all eight records, and
tests/validation passes (66 tests).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01669XzoL6hmKuTVmf44xn83