### PR TITLE
Make the apt steps survive a slow archive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,13 +52,32 @@ jobs:
         run: |
           unzip -o sim-data-files.zip -d ${{ github.workspace }}/plots/${{ matrix.dir }}
 
+      # This is the step that times out. TeX Live is not optional -- every
+      # draw_plots.sh runs matplotlib with the pgf backend and text.usetex, so
+      # the host needs a real xelatex -- but the recommends around it are, and
+      # they are two thirds of the package count. Retries and per-connection
+      # timeouts cover the archive stalling, which is what actually burns the
+      # twenty minutes when this fails.
       - name: Install build dependencies
-        timeout-minutes: 20
+        timeout-minutes: 25
         run: |
-          sudo apt-get update
-          sudo apt-get install -y g++ make libeigen3-dev \
-            texlive-xetex texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra texlive-fonts-extra dvipng \
-            inkscape graphviz python3-pip python3-matplotlib python3-numpy python3-pandas
+          set -euo pipefail
+          apt_get() {
+            sudo env DEBIAN_FRONTEND=noninteractive apt-get \
+              -o Acquire::Retries=5 \
+              -o Acquire::http::Timeout=30 \
+              -o Acquire::https::Timeout=30 \
+              -o Dpkg::Use-Pty=0 \
+              "$@"
+          }
+          apt_get update
+          apt_get install -y --no-install-recommends \
+            g++ make libeigen3-dev \
+            texlive-xetex texlive-latex-recommended texlive-fonts-recommended \
+            texlive-latex-extra texlive-fonts-extra dvipng \
+            inkscape graphviz python3-pip \
+            python3-matplotlib python3-numpy python3-pandas python3-scipy \
+            fonts-dejavu-core
 
       - name: Compile tests (${{ matrix.dir }})
         run: |

--- a/.github/workflows/ou-validation.yml
+++ b/.github/workflows/ou-validation.yml
@@ -90,9 +90,22 @@ jobs:
       - name: Install dependencies
         timeout-minutes: 20
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq \
-            g++ make libeigen3-dev unzip \
+          set -euo pipefail
+          # Retries and per-connection timeouts, because the archive stalls
+          # often enough that one slow fetch decides whether a job finishes.
+          # No -qq: a stall has to be legible in the log as a slow download
+          # rather than as a step that appears to hang.
+          apt_get() {
+            sudo env DEBIAN_FRONTEND=noninteractive apt-get \
+              -o Acquire::Retries=5 \
+              -o Acquire::http::Timeout=30 \
+              -o Acquire::https::Timeout=30 \
+              -o Dpkg::Use-Pty=0 \
+              "$@"
+          }
+          apt_get update
+          apt_get install -y --no-install-recommends \
+            g++ make libeigen3-dev \
             python3-numpy python3-matplotlib
 
       - name: Download versioned simulation data
@@ -160,9 +173,22 @@ jobs:
       - name: Install dependencies
         timeout-minutes: 20
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq \
-            g++ make libeigen3-dev unzip \
+          set -euo pipefail
+          # Retries and per-connection timeouts, because the archive stalls
+          # often enough that one slow fetch decides whether a job finishes.
+          # No -qq: a stall has to be legible in the log as a slow download
+          # rather than as a step that appears to hang.
+          apt_get() {
+            sudo env DEBIAN_FRONTEND=noninteractive apt-get \
+              -o Acquire::Retries=5 \
+              -o Acquire::http::Timeout=30 \
+              -o Acquire::https::Timeout=30 \
+              -o Dpkg::Use-Pty=0 \
+              "$@"
+          }
+          apt_get update
+          apt_get install -y --no-install-recommends \
+            g++ make libeigen3-dev \
             python3-numpy python3-matplotlib
 
       - name: Download versioned simulation data
@@ -228,9 +254,22 @@ jobs:
       - name: Install dependencies
         timeout-minutes: 20
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq \
-            g++ make libeigen3-dev unzip \
+          set -euo pipefail
+          # Retries and per-connection timeouts, because the archive stalls
+          # often enough that one slow fetch decides whether a job finishes.
+          # No -qq: a stall has to be legible in the log as a slow download
+          # rather than as a step that appears to hang.
+          apt_get() {
+            sudo env DEBIAN_FRONTEND=noninteractive apt-get \
+              -o Acquire::Retries=5 \
+              -o Acquire::http::Timeout=30 \
+              -o Acquire::https::Timeout=30 \
+              -o Dpkg::Use-Pty=0 \
+              "$@"
+          }
+          apt_get update
+          apt_get install -y --no-install-recommends \
+            g++ make libeigen3-dev \
             python3-numpy python3-matplotlib
 
       # The combine step re-derives the calibrated tuning points and the
