### PR TITLE
Tune the dynamically scaled EMA smoothers on the drift-correction channels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,16 @@ w3d_*.csv
 wave_spectrum_*.csv
 wave_tracker_data.csv
 
+# Same category, written by the rest of the suite that `make all` runs.
+# Together these are about two gigabytes per run and are regenerated from the
+# fetched records every time, so they are build output rather than evidence.
+qmekf_*.csv
+freq_track_*.csv
+adaptive_wave_detrender*_output.csv
+adaptive_wave_detrender*_summary.csv
+calibrate_imu_test_*.csv
+vertical_accel_drift_*.csv
+
 # Compiled test executables (extensionless, so not covered by the rules above)
 tests/*/*-sim
 tests/*/*-test

--- a/README.md
+++ b/README.md
@@ -213,3 +213,9 @@ it shows a consistent stationary vertical OU-III benefit but mixed 3D,
 transition, and adaptation outcomes rather than uniform superiority. See
 [`docs/ou-validation.md`](docs/ou-validation.md) for the protocol, seed controls,
 and interpretation.
+
+The adaptation channels themselves smooth their targets with an EMA whose time
+constant scales with the OU operating point. `tools/ou_ema_adapt_study.py`
+sweeps those horizons against synthesized sea-state transitions, which is the
+only instrument that can see them; see
+[`docs/ou-ema-adaptation-tuning.md`](docs/ou-ema-adaptation-tuning.md).

