### PR TITLE
Put the recommends back before the plots stop rendering

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,12 +52,18 @@ jobs:
         run: |
           unzip -o sim-data-files.zip -d ${{ github.workspace }}/plots/${{ matrix.dir }}
 
-      # This is the step that times out. TeX Live is not optional -- every
-      # draw_plots.sh runs matplotlib with the pgf backend and text.usetex, so
-      # the host needs a real xelatex -- but the recommends around it are, and
-      # they are two thirds of the package count. Retries and per-connection
-      # timeouts cover the archive stalling, which is what actually burns the
-      # twenty minutes when this fails.
+      # Retries and per-connection timeouts, because the archive stalling is
+      # what actually burns the twenty minutes when this step fails.
+      #
+      # Installed *with* recommends, deliberately. Cutting them takes the
+      # package count from 339 to 136, and it also silently removed cm-super
+      # and texlive-plain-generic, which matplotlib's text.usetex path needs.
+      # Every draw_plots.sh then failed identically with "No pages of output"
+      # from the texcache -- nine of ten dirs in run 31048810866. The set is
+      # recoverable by naming those two explicitly, but the saving is not
+      # worth another round of finding out which package the plots need next
+      # by breaking main, and the timeout this was meant to help is a slow
+      # mirror rather than package volume.
       - name: Install build dependencies
         timeout-minutes: 25
         run: |
@@ -71,10 +77,11 @@ jobs:
               "$@"
           }
           apt_get update
-          apt_get install -y --no-install-recommends \
+          apt_get install -y \
             g++ make libeigen3-dev \
             texlive-xetex texlive-latex-recommended texlive-fonts-recommended \
-            texlive-latex-extra texlive-fonts-extra dvipng \
+            texlive-latex-extra texlive-fonts-extra dvipng cm-super \
+            texlive-plain-generic \
             inkscape graphviz python3-pip \
             python3-matplotlib python3-numpy python3-pandas python3-scipy \
             fonts-dejavu-core


### PR DESCRIPTION
**Main is red and this is the fix.** #235's `--no-install-recommends` broke the plot step in **9 of 10 dirs** in [run 31048810866](https://github.com/bareboat-necessities/ocean-imu/actions/runs/31048810866), and run 31049010611 on main is failing the same way.

## What broke

Every failing job ends identically:

```
               [utf8]{inputenc}^^M
No pages of output.
Transcript written on d174ba5a1278c3ea3324ab2ddb79f45c.log.
##[error]Process completed with exit code 1.
```

The same MD5 transcript name in all nine is matplotlib's `usetex` texcache, so this is **Generate PGF plots** on the host, not the document build. Cutting recommends dropped 203 packages, two of which matter:

- **`cm-super`** — matplotlib's documented `usetex` requirement (Type1 Computer Modern)
- **`texlive-plain-generic`** — carries the `type1cm`/`underscore` support matplotlib's preamble pulls in

Note what the failure does *not* say: no missing-package error, no missing-font error. Just "No pages of output" from a temp file named by hash. That's the failure mode that makes this class of change dangerous.

## What this does

Restores `apt-get install -y` with recommends. The resulting set is 339 packages — verified a **superset** of the pre-#235 working set, with `comm` showing nothing from it missing.

I could instead name `cm-super` and `texlive-plain-generic` explicitly and keep the 339 → 136 cut. That's the tempting fix, and it's the same reasoning that broke main: a package list that *resolves* is not a build that *renders*, and the next missing font fails just as silently. The saving was never the point — the 20-minute timeout is a slow mirror, which the retries already address.

## What is kept from #235

- **retry and timeout options** on every apt step — the actual fix for the original timeout, and untouched by this
- **`python3-scipy` and `fonts-dejavu-core`** named explicitly — they were arriving only as recommends of packages that happen to pull them, which is worth fixing whether recommends are on or off
- **`--no-install-recommends` in `ou-validation`** — its tools call `matplotlib.use("Agg")` and never invoke LaTeX, so nothing there touches the packages this restores. That workflow's gate passed on #235.

## Verification

`actionlint` clean. Package set diffed against the known-good pre-#235 set with `apt-get install -s` on ubuntu-24.04: empty difference. The real check is this PR's own build run rendering all ten dirs — which is the check #235 should have had before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtfkQ2ehkn5D92YNMKKXxd)_