@@ -312,8 +351,22 @@ jobs:
       - name: Install dependencies
         timeout-minutes: 20
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq unzip python3-numpy python3-matplotlib
+          set -euo pipefail
+          # Retries and per-connection timeouts, because the archive stalls
+          # often enough that one slow fetch decides whether a job finishes.
+          # No -qq: a stall has to be legible in the log as a slow download
+          # rather than as a step that appears to hang.
+          apt_get() {
+            sudo env DEBIAN_FRONTEND=noninteractive apt-get \
+              -o Acquire::Retries=5 \
+              -o Acquire::http::Timeout=30 \
+              -o Acquire::https::Timeout=30 \
+              -o Dpkg::Use-Pty=0 \
+              "$@"
+          }
+          apt_get update
+          apt_get install -y --no-install-recommends \
+            python3-numpy python3-matplotlib
 
       # The consistency step hashes every non-code source the manifest names,
       # and those include the simulation records. Without them the check errors


### PR DESCRIPTION
Build run 3028 lost the `freq` and `kalman_ou_ii` jobs to `The action 'Install build dependencies' has timed out after 20 minutes`. The log shows that was real downloading, not a hang — `python3-scipy` took 7 minutes, `unicode-data` 4 — against an archive with no retry configured.

## Changes

**Retries and per-connection timeouts** on all five apt steps (`build`, plus the four in `ou-validation`): `Acquire::Retries=5` with 30 s http/https timeouts, so one stalled connection no longer decides whether the job finishes.

**`-qq` dropped** from the `ou-validation` steps. It suppresses per-package progress, so a slow mirror there would look like a step that stopped responding rather than one still working. (`build.yml` never had it, which is why its stall was legible.)

**`--no-install-recommends`,** measured on ubuntu-24.04:

| | packages | download |
|---|---|---|
| before | 339 | 1050.1 MB |
| after | 136 | 815.2 MB |

Two packages have to be named explicitly once recommends are gone, and both would have failed silently at plot time:

- `python3-scipy` — the plot scripts `from scipy import special, ndimage`, but it only arrived as a recommend of pandas
- `fonts-dejavu-core` — all 13 preambles do `\setmainfont{DejaVu Serif}`, and DejaVu was riding in behind `texlive-fonts-extra`

**`unzip` no longer installed.** It ships in the ubuntu-24.04 runner image, and if that changes the failure is immediate rather than subtle.

**TeX Live stays.** Every `draw_plots.sh` runs matplotlib with `mpl.use("pgf")` and `text.usetex: True`, so the host needs a real xelatex — the `latex-action` container can't supply it. The step's timeout goes 20 → 25 minutes as a margin, not as the fix.

## What this deliberately does not do

**No swap to pip wheels for numpy/matplotlib.** It looks attractive — wheels are far faster than the apt dependency tree, and `cache: pip` would help across the nine installs a full regeneration does — but the pins can't be honoured. The bundle currently on main was produced with:

```
numpy        1.26.4
matplotlib   3.6.3
```

`matplotlib==3.6.3` has no Python 3.12 distribution at all (earliest is 3.7.3), so pip on the runner's interpreter cannot reproduce it. Unpinned, `pip install numpy matplotlib` gets numpy 2.x — and `tools/ou_validation.py` records `numpy.__version__` as provenance while `test_restating_the_committed_bundle_reproduces_its_derived_files` re-derives the tables and byte-compares them against the committed ones. A version change there can move the evidence or fail the gate with nothing in the diff explaining why.

It's also not where the time goes: that step takes **26–59 s** across the regeneration shards. The 20-minute timeout is `build.yml`'s TeX Live install, which is what this PR targets.

**No removal of `texlive-fonts-extra`,** though it is 600 MB — 57% of the current download — and nothing in any preamble references it. Left alone deliberately; it would take a run that actually typesets all ten dirs to prove safe.

## Verification

`actionlint` clean on both workflows; every embedded apt script passes `bash -n`. Package sets measured on ubuntu-24.04 with `apt-get --print-uris`, confirming `fonts-dejavu-core`, `fonts-lmodern`, `python3-scipy` and `python3-tk` all survive the recommends cut. Both tools call `matplotlib.use("Agg")`, so no GUI recommends are needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtfkQ2ehkn5D92YNMKKXxd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated build and validation reliability with installation retries, connection timeouts, and stricter error handling.
  * Reduced unnecessary package installation during automated workflows.
  * Added required support for archive extraction and DejaVu fonts in build environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->