--- a/docs/ou-ema-adaptation-tuning.md
+++ b/docs/ou-ema-adaptation-tuning.md
@@ -1,0 +1,254 @@
+# Tuning the dynamically scaled EMA smoothers on the drift-correction channels
+
+Three channels in the two OU filters smooth their adaptation target with an
+exponential moving average whose time constant is proportional to the current
+OU operating point rather than fixed in seconds:
+
+| family | channel | target law | horizon |
+| --- | --- | --- | --- |
+| OU-III | `r_S` | `R_S_coeff * sigma_a * tau^3` | `ADAPT_RS_MULT * tau_target` |
+| OU-II | `r_p0` | `R_p0_coeff * sigma_a * tau^2` | `ADAPT_R_p0_MULT * tau_target` |
+| OU-II | `r_v0` | `R_v0_coeff * sigma_a * tau` | `ADAPT_R_v0_MULT * tau_target` |
+
+All three multipliers shipped at `5.0`. That value had never been measured
+against an alternative. This document is the measurement.
+
+Everything below is measured on the versioned simulation records
+(`bareboat-necessities/oceanography-waves-lib`, `v1.1.3`) with
+`tests/kalman_ou_ii/kalman_ou_ii-sim` and
+`tests/kalman_ou_iii/kalman_ou_iii-sim`, scoring the trailing 900 s.
+`tools/ou_ema_adapt_study.py` reproduces every table.
+
+**Result.** All three multipliers move from `5.0` to `3.0`. The stationary
+records are nearly indifferent; the gain is on sea-state transitions, where the
+shipped horizon lagged the target by 10 to 20 s.
+
+## 1. Why the stationary records cannot answer the question
+
+A smoothing horizon is only observable while its target moves. On a stationary
+record the target settles after warmup and every horizon converges to the same
+value, so the whole sweep collapses into the noise:
+
+| `ADAPT_RS_MULT` | 3D RMS | Z RMS | roll/pitch | accel bias |
+| --- | --- | --- | --- | --- |
+| 1.0 | 0.9992 | 0.9966 | 1.0033 | 1.0003 |
+| 2.0 | 0.9996 | 0.9990 | 1.0064 | 1.0052 |
+| 3.0 | 0.9999 | 0.9997 | 1.0039 | 1.0033 |
+| 4.0 | 1.0000 | 0.9999 | 1.0018 | 1.0016 |
+| 5.0 (shipped) | 1.0000 | 1.0000 | 1.0000 | 1.0000 |
+| 8.0 | 0.9998 | 0.9999 | 1.0003 | 1.0014 |
+
+Ratios to the shipped multiplier on the same record and seed, pooled by
+geometric mean over the four JONSWAP and four PM-Stokes records at three IMU
+seed triplets (n = 24). Every entry is inside ±0.6%. A 16x change in the
+smoothing horizon is worth less than a percent, which is the expected answer
+for an instrument that holds the target still.
+
+## 2. The instrument: synthesized sea-state transitions
+
+`tools/ou_ema_adapt_study.py transition` builds non-stationary records with the
+same C2 quintic crossfade `tools/ou_validation.py` uses for its transition
+scenario: two independently phase-randomized realizations blended over
+420-780 s of a 1200 s record, with displacement, velocity and acceleration all
+carrying the blend's derivatives so the record stays kinematically consistent.
+The 900 s scoring window opens at 300 s, so it contains 120 s of the start sea,
+the whole crossfade and 420 s of the endpoint sea. Those three intervals are
+scored separately through `W3D_VALIDATION_SEGMENTS`.
+
+Two endpoint pairs are used, each run in both directions (sea building and sea
+decaying) at five wave-phase seeds:
+
+| pair | start sea | endpoint sea | mean `tau_applied` |
+| --- | --- | --- | --- |
+| `large` | JONSWAP H_s = 1.5 m | H_s = 8.5 m record rescaled to 4.0 m | 3.15 s |
+| `small` | JONSWAP H_s = 0.27 m | H_s = 1.5 m record rescaled to 0.7 m | 1.77 s |
+
+Across the `large` transition `tau` roughly doubles, and `r_S ~ sigma_a tau^3`
+moves by more than an order of magnitude. That is the excursion the smoother
+has to follow.
+
+## 3. What the shipped horizon costs
+
+Sweeping `ADAPT_RS_MULT` on the `large` pair, scoring the crossfade interval
+only (10 records x 3 IMU seed triplets, n = 30, ratios to the shipped value):
+
+| `ADAPT_RS_MULT` | 3D RMS | Z RMS | Z RMS worst | roll/pitch | accel bias |
+| --- | --- | --- | --- | --- | --- |
+| 1.0 | 0.9850 | 0.9796 | 1.0130 | 1.0025 | 1.0077 |
+| 1.5 | 0.9872 | 0.9832 | 1.0107 | 0.9917 | 0.9926 |
+| 2.0 | 0.9891 | 0.9865 | 1.0079 | 0.9976 | 0.9993 |
+| 2.5 | 0.9909 | 0.9892 | 1.0052 | 0.9975 | 0.9986 |
+| 3.0 | 0.9927 | 0.9916 | 1.0030 | 0.9976 | 0.9980 |
+| 4.0 | 0.9963 | 0.9960 | 1.0004 | 0.9994 | 0.9995 |
+| 5.0 (shipped) | 1.0000 | 1.0000 | 1.0000 | 1.0000 | 1.0000 |
+| 8.0 | 1.0185 | 1.0201 | 1.0422 | 1.0099 | 1.0098 |
+| 20 | 1.0596 | 1.0621 | 1.1268 | 1.0262 | 1.0246 |
+| 50 | 1.1176 | 1.1242 | 1.2809 | 1.0305 | 1.0209 |
+
+The displacement error is monotone in the horizon over two decades of
+multiplier. It flattens below about 1.5, where roll/pitch and the accelerometer
+bias start to degrade instead: at that point the smoother has stopped rejecting
+tuner jitter and is passing it into `r_S`.
+
+OU-II behaves the same way, with the two channels separating cleanly. Sweeping
+one multiplier at a time on the `large` pair, crossfade interval, one IMU seed
+triplet (n = 10):
+
+| multiplier | 3D RMS (`r_p0` swept) | 3D RMS (`r_v0` swept) | accel bias (`r_v0` swept) |
+| --- | --- | --- | --- |
+| 0.35 | 0.9827 | 0.9998 | 0.9523 |
+| 1.0 | 0.9877 | 1.0005 | 0.9028 |
+| 2.0 | 0.9922 | 1.0003 | 0.9547 |
+| 5.0 (shipped) | 1.0000 | 1.0000 | 1.0000 |
+| 12 | 1.0152 | 1.0013 | 1.0105 |
+| 20 | 1.0297 | 1.0032 | 0.9818 |
+
+`r_p0` owns the displacement error and moves little else; `r_v0` does not move
+displacement at all but owns roll/pitch and the accelerometer bias, with an
+optimum near 1-2 rather than at the short end. That split follows
+the two laws: `r_p0 ~ tau^2` prices position drift, `r_v0 ~ tau` prices velocity
+drift, and the velocity channel is what the bias estimator competes with.
+
+## 4. The scaling law is right; the constant was not
+
+The horizon is proportional to `tau`, i.e. it is a fixed number of wave periods
+rather than a fixed number of seconds. Repeating the OU-III sweep on the
+`small` pair, whose `tau` is 1.8x smaller, separates the two candidate laws: a
+fixed-seconds law would want a multiplier 1.8x larger there.
+
+Crossfade interval, one IMU seed triplet, n = 10 per pair:
+
+| `ADAPT_RS_MULT` | blend 3D RMS, `large` pair | blend 3D RMS, `small` pair |
+| --- | --- | --- |
+| 0.5 | 0.9808 | 0.9920 |
+| 1.0 | 0.9837 | 0.9917 |
+| 1.5 | 0.9861 | 0.9927 |
+| 2.0 | 0.9880 | 0.9938 |
+| 3.0 | 0.9920 | 0.9960 |
+| 5.0 (shipped) | 1.0000 | 1.0000 |
+| 20 | 1.0544 | 1.0223 |
+
+Both pairs are minimized by the same multiplier to within the resolution of the
+sweep, and the optimum does not shift toward larger multipliers in the shorter
+sea. The tau-proportional law is not refuted; only its constant was wrong.
+
+At the deployed operating points the constant is what decides whether the
+smoother is a filter or a lag:
+
+| record | `tau_applied` | horizon at 5.0 | horizon at 3.0 |
+| --- | --- | --- | --- |
+| JONSWAP H_s = 0.27 m | 1.28 s | 6.4 s | 3.8 s |
+| JONSWAP H_s = 1.5 m | 2.18 s | 10.9 s | 6.5 s |
+| JONSWAP H_s = 4.0 m | 3.59 s | 18.0 s | 10.8 s |
+| JONSWAP H_s = 8.5 m | 4.23 s | 21.1 s | 12.7 s |
+
+In a developed sea the shipped horizon was 21 s, a substantial fraction of the
+360 s crossfade it had to follow, so `r_S` spent most of the transition on a
+stale operating point. That is the lag the sweep is measuring.
+
+## 5. A discrepancy-gated horizon does not help
+
+The two instruments want opposite things - a stationary sea wants a long
+horizon for noise rejection, a moving sea wants a short one - which suggests
+making the horizon depend on how far the target has drifted from the applied
+value rather than picking one constant. `seastate::common::adaptiveSmoothingHorizonSec`
+implements that: with a threshold `slew_log > 0` the horizon is divided by
+`1 + (|ln(target/applied)| / slew_log)^2`, so jitter inside the threshold leaves
+the long horizon intact while a sustained move shortens it quadratically.
+
+Measured on the `large` pair at the shipped multiplier, crossfade interval,
+one IMU seed triplet (n = 10):
+
+| `slew_log` | 3D RMS | roll/pitch | accel bias |
+| --- | --- | --- | --- |
+| 0.1 | 0.9860 | 1.0726 | 1.1214 |
+| 0.2 | 0.9900 | 1.0628 | 1.1056 |
+| 0.35 | 0.9940 | 1.0433 | 1.0796 |
+| 0.75 | 0.9980 | 0.9924 | 1.0052 |
+| 1.5 | 0.9993 | 1.0090 | 1.0184 |
+| off (deployed) | 1.0000 | 1.0000 | 1.0000 |
+
+It reaches the same displacement as a short fixed horizon and pays far more for
+it: `slew_log = 0.1` buys 3D RMS 0.986, which `ADAPT_RS_MULT = 1.5` also buys,
+but at 7.3% worse roll/pitch and 12.1% worse accelerometer bias instead of
+better. The reason is that the gate keys on the *instantaneous* discrepancy,
+which on a stationary sea is dominated by tuner jitter rather than by any real
+move, so the horizon collapses on every excursion. Distinguishing a real move
+from jitter needs persistence, not magnitude.
+
+The mechanism is kept, disabled (`ADAPT_RS_SLEW_LOG = 0`,
+`ADAPT_R_SLEW_LOG = 0`) and reachable through
+`OU_ADAPT_RS_SLEW_LOG` / `OU_ADAPT_R_SLEW_LOG`, so the claim stays
+reproducible. It is not a recommended configuration.
+
+## 6. Adopted values
+
+`ADAPT_RS_MULT`, `ADAPT_R_p0_MULT` and `ADAPT_R_v0_MULT` all move from `5.0` to
+`3.0`. Ratios to the shipped configuration, pooled by geometric mean:
+
+| | OU-III stationary | OU-III blend | OU-II stationary | OU-II blend |
+| --- | --- | --- | --- | --- |
+| n | 24 | 30 | 24 | 30 |
+| 3D RMS | 0.9999 | **0.9927** | 0.9989 | **0.9957** |
+| Z RMS | 0.9997 | **0.9916** | 0.9998 | **0.9944** |
+| Z RMS, worst record | 1.0066 | 1.0030 | 1.0073 | 1.0022 |
+| roll/pitch | 1.0039 | 0.9976 | 0.9974 | 0.9885 |
+| yaw | 1.0000 | 0.9995 | 0.9991 | 1.0012 |
+| accel bias | 1.0033 | 0.9980 | 0.9990 | 0.9841 |
+
+Over the whole 900 s transition window - the convention the committed
+validation scores, three quarters of which is stationary - the same change is
+worth 0.31% of 3D RMS for OU-III and 0.21% for OU-II.
+
+The shorter horizons were not taken further than 3.0 even though the crossfade
+score keeps improving down to about 1.5, because the stationary worst-record
+vertical error rises monotonically the other way and the accelerometer-bias
+sentinel moves with it. 3.0 is where the two curves cross at a cost worth
+paying.
+
+### Sentinel re-derivation
+
+`bias_3d_percent` is the only gate in either simulator that the change moves
+past its limit; every other sentinel still passes on its existing value.
+
+| family | before | after | binding record |
+| --- | --- | --- | --- |
+| OU-III | 106.25 (limit 106.8) | 108.88 (limit 109.4) | JONSWAP H_s = 1.5 m, accel |
+| OU-II | 77.38 (limit 77.8) | 81.75 (limit 82.3) | JONSWAP H_s = 1.5 m, accel |
+
+These sentinels carry about half a percent of headroom by construction, so any
+change to the operating point moves them; even `ADAPT_RS_MULT = 4.0` exceeds
+the old OU-III limit (107.35). What the number reports is the horizontal
+accelerometer bias on the H_s = 1.5 m record, where the estimate is already
+worse than predicting zero - 130% of the maximum true bias for OU-II and 182%
+for OU-III before the change. The shorter horizon lets the pseudo-measurements
+absorb low-frequency content the bias state was absorbing, which is why the
+displacement error on that same record is unchanged (OU-II 20.779% -> 20.776%)
+while the bias aggregate rises. It is a redistribution between two states, not
+a loss of displacement accuracy.
+
+## 7. Reproducing
+
+```sh
+# stationary sweep, one knob at a time
+tools/ou_ema_adapt_study.py stage1 --family OU_III --records jonswap,pmstokes
+
+# crossfade sweep, both transition directions, five wave-phase seeds
+tools/ou_ema_adapt_study.py transition --family OU_III \
+    --transition-pair large --transition-seeds 11,12,13,14,15
+
+# scaling-law check: same sweep one octave down in wave period
+tools/ou_ema_adapt_study.py transition --family OU_III --transition-pair small
+
+# joint (r_p0, r_v0) grid for OU-II
+tools/ou_ema_adapt_study.py transition --family OU_II --transition-stage grid2d
+
+# a named point across three IMU seed triplets
+tools/ou_ema_adapt_study.py transition --family OU_II --transition-stage confirm \
+    --point 'p0=3,v0=3:OU_ADAPT_R_P0_MULT=3:OU_ADAPT_R_V0_MULT=3' \
+    --seeds default,7,99
+```
+
+The multipliers are also reachable at runtime through
+`setRSAdaptMult()` (OU-III) and `setR_p0_AdaptMult()` / `setR_v0_AdaptMult()`
+(OU-II), and are part of the `tools/ou_tuning_sweep.py` search space.

