### PR TITLE
Give up on a stalled mirror in eight minutes and try again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,26 +65,42 @@ jobs:
       # by breaking main, and the timeout this was meant to help is a slow
       # mirror rather than package volume.
       - name: Install build dependencies
-        timeout-minutes: 25
+        timeout-minutes: 27
         run: |
-          set -euo pipefail
+          set -uo pipefail
+          # Each attempt is capped at 8 minutes and there are two retries.
+          # A stalled mirror is then abandoned and retried against whatever
+          # the load balancer hands out next, instead of holding the step
+          # until its own timeout kills the job with nothing installed.
           apt_get() {
-            sudo env DEBIAN_FRONTEND=noninteractive apt-get \
-              -o Acquire::Retries=5 \
-              -o Acquire::http::Timeout=30 \
-              -o Acquire::https::Timeout=30 \
+            sudo timeout 8m env DEBIAN_FRONTEND=noninteractive apt-get \
+              -o Acquire::Retries=2 \
+              -o Acquire::http::Timeout=15 \
+              -o Acquire::https::Timeout=15 \
               -o Dpkg::Use-Pty=0 \
               "$@"
           }
-          apt_get update
-          apt_get install -y \
-            g++ make libeigen3-dev \
-            texlive-xetex texlive-latex-recommended texlive-fonts-recommended \
-            texlive-latex-extra texlive-fonts-extra dvipng cm-super \
-            texlive-plain-generic \
-            inkscape graphviz python3-pip \
-            python3-matplotlib python3-numpy python3-pandas python3-scipy \
-            fonts-dejavu-core
+          install_deps() {
+            apt_get update && apt_get install -y \
+              g++ make libeigen3-dev \
+              texlive-xetex texlive-latex-recommended texlive-fonts-recommended \
+              texlive-latex-extra texlive-fonts-extra dvipng cm-super \
+              texlive-plain-generic \
+              inkscape graphviz python3-pip \
+              python3-matplotlib python3-numpy python3-pandas python3-scipy \
+              fonts-dejavu-core
+          }
+          for attempt in 1 2 3; do
+            if install_deps; then
+              echo "dependencies installed on attempt ${attempt}"
+              exit 0
+            fi
+            echo "attempt ${attempt} failed; clearing any half-configured state"
+            sudo dpkg --configure -a || true
+            sleep $((attempt * 15))
+          done
+          echo "apt-get did not succeed after 3 attempts"
+          exit 1
 
       - name: Compile tests (${{ matrix.dir }})
         run: |

--- a/.github/workflows/ou-validation.yml
+++ b/.github/workflows/ou-validation.yml
@@ -88,25 +88,37 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install dependencies
-        timeout-minutes: 20
+        timeout-minutes: 27
         run: |
-          set -euo pipefail
-          # Retries and per-connection timeouts, because the archive stalls
-          # often enough that one slow fetch decides whether a job finishes.
-          # No -qq: a stall has to be legible in the log as a slow download
-          # rather than as a step that appears to hang.
+          set -uo pipefail
+          # Each attempt is capped at 8 minutes and there are two retries.
+          # A stalled mirror is then abandoned and retried against whatever
+          # the load balancer hands out next, instead of holding the step
+          # until its own timeout kills the job with nothing installed.
           apt_get() {
-            sudo env DEBIAN_FRONTEND=noninteractive apt-get \
-              -o Acquire::Retries=5 \
-              -o Acquire::http::Timeout=30 \
-              -o Acquire::https::Timeout=30 \
+            sudo timeout 8m env DEBIAN_FRONTEND=noninteractive apt-get \
+              -o Acquire::Retries=2 \
+              -o Acquire::http::Timeout=15 \
+              -o Acquire::https::Timeout=15 \
               -o Dpkg::Use-Pty=0 \
               "$@"
           }
-          apt_get update
-          apt_get install -y --no-install-recommends \
-            g++ make libeigen3-dev \
-            python3-numpy python3-matplotlib
+          install_deps() {
+            apt_get update && apt_get install -y --no-install-recommends \
+              g++ make libeigen3-dev \
+              python3-numpy python3-matplotlib
+          }
+          for attempt in 1 2 3; do
+            if install_deps; then
+              echo "dependencies installed on attempt ${attempt}"
+              exit 0
+            fi
+            echo "attempt ${attempt} failed; clearing any half-configured state"
+            sudo dpkg --configure -a || true
+            sleep $((attempt * 15))
+          done
+          echo "apt-get did not succeed after 3 attempts"
+          exit 1
 
       - name: Download versioned simulation data
         env:
