### PR TITLE
Let the release job survive a skipped ou-evidence

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -298,7 +298,18 @@ jobs:
           if-no-files-found: warn
           
   release:
-    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    # ou-evidence only runs on main, and a skipped job propagates through the
+    # graph: build survives it with !cancelled(), but release inherited the skip
+    # from build's ancestor and never ran off main. That is why v1.1.2 and
+    # v1.1.3 shipped with source code only while v1.1.1, tagged before the
+    # evidence job existed, got its assets. Naming a status function here stops
+    # the automatic skip, so the results of the two jobs that actually produce
+    # the assets are what decides.
+    if: >-
+      ${{ !cancelled()
+          && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+          && needs.build.result == 'success'
+          && needs['build-MCU'].result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     needs: [build, build-MCU]


### PR DESCRIPTION
Releases 1.1.2 and 1.1.3 carry nothing but the source tarball. Both tag
runs are green and every build and build-MCU job in them succeeded, so
the PDFs, SVGs and MCU zips were built and uploaded as workflow
artifacts -- the release job that copies them onto the release was
skipped instead of run.

ou-evidence is gated on main, so on a tag it is skipped. build clears
that with !cancelled(), but release carried no status function, so its
implicit success() looked past build to the skipped ancestor and skipped
in turn. 1.1.1 was tagged before ou-evidence existed, which is why it is
the last release with assets.

Name a status function on release and decide from the results of the two
jobs that actually produce the assets. On main this also means a failed
evidence check no longer withholds the vTest upload, which matches the
reason build ignores it: by then the bundle has landed and the run is
already red on its own.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VVSFzm7yAkN2h1cFyWs2h8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation checks.
  * Releases now run only for pushes or manual triggers after required build jobs complete successfully.
  * Prevented releases from proceeding when a workflow has been cancelled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->