--- a/src/kalman_common/SeaStateFusionFilterCommon.h
+++ b/src/kalman_common/SeaStateFusionFilterCommon.h
@@ -237,6 +237,50 @@ inline DetrenderConfig defaultDisplacementDetrenderConfig(float freq_guess_hz) {
     return seastate::tuner::common::defaultDisplacementDetrenderConfig<DetrenderConfig>(freq_guess_hz);
 }
 
+// Smoothing horizon for a drift-correction channel whose target is a power law
+// in the OU operating point (r_S ~ sigma_aw tau^3, r_p0 ~ sigma_aw tau^2,
+// r_v0 ~ sigma_aw tau).  Those targets are rebuilt every step from the raw
+// tuner estimates, so the channel needs an exponential smoother that its
+// inputs do not already provide.
+//
+// The horizon is `mult * tau`, i.e. a fixed number of wave periods rather than
+// a fixed number of seconds, so it follows the sea state.  A single horizon has
+// to serve two regimes that want opposite things: while the sea is stationary
+// the target only jitters and a long horizon rejects that jitter, but while the
+// sea state moves the same long horizon lags the target and the filter runs on
+// a stale operating point.
+//
+// `slew_log` resolves that.  It is the size, in natural-log units of the
+// target-to-applied ratio, of a discrepancy considered "real" rather than
+// jitter.  The horizon is divided by 1 + (discrepancy / slew_log)^2, so jitter
+// well inside the threshold leaves the long horizon intact while a sustained
+// move shortens it quadratically.  slew_log <= 0 disables the term and leaves
+// the plain proportional horizon.
+inline float adaptiveSmoothingHorizonSec(float mult,
+                                         float tau_sec,
+                                         float target,
+                                         float applied,
+                                         float slew_log,
+                                         float dt)
+{
+    float horizon = mult * tau_sec;
+
+    if (slew_log > 0.0f && target > 0.0f && applied > 0.0f &&
+        std::isfinite(target) && std::isfinite(applied))
+    {
+        const float discrepancy = std::fabs(std::log(target / applied));
+        if (std::isfinite(discrepancy)) {
+            const float k = discrepancy / slew_log;
+            horizon /= (1.0f + k * k);
+        }
+    }
+
+    // The horizon is proportional to the operating point, so a degenerate tau
+    // must not collapse it to zero and turn the EMA into a pass-through.  One
+    // step is the shortest meaningful horizon.
+    return std::max(horizon, dt);
+}
+
 template<typename MekfPtr, typename EnterColdFn, typename ApplyTuneFn>
 inline void finalizeInitialization(MekfPtr& mekf, EnterColdFn&& enterCold, ApplyTuneFn&& applyTune) {
     enterCold();

--- a/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
+++ b/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
@@ -127,8 +127,19 @@ constexpr float MAX_R_v0_std  = 40.0f;
 
 constexpr float ADAPT_TAU_SEC              = 1.8f;
 constexpr float ADAPT_EVERY_SECS           = 0.1f;
-constexpr float ADAPT_R_p0_MULT            = 5.0f;   // dimensionless
-constexpr float ADAPT_R_v0_MULT            = 5.0f;   // dimensionless
+// Smoothing horizons of the two drift-correction channels, in units of
+// tau_target.  Measured on the versioned records against synthesized sea-state
+// transitions: the error during a transition falls monotonically as these
+// shorten, the stationary worst-record vertical error rises monotonically, and
+// 3.0 is where the two cross at an acceptable cost for both channels.  See
+// docs/ou-ema-adaptation-tuning.md.
+constexpr float ADAPT_R_p0_MULT            = 3.0f;   // dimensionless
+constexpr float ADAPT_R_v0_MULT            = 3.0f;   // dimensionless
+// Discrepancy, in natural-log units of the target-to-applied ratio, above
+// which the smoothing horizon of either drift-correction channel shortens.
+// Zero keeps the plain proportional horizon; see
+// docs/ou-ema-adaptation-tuning.md.
+constexpr float ADAPT_R_SLEW_LOG           = 0.0f;   // ln units
 constexpr float ONLINE_TUNE_WARMUP_SEC     = 5.0f;
 constexpr float MAG_DELAY_SEC              = 7.0f;
 
@@ -582,6 +593,34 @@ public:
         if (std::isfinite(tau_sec) && tau_sec > 0.0f) adapt_tau_sec_ = tau_sec;
     }
 
+    // Smoothing-horizon multipliers for the two drift-correction channels.
+    // The EMA time constant of each channel is mult * tau_target, so the
+    // horizon follows the sea state instead of being pinned to one second
+    // count.  r_p0 ~ sigma_aw * tau^2 and r_v0 ~ sigma_aw * tau amplify a tau
+    // error by different powers, so the two channels need not share a
+    // multiplier; see docs/ou-ema-adaptation-tuning.md.
+    void setR_p0_AdaptMult(float m) {
+        if (std::isfinite(m) && m > 0.0f) adapt_R_p0_mult_ = m;
+    }
+
+    void setR_v0_AdaptMult(float m) {
+        if (std::isfinite(m) && m > 0.0f) adapt_R_v0_mult_ = m;
+    }
+
+    // Size, in natural-log units of the target-to-applied ratio, of a
+    // discrepancy the smoothers should treat as a real sea-state move rather
+    // than tuner jitter.  Both channels are driven by the same tau and sigma
+    // estimates, so their discrepancies move together and share one threshold.
+    // Zero or negative leaves the plain proportional horizon.  See
+    // seastate::common::adaptiveSmoothingHorizonSec.
+    void setR_AdaptSlewLog(float d) {
+        if (std::isfinite(d)) adapt_R_slew_log_ = d;
+    }
+
+    float getR_p0_AdaptMult() const noexcept { return adapt_R_p0_mult_; }
+    float getR_v0_AdaptMult() const noexcept { return adapt_R_v0_mult_; }
+    float getR_AdaptSlewLog() const noexcept { return adapt_R_slew_log_; }
+
     void setAdaptationUpdatePeriod(float every_sec) {
         if (std::isfinite(every_sec) && every_sec > 0.0f) adapt_every_secs_ = every_sec;
     }
@@ -814,8 +853,12 @@ private:
     void adapt_mekf(float dt, float tau_t, float sigma_t, float R_p0_t, float R_v0_t) {
         const float alpha = 1.0f - std::exp(-dt / adapt_tau_sec_);
 
-        const float R_p0_sec   = ADAPT_R_p0_MULT * tau_t;
-        const float R_v0_sec   = ADAPT_R_v0_MULT * tau_t;
+        const float R_p0_sec = seastate::common::adaptiveSmoothingHorizonSec(
+            adapt_R_p0_mult_, tau_t, R_p0_t, tune_.R_p0_std_applied,
+            adapt_R_slew_log_, dt);
+        const float R_v0_sec = seastate::common::adaptiveSmoothingHorizonSec(
+            adapt_R_v0_mult_, tau_t, R_v0_t, tune_.R_v0_std_applied,
+            adapt_R_slew_log_, dt);
         const float alpha_R_p0 = 1.0f - std::exp(-dt / R_p0_sec);
         const float alpha_R_v0 = 1.0f - std::exp(-dt / R_v0_sec);
 
@@ -966,6 +1009,9 @@ private:
     float MIN_R_v0_std_           = MIN_R_v0_std;
     float MAX_R_v0_std_           = MAX_R_v0_std;
     float adapt_tau_sec_          = ADAPT_TAU_SEC;
+    float adapt_R_p0_mult_        = ADAPT_R_p0_MULT;
+    float adapt_R_v0_mult_        = ADAPT_R_v0_MULT;
+    float adapt_R_slew_log_       = ADAPT_R_SLEW_LOG;
     float adapt_every_secs_       = ADAPT_EVERY_SECS;
     float online_tune_warmup_sec_ = ONLINE_TUNE_WARMUP_SEC;
     float mag_delay_sec_          = MAG_DELAY_SEC;

--- a/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
+++ b/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
@@ -111,7 +111,18 @@ constexpr float MAX_R_S     = 400.0f;
 
 constexpr float ADAPT_TAU_SEC              = 1.8f;
 constexpr float ADAPT_EVERY_SECS           = 0.1f;
-constexpr float ADAPT_RS_MULT              = 5.0f;   // dimensionless
+// Smoothing horizon of the r_S channel, in units of tau_target.  Measured on
+// the versioned records against synthesized sea-state transitions: the error
+// during a transition falls monotonically as this shortens, the stationary
+// worst-record vertical error rises monotonically, and 3.0 is where the two
+// cross at an acceptable cost.  r_S ~ sigma_aw tau^3 amplifies tau noise by
+// the third power, which is why this sits above OU-II's tau^2 and tau^1
+// channels.  See docs/ou-ema-adaptation-tuning.md.
+constexpr float ADAPT_RS_MULT              = 3.0f;   // dimensionless
+// Discrepancy, in natural-log units of the r_S target-to-applied ratio, above
+// which the smoothing horizon shortens.  Zero keeps the plain proportional
+// horizon; see docs/ou-ema-adaptation-tuning.md.
+constexpr float ADAPT_RS_SLEW_LOG          = 0.0f;   // ln units
 constexpr float ONLINE_TUNE_WARMUP_SEC     = 5.0f;
 constexpr float MAG_DELAY_SEC              = 7.0f;
 
@@ -620,6 +631,27 @@ public:
         if (std::isfinite(tau_sec) && tau_sec > 0.0f)   adapt_tau_sec_   = tau_sec;
      }
 