@@ -171,25 +183,37 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install dependencies
-        timeout-minutes: 20
+        timeout-minutes: 27
         run: |
-          set -euo pipefail
-          # Retries and per-connection timeouts, because the archive stalls
-          # often enough that one slow fetch decides whether a job finishes.
-          # No -qq: a stall has to be legible in the log as a slow download
-          # rather than as a step that appears to hang.
+          set -uo pipefail
+          # Each attempt is capped at 8 minutes and there are two retries.
+          # A stalled mirror is then abandoned and retried against whatever
+          # the load balancer hands out next, instead of holding the step
+          # until its own timeout kills the job with nothing installed.
           apt_get() {
-            sudo env DEBIAN_FRONTEND=noninteractive apt-get \
-              -o Acquire::Retries=5 \
-              -o Acquire::http::Timeout=30 \
-              -o Acquire::https::Timeout=30 \
+            sudo timeout 8m env DEBIAN_FRONTEND=noninteractive apt-get \
+              -o Acquire::Retries=2 \
+              -o Acquire::http::Timeout=15 \
+              -o Acquire::https::Timeout=15 \
               -o Dpkg::Use-Pty=0 \
               "$@"
           }
-          apt_get update
-          apt_get install -y --no-install-recommends \
-            g++ make libeigen3-dev \
-            python3-numpy python3-matplotlib
+          install_deps() {
+            apt_get update && apt_get install -y --no-install-recommends \
+              g++ make libeigen3-dev \
+              python3-numpy python3-matplotlib
+          }
+          for attempt in 1 2 3; do
+            if install_deps; then
+              echo "dependencies installed on attempt ${attempt}"
+              exit 0
+            fi
+            echo "attempt ${attempt} failed; clearing any half-configured state"
+            sudo dpkg --configure -a || true
+            sleep $((attempt * 15))
+          done
+          echo "apt-get did not succeed after 3 attempts"
+          exit 1
 
       - name: Download versioned simulation data
         env:
@@ -252,26 +276,37 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install dependencies
-        timeout-minutes: 20
+        timeout-minutes: 27
         run: |
-          set -euo pipefail
-          # Retries and per-connection timeouts, because the archive stalls
-          # often enough that one slow fetch decides whether a job finishes.
-          # No -qq: a stall has to be legible in the log as a slow download
-          # rather than as a step that appears to hang.
+          set -uo pipefail
+          # Each attempt is capped at 8 minutes and there are two retries.
+          # A stalled mirror is then abandoned and retried against whatever
+          # the load balancer hands out next, instead of holding the step
+          # until its own timeout kills the job with nothing installed.
           apt_get() {
-            sudo env DEBIAN_FRONTEND=noninteractive apt-get \
-              -o Acquire::Retries=5 \
-              -o Acquire::http::Timeout=30 \
-              -o Acquire::https::Timeout=30 \
+            sudo timeout 8m env DEBIAN_FRONTEND=noninteractive apt-get \
+              -o Acquire::Retries=2 \
+              -o Acquire::http::Timeout=15 \
+              -o Acquire::https::Timeout=15 \
               -o Dpkg::Use-Pty=0 \
               "$@"
           }
-          apt_get update
-          apt_get install -y --no-install-recommends \
-            g++ make libeigen3-dev \
-            python3-numpy python3-matplotlib
-
+          install_deps() {
+            apt_get update && apt_get install -y --no-install-recommends \
+              g++ make libeigen3-dev \
+              python3-numpy python3-matplotlib
+          }
+          for attempt in 1 2 3; do
+            if install_deps; then
+              echo "dependencies installed on attempt ${attempt}"
+              exit 0
+            fi
+            echo "attempt ${attempt} failed; clearing any half-configured state"
+            sudo dpkg --configure -a || true
+            sleep $((attempt * 15))
+          done
+          echo "apt-get did not succeed after 3 attempts"
+          exit 1
       # The combine step re-derives the calibrated tuning points and the
       # transition diagnostic, which are simulator work, so it needs the same
       # records and toolchain the shards had.
@@ -349,25 +384,36 @@ jobs:
           ref: ${{ github.ref_name }}
 
       - name: Install dependencies
-        timeout-minutes: 20
+        timeout-minutes: 27
         run: |
