### PR TITLE
Schedule the PII observer off accel sigma instead of frequency alone

### DIFF
--- a/src/pii_observer/AdaptiveVerticalPII.h
+++ b/src/pii_observer/AdaptiveVerticalPII.h
@@ -160,8 +160,8 @@ public:
     struct Config {
         ObserverConfig observer = [] {
             ObserverConfig cfg{};
-            cfg.r = T(0.150);
-            cfg.tau_a = T(0.68);
+            cfg.r = T(0.125);
+            cfg.tau_a = T(0.40);
             cfg.tau_d = T(49.0);
             cfg.kb = T(2.5e-5);
             cfg.lambda_b = T(3.0e-3);
@@ -179,20 +179,20 @@ public:
             cfg.enabled = true;
             cfg.min_confidence = T(0.22);
             cfg.f_disp_ref_hz = T(0.12);
-            cfg.sigma_a_ref = T(0.95);
-            cfg.input_smooth_tau = T(4.5);
-            cfg.param_smooth_tau = T(7.5);
-            cfg.r_freq_exp = T(0.28);
-            cfg.r_sigma_exp = T(0.02);
-            cfg.tau_a_freq_exp = T(-0.40);
-            cfg.tau_a_sigma_exp = T(-0.03);
+            cfg.sigma_a_ref = T(1.10);
+            cfg.input_smooth_tau = T(55.0);
+            cfg.param_smooth_tau = T(50.0);
+            cfg.r_freq_exp = T(0.23);
+            cfg.r_sigma_exp = T(0.65);
+            cfg.tau_a_freq_exp = T(-0.25);
+            cfg.tau_a_sigma_exp = T(-1.20);
             cfg.tau_d_freq_exp = T(-0.03);
             cfg.tau_d_sigma_exp = T(-0.01);
             cfg.kb_freq_exp = T(0.02);
             cfg.kb_sigma_exp = T(0.08);
-            cfg.r_min = T(0.145);
-            cfg.r_max = T(0.225);
-            cfg.tau_a_min = T(0.50);
+            cfg.r_min = T(0.06);
+            cfg.r_max = T(0.26);
+            cfg.tau_a_min = T(0.15);
             cfg.tau_a_max = T(0.90);
             cfg.tau_d_min = T(44.0);
             cfg.tau_d_max = T(58.0);

--- a/src/pii_observer/AdaptiveVerticalPIIMahony.h
+++ b/src/pii_observer/AdaptiveVerticalPIIMahony.h
@@ -36,8 +36,8 @@ public:
     struct Config {
         CoreConfig core = [] {
             CoreConfig cfg{};
-            cfg.observer.r = T(0.150);
-            cfg.observer.tau_a = T(0.68);
+            cfg.observer.r = T(0.125);
+            cfg.observer.tau_a = T(0.40);
             cfg.observer.tau_d = T(49.0);
             cfg.observer.kb = T(2.5e-5);
             cfg.observer.lambda_b = T(3.0e-3);
@@ -50,20 +50,20 @@ public:
             cfg.adaptation.enabled = true;
             cfg.adaptation.min_confidence = T(0.22);
             cfg.adaptation.f_disp_ref_hz = T(0.12);
-            cfg.adaptation.sigma_a_ref = T(0.95);
-            cfg.adaptation.input_smooth_tau = T(4.5);
-            cfg.adaptation.param_smooth_tau = T(7.5);
-            cfg.adaptation.r_freq_exp = T(0.28);
-            cfg.adaptation.r_sigma_exp = T(0.02);
-            cfg.adaptation.tau_a_freq_exp = T(-0.40);
-            cfg.adaptation.tau_a_sigma_exp = T(-0.03);
+            cfg.adaptation.sigma_a_ref = T(1.10);
+            cfg.adaptation.input_smooth_tau = T(55.0);
+            cfg.adaptation.param_smooth_tau = T(50.0);
+            cfg.adaptation.r_freq_exp = T(0.23);
+            cfg.adaptation.r_sigma_exp = T(0.65);
+            cfg.adaptation.tau_a_freq_exp = T(-0.25);
+            cfg.adaptation.tau_a_sigma_exp = T(-1.20);
             cfg.adaptation.tau_d_freq_exp = T(-0.03);
             cfg.adaptation.tau_d_sigma_exp = T(-0.01);
             cfg.adaptation.kb_freq_exp = T(0.02);
             cfg.adaptation.kb_sigma_exp = T(0.08);
-            cfg.adaptation.r_min = T(0.145);
-            cfg.adaptation.r_max = T(0.225);
-            cfg.adaptation.tau_a_min = T(0.50);
+            cfg.adaptation.r_min = T(0.06);
+            cfg.adaptation.r_max = T(0.26);
+            cfg.adaptation.tau_a_min = T(0.15);
             cfg.adaptation.tau_a_max = T(0.90);
             cfg.adaptation.tau_d_min = T(44.0);
             cfg.adaptation.tau_d_max = T(58.0);

--- a/src/pii_observer/VerticalPIIObserver.h
+++ b/src/pii_observer/VerticalPIIObserver.h
@@ -98,8 +98,8 @@ class VerticalPIIObserver {
 public:
     struct Config {
         // Base (reference) observer parameters
-        T r      = T(0.150); // repeated real pole rate for PII core [1/s]
-        T tau_a  = T(0.68);  // acceleration LPF time constant [s]
+        T r      = T(0.125); // repeated real pole rate for PII core [1/s]
+        T tau_a  = T(0.40);  // acceleration LPF time constant [s]
 
         // Optional bias-trend channel
         T tau_d    = T(49.0);   // slow trend extractor time constant [s]
@@ -132,11 +132,17 @@ public:
         // These should reflect a "typical" sea state for which Config::r and
         // Config::tau_a are already reasonable.
         T f_disp_ref_hz = T(0.12);
-        T sigma_a_ref   = T(0.95);
+        T sigma_a_ref   = T(1.10);
 
         // Smoothing of tracker inputs and scheduled parameters.
-        T input_smooth_tau = T(4.5);  // [s] smoothing for f_disp and sigma_a
-        T param_smooth_tau = T(7.5);   // [s] smoothing for scheduled params
+        //
+        // These are deliberately on the order of a minute rather than a few
+        // seconds.  What the schedule is tracking is the sea state, which moves
+        // over tens of minutes; anything faster only lets per-wave jitter in the
+        // frequency and sigma estimates modulate the observer gains, and that
+        // modulation shows up directly as heave error.
+        T input_smooth_tau = T(55.0);  // [s] smoothing for f_disp and sigma_a
+        T param_smooth_tau = T(50.0);   // [s] smoothing for scheduled params
 
         // Frequency and sigma influence on the PII pole rate:
         //
@@ -147,8 +153,16 @@ public:
         // Recommended interpretation:
         //   r_freq_exp  > 0 : faster displacement waves allow a somewhat faster PII core
         //   r_sigma_exp > 0 : higher accel sigma reduces restoring aggressiveness
-        T r_freq_exp  = T(0.28);
-        T r_sigma_exp = T(0.02);
+        //
+        // Sigma carries most of the scheduling here, and not because frequency
+        // matters less physically.  The two are competing estimates of the same
+        // sea state, and the accel-derived frequency proxy is compressed: the
+        // acceleration spectrum is weighted by omega^4, so its dominant
+        // frequency sits well above the wave peak and barely separates a 3 s sea
+        // from an 11 s one.  Accel sigma separates the same sea states by a
+        // factor of five, so it is the better-conditioned regressor of the two.
+        T r_freq_exp  = T(0.23);
+        T r_sigma_exp = T(0.65);
 
         // Frequency and sigma influence on acceleration LPF time constant:
         //
@@ -159,8 +173,8 @@ public:
         // With defaults:
         //   faster displacement waves -> smaller tau_a (faster LPF)
         //   larger sigma              -> larger tau_a (more smoothing)
-        T tau_a_freq_exp  = T(-0.40);
-        T tau_a_sigma_exp = T(-0.03);
+        T tau_a_freq_exp  = T(-0.25);
+        T tau_a_sigma_exp = T(-1.20);
 
         // Optional scheduling of bias-trend channel.
         // Conservative defaults:
@@ -173,10 +187,10 @@ public:
         T kb_sigma_exp    = T(0.08);
 
         // Hard bounds on scheduled parameters.
-        T r_min     = T(0.145);
-        T r_max     = T(0.225);
+        T r_min     = T(0.06);
+        T r_max     = T(0.26);
 
-        T tau_a_min = T(0.50);
+        T tau_a_min = T(0.15);
         T tau_a_max = T(0.90);
 
         T tau_d_min = T(44.0);

--- a/tests/pii_observer/pii_observer-adaptive.cpp
+++ b/tests/pii_observer/pii_observer-adaptive.cpp
@@ -43,9 +43,14 @@ static constexpr int RMS_WINDOW_SEC_LABEL = static_cast<int>(RMS_WINDOW_SEC);
 // Re-derived for the 900 s scoring window: a sentinel fitted to the previous
 // 60 s window is not a sentinel for this one, it is just a number the observer
 // passes by a wide margin.
+//
+// Re-derived again for the sea-state-scheduled tuning below.  The worst record
+// moved from the calmest sea to the roughest one, because scheduling the PII
+// pole rate off accel sigma is what removed the calm-sea error; leaving the old
+// numbers in place would have retired the gate rather than kept it.
 static constexpr W3dFailureLimits FAIL_LIMITS{
-    .err_limit_percent_z_jonswap = 15.8f,   // worst 15.71 (jonswap H0.27)
-    .err_limit_percent_z_pmstokes = 16.6f,  // worst 16.42 (pmstokes H0.27)
+    .err_limit_percent_z_jonswap = 9.0f,    // worst 8.87 (jonswap H8.5)
+    .err_limit_percent_z_pmstokes = 9.5f,   // worst 9.36 (pmstokes H8.5)
     .err_limit_yaw_deg = 10.9f,             // worst 10.78 (pmstokes H8.5)
 };
 
@@ -263,8 +268,8 @@ private:
         HeaveFilter::Config cfg{};
 
         // Base observer
-        cfg.core.observer.r          = 0.150f;
-        cfg.core.observer.tau_a      = 0.68f;
+        cfg.core.observer.r          = 0.125f;
+        cfg.core.observer.tau_a      = 0.40f;
         cfg.core.observer.tau_d      = 49.0f;
         cfg.core.observer.kb         = 2.5e-5f;
         cfg.core.observer.lambda_b   = 3.0e-3f;
@@ -281,15 +286,15 @@ private:
         cfg.core.adaptation.min_confidence = 0.22f;
 
         cfg.core.adaptation.f_disp_ref_hz    = 0.12f;
-        cfg.core.adaptation.sigma_a_ref      = 0.95f;
-        cfg.core.adaptation.input_smooth_tau = 4.5f;
-        cfg.core.adaptation.param_smooth_tau = 7.5f;
+        cfg.core.adaptation.sigma_a_ref      = 1.10f;
+        cfg.core.adaptation.input_smooth_tau = 55.0f;
+        cfg.core.adaptation.param_smooth_tau = 50.0f;
 
-        cfg.core.adaptation.r_freq_exp   = 0.28f;
-        cfg.core.adaptation.r_sigma_exp  = 0.02f;
+        cfg.core.adaptation.r_freq_exp   = 0.23f;
+        cfg.core.adaptation.r_sigma_exp  = 0.65f;
 
-        cfg.core.adaptation.tau_a_freq_exp   = -0.40f;
-        cfg.core.adaptation.tau_a_sigma_exp  = -0.03f;
+        cfg.core.adaptation.tau_a_freq_exp   = -0.25f;
+        cfg.core.adaptation.tau_a_sigma_exp  = -1.20f;
 
         cfg.core.adaptation.tau_d_freq_exp   = -0.03f;
         cfg.core.adaptation.tau_d_sigma_exp  = -0.01f;
@@ -297,10 +302,10 @@ private:
         cfg.core.adaptation.kb_freq_exp   = 0.02f;
         cfg.core.adaptation.kb_sigma_exp  = 0.08f;
 
-        cfg.core.adaptation.r_min = 0.145f;
-        cfg.core.adaptation.r_max = 0.225f;
+        cfg.core.adaptation.r_min = 0.06f;
+        cfg.core.adaptation.r_max = 0.26f;
 
-        cfg.core.adaptation.tau_a_min = 0.50f;
+        cfg.core.adaptation.tau_a_min = 0.15f;
         cfg.core.adaptation.tau_a_max = 0.90f;
 
         cfg.core.adaptation.tau_d_min = 44.0f;


### PR DESCRIPTION
The adaptive PII observer had two scheduling regressors available, wave
frequency and accel sigma, and was using only the first: r_sigma_exp was
0.02 and tau_a_sigma_exp was -0.03, both close enough to zero to do
nothing.  That left the whole schedule riding on the accel-derived
frequency proxy, which is the worse of the two signals for this job.  The
acceleration spectrum is weighted by omega^4, so its dominant frequency
sits well above the wave peak and lands between 0.22 and 0.34 Hz across
sea states whose true peaks span 0.09 to 0.33 Hz.  Compressed that far,
the schedule moved the active pole rate only from 0.177 to 0.203 over the
whole corpus.

The pole rate wants a much wider spread than that.  A calm short-period
sea needs a fast PII core, because there the error is low-frequency
wander rather than passband distortion; a rough long-period sea needs a
slow one, because r = 0.19 against a 0.088 Hz wave is a third-order
high-pass sitting inside the signal band.  Accel sigma separates those
same sea states by a factor of five, so it is the better-conditioned
regressor, and moving the weight onto it lets the active pole rate range
from 0.104 to 0.260 without either end being clamped.

The adaptation horizons were also far too short.  Every one of them
improved monotonically when lengthened: what the schedule tracks is the
sea state, which moves over tens of minutes, and at a 4.5 s input horizon
per-wave jitter in the frequency and sigma estimates was modulating the
observer gains and showing up as heave error.  Both smoothing horizons
now sit near a minute, which is where the scored error stops improving
and starts degrading again.

Scored on the same 900 s window over the eight shipped records:

  Z RMS %Hs      before   after
  mean            11.91    7.12
  worst           16.42    9.36

Every record improves; the two calmest, which were the worst before, drop
by about two thirds.  The gains hold on four independent noise
realizations and in the no-mag configuration, none of which were used
while tuning.  Attitude RMS is bit-identical, since nothing on the Mahony
path changed, and the envelope estimator keeps its OU-aligned constants:
the sigma rescaling it would otherwise have needed is folded into
sigma_a_ref, so the reported wave-height telemetry is untouched.  The
bias-trend channel is left alone as well, having turned out to be worth
less than 0.01 %Hs anywhere in its usable range.

The quality gates are re-derived by the rule the file documents.  The
worst record has moved from the calmest sea to the roughest one, so
keeping the old sentinels would have retired the gate rather than kept
it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XrMNdXsrGvBTywhQUtF9BF