+    // Smoothing-horizon multiplier for the r_S channel.  The EMA time
+    // constant is mult * tau_target, so the horizon follows the sea state
+    // instead of being pinned to one second count.  r_S ~ sigma_aw * tau^3
+    // amplifies a tau error by the third power, which is what sets the
+    // multiplier apart from the tau/sigma one; see
+    // docs/ou-ema-adaptation-tuning.md.
+    void setRSAdaptMult(float m) {
+        if (std::isfinite(m) && m > 0.0f) adapt_RS_mult_ = m;
+    }
+
+    // Size, in natural-log units of the r_S target-to-applied ratio, of a
+    // discrepancy the smoother should treat as a real sea-state move rather
+    // than tuner jitter.  Zero or negative leaves the plain proportional
+    // horizon.  See seastate::common::adaptiveSmoothingHorizonSec.
+    void setRSAdaptSlewLog(float d) {
+        if (std::isfinite(d)) adapt_RS_slew_log_ = d;
+    }
+
+    float getRSAdaptMult() const noexcept { return adapt_RS_mult_; }
+    float getRSAdaptSlewLog() const noexcept { return adapt_RS_slew_log_; }
+
     void setAdaptationUpdatePeriod(float every_sec) {
         if (std::isfinite(every_sec) && every_sec > 0.0f) {
             adapt_every_secs_ = every_sec;
@@ -875,7 +907,8 @@ private:
     void adapt_mekf(float dt, float tau_t, float sigma_t, float RS_t) {
         const float alpha = 1.0f - std::exp(-dt / adapt_tau_sec_);
 
-        const float RS_sec   = ADAPT_RS_MULT * tau_t;
+        const float RS_sec = seastate::common::adaptiveSmoothingHorizonSec(
+            adapt_RS_mult_, tau_t, RS_t, tune_.RS_applied, adapt_RS_slew_log_, dt);
         const float alpha_RS = 1.0f - std::exp(-dt / RS_sec);
 
         tune_.tau_applied   += alpha    * (tau_t   - tune_.tau_applied);
@@ -1024,6 +1057,8 @@ private:
     float min_R_S_                = MIN_R_S;
     float max_R_S_                = MAX_R_S;
     float adapt_tau_sec_          = ADAPT_TAU_SEC;
+    float adapt_RS_mult_          = ADAPT_RS_MULT;
+    float adapt_RS_slew_log_      = ADAPT_RS_SLEW_LOG;
     float adapt_every_secs_       = ADAPT_EVERY_SECS;
     float online_tune_warmup_sec_ = ONLINE_TUNE_WARMUP_SEC;
     float mag_delay_sec_          = MAG_DELAY_SEC;

--- a/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
+++ b/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
@@ -142,6 +142,31 @@ public:
                 filter.setAdaptationTimeConstants(v);
             }
 
+            // Smoothing horizons of the two drift-correction EMAs, in units
+            // of tau_target.
+            if (env_float("OU_ADAPT_R_P0_MULT", v)) {
+                filter.setR_p0_AdaptMult(v);
+            }
+            if (env_float("OU_II_ADAPT_R_P0_MULT", v)) {
+                filter.setR_p0_AdaptMult(v);
+            }
+
+            if (env_float("OU_ADAPT_R_V0_MULT", v)) {
+                filter.setR_v0_AdaptMult(v);
+            }
+            if (env_float("OU_II_ADAPT_R_V0_MULT", v)) {
+                filter.setR_v0_AdaptMult(v);
+            }
+
+            // Discrepancy threshold that shortens both horizons when the sea
+            // state actually moves.  0 keeps the plain proportional horizon.
+            if (env_float("OU_ADAPT_R_SLEW_LOG", v)) {
+                filter.setR_AdaptSlewLog(v);
+            }
+            if (env_float("OU_II_ADAPT_R_SLEW_LOG", v)) {
+                filter.setR_AdaptSlewLog(v);
+            }
+
             if (env_float("OU_ADAPT_EVERY_SECS", v)) {
                 filter.setAdaptationUpdatePeriod(v);
             }
@@ -411,14 +436,21 @@ private:
 // Re-derived for the 900 s scoring window: a sentinel fitted to the previous
 // 60 s window is not a sentinel for this one, it is just a number the filter
 // passes by a wide margin.
+//
+// bias_3d_percent re-derived again when the r_p0 and r_v0 smoothing horizons
+// were shortened from 5 to 3 wave-period-halves.  The binding record moves from
+// pmstokes H0.27 to jonswap H1.5, where the horizontal accelerometer bias is
+// already unobservable -- the error exceeds the true bias with either horizon
+// -- and the displacement error on that record is unchanged.  See
+// docs/ou-ema-adaptation-tuning.md.
 static constexpr W3dFailureLimits FAIL_LIMITS{
-    .err_limit_percent_z_jonswap   = 7.0f,    // worst 6.90 (jonswap H0.27)
-    .err_limit_percent_z_pmstokes  = 6.9f,    // worst 6.84 (pmstokes H0.27)
+    .err_limit_percent_z_jonswap   = 7.0f,    // worst 6.87 (jonswap H0.27)
+    .err_limit_percent_z_pmstokes  = 6.9f,    // worst 6.86 (pmstokes H0.27)
     .err_limit_yaw_deg             = 2.2f,    // worst 2.13 (pmstokes H0.27)
     .err_limit_percent_3d_jonswap  = 20.9f,   // worst 20.78 (jonswap H1.5)
-    .err_limit_percent_3d_pmstokes = 20.7f,   // worst 20.59 (pmstokes H8.5)
+    .err_limit_percent_3d_pmstokes = 20.7f,   // worst 20.54 (pmstokes H8.5)
     .acc_z_bias_percent            = 5.9f,    // worst 5.84 (pmstokes H8.5)
-    .bias_3d_percent               = 77.8f,   // worst 77.38 (pmstokes H0.27, accel)
+    .bias_3d_percent               = 82.3f,   // worst 81.75 (jonswap H1.5, accel)
 };
 
 static constexpr W3dSummaryLabels SUMMARY_LABELS{

--- a/tests/kalman_ou_iii/kalman_ou_iii-sim.cpp
+++ b/tests/kalman_ou_iii/kalman_ou_iii-sim.cpp
@@ -138,6 +138,23 @@ public:
                 filter.setAdaptationTimeConstants(v);
             }
 
+            // Smoothing horizon of the r_S EMA, in units of tau_target.
+            if (env_float("OU_ADAPT_RS_MULT", v)) {
+                filter.setRSAdaptMult(v);
+            }
+            if (env_float("OU_III_ADAPT_RS_MULT", v)) {
+                filter.setRSAdaptMult(v);
+            }
+
+            // Discrepancy threshold that shortens that horizon when the sea
+            // state actually moves.  0 keeps the plain proportional horizon.
+            if (env_float("OU_ADAPT_RS_SLEW_LOG", v)) {
+                filter.setRSAdaptSlewLog(v);
+            }
+            if (env_float("OU_III_ADAPT_RS_SLEW_LOG", v)) {
+                filter.setRSAdaptSlewLog(v);
+            }
+
             if (env_float("OU_ADAPT_EVERY_SECS", v)) {
                 filter.setAdaptationUpdatePeriod(v);
             }
@@ -405,14 +422,22 @@ private:
 // Re-derived for the 900 s scoring window: a sentinel fitted to the
 // previous 60 s window is not a sentinel for this one, it is just a number the
 // filter passes by a wide margin.
+//
+// bias_3d_percent re-derived again when the r_S smoothing horizon was
+// shortened from 5 to 3 wave-period-halves.  That gate is dominated by the
+// horizontal accelerometer bias on jonswap H1.5, which is already unobservable
+// there -- the error exceeds the true bias with either horizon -- and the
+// shorter horizon moves the aggregate from 106.2 to 108.9 while the
+// displacement error on the same record is unchanged.  See
+// docs/ou-ema-adaptation-tuning.md.
 static constexpr W3dFailureLimits FAIL_LIMITS{
     .err_limit_percent_z_jonswap   = 5.4f,    // worst 5.34 (jonswap H0.27)
     .err_limit_percent_z_pmstokes  = 5.3f,    // worst 5.25 (pmstokes H0.27)
-    .err_limit_yaw_deg             = 2.2f,    // worst 2.16 (pmstokes H8.5)
-    .err_limit_percent_3d_jonswap  = 21.4f,   // worst 21.22 (jonswap H1.5)
+    .err_limit_yaw_deg             = 2.2f,    // worst 2.17 (pmstokes H8.5)
+    .err_limit_percent_3d_jonswap  = 21.4f,   // worst 21.23 (jonswap H1.5)
     .err_limit_percent_3d_pmstokes = 22.0f,   // worst 21.85 (pmstokes H0.27)
-    .acc_z_bias_percent            = 5.9f,    // worst 5.85 (pmstokes H8.5)
-    .bias_3d_percent               = 106.8f,  // worst 106.25 (jonswap H1.5, accel)
+    .acc_z_bias_percent            = 5.9f,    // worst 5.84 (pmstokes H8.5)
+    .bias_3d_percent               = 109.4f,  // worst 108.88 (jonswap H1.5, accel)
 };
 
 static constexpr W3dSummaryLabels SUMMARY_LABELS{

--- a/tools/ou_ema_adapt_study.py
+++ b/tools/ou_ema_adapt_study.py
@@ -1,0 +1,531 @@
+#!/usr/bin/env python3
+"""Tune the dynamically scaled EMA smoothers on the drift-correction channels.
+
+Three channels smooth their target with an exponential moving average whose
+time constant is proportional to the current OU operating point:
+
+    OU-III  r_S    tau_ema = OU_ADAPT_RS_MULT    * tau_target
+    OU-II   r_p0   tau_ema = OU_ADAPT_R_P0_MULT  * tau_target
+    OU-II   r_v0   tau_ema = OU_ADAPT_R_V0_MULT  * tau_target
+
+All three multipliers ship at 5.0, which was never measured against an
+alternative.  This tool sweeps them and reports, for every setting, the error
+of the resulting estimate relative to the shipped default.
+
+Instrument.  A smoothing horizon is only observable while its target moves, so
+the stationary records answer almost nothing: after warmup the target sits
+still and every horizon converges to the same value.  The `transition` stage
+therefore synthesizes non-stationary records with the same C2 quintic crossfade
+`tools/ou_validation.py` uses, and scores the crossfade interval on its own.
+
+Scoring.  Per record the simulator reports RMS errors over a window.  Each
+candidate is scored by the ratio of its error to the default's error on the
+same record, seed and interval, so records of wildly different sea states can
+be pooled.  Ratios are pooled with a geometric mean -- a scale-free average of
+relative change -- and reported alongside the worst record, because a horizon
+that wins on average by losing badly somewhere is not an improvement.
+
+Usage:
+  tools/ou_ema_adapt_study.py stage1     --family OU_III
+  tools/ou_ema_adapt_study.py transition --family OU_III
+  tools/ou_ema_adapt_study.py grid2d     --family OU_II
+  tools/ou_ema_adapt_study.py confirm    --family OU_II --point 'a:OU_ADAPT_R_P0_MULT=8'
+"""
+
+import argparse
+import csv
+import itertools
+import math
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections import defaultdict
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+FAMILIES = {
+    "OU_II": {
+        "subdir": "kalman_ou_ii",
+        "binary": "kalman_ou_ii-sim",
+        "knobs": ["OU_ADAPT_R_P0_MULT", "OU_ADAPT_R_V0_MULT"],
+        "short": ["p0", "v0"],
+    },
+    "OU_III": {
+        "subdir": "kalman_ou_iii",
+        "binary": "kalman_ou_iii-sim",
+        "knobs": ["OU_ADAPT_RS_MULT"],
+        "short": ["rs"],
+    },
+}
+
+# Shipped value of every multiplier.  A candidate that sets no knob is the
+# baseline and must reproduce it exactly.
+DEFAULT_MULT = 5.0
+
+# Scoring window, matching the committed 900 s convention.
+WINDOW_SEC = 900.0
+RECORD_SEC = 1200.0
+DT_SEC = 1.0 / 200.0
+
+# Crossfade interval of the synthesized transition records, in seconds from the
+# start of the record.  These are tools/ou_validation.py's defaults for a
+# 1200 s record (0.35 and 0.65 of the duration).
+TRANSITION_START_SEC = 420.0
+TRANSITION_END_SEC = 780.0
+
+METRIC_RENAME = {
+    "disp_3d_rms_m": "rms_3d",
+    "disp_z_rms_m": "z_rms",
+    "disp_x_rms_m": "x_rms",
+    "disp_y_rms_m": "y_rms",
+    "roll_rms_deg": "roll_rms",
+    "pitch_rms_deg": "pitch_rms",
+    "yaw_rms_deg": "yaw_rms",
+    "accel_bias_3d_rms_mps2": "acc_bias_rms_3d",
+    "tau_applied_s": "tau_applied",
+    "tuning_applied": "channel_applied",
+}
+
+METRICS = ("rms_3d", "z_rms", "xy_rms", "roll_pitch_rms", "yaw_rms", "acc_bias_rms_3d")
+
+RX_GATE = re.compile(r"QUALITY_GATE:\s+PASS=(\d)\s+REASON=(.*)")
+
+
+def log(msg):
+    print(msg, flush=True)
+
+
+def records(family):
+    tdir = ROOT / "tests" / FAMILIES[family]["subdir"]
+    return sorted(str(p) for p in tdir.glob("wave_data_*.csv"))
+
+
+def parse(text):
+    """One row per VALIDATION_METRICS line, plus the record's quality gate."""
+    rows = []
+    gate_pass, gate_reason = False, ""
+
+    for line in text.splitlines():
+        m = RX_GATE.search(line)
+        if m:
+            gate_pass = m.group(1) == "1"
+            gate_reason = m.group(2).strip()
+            continue
+        # The trailing window is tagged VALIDATION_METRICS; each extra scoring
+        # interval requested through W3D_VALIDATION_SEGMENTS is tagged
+        # VALIDATION_SEGMENT.  Both carry the same key=value payload.
+        if not (line.startswith("VALIDATION_METRICS ")
+                or line.startswith("VALIDATION_SEGMENT ")):
+            continue
+
+        row = {}
+        for token in line.split()[1:]:
+            key, _, value = token.partition("=")
+            key = METRIC_RENAME.get(key, key)
+            try:
+                row[key] = float(value)
+            except ValueError:
+                row[key] = value
+        row["wave_dataset"] = os.path.basename(str(row.get("input", "")))
+        row["xy_rms"] = math.hypot(row.get("x_rms", 0.0), row.get("y_rms", 0.0))
+        row["roll_pitch_rms"] = math.hypot(row.get("roll_rms", 0.0),
+                                           row.get("pitch_rms", 0.0))
+        rows.append(row)
+
+    for row in rows:
+        row["gate_pass"] = gate_pass
+        row["gate_reason"] = gate_reason
+    return rows
+
+
+def run_one(job):
+    """Run the simulator on a single record with a single knob setting."""
+    family, label, knobs, seed, record, segments, timeout_sec = job
+    cfg = FAMILIES[family]
+    tdir = ROOT / "tests" / cfg["subdir"]
+
+    env = os.environ.copy()
+    # "default" reproduces the shipped deterministic realization, which every
+    # committed number in the repository is scored on.  Any other value expands
+    # into independent sensor streams.
+    if seed == "default":
+        env.pop("W3D_SEED", None)
+    else:
+        env["W3D_SEED"] = str(seed)
+    # The study reads only the RMS summaries.  Skipping the per-sample CSV both
+    # speeds the run up and lets candidates run in parallel in one directory
+    # without fighting over output filenames.
+    env["W3D_WRITE_TIMESERIES"] = "0"
+    env["W3D_COLLECT_ALL_GATES"] = "1"
+    env["W3D_VALIDATION_WINDOW_SEC"] = f"{WINDOW_SEC:g}"
+    if segments:
+        env["W3D_VALIDATION_SEGMENTS"] = segments
+    for k, v in knobs.items():
+        env[k] = f"{v:.9g}"
+
+    # Keyed by the full path, not the basename: synthesized transition records
+    # all carry the same conforming filename in separate directories, and a
+    # basename key would collapse them onto one baseline.
+    stub = {"family": family, "label": label, "seed": seed,
+            "wave_dataset": record, **knobs}
+
+    try:
+        pr = subprocess.run(
+            [str(tdir / cfg["binary"]), "--input", record],
+            cwd=tdir, text=True, capture_output=True, env=env, timeout=timeout_sec,
+        )
+    except subprocess.TimeoutExpired:
+        return [{**stub, "segment": "window", "gate_pass": False,
+                 "gate_reason": "timeout", "returncode": -2}]
+
+    rows = parse(pr.stdout + "\n" + pr.stderr)
+    if not rows:
+        return [{**stub, "segment": "window", "gate_pass": False,
+                 "gate_reason": f"no_output(rc={pr.returncode})",
+                 "returncode": pr.returncode}]
+
+    for r in rows:
+        r.update({**stub, "returncode": pr.returncode})
+    return rows
+
+
+def run_candidates(family, candidates, seeds, recs, jobs, timeout_sec, segments=""):
+    work = [
+        (family, label, knobs, seed, rec, segments, timeout_sec)
+        for label, knobs in candidates
+        for seed in seeds
+        for rec in recs
+    ]
+    log(f"RUN family={family} candidates={len(candidates)} seeds={len(seeds)} "
+        f"records={len(recs)} runs={len(work)}")
+
+    out, done = [], 0
+    with ProcessPoolExecutor(max_workers=jobs) as ex:
+        for rows in ex.map(run_one, work, chunksize=1):
+            out.extend(rows)
+            done += 1
+            if done % 25 == 0 or done == len(work):
+                log(f"  progress {done}/{len(work)}")
+    return out
+
+
+def geomean(values):
+    vals = [v for v in values if math.isfinite(v) and v > 0.0]
+    if not vals:
+        return float("nan")
+    return math.exp(sum(math.log(v) for v in vals) / len(vals))
+
+
+def summarize(rows, baseline_label="baseline", segment="window"):
+    """Ratio every candidate against the baseline on the same record+seed."""
+    rows = [r for r in rows if r.get("segment", "window") == segment]
+
+    base = {}
+    for r in rows:
+        if r.get("label") == baseline_label:
+            base[(r["family"], r["wave_dataset"], r["seed"])] = r
+
+    by_label = defaultdict(list)
+    for r in rows:
+        by_label[(r["family"], r["label"])].append(r)
+
+    summary = []
+    for (family, label), items in sorted(by_label.items()):
+        ratios = defaultdict(list)
+        failures = regressions = 0
+        for r in items:
+            b = base.get((family, r["wave_dataset"], r["seed"]))
+            if not (r.get("gate_pass", False) and r.get("returncode", 0) == 0):
+                failures += 1
+                # Several records fail the acceleration-bias gate for the
+                # default too.  Only a gate the default passes and the
+                # candidate breaks is evidence against the candidate.
+                if b is not None and b.get("gate_pass", False):
+                    regressions += 1
+            if b is None:
+                continue
+            for m in METRICS:
+                num, den = r.get(m), b.get(m)
+                if num is None or den is None or den <= 0.0:
+                    continue
+                ratios[m].append(num / den)
+
+        row = {"family": family, "label": label, "segment": segment,
+               "n": len(items), "gate_failures": failures,
+               "gate_regressions": regressions}
+        for m in METRICS:
+            row[f"{m}_gm"] = geomean(ratios[m])
+            row[f"{m}_max"] = max(ratios[m]) if ratios[m] else float("nan")
+        # One number to order candidates by.  Displacement dominates because
+        # these channels exist to suppress double-integration drift; the
+        # worst-record terms keep an average win from hiding a local loss.
+        row["score"] = (
+            3.0 * row["rms_3d_gm"] + 1.0 * row["rms_3d_max"]
+            + 2.0 * row["z_rms_gm"] + 0.7 * row["z_rms_max"]
+            + 0.8 * row["roll_pitch_rms_gm"] + 0.3 * row["yaw_rms_gm"]
+            + 0.2 * row["acc_bias_rms_3d_gm"]
+            + 100.0 * regressions
+        )
+        summary.append(row)
+
+    summary.sort(key=lambda r: (r["family"], r["score"]))
+    return summary
+
+
+def write_rows(path, rows):
+    if not rows:
+        return
+    keys = []
+    for r in rows:
+        for k in r:
+            if k not in keys:
+                keys.append(k)
+    with open(path, "w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=keys, extrasaction="ignore")
+        w.writeheader()
+        w.writerows(rows)
+    log(f"WROTE {path}")
+
+
+def print_summary(summary, title=""):
+    hdr = (f"{'family':7s} {'candidate':22s} {'seg':7s} {'3D gm':>7s} {'3D max':>7s} "
+           f"{'Z gm':>7s} {'Z max':>7s} {'RP gm':>7s} {'yaw gm':>7s} "
+           f"{'bias gm':>7s} {'regr':>5s} {'score':>7s}")
+    log("")
+    if title:
+        log(title)
+    log(hdr)
+    log("-" * len(hdr))
+    for r in summary:
+        log(f"{r['family']:7s} {r['label']:22s} {r['segment']:7s} "
+            f"{r['rms_3d_gm']:7.4f} {r['rms_3d_max']:7.4f} "
+            f"{r['z_rms_gm']:7.4f} {r['z_rms_max']:7.4f} "
+            f"{r['roll_pitch_rms_gm']:7.4f} {r['yaw_rms_gm']:7.4f} "
+            f"{r['acc_bias_rms_3d_gm']:7.4f} {r['gate_regressions']:5d} "
+            f"{r['score']:7.4f}")
+    log("")
+
+
+#  Transition records
+
+
+# Endpoint seas of the synthesized transitions.  "large" is the pair the
+# committed validation uses.  "small" runs the same relative sea-state change
+# one octave down in wave period, which is what separates the two candidate
+# scaling laws: if the best horizon is the same *multiple of tau* on both
+# pairs, the deployed tau-proportional law is right; if it is the same number
+# of *seconds*, the scaling is not earning its place.
+TRANSITION_PAIRS = {
+    #          low sea (H_s, source tokens)      high sea, rescaled to H_s
+    "large": (("1.500", "50.710", 1.500), ("8.500", "202.839", 4.000)),
+    "small": (("0.270", "14.047", 0.270), ("1.500", "50.710", 0.700)),
+}
+
+
+def build_transition_records(family, seeds, out_dir, directions, pairs):
+    """Synthesize non-stationary records with ou_validation's crossfade."""
+    sys.path.insert(0, str(ROOT / "tools"))
+    import ou_validation as ov
+
+    data_dir = ROOT / "tests" / FAMILIES[family]["subdir"]
+    out_dir.mkdir(parents=True, exist_ok=True)
+    paths = []
+
+    for pair in pairs:
+        (lo_h, lo_l, _), (hi_h, hi_l, hi_target) = TRANSITION_PAIRS[pair]
+        lo_path = ov.find_default_input(data_dir, lo_h, lo_l)
+        hi_path = ov.find_default_input(data_dir, hi_h, hi_l)
+        columns, lo_data = ov.read_wave_csv(lo_path, RECORD_SEC)
+        _, hi_data = ov.read_wave_csv(hi_path, RECORD_SEC)
+        # The endpoint sea keeps the source record's period and is rescaled in
+        # height, exactly as the committed validation builds its transition.
+        hi_scaled = ov.scale_wave_motion(columns, hi_data, hi_target / float(hi_h))
+
+        for direction in directions:
+            if direction == "up":
+                start, end = lo_data, hi_scaled
+            elif direction == "down":
+                start, end = hi_scaled, lo_data
+            else:
+                raise SystemExit(f"unknown transition direction {direction}")
+            for seed in seeds:
+                generated = ov.make_nonstationary_wave(
+                    columns, start, end, seed, 1.0,
+                    TRANSITION_START_SEC, TRANSITION_END_SEC,
+                )
+                # The simulator infers the spectrum and the nominal H_s and
+                # azimuth from the filename, so a synthesized record has to
+                # carry a conforming name.  A per-record directory keeps the
+                # names unique without inventing sea-state tokens that do not
+                # describe the file.
+                sub = out_dir / f"{pair}_{direction}_{seed}"
+                sub.mkdir(parents=True, exist_ok=True)
+                name = (f"wave_data_jonswap_H{hi_target:.3f}_L{hi_l}"
+                        f"_A-30.00_P120.00.csv")
+                path = sub / name
+                ov.write_wave_csv(path, columns, generated)
+                paths.append(str(path))
+                log(f"  generated {pair}/{direction} seed={seed} -> {path}")
+    return paths
+
+
+#  Candidate construction
+
+
+def parse_grid(text):
+    return [float(v) for v in text.split(",") if v.strip()]
+
+
+def stage1_candidates(family, grid):
+    """One knob at a time, every other knob at its shipped value."""
+    cfg = FAMILIES[family]
+    cands = [("baseline", {})]
+    for knob, short in zip(cfg["knobs"], cfg["short"]):
+        for v in grid:
+            if abs(v - DEFAULT_MULT) < 1e-9:
+                continue
+            cands.append((f"{short}={v:g}", {knob: v}))
+    return cands
+
+
+def grid2d_candidates(family, grid_a, grid_b):
+    cfg = FAMILIES[family]
+    if len(cfg["knobs"]) != 2:
+        raise SystemExit(f"grid2d needs a two-knob family; {family} has "
+                         f"{len(cfg['knobs'])}")
+    ka, kb = cfg["knobs"]
+    sa, sb = cfg["short"]
+    cands = [("baseline", {})]
+    for a, b in itertools.product(grid_a, grid_b):
+        if abs(a - DEFAULT_MULT) < 1e-9 and abs(b - DEFAULT_MULT) < 1e-9:
+            continue
+        cands.append((f"{sa}={a:g},{sb}={b:g}", {ka: a, kb: b}))
+    return cands
+
+
+def confirm_candidates(points):
+    """points: list of "name:KNOB=value[:KNOB=value]" strings."""
+    cands = [("baseline", {})]
+    for spec in points:
+        name, _, rest = spec.partition(":")
+        knobs = {}
+        for item in rest.split(":"):
+            if not item.strip():
+                continue
+            k, _, v = item.partition("=")
+            knobs[k.strip()] = float(v)
+        cands.append((name, knobs))
+    return cands
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("stage", choices=["stage1", "grid2d", "confirm", "transition"])
+    ap.add_argument("--family", default="OU_III", choices=sorted(FAMILIES))
+    ap.add_argument("--grid", default="0.5,1,1.5,2,3,5,8,12,20,32,50",
+                    help="stage1/transition multiplier grid")
+    ap.add_argument("--grid-a", default="2,3,5,8,12", help="grid2d: first knob")
+    ap.add_argument("--grid-b", default="2,3,5,8,12", help="grid2d: second knob")
+    ap.add_argument("--point", action="append", default=[],
+                    help="confirm stage: name:KNOB=value[:KNOB=value]")
+    ap.add_argument("--seeds", default="default",
+                    help="comma-separated; 'default' keeps the shipped realization")
+    ap.add_argument("--records", default="",
+                    help="comma-separated substrings selecting stationary records")
+    ap.add_argument("--transition-seeds", default="11,12,13",
+                    help="wave phase seeds for the synthesized transition records")
+    ap.add_argument("--transition-dir", default="up,down",
+                    help="'up' (sea builds), 'down' (sea decays), or both")
+    ap.add_argument("--transition-pair", default="large",
+                    help=f"endpoint seas: {','.join(TRANSITION_PAIRS)}")
+    ap.add_argument("--transition-stage", default="stage1",
+                    choices=["stage1", "grid2d", "confirm"],
+                    help="which candidate set to run on the transition records")
+    ap.add_argument("--keep-generated", default="",
+                    help="directory to keep the synthesized records in")
+    ap.add_argument("--jobs", type=int, default=max(1, (os.cpu_count() or 2)))
+    ap.add_argument("--timeout", type=float, default=1800.0)
+    ap.add_argument("--out", default="")
+    args = ap.parse_args()
+
+    seeds = [s.strip() if s.strip() == "default" else int(s)
+             for s in args.seeds.split(",") if s.strip()]
+
+    def candidates_for(stage):
+        if stage == "stage1":
+            return stage1_candidates(args.family, parse_grid(args.grid))
+        if stage == "grid2d":
+            return grid2d_candidates(args.family, parse_grid(args.grid_a),
+                                     parse_grid(args.grid_b))
+        if not args.point:
+            raise SystemExit("confirm stage needs at least one --point")
+        return confirm_candidates(args.point)
+
+    tmp_dir = None
+    segments = ""
+    if args.stage == "transition":
+        cands = candidates_for(args.transition_stage)
+        gen_root = (Path(args.keep_generated) if args.keep_generated
+                    else Path(tempfile.mkdtemp(prefix="ou_ema_transition_")))
+        if not args.keep_generated:
+            tmp_dir = gen_root
+        log(f"GENERATE transition records in {gen_root}")
+        recs = build_transition_records(
+            args.family,
+            [int(s) for s in args.transition_seeds.split(",") if s.strip()],
+            gen_root,
+            [d.strip() for d in args.transition_dir.split(",") if d.strip()],
+            [p.strip() for p in args.transition_pair.split(",") if p.strip()],
+        )
+        # The scored window opens at 300 s, so it contains 120 s of the start
+        # sea, the whole crossfade, and 420 s of the endpoint sea.  Splitting
+        # it keeps the crossfade from being diluted by the two stationary
+        # stretches that surround it.
+        segments = (f"start:{RECORD_SEC - WINDOW_SEC:g}:"
+                    f"{TRANSITION_START_SEC:g},"
+                    f"blend:{TRANSITION_START_SEC:g}:{TRANSITION_END_SEC:g},"
+                    f"end:{TRANSITION_END_SEC:g}:{RECORD_SEC:g}")
+        report_segments = ["window", "blend", "end", "start"]
+    else:
+        cands = candidates_for(args.stage)
+        recs = records(args.family)
+        if args.records:
+            want = [s.strip() for s in args.records.split(",") if s.strip()]
+            recs = [r for r in recs if any(w in os.path.basename(r) for w in want)]
+        report_segments = ["window"]
+
+    if not recs:
+        raise SystemExit(f"no records for {args.family}; run `make fetch-sim-data`")
+
+    try:
+        rows = run_candidates(args.family, cands, seeds, recs, args.jobs,
+                              args.timeout, segments)
+    finally:
+        if tmp_dir:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    all_summary = []
+    for seg in report_segments:
+        summary = summarize(rows, "baseline", seg)
+        if not summary:
+            continue
+        print_summary(summary, title=f"segment: {seg}")
+        all_summary.extend(summary)
+
+    if args.out:
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        write_rows(out, rows)
+        write_rows(out.with_name(out.stem + "_summary.csv"), all_summary)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/ou_tuning_sweep.py
+++ b/tools/ou_tuning_sweep.py
@@ -78,12 +78,18 @@ OU_II_EXTRA_SPECS = {
     "OU_R_P0_XY_FACTOR": (0.30, 1.00, "log"),
     "OU_P_FACTOR": (1.20, 1.80, "log"),
     "OU_R_V0_COEFF": (0.90, 2.50, "log"),
+    # Smoothing horizons of the two drift-correction channels, in units of
+    # tau_target.  Ranges bracket the deployed 3.0 on both sides; the
+    # productive region is characterized in docs/ou-ema-adaptation-tuning.md.
+    "OU_ADAPT_R_P0_MULT": (0.80, 8.00, "log"),
+    "OU_ADAPT_R_V0_MULT": (0.80, 8.00, "log"),
 }
 
 # OU_III-specific analogues missing from the sweep.
 OU_III_EXTRA_SPECS = {
     "OU_III_R_S_COEFF": (0.70, 3.20, "log"),
     "OU_III_R_S_XY_FACTOR": (0.20, 0.65, "log"),
+    "OU_ADAPT_RS_MULT": (0.80, 8.00, "log"),
 }
 
 # tuning mag behavior.


### PR DESCRIPTION
The r_S horizon in OU-III and the r_p0/r_v0 horizons in OU-II are all
`5.0 * tau_target`, a constant that had never been measured against an
alternative. Measure it, and move all three to 3.0.

Stationary records cannot see this parameter: after warmup the target
stops moving and a 16x change in horizon is worth under a percent. The
study therefore synthesizes non-stationary records with the same C2
quintic crossfade tools/ou_validation.py uses, and scores the crossfade
interval separately. There the displacement error is monotone in the
horizon over two decades: at 5.0 a developed sea rebuilt r_S on a 21 s
horizon while following a 360 s sea-state change.

Repeating the sweep one octave down in wave period leaves the optimal
multiplier where it was, so the tau-proportional scaling law holds and
only its constant was wrong.

Pooled over 3 IMU seed triplets, relative to the previous value, the
crossfade interval improves 3D RMS by 0.73% (OU-III) and 0.43% (OU-II)
and vertical RMS by 0.84% and 0.56%, with the stationary records within
0.1%. Shorter horizons keep improving down to about 1.5 but the
stationary worst-record vertical error rises the other way; 3.0 is where
the two cross.

A discrepancy-gated horizon was measured as an alternative to a single
constant and is dominated by simply shortening it, so it ships disabled
and reachable only through the study knobs.

bias_3d_percent is the only sentinel the change moves past its limit in
either simulator; it is re-derived, and the metric it reports is the
horizontal accelerometer bias on a record where that state is already
unobservable and the displacement error is unchanged.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01E3yRvtXBjJv6CGzoydk191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable adaptive smoothing for OU-II and OU-III adaptation channels.
  * Added optional discrepancy-based horizon shortening for faster response to changing targets.
  * Added command-line tools for evaluating smoothing multipliers across stationary and transitioning conditions.

* **Documentation**
  * Documented EMA adaptation behavior, tuning results, validation metrics, and reproduction steps.

* **Tests**
  * Added environment-variable overrides for adaptation settings and refreshed regression thresholds and metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->