-          set -euo pipefail
-          # Retries and per-connection timeouts, because the archive stalls
-          # often enough that one slow fetch decides whether a job finishes.
-          # No -qq: a stall has to be legible in the log as a slow download
-          # rather than as a step that appears to hang.
+          set -uo pipefail
+          # Each attempt is capped at 8 minutes and there are two retries.
+          # A stalled mirror is then abandoned and retried against whatever
+          # the load balancer hands out next, instead of holding the step
+          # until its own timeout kills the job with nothing installed.
           apt_get() {
-            sudo env DEBIAN_FRONTEND=noninteractive apt-get \
-              -o Acquire::Retries=5 \
-              -o Acquire::http::Timeout=30 \
-              -o Acquire::https::Timeout=30 \
+            sudo timeout 8m env DEBIAN_FRONTEND=noninteractive apt-get \
+              -o Acquire::Retries=2 \
+              -o Acquire::http::Timeout=15 \
+              -o Acquire::https::Timeout=15 \
               -o Dpkg::Use-Pty=0 \
               "$@"
           }
-          apt_get update
-          apt_get install -y --no-install-recommends \
-            python3-numpy python3-matplotlib
-
+          install_deps() {
+            apt_get update && apt_get install -y --no-install-recommends \
+              python3-numpy python3-matplotlib
+          }
+          for attempt in 1 2 3; do
+            if install_deps; then
+              echo "dependencies installed on attempt ${attempt}"
+              exit 0
+            fi
+            echo "attempt ${attempt} failed; clearing any half-configured state"
+            sudo dpkg --configure -a || true
+            sleep $((attempt * 15))
+          done
+          echo "apt-get did not succeed after 3 attempts"
+          exit 1
       # The consistency step hashes every non-code source the manifest names,
       # and those include the simulation records. Without them the check errors
       # out on a missing file instead of reporting whether the numbers moved,


### PR DESCRIPTION
The `nlo` article job went down in `Install build dependencies` again, despite the `Acquire::Retries=5` added in #235.

## Why the existing retry didn't help

`Acquire::Retries` re-attempts a fetch against the mirror apt already picked. A host that completes the TCP handshake and then stops sending data isn't a fetch *error* — it's a slow transfer, so the retry never triggers. The install stays alive until the step's own `timeout-minutes` kills it, and the job ends 20-odd minutes in with no packages on the runner.

## What changes

Each attempt is capped at **8 minutes** with **2 retries** (three attempts total):

```bash
apt_get() {
  sudo timeout 8m env DEBIAN_FRONTEND=noninteractive apt-get \
    -o Acquire::Retries=2 \
    -o Acquire::http::Timeout=15 \
    -o Acquire::https::Timeout=15 \
    -o Dpkg::Use-Pty=0 "$@"
}
for attempt in 1 2 3; do
  if install_deps; then exit 0; fi
  sudo dpkg --configure -a || true
  sleep $((attempt * 15))
done
exit 1
```

A stalled mirror is now abandoned with time left to get the packages from whichever host the load balancer hands out next, instead of consuming the whole budget on one dead connection.

Two details that matter:

- **`dpkg --configure -a` between attempts.** Killing apt part way through can leave a package unpacked but unconfigured, and the next attempt would fail on the state the previous one left rather than on the network.
- **`Acquire::Retries` drops 5 → 2 and connection timeouts 30 s → 15 s**, so apt's internal retries can't eat the 8-minute budget before the outer loop gets a turn.

Worst case is 3 × 8 min plus 45 s of backoff, so `timeout-minutes` goes to 27 — enough for the loop to report its own failure rather than being killed mid-retry. Applied to all five install steps (`build`, plus the four in `ou-validation`).

## Verification

`actionlint` clean; all five embedded scripts pass `bash -n`. Retry loop exercised directly: three attempts then exit 1 on persistent failure, and early exit 0 when an attempt succeeds.

Worth noting what this does *not* do: if the archive is broadly slow rather than one host being dead, three capped attempts fail faster than one long one did. That's the intended trade — a job that fails in 25 minutes having genuinely tried three mirrors is more useful than one that fails in 20 having tried one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtfkQ2ehkn5D92YNMKKXxd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the reliability of automated builds and validation workflows.
  - Added bounded retries and recovery handling for temporary dependency-installation failures.
  - Improved timeout behavior to prevent stalled jobs from running indefinitely.
  - Validation jobs now provide clearer failure results when required dependencies cannot be installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->