### PR TITLE
Price the body-Z proxy as the wave-period estimator input

### DIFF
--- a/doc/kalman_ou_iii/w3d-fus-methods.tex-part
+++ b/doc/kalman_ou_iii/w3d-fus-methods.tex-part
@@ -237,13 +237,15 @@ pseudo-measurement.
 Reading the attitude solution is itself a weaker coupling, and it is worth
 stating plainly because the stability appendix has to account for it.  Levelling
 uses the attitude estimate, so $\delta\vct\theta$ reaches $f$, hence $\tau$
-and $r_S$, hence the gains.  Measured on a settled filter, a \SI{0.25}{rad}
-attitude displacement moves the estimated period from \SI{8.05}{s} to
-\SI{10.3}{s} and $\tau$ by a factor $1.28$.  The coupling also reaches the
-linear block indirectly, since displacing $\vct v$, $\vct p$, $\vct S$ or
-$\vct a_w$ perturbs attitude through the filter's cross-covariances.  What the
-displacement construction rules out is the strong direct loop above, not all
-coupling; see Sec.~\ref{app:iss-tuner}.
+and $r_S$, hence the gains.  That is why the deployed input is not levelled
+with the filter's attitude at all: it is levelled with a private Mahony
+observer reading only the raw gyro and accelerometer, so $\vct\vartheta$ is a
+function of the measurements alone.  Selecting the older attitude-levelled
+input instead reinstates the loop --- a \SI{0.25}{rad} attitude displacement
+then moves the estimated period from \SI{8.05}{s} to \SI{10.3}{s} and $\tau$
+by a factor $1.28$, and reaches the linear block indirectly besides, since
+displacing $\vct v$, $\vct p$, $\vct S$ or $\vct a_w$ perturbs attitude
+through the filter's cross-covariances; see Sec.~\ref{app:iss-tuner}.
 
 The tuner input frequency is $1/\widehat{T}_z$, or the tracker frequency until
 the period estimator settles.  It is smoothed by a fixed-horizon EMA with time

--- a/doc/kalman_ou_iii/w3d-iss-stability.tex-part
+++ b/doc/kalman_ou_iii/w3d-iss-stability.tex-part
@@ -543,27 +543,48 @@ the raw accelerometer body-$z$ channel. Displacing every estimator state,
 attitude and linear block alike, leaves it bit-for-bit unchanged; this is
 asserted in \texttt{tests/kalman\_ou\_iii/tuner\_coupling-test.cpp}.
 
-\paragraph{The frequency channel is not.}
+\paragraph{The frequency channel was not, and now is.}
 The tuning frequency does not come from the raw tracker. It comes from
-\texttt{wave\_period\_}, which is fed \texttt{direction\_accel.up\_ms2}, the
-\emph{leveled} vertical acceleration, and levelling uses the attitude
-estimate. Since $\tau=c_\tau/2f$ and $r_S=c_R\sigma_a\tau^3$, the path
+\texttt{wave\_period\_}, and what that estimator is fed decides the question.
+
+Fed \texttt{direction\_accel.up\_ms2}, the vertical acceleration levelled with
+the \emph{attitude estimate}, it closed a loop. Since $\tau=c_\tau/2f$ and
+$r_S=c_R\sigma_a\tau^3$, the path
 \begin{equation}
 \delta\vct\theta\;\longrightarrow\;f\;\longrightarrow\;
 \vct\vartheta\;\longrightarrow\;\text{gains}\;\longrightarrow\;\delta\vct\theta
 \end{equation}
-is a genuine feedback loop. Measured: a $0.25$~rad attitude displacement moves
-the estimated wave period from $8.05$ to $10.3$~s and $\tau$ by a factor
-$1.28$.
-
-The loop also reaches the linear states, indirectly. Displacing $\vct v$,
+was a genuine feedback loop: a $0.25$~rad attitude displacement moved the
+estimated wave period from $8.05$ to $10.3$~s and $\tau$ by a factor $1.28$.
+It reached the linear states indirectly as well, since displacing $\vct v$,
 $\vct p$, $\vct S$ or $\vct a_w$ perturbs attitude through the filter's
-cross-covariances, which moves the tuner: even a displacement of $0.02$ in
-each linear state shifts $\tau$ from $4.07$ to $4.53$. The source comment at
-the \texttt{wave\_period\_} call states that the leveled signal ``depends on
-attitude but not on the linear block, so it does not close a loop through the
-quantity being tuned''. That is true of the signal in isolation and false of
-the closed filter.
+cross-covariances: a displacement of $0.02$ in each linear state shifted
+$\tau$ from $4.07$ to $4.53$.
+
+Levelling is not what caused this; levelling \emph{with an estimator state}
+was. The estimator needs a levelled input, because double integration weights
+a spectrum by $\omega^{-4}$ and the sub-band gravity a tilting platform leaks
+into the raw body-$z$ proxy then dominates the elevation proxy --- fed that
+proxy the estimator reports $6.8$--$10.0$~s whatever the sea does, against a
+truth of $2.4$--$8.7$~s, and vertical RMS degrades by a factor $2.5$. Both
+requirements are met at once by levelling with a \emph{private} attitude
+solution: \texttt{src/tuner/VerticalAccelComplementary.h} runs a Mahony
+observer on the raw gyro and accelerometer, reading no calibrated value and no
+filter state, and reports $-\bigl((\mat R\vct f)_z+g\bigr)$ from its own
+quaternion. Its correction corner is placed an order of magnitude below the
+wave band ($\approx0.016$~Hz against $0.11$--$0.42$~Hz) so that the gyro
+carries attitude through the band and the accelerometer only trims drift; a
+faster corner chases horizontal orbital acceleration into tilt and reproduces
+the body-$z$ failure.
+
+This is the deployed default, and it costs nothing: over the eight reference
+records it reproduces the attitude-levelled input to within $0.2\%$ of vertical
+RMS and $0.1\%$ of 3D RMS, geometric-mean ratio $1.000$ on both OU-II and
+OU-III, with the reported $T_z$ matching to $0.01$~s. Displacing every
+estimator state now leaves the reported period \emph{and} $\vct\vartheta$
+bit-for-bit unchanged, asserted alongside the variance channel in the same
+test. The older attitude-levelled input remains selectable for ablation, and
+the test still bounds its gain at $2$ so the comparison stays interpretable.
 
 \paragraph{One further state-dependent branch.}
 A gate reads the attitude estimate and re-locks the filter above $70^\circ$
@@ -572,20 +593,28 @@ is $\arccos(\cos 0.70\cos 0.45)=46.5^\circ$, or on the trajectories used
 here, which peak at $54^\circ$. The margin is pinned by the same test.
 
 \paragraph{What this means for the certificate.}
-The interconnection is real, so it is \emph{not} discharged, and the honest
-statement of scope is narrower than the rest of this appendix might suggest:
-Secs.~\ref{app:iss-trajectory} and the sweep certify the estimator under an
-\emph{externally supplied} $\vct\vartheta$ schedule, whereas the deployed
-schedule is partly a function of $\delta\vct\theta$. Closing it needs either
-$\vct\vartheta$'s generator included in the certified coordinate, or a
-small-gain argument bounding the $\delta\vct\theta\to\vct\vartheta$ gain
-against the estimator's own contraction. The measured factor of $1.28$ for a
-$0.25$~rad displacement is the quantity such an argument would consume, and
-the test bounds it at $2$ so the premise cannot rot unnoticed.
+With both channels exogenous, $\vct\vartheta$ is a function of the measured
+signals alone and the deployed schedule is an externally supplied one. That is
+exactly the hypothesis Secs.~\ref{app:iss-trajectory} and the sweep assume, so
+the gap between what is certified and what is deployed closes: no composite
+Lyapunov function and no small-gain condition is needed, because there is no
+interconnection to bound.
 
-What the exogenous-schedule results below do establish is that the estimator
-tolerates $\vct\vartheta$ moving anywhere in $\Theta$, arbitrarily fast,
-which is the part a small-gain argument would still need.
+This is a change of configuration, not a change of proof. The earlier text
+recorded the loop as this appendix's open item and offered two routes to close
+it --- include $\vct\vartheta$'s generator in the certified coordinate, or
+bound the $\delta\vct\theta\to\vct\vartheta$ gain against the estimator's own
+contraction. Removing the dependence is the third, and the bit-for-bit
+assertion is what makes it checkable rather than argued. Two caveats survive.
+The claim is conditional on the input source: selecting the attitude-levelled
+ablation reinstates the loop and with it the earlier, narrower scope. And the
+private observer's corner is fixed while the wave band moves down as the sea
+grows, so the order-of-magnitude margin quoted above is a property of the
+reference records, not a theorem.
+
+The exogenous-schedule results below therefore now speak directly to the
+deployed filter: the estimator tolerates $\vct\vartheta$ moving anywhere in
+$\Theta$, arbitrarily fast.
 
 \paragraph{An exogenous schedule is not automatically harmless either.}
 Set the coupling aside and ask what an arbitrary bounded schedule can do. A

--- a/docs/ou-iii-adaptation-and-travel-sense.md
+++ b/docs/ou-iii-adaptation-and-travel-sense.md
@@ -169,6 +169,31 @@ displacement would: the integral pseudo-measurement high-passes displacement,
 which raises the apparent frequency, which shortens `tau`, which strengthens the
 pseudo-measurement.
 
+The leveled input is what puts attitude inside the tuning loop, so the body-Z
+proxy is worth pricing rather than dismissing: it is the one input that opens
+that loop completely, being the same signal the frequency tracker already
+runs on and owing nothing to the attitude solution. `W3D_WAVE_PERIOD_INPUT=body_z`
+(`setWavePeriodInputBodyZ(true)`) selects it, and
+`tools/ou_wave_period_input_study.py` replays all eight reference records both
+ways under the deterministic single-seed protocol of `tools/ou_sim_table.py`.
+Opening the loop costs more than the loop does:
+
+| filter | vertical RMS | 3D RMS | worst record |
+| --- | --- | --- | --- |
+| OU-II | 1.88x | 1.63x | +350% vertical, PM-Stokes `H_s = 0.27` m |
+| OU-III | 2.51x | 2.24x | +625% vertical, PM-Stokes `H_s = 0.27` m |
+
+The first two columns are geometric means of the per-record ratio
+body-Z / leveled over the eight records. Degradation is monotone in sea state
+and worst in the calmest records, which is the reported-period error read
+straight through: the body-Z estimate is pinned near 6.8-10.0 s whatever the
+sea does, so it is 2.5-3.5x too long at `H_s = 0.27` m and only 15-21% too long
+at `H_s = 8.5` m. `tau` is a fixed multiple of `T_z`, so a period that never
+moves is the uninformative operating point of section 1.2 with extra steps.
+Attitude RMS is essentially unmoved either way (roll within 0.03 deg, yaw
+slightly better under body-Z), confirming the loss is the operating point and
+not the attitude solution.
+
 The estimator settles in about a minute, so the tracker frequency is used until
 it is ready.
 

--- a/docs/ou-iii-adaptation-and-travel-sense.md
+++ b/docs/ou-iii-adaptation-and-travel-sense.md
@@ -171,11 +171,13 @@ pseudo-measurement.
 
 ### Opening the loop
 
-The leveled input is what puts attitude inside the tuning loop. Two inputs open
-it, both pure functions of the measurements, and
+Levelling with the filter's own attitude is what puts the tuner inside a loop.
+Two inputs open it, both pure functions of the measurements, and
 `tools/ou_wave_period_input_study.py` replays all eight reference records under
 each of them (`W3D_WAVE_PERIOD_INPUT`, `setWavePeriodInput()`) on the
-deterministic single-seed protocol of `tools/ou_sim_table.py`.
+deterministic single-seed protocol of `tools/ou_sim_table.py`. The second one
+is now the default; ratios below are still taken against attitude levelling,
+since the question is what changed relative to it.
 
 **`body_z`** is the raw proxy the frequency tracker already runs on. It opens
 the loop and is not usable:
@@ -196,10 +198,10 @@ unmoved either way, confirming the loss is the operating point and not the
 attitude solution.
 
 **`complementary`** is the measurement-only *leveled* signal the paragraph above
-asks for. `src/tuner/VerticalAccelComplementary.h` runs a private Mahony
-observer on the raw gyro and accelerometer - never the calibrated values, never
-any filter state - and reports `-((R f)_z + g)` from its own quaternion. It
-costs nothing:
+asks for, and is what the filter now ships.
+`src/tuner/VerticalAccelComplementary.h` runs a private Mahony observer on the
+raw gyro and accelerometer - never the calibrated values, never any filter
+state - and reports `-((R f)_z + g)` from its own quaternion. It costs nothing:
 
 | filter | vertical RMS | 3D RMS | largest per-record deviation |
 | --- | --- | --- | --- |
@@ -225,10 +227,17 @@ integral term is another slow state that can wind up against a sustained
 horizontal acceleration.
 
 `tests/kalman_ou_iii/tuner_coupling-test.cpp` asserts the exogeneity
-bit-for-bit rather than by tolerance: with `Complementary` selected, displacing
-*every* estimator state - attitude and all linear states - leaves the reported
-period and `tau_target` numerically identical. Under `Leveled` the same
-displacement moves the period 8.05 -> 10.32 s and `tau` by 1.28x.
+bit-for-bit rather than by tolerance, and does so on the default path with
+nothing selected: displacing *every* estimator state - attitude and all linear
+states - leaves the reported period and `tau_target` numerically identical.
+The `Leveled` ablation, which must now be selected explicitly, moves them
+8.05 -> 10.32 s and 1.28x under the same displacement.
+
+This closes the item `app:iss-tuner` in the stability appendix was written
+around. Both tuner channels are now exogenous, so the estimator and the tuner
+do not form a feedback interconnection and no composite Lyapunov function or
+small-gain condition is needed to describe the deployed schedule. The appendix
+records the loop as it stood, and what removing it changed.
 
 The estimator settles in about a minute, so the tracker frequency is used until
 it is ready.

--- a/docs/ou-iii-adaptation-and-travel-sense.md
+++ b/docs/ou-iii-adaptation-and-travel-sense.md
@@ -169,14 +169,16 @@ displacement would: the integral pseudo-measurement high-passes displacement,
 which raises the apparent frequency, which shortens `tau`, which strengthens the
 pseudo-measurement.
 
-The leveled input is what puts attitude inside the tuning loop, so the body-Z
-proxy is worth pricing rather than dismissing: it is the one input that opens
-that loop completely, being the same signal the frequency tracker already
-runs on and owing nothing to the attitude solution. `W3D_WAVE_PERIOD_INPUT=body_z`
-(`setWavePeriodInputBodyZ(true)`) selects it, and
-`tools/ou_wave_period_input_study.py` replays all eight reference records both
-ways under the deterministic single-seed protocol of `tools/ou_sim_table.py`.
-Opening the loop costs more than the loop does:
+### Opening the loop
+
+The leveled input is what puts attitude inside the tuning loop. Two inputs open
+it, both pure functions of the measurements, and
+`tools/ou_wave_period_input_study.py` replays all eight reference records under
+each of them (`W3D_WAVE_PERIOD_INPUT`, `setWavePeriodInput()`) on the
+deterministic single-seed protocol of `tools/ou_sim_table.py`.
+
+**`body_z`** is the raw proxy the frequency tracker already runs on. It opens
+the loop and is not usable:
 
 | filter | vertical RMS | 3D RMS | worst record |
 | --- | --- | --- | --- |
@@ -184,15 +186,49 @@ Opening the loop costs more than the loop does:
 | OU-III | 2.51x | 2.24x | +625% vertical, PM-Stokes `H_s = 0.27` m |
 
 The first two columns are geometric means of the per-record ratio
-body-Z / leveled over the eight records. Degradation is monotone in sea state
-and worst in the calmest records, which is the reported-period error read
-straight through: the body-Z estimate is pinned near 6.8-10.0 s whatever the
-sea does, so it is 2.5-3.5x too long at `H_s = 0.27` m and only 15-21% too long
-at `H_s = 8.5` m. `tau` is a fixed multiple of `T_z`, so a period that never
-moves is the uninformative operating point of section 1.2 with extra steps.
-Attitude RMS is essentially unmoved either way (roll within 0.03 deg, yaw
-slightly better under body-Z), confirming the loss is the operating point and
-not the attitude solution.
+body-Z / leveled. Degradation is monotone in sea state and worst in the calmest
+records, which is the reported-period error read straight through: the body-Z
+estimate is pinned near 6.8-10.0 s whatever the sea does, so it is 2.5-3.5x too
+long at `H_s = 0.27` m and only 15-21% too long at `H_s = 8.5` m. `tau` is a
+fixed multiple of `T_z`, so a period that never moves is the uninformative
+operating point of section 1.2 with extra steps. Attitude RMS is essentially
+unmoved either way, confirming the loss is the operating point and not the
+attitude solution.
+
+**`complementary`** is the measurement-only *leveled* signal the paragraph above
+asks for. `src/tuner/VerticalAccelComplementary.h` runs a private Mahony
+observer on the raw gyro and accelerometer - never the calibrated values, never
+any filter state - and reports `-((R f)_z + g)` from its own quaternion. It
+costs nothing:
+
+| filter | vertical RMS | 3D RMS | largest per-record deviation |
+| --- | --- | --- | --- |
+| OU-II | 1.000x | 1.000x | 0.2% |
+| OU-III | 1.000x | 1.000x | 0.1% |
+
+Across all sixteen record-filter pairs the reported `T_z` matches the leveled
+value to 0.01 s and the RMS to within 0.2%, which is replay noise. The loop is
+gone for free.
+
+The gain matters and the direction of the sensitivity confirms why. `two_kp`
+sets the rate at which the accelerometer corrects the gyro, roughly a corner at
+`two_kp/2` rad/s, and it must sit *below* the wave band: a fast observer chases
+horizontal orbital acceleration into tilt, which is the body-Z leakage failure
+by another route. The default 0.2 puts the corner near 0.016 Hz against a
+0.11-0.42 Hz band. Sweeping it on the `H_s = 8.5` m JONSWAP record moves
+reported `T_z` 8.42 -> 8.63 s and vertical RMS 0.3337 -> 0.3399 m as `two_kp`
+goes 0.05 -> 2.0, i.e. monotonically worse as the corner climbs into the band,
+and flat below 0.5. Bias is deliberately not estimated (`two_ki = 0`): at the
+reference bias range a constant gyro bias leaves a static tilt error near
+0.5 deg, which the estimator's two high-pass stages reject anyway, while an
+integral term is another slow state that can wind up against a sustained
+horizontal acceleration.
+
+`tests/kalman_ou_iii/tuner_coupling-test.cpp` asserts the exogeneity
+bit-for-bit rather than by tolerance: with `Complementary` selected, displacing
+*every* estimator state - attitude and all linear states - leaves the reported
+period and `tau_target` numerically identical. Under `Leveled` the same
+displacement moves the period 8.05 -> 10.32 s and `tau` by 1.28x.
 
 The estimator settles in about a minute, so the tracker frequency is used until
 it is ready.
@@ -304,7 +340,9 @@ it is in OU-III: fed the leveled vertical acceleration the direction stage
 already forms, consulted only once it reports ready, and ablatable back to the
 old behaviour with `setWaveBandTuning(false)` / `W3D_TUNING_BAND=acceleration`.
 The estimator itself is unchanged and shared, so the `T_z` accuracy table in
-section 1.6 applies unaltered.
+section 1.6 applies unaltered, as does the input study beside it -
+`setWavePeriodInput()` exists on both filters and the eight-record numbers for
+both are in section 1.6.
 
 Coefficients were re-fitted the same way, one factor at a time over the four
 stationary JONSWAP records with three seed triplets each, scored on the mean

--- a/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
+++ b/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
@@ -349,10 +349,17 @@ public:
         // leveled input tracks the sea state.  The leveled signal depends on
         // attitude but not on the linear block, so it does not close a loop
         // through the quantity being tuned.
+        //
+        // setWavePeriodInputBodyZ(true) is the measurement-only ablation: the
+        // estimator is then driven by the same body-Z proxy the frequency
+        // tracker sees, which owes nothing to the attitude solution and so
+        // opens the remaining coupling entirely, at the cost of the sub-band
+        // gravity leakage described above.
+        const bool use_leveled =
+            !wave_period_input_body_z_ && direction_accel.heading_valid;
         wave_period_.update(dt,
-                            direction_accel.heading_valid
-                                ? direction_accel.up_ms2
-                                : a_body_z_up_proxy_);
+                            use_leveled ? direction_accel.up_ms2
+                                        : a_body_z_up_proxy_);
 
         dir_filter_.update(direction_accel.forward_ms2,
                            direction_accel.starboard_ms2,
@@ -696,6 +703,15 @@ public:
     void setWaveBandTuning(bool flag) { wave_band_tuning_ = flag; }
     bool waveBandTuning() const noexcept { return wave_band_tuning_; }
 
+    // Drive the wave-period estimator from the raw body-Z proxy - the same
+    // signal the frequency tracker gets - instead of the leveled vertical
+    // acceleration.  The body-Z proxy does not pass through the attitude
+    // solution, so this opens the tuner coupling documented at the call site;
+    // the cost is the sub-band gravity leakage a tilting platform puts into
+    // body Z.  Default false, i.e. leveled.
+    void setWavePeriodInputBodyZ(bool flag) { wave_period_input_body_z_ = flag; }
+    bool wavePeriodInputBodyZ() const noexcept { return wave_period_input_body_z_; }
+
     inline WaveDirection getDirSignState() const noexcept { return dir_sign_state_; }
 
     // Propagation-plane angle relative to boat +X, modulo 180 degrees.
@@ -998,6 +1014,7 @@ private:
     double last_aw_cov_sync_sec_ = 0.0;
 
     bool  wave_band_tuning_       = true;
+    bool  wave_period_input_body_z_ = false;
     float min_tune_freq_hz_       = MIN_TUNE_FREQ_HZ;
     float min_freq_hz_            = MIN_FREQ_HZ;
     float max_freq_hz_            = MAX_FREQ_HZ;

--- a/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
+++ b/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
@@ -349,22 +349,30 @@ public:
         // carrier the direction demodulator needs, while the OU operating point
         // needs the wave band.
         //
-        // It is fed the leveled vertical acceleration rather than the body-Z
-        // proxy.  Double integration weights a spectrum by 1/omega^4, so the
-        // sub-band gravity leakage a tilting platform puts into the body-Z
-        // proxy dominates the elevation proxy: on the reference records the
-        // body-Z input reported 6.8-10.0 s against a true 2.5-8.6 s, while the
-        // leveled input tracks the sea state.  The leveled signal depends on
-        // attitude but not on the linear block, so it does not close a loop
-        // through the quantity being tuned.
+        // The input must be levelled and must not read estimator state, and
+        // those two requirements pulled against each other for a while.
         //
-        // setWavePeriodInput() selects what opens it.  BodyZ feeds the same
-        // raw proxy the frequency tracker sees, which owes nothing to the
-        // attitude solution but trades the coupling for the sub-band gravity
-        // leakage described above.  Complementary levels with a private Mahony
-        // observer instead: also a pure function of the measurements, so the
-        // interconnection is equally open, but levelled, so the leakage is
-        // removed rather than accepted.
+        // Levelled, because double integration weights a spectrum by
+        // 1/omega^4, so the sub-band gravity leakage a tilting platform puts
+        // into the body-Z proxy dominates the elevation proxy.  Fed the raw
+        // body-Z proxy the estimator reports 6.8-10.0 s whatever the sea does,
+        // against a truth of 2.4-8.7 s, and vertical RMS degrades 2.5x.
+        //
+        // Exogenous, because levelling with the filter's own attitude closes a
+        // loop: a 0.25 rad attitude displacement moved the reported period
+        // 8.05 -> 10.3 s and tau by 1.28x, and it reached the linear block too,
+        // since displacing v, p, S or a_w perturbs attitude through the
+        // filter's cross-covariances.  The stability appendix carried that as
+        // its open interconnection.
+        //
+        // VerticalAccelComplementary satisfies both: it levels, but with a
+        // private Mahony observer reading only the raw gyro and accelerometer,
+        // so it is a pure function of the measurements.  It costs nothing --
+        // over the eight reference records it matches the old attitude-levelled
+        // input to within 0.2% of vertical RMS -- and it is the default.
+        // setWavePeriodInput() still reaches the other two for ablation;
+        // tests/kalman_ou_iii/tuner_coupling-test.cpp asserts the default is
+        // exogenous bit-for-bit and bounds the Leveled path's gain.
         wave_period_.update(dt, wave_period_input_ms2_(direction_accel));
 
         dir_filter_.update(direction_accel.forward_ms2,
@@ -710,9 +718,11 @@ public:
     bool waveBandTuning() const noexcept { return wave_band_tuning_; }
 
     // Select which vertical acceleration drives the wave-period estimator.
-    // Leveled (default) uses the main filter's attitude and so keeps the tuner
-    // inside a loop; BodyZ and Complementary are both measurement-only and
-    // open it.  See the call site in updateTime for what each one costs.
+    // Complementary (default) levels with the private Mahony observer and is
+    // measurement-only, so the tuner is outside the estimator's loop.  Leveled
+    // is the older behaviour, which levels with the main filter's attitude and
+    // closes that loop; BodyZ is measurement-only but unlevelled.  See the call
+    // site in updateTime for what each one costs.
     void setWavePeriodInput(WavePeriodInputSource source) {
         wave_period_input_ = source;
     }
@@ -720,8 +730,9 @@ public:
         return wave_period_input_;
     }
 
-    // Gains of the private Mahony observer; only meaningful under
-    // WavePeriodInputSource::Complementary.
+    // Gains of the private Mahony observer that levels the default input.
+    // two_kp sets the accelerometer-to-gyro correction corner, which must stay
+    // below the wave band; see VerticalAccelComplementary.h.
     void setWavePeriodComplementaryGains(float two_kp, float two_ki) {
         vertical_accel_comp_.setGains(two_kp, two_ki);
     }
@@ -1050,7 +1061,7 @@ private:
     double last_aw_cov_sync_sec_ = 0.0;
 
     bool  wave_band_tuning_       = true;
-    WavePeriodInputSource wave_period_input_ = WavePeriodInputSource::Leveled;
+    WavePeriodInputSource wave_period_input_ = WavePeriodInputSource::Complementary;
     float min_tune_freq_hz_       = MIN_TUNE_FREQ_HZ;
     float min_freq_hz_            = MIN_FREQ_HZ;
     float max_freq_hz_            = MAX_FREQ_HZ;

--- a/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
+++ b/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
@@ -67,6 +67,7 @@
 #include "freq/FrequencyTrackerPolicy.h"
 #include "tuner/SeaStateAutoTuner.h"
 #include "tuner/WavePeriodEstimator.h"
+#include "tuner/VerticalAccelComplementary.h"
 #include "tuner/MagAutoTuner.h"
 #include "kalman_ou_ii/Kalman3D_Wave_OU_II.h"
 #include "wave_dir/KalmanWaveDirection.h"
@@ -234,6 +235,13 @@ public:
         //   acc.z() ~ -g at rest  => proxy ~ 0
         const float a_z_body_proxy = acc.z() + g_std;
 
+        // Private Mahony observer for the wave-period estimator.  It is fed the
+        // raw gyro and accelerometer, before the MEKF sees them, so that the
+        // levelling it provides stays a pure function of the measurements.
+        // Stepping it unconditionally keeps its transient off the critical path
+        // when the input source is switched at runtime.
+        vertical_accel_comp_.update(dt, gyro, acc, g_std);
+
         // MEKF updates first (attitude + latent a_w)
         mekf_->time_update(gyro, dt);
         mekf_->measurement_update_acc_only(acc, tempC);
@@ -350,16 +358,14 @@ public:
         // attitude but not on the linear block, so it does not close a loop
         // through the quantity being tuned.
         //
-        // setWavePeriodInputBodyZ(true) is the measurement-only ablation: the
-        // estimator is then driven by the same body-Z proxy the frequency
-        // tracker sees, which owes nothing to the attitude solution and so
-        // opens the remaining coupling entirely, at the cost of the sub-band
-        // gravity leakage described above.
-        const bool use_leveled =
-            !wave_period_input_body_z_ && direction_accel.heading_valid;
-        wave_period_.update(dt,
-                            use_leveled ? direction_accel.up_ms2
-                                        : a_body_z_up_proxy_);
+        // setWavePeriodInput() selects what opens it.  BodyZ feeds the same
+        // raw proxy the frequency tracker sees, which owes nothing to the
+        // attitude solution but trades the coupling for the sub-band gravity
+        // leakage described above.  Complementary levels with a private Mahony
+        // observer instead: also a pure function of the measurements, so the
+        // interconnection is equally open, but levelled, so the leakage is
+        // removed rather than accepted.
+        wave_period_.update(dt, wave_period_input_ms2_(direction_accel));
 
         dir_filter_.update(direction_accel.forward_ms2,
                            direction_accel.starboard_ms2,
@@ -703,14 +709,22 @@ public:
     void setWaveBandTuning(bool flag) { wave_band_tuning_ = flag; }
     bool waveBandTuning() const noexcept { return wave_band_tuning_; }
 
-    // Drive the wave-period estimator from the raw body-Z proxy - the same
-    // signal the frequency tracker gets - instead of the leveled vertical
-    // acceleration.  The body-Z proxy does not pass through the attitude
-    // solution, so this opens the tuner coupling documented at the call site;
-    // the cost is the sub-band gravity leakage a tilting platform puts into
-    // body Z.  Default false, i.e. leveled.
-    void setWavePeriodInputBodyZ(bool flag) { wave_period_input_body_z_ = flag; }
-    bool wavePeriodInputBodyZ() const noexcept { return wave_period_input_body_z_; }
+    // Select which vertical acceleration drives the wave-period estimator.
+    // Leveled (default) uses the main filter's attitude and so keeps the tuner
+    // inside a loop; BodyZ and Complementary are both measurement-only and
+    // open it.  See the call site in updateTime for what each one costs.
+    void setWavePeriodInput(WavePeriodInputSource source) {
+        wave_period_input_ = source;
+    }
+    WavePeriodInputSource wavePeriodInput() const noexcept {
+        return wave_period_input_;
+    }
+
+    // Gains of the private Mahony observer; only meaningful under
+    // WavePeriodInputSource::Complementary.
+    void setWavePeriodComplementaryGains(float two_kp, float two_ki) {
+        vertical_accel_comp_.setGains(two_kp, two_ki);
+    }
 
     inline WaveDirection getDirSignState() const noexcept { return dir_sign_state_; }
 
@@ -895,6 +909,27 @@ private:
         }
     }
 
+    // Vertical acceleration the wave-period estimator is driven by.  Each
+    // measurement-only source falls back to the body-Z proxy while it is
+    // unusable, which is what the leveled source already does when heading is
+    // not yet resolved.
+    float wave_period_input_ms2_(
+        const wave_direction::HeadingFrameAcceleration<float>& leveled) const
+    {
+        switch (wave_period_input_) {
+            case WavePeriodInputSource::BodyZ:
+                return a_body_z_up_proxy_;
+            case WavePeriodInputSource::Complementary:
+                return vertical_accel_comp_.isReady()
+                           ? vertical_accel_comp_.verticalAccelUpMs2()
+                           : a_body_z_up_proxy_;
+            case WavePeriodInputSource::Leveled:
+            default:
+                return leveled.heading_valid ? leveled.up_ms2
+                                             : a_body_z_up_proxy_;
+        }
+    }
+
     float tuner_frequency_hz_(float tracker_hz) const {
         if (wave_band_tuning_ && wave_period_.isReady()) {
             const float wave_hz = wave_period_.getFrequencyHz();
@@ -906,6 +941,7 @@ private:
     void resetTrackingState_() {
         tracker_policy_ = TrackingPolicy{};
         wave_period_    = WavePeriodEstimator{};
+        vertical_accel_comp_.reset();
         freq_input_lpf_ = FreqInputLPF{};
         freq_stillness_ = StillnessAdapter(g_std, min_freq_hz_, FREQ_GUESS);
         freq_input_lpf_.setCutoff(max_freq_hz_);
@@ -1014,7 +1050,7 @@ private:
     double last_aw_cov_sync_sec_ = 0.0;
 
     bool  wave_band_tuning_       = true;
-    bool  wave_period_input_body_z_ = false;
+    WavePeriodInputSource wave_period_input_ = WavePeriodInputSource::Leveled;
     float min_tune_freq_hz_       = MIN_TUNE_FREQ_HZ;
     float min_freq_hz_            = MIN_FREQ_HZ;
     float max_freq_hz_            = MAX_FREQ_HZ;
@@ -1050,6 +1086,7 @@ private:
     FirstOrderIIRSmoother<float> freq_slow_smoother_{FREQ_SMOOTHER_DT, 10.0f};
     SeaStateAutoTuner            tuner_;
     WavePeriodEstimator          wave_period_;
+    VerticalAccelComplementary   vertical_accel_comp_{};
     TuneState                    tune_;
 
     float tau_target_      = NAN;

--- a/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
+++ b/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
@@ -328,35 +328,30 @@ public:
         // carrier the direction demodulator needs, while the OU operating point
         // needs the wave band.
         //
-        // It is fed the leveled vertical acceleration rather than the body-Z
-        // proxy.  Double integration weights a spectrum by 1/omega^4, so the
-        // sub-band gravity leakage a tilting platform puts into the body-Z
-        // proxy dominates the elevation proxy: on the reference records the
-        // body-Z input reported 6.8-10.0 s against a true 2.5-8.6 s, while the
-        // leveled input tracks the sea state.
+        // The input must be levelled and must not read estimator state, and
+        // those two requirements pulled against each other for a while.
         //
-        // The leveled signal depends on attitude.  That is a real coupling
-        // from the estimator back into the tuning, and it is weaker than the
-        // displacement loop this avoids but not absent: a 0.25 rad attitude
-        // displacement moves the reported period 8.05 -> 10.3 s and tau by
-        // 1.28x.  It reaches the linear block too, indirectly, because
-        // displacing v, p, S or a_w perturbs attitude through the filter's
-        // cross-covariances -- so the earlier claim here, that this "does not
-        // close a loop through the quantity being tuned", holds for the signal
-        // in isolation and not for the closed filter.
+        // Levelled, because double integration weights a spectrum by
+        // 1/omega^4, so the sub-band gravity leakage a tilting platform puts
+        // into the body-Z proxy dominates the elevation proxy.  Fed the raw
+        // body-Z proxy the estimator reports 6.8-10.0 s whatever the sea does,
+        // against a truth of 2.4-8.7 s, and vertical RMS degrades 2.5x.
         //
-        // The stability appendix treats this as its open interconnection, and
-        // tests/kalman_ou_iii/tuner_coupling-test.cpp bounds the gain so it
-        // cannot grow unnoticed.  Feeding the period estimator a
-        // measurement-only leveled signal would remove it.
+        // Exogenous, because levelling with the filter's own attitude closes a
+        // loop: a 0.25 rad attitude displacement moved the reported period
+        // 8.05 -> 10.3 s and tau by 1.28x, and it reached the linear block too,
+        // since displacing v, p, S or a_w perturbs attitude through the
+        // filter's cross-covariances.  The stability appendix carried that as
+        // its open interconnection.
         //
-        // setWavePeriodInput() selects what opens it.  BodyZ feeds the same
-        // raw proxy the frequency tracker sees, which owes nothing to the
-        // attitude solution but trades the coupling for the sub-band gravity
-        // leakage described above.  Complementary levels with a private Mahony
-        // observer instead: also a pure function of the measurements, so the
-        // interconnection is equally open, but levelled, so the leakage is
-        // removed rather than accepted.
+        // VerticalAccelComplementary satisfies both: it levels, but with a
+        // private Mahony observer reading only the raw gyro and accelerometer,
+        // so it is a pure function of the measurements.  It costs nothing --
+        // over the eight reference records it matches the old attitude-levelled
+        // input to within 0.2% of vertical RMS -- and it is the default.
+        // setWavePeriodInput() still reaches the other two for ablation;
+        // tests/kalman_ou_iii/tuner_coupling-test.cpp asserts the default is
+        // exogenous bit-for-bit and bounds the Leveled path's gain.
         wave_period_.update(dt, wave_period_input_ms2_(direction_accel));
 
         dir_filter_.update(direction_accel.forward_ms2,
@@ -755,9 +750,11 @@ public:
     bool waveBandTuning() const noexcept { return wave_band_tuning_; }
 
     // Select which vertical acceleration drives the wave-period estimator.
-    // Leveled (default) uses the main filter's attitude and so keeps the tuner
-    // inside a loop; BodyZ and Complementary are both measurement-only and
-    // open it.  See the call site in updateTime for what each one costs.
+    // Complementary (default) levels with the private Mahony observer and is
+    // measurement-only, so the tuner is outside the estimator's loop.  Leveled
+    // is the older behaviour, which levels with the main filter's attitude and
+    // closes that loop; BodyZ is measurement-only but unlevelled.  See the call
+    // site in updateTime for what each one costs.
     void setWavePeriodInput(WavePeriodInputSource source) {
         wave_period_input_ = source;
     }
@@ -765,8 +762,9 @@ public:
         return wave_period_input_;
     }
 
-    // Gains of the private Mahony observer; only meaningful under
-    // WavePeriodInputSource::Complementary.
+    // Gains of the private Mahony observer that levels the default input.
+    // two_kp sets the accelerometer-to-gyro correction corner, which must stay
+    // below the wave band; see VerticalAccelComplementary.h.
     void setWavePeriodComplementaryGains(float two_kp, float two_ki) {
         vertical_accel_comp_.setGains(two_kp, two_ki);
     }
@@ -1113,7 +1111,7 @@ private:
     double last_aw_cov_sync_sec_ = 0.0;
 
     bool  wave_band_tuning_       = true;
-    WavePeriodInputSource wave_period_input_ = WavePeriodInputSource::Leveled;
+    WavePeriodInputSource wave_period_input_ = WavePeriodInputSource::Complementary;
     float min_tune_freq_hz_       = MIN_TUNE_FREQ_HZ;
     float min_freq_hz_            = MIN_FREQ_HZ;
     float max_freq_hz_            = MAX_FREQ_HZ;

--- a/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
+++ b/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
@@ -341,10 +341,17 @@ public:
         // tests/kalman_ou_iii/tuner_coupling-test.cpp bounds the gain so it
         // cannot grow unnoticed.  Feeding the period estimator a
         // measurement-only leveled signal would remove it.
+        //
+        // setWavePeriodInputBodyZ(true) is that measurement-only ablation: the
+        // estimator is then driven by the same body-Z proxy the frequency
+        // tracker sees, which owes nothing to the attitude solution and so
+        // opens the interconnection entirely.  It is off by default because it
+        // trades the coupling for the sub-band gravity leakage described above.
+        const bool use_leveled =
+            !wave_period_input_body_z_ && direction_accel.heading_valid;
         wave_period_.update(dt,
-                            direction_accel.heading_valid
-                                ? direction_accel.up_ms2
-                                : a_body_z_up_proxy_);
+                            use_leveled ? direction_accel.up_ms2
+                                        : a_body_z_up_proxy_);
 
         dir_filter_.update(direction_accel.forward_ms2,
                            direction_accel.starboard_ms2,
@@ -741,6 +748,15 @@ public:
     void setWaveBandTuning(bool flag) { wave_band_tuning_ = flag; }
     bool waveBandTuning() const noexcept { return wave_band_tuning_; }
 
+    // Drive the wave-period estimator from the raw body-Z proxy - the same
+    // signal the frequency tracker gets - instead of the leveled vertical
+    // acceleration.  The body-Z proxy does not pass through the attitude
+    // solution, so this opens the tuner coupling documented at the call site;
+    // the cost is the sub-band gravity leakage a tilting platform puts into
+    // body Z.  Default false, i.e. leveled.
+    void setWavePeriodInputBodyZ(bool flag) { wave_period_input_body_z_ = flag; }
+    bool wavePeriodInputBodyZ() const noexcept { return wave_period_input_body_z_; }
+
     inline WaveDirection getDirSignState() const noexcept { return dir_sign_state_; }
 
     // Propagation-plane angle relative to boat +X, modulo 180 degrees.
@@ -1061,6 +1077,7 @@ private:
     double last_aw_cov_sync_sec_ = 0.0;
 
     bool  wave_band_tuning_       = true;
+    bool  wave_period_input_body_z_ = false;
     float min_tune_freq_hz_       = MIN_TUNE_FREQ_HZ;
     float min_freq_hz_            = MIN_FREQ_HZ;
     float max_freq_hz_            = MAX_FREQ_HZ;

--- a/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
+++ b/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
@@ -56,6 +56,7 @@
 #include "freq/FrequencyTrackerPolicy.h"
 #include "tuner/SeaStateAutoTuner.h"
 #include "tuner/WavePeriodEstimator.h"
+#include "tuner/VerticalAccelComplementary.h"
 #include "tuner/MagAutoTuner.h"
 #include "kalman_ou_iii/Kalman3D_Wave_OU_III.h"
 #include "wave_dir/KalmanWaveDirection.h"
@@ -214,6 +215,13 @@ public:
         //   acc.z() ~ -g at rest  => proxy ~ 0
         const float a_z_body_proxy = acc.z() + g_std;
 
+        // Private Mahony observer for the wave-period estimator.  It is fed the
+        // raw gyro and accelerometer, before the MEKF sees them, so that the
+        // levelling it provides stays a pure function of the measurements.
+        // Stepping it unconditionally keeps its transient off the critical path
+        // when the input source is switched at runtime.
+        vertical_accel_comp_.update(dt, gyro, acc, g_std);
+
         // MEKF updates first (attitude + latent a_w)
         mekf_->time_update(gyro, dt);
         mekf_->measurement_update_acc_only(acc, tempC);
@@ -342,16 +350,14 @@ public:
         // cannot grow unnoticed.  Feeding the period estimator a
         // measurement-only leveled signal would remove it.
         //
-        // setWavePeriodInputBodyZ(true) is that measurement-only ablation: the
-        // estimator is then driven by the same body-Z proxy the frequency
-        // tracker sees, which owes nothing to the attitude solution and so
-        // opens the interconnection entirely.  It is off by default because it
-        // trades the coupling for the sub-band gravity leakage described above.
-        const bool use_leveled =
-            !wave_period_input_body_z_ && direction_accel.heading_valid;
-        wave_period_.update(dt,
-                            use_leveled ? direction_accel.up_ms2
-                                        : a_body_z_up_proxy_);
+        // setWavePeriodInput() selects what opens it.  BodyZ feeds the same
+        // raw proxy the frequency tracker sees, which owes nothing to the
+        // attitude solution but trades the coupling for the sub-band gravity
+        // leakage described above.  Complementary levels with a private Mahony
+        // observer instead: also a pure function of the measurements, so the
+        // interconnection is equally open, but levelled, so the leakage is
+        // removed rather than accepted.
+        wave_period_.update(dt, wave_period_input_ms2_(direction_accel));
 
         dir_filter_.update(direction_accel.forward_ms2,
                            direction_accel.starboard_ms2,
@@ -748,14 +754,22 @@ public:
     void setWaveBandTuning(bool flag) { wave_band_tuning_ = flag; }
     bool waveBandTuning() const noexcept { return wave_band_tuning_; }
 
-    // Drive the wave-period estimator from the raw body-Z proxy - the same
-    // signal the frequency tracker gets - instead of the leveled vertical
-    // acceleration.  The body-Z proxy does not pass through the attitude
-    // solution, so this opens the tuner coupling documented at the call site;
-    // the cost is the sub-band gravity leakage a tilting platform puts into
-    // body Z.  Default false, i.e. leveled.
-    void setWavePeriodInputBodyZ(bool flag) { wave_period_input_body_z_ = flag; }
-    bool wavePeriodInputBodyZ() const noexcept { return wave_period_input_body_z_; }
+    // Select which vertical acceleration drives the wave-period estimator.
+    // Leveled (default) uses the main filter's attitude and so keeps the tuner
+    // inside a loop; BodyZ and Complementary are both measurement-only and
+    // open it.  See the call site in updateTime for what each one costs.
+    void setWavePeriodInput(WavePeriodInputSource source) {
+        wave_period_input_ = source;
+    }
+    WavePeriodInputSource wavePeriodInput() const noexcept {
+        return wave_period_input_;
+    }
+
+    // Gains of the private Mahony observer; only meaningful under
+    // WavePeriodInputSource::Complementary.
+    void setWavePeriodComplementaryGains(float two_kp, float two_ki) {
+        vertical_accel_comp_.setGains(two_kp, two_ki);
+    }
 
     inline WaveDirection getDirSignState() const noexcept { return dir_sign_state_; }
 
@@ -955,6 +969,27 @@ private:
         }
     }
 
+    // Vertical acceleration the wave-period estimator is driven by.  Each
+    // measurement-only source falls back to the body-Z proxy while it is
+    // unusable, which is what the leveled source already does when heading is
+    // not yet resolved.
+    float wave_period_input_ms2_(
+        const wave_direction::HeadingFrameAcceleration<float>& leveled) const
+    {
+        switch (wave_period_input_) {
+            case WavePeriodInputSource::BodyZ:
+                return a_body_z_up_proxy_;
+            case WavePeriodInputSource::Complementary:
+                return vertical_accel_comp_.isReady()
+                           ? vertical_accel_comp_.verticalAccelUpMs2()
+                           : a_body_z_up_proxy_;
+            case WavePeriodInputSource::Leveled:
+            default:
+                return leveled.heading_valid ? leveled.up_ms2
+                                             : a_body_z_up_proxy_;
+        }
+    }
+
     float tuner_frequency_hz_(float tracker_hz) const {
         if (wave_band_tuning_ && wave_period_.isReady()) {
             const float wave_hz = wave_period_.getFrequencyHz();
@@ -966,6 +1001,7 @@ private:
     void resetTrackingState_() {
         tracker_policy_       = TrackingPolicy{};
         wave_period_          = WavePeriodEstimator{};
+        vertical_accel_comp_.reset();
         freq_input_lpf_       = FreqInputLPF{};
         freq_stillness_       = StillnessAdapter(g_std, min_freq_hz_, FREQ_GUESS);
         freq_input_lpf_.setCutoff(max_freq_hz_);
@@ -1077,7 +1113,7 @@ private:
     double last_aw_cov_sync_sec_ = 0.0;
 
     bool  wave_band_tuning_       = true;
-    bool  wave_period_input_body_z_ = false;
+    WavePeriodInputSource wave_period_input_ = WavePeriodInputSource::Leveled;
     float min_tune_freq_hz_       = MIN_TUNE_FREQ_HZ;
     float min_freq_hz_            = MIN_FREQ_HZ;
     float max_freq_hz_            = MAX_FREQ_HZ;
@@ -1107,6 +1143,7 @@ private:
     FirstOrderIIRSmoother<float>    freq_slow_smoother_{FREQ_SMOOTHER_DT, 10.0f};
     SeaStateAutoTuner               tuner_;
     WavePeriodEstimator             wave_period_;
+    VerticalAccelComplementary      vertical_accel_comp_{};
     TuneState                       tune_;
 
     float tau_target_   = NAN;

--- a/src/tuner/VerticalAccelComplementary.h
+++ b/src/tuner/VerticalAccelComplementary.h
@@ -1,0 +1,175 @@
+#pragma once
+
+/*
+  Copyright (c) 2025-2026  Mikhail Grushinskiy
+
+  VerticalAccelComplementary - vertical acceleration from a private Mahony
+  complementary filter, so the wave-period estimator can be levelled without
+  reading the main filter's attitude.
+
+  Why this exists
+  ---------------
+  The OU operating point is set from the zero-crossing wave period, which
+  WavePeriodEstimator derives from a vertical acceleration.  Levelling that
+  acceleration with the main filter's own quaternion is what puts the tuner
+  inside a loop: displacing v, p, S or a_w perturbs attitude through the
+  filter's cross-covariances, attitude moves the reported period, the period
+  moves tau, and tau feeds back into the linear block.
+
+  The body-Z proxy -(acc.z + g) opens that loop, being a raw measurement, but
+  it is not usable: double integration weights a spectrum by 1/omega^4, so the
+  gravity a tilting platform leaks into body Z swamps the elevation proxy.  Fed
+  the body-Z proxy the estimator reports 6.8-10.0 s whatever the sea does,
+  against a truth of 2.4-8.7 s.
+
+  This class is the third option: level with an attitude solution that is also
+  a pure function of the measurements.  It runs its own Mahony observer on the
+  raw gyro and accelerometer - never the calibrated or bias-corrected values,
+  never any filter state - and reports
+
+      up = -( (R f)_z + g ),   R = body -> NED from the private quaternion.
+
+  Nothing it produces depends on the linear block or on the MEKF, so the
+  interconnection is open by construction and stays open however the main
+  filter is retuned.
+
+  Gain
+  ----
+  two_kp sets the rate at which the accelerometer corrects the gyro, roughly a
+  first-order corner at two_kp/2 rad/s.  It must sit *below* the wave band, not
+  above it: a fast observer chases the horizontal orbital acceleration into
+  tilt, which is the same gravity-leakage failure by another route.  The
+  default 0.2 puts the corner near 0.016 Hz, an order of magnitude under the
+  0.11-0.42 Hz the reference records occupy, so the gyro carries attitude
+  through the wave band and the accelerometer only trims slow drift.
+
+  With two_ki = 0 a constant gyro bias b leaves a static tilt error of about
+  2b/two_kp.  At the reference bias range (0.05 deg/s) that is ~0.5 deg, and it
+  is static, so the estimator's two high-pass stages reject it.  Bias is
+  deliberately not estimated here: an integral term is another slow state that
+  can wind up against a sustained horizontal acceleration.
+
+  Yaw is unobservable without a magnetometer and is left to drift.  It does not
+  matter: only the vertical component is used, and that depends on tilt alone.
+*/
+
+#ifdef EIGEN_NON_ARDUINO
+#include <Eigen/Dense>
+#include <Eigen/Geometry>
+#else
+#include <ArduinoEigenDense.h>
+#endif
+
+#include <cmath>
+
+#include "ahrs/Mahony_AHRS.h"
+
+// Which vertical acceleration the wave-period estimator is driven by.
+enum class WavePeriodInputSource {
+    Leveled,        // heading-frame up from the main filter's attitude
+    BodyZ,          // raw -(acc.z + g) proxy, the frequency tracker's input
+    Complementary,  // private Mahony observer; measurement-only
+};
+
+class VerticalAccelComplementary {
+public:
+    // two_kp     : accelerometer-to-gyro correction gain; corner ~ two_kp/2 rad/s.
+    // two_ki     : integral (bias) gain.  0 disables it; see the note above.
+    // settle_sec : hold isReady() low this long after the first sample, so the
+    //              levelling transient never reaches the period statistics.
+    explicit VerticalAccelComplementary(float two_kp = 0.2f,
+                                        float two_ki = 0.0f,
+                                        float settle_sec = 20.0f)
+        : two_kp_(two_kp), two_ki_(two_ki),
+          settle_sec_(std::max(0.0f, settle_sec))
+    {
+        reset();
+    }
+
+    void reset() {
+        ahrs_.reset(-1.0f, -1.0f);
+        ahrs_.init(two_kp_, two_ki_);
+        initialized_ = false;
+        elapsed_sec_ = 0.0f;
+        up_ms2_ = 0.0f;
+    }
+
+    void setGains(float two_kp, float two_ki) {
+        two_kp_ = two_kp;
+        two_ki_ = two_ki;
+        ahrs_.init(two_kp_, two_ki_);
+    }
+
+    // gyro : body angular rate [rad/s], raw.
+    // acc  : body specific force [m/s^2], raw.  acc.z ~ -g at rest, matching
+    //        the z-down body frame the rest of the filter uses.
+    void update(float dt_sec,
+                const Eigen::Vector3f& gyro,
+                const Eigen::Vector3f& acc,
+                float gravity_ms2)
+    {
+        if (!(dt_sec > 0.0f) || !std::isfinite(dt_sec) ||
+            !gyro.allFinite() || !acc.allFinite()) {
+            return;
+        }
+
+        // Mahony drives the measured vector toward the world z axis expressed
+        // in body coordinates.  Here world z is NED down, and a specific force
+        // of (0,0,-g) at rest points up, so the observer is fed -acc.
+        const float acc_norm = acc.norm();
+        if (!initialized_) {
+            if (!(acc_norm > 1e-3f)) return;
+            seed_from_acc_(acc / acc_norm);
+            initialized_ = true;
+        }
+
+        float pitch_deg = 0.0f, roll_deg = 0.0f, yaw_deg = 0.0f;
+        ahrs_.update(gyro.x(), gyro.y(), gyro.z(),
+                     -acc.x(), -acc.y(), -acc.z(),
+                     &pitch_deg, &roll_deg, &yaw_deg,
+                     dt_sec);
+
+        // Third row of R(body->NED); dotting it with the specific force gives
+        // the down component, and it is also the down axis in body coordinates.
+        const float w = ahrs_.q0, x = ahrs_.q1, y = ahrs_.q2, z = ahrs_.q3;
+        const Eigen::Vector3f down_row(2.0f * (x * z - w * y),
+                                       2.0f * (y * z + w * x),
+                                       w * w - x * x - y * y + z * z);
+
+        // a_ned.z = (R f)_z + g, and up is its negation.
+        up_ms2_ = -(down_row.dot(acc) + gravity_ms2);
+
+        elapsed_sec_ += dt_sec;
+    }
+
+    // Up-positive vertical acceleration with gravity removed [m/s^2].
+    float verticalAccelUpMs2() const noexcept { return up_ms2_; }
+
+    bool isReady() const noexcept {
+        return initialized_ && elapsed_sec_ >= settle_sec_;
+    }
+
+private:
+    // Point the private world z axis along the measured gravity direction, so
+    // the observer starts levelled instead of rotating in from identity.
+    void seed_from_acc_(const Eigen::Vector3f& acc_unit) {
+        // Down in body coordinates is opposite the specific force at rest.
+        const Eigen::Vector3f down_body = -acc_unit;
+        // q maps body -> NED, so it must carry down_body onto +Z.  Yaw is left
+        // at whatever FromTwoVectors picks; it is unobservable and unused.
+        const Eigen::Quaternionf q = Eigen::Quaternionf::FromTwoVectors(
+            down_body, Eigen::Vector3f::UnitZ());
+        ahrs_.q0 = q.w();
+        ahrs_.q1 = q.x();
+        ahrs_.q2 = q.y();
+        ahrs_.q3 = q.z();
+    }
+
+    Mahony_AHRS<float> ahrs_{};
+    float two_kp_;
+    float two_ki_;
+    float settle_sec_;
+    bool  initialized_ = false;
+    float elapsed_sec_ = 0.0f;
+    float up_ms2_ = 0.0f;
+};

--- a/src/tuner/VerticalAccelComplementary.h
+++ b/src/tuner/VerticalAccelComplementary.h
@@ -22,16 +22,18 @@
   the body-Z proxy the estimator reports 6.8-10.0 s whatever the sea does,
   against a truth of 2.4-8.7 s.
 
-  This class is the third option: level with an attitude solution that is also
-  a pure function of the measurements.  It runs its own Mahony observer on the
-  raw gyro and accelerometer - never the calibrated or bias-corrected values,
-  never any filter state - and reports
+  This class is the third option, and the deployed one: level with an attitude
+  solution that is also a pure function of the measurements.  It runs its own
+  Mahony observer on the raw gyro and accelerometer - never the calibrated or
+  bias-corrected values, never any filter state - and reports
 
       up = -( (R f)_z + g ),   R = body -> NED from the private quaternion.
 
   Nothing it produces depends on the linear block or on the MEKF, so the
   interconnection is open by construction and stays open however the main
-  filter is retuned.
+  filter is retuned.  Over the eight reference records it reproduces the
+  attitude-levelled input to within 0.2% of vertical RMS, so the loop is
+  removed at no cost, which is why it is the default rather than an option.
 
   Gain
   ----
@@ -65,10 +67,11 @@
 #include "ahrs/Mahony_AHRS.h"
 
 // Which vertical acceleration the wave-period estimator is driven by.
+// Complementary is the default; the other two are kept for ablation.
 enum class WavePeriodInputSource {
     Leveled,        // heading-frame up from the main filter's attitude
     BodyZ,          // raw -(acc.z + g) proxy, the frequency tracker's input
-    Complementary,  // private Mahony observer; measurement-only
+    Complementary,  // private Mahony observer; levelled and measurement-only
 };
 
 class VerticalAccelComplementary {

--- a/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
+++ b/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
@@ -214,7 +214,9 @@ public:
                 } else if (value == "complementary") {
                     filter.setWavePeriodInput(
                         WavePeriodInputSource::Complementary);
-                } else if (value != "leveled") {
+                } else if (value == "leveled") {
+                    filter.setWavePeriodInput(WavePeriodInputSource::Leveled);
+                } else {
                     throw std::runtime_error(
                         "W3D_WAVE_PERIOD_INPUT must be leveled, body_z or "
                         "complementary");

--- a/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
+++ b/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
@@ -201,17 +201,34 @@ public:
                 }
             }
 
-            // Ablate the wave-period estimator's input from the leveled
-            // vertical acceleration (default) to the body-Z proxy the
-            // frequency tracker already runs on, which does not pass through
-            // the attitude solution and so opens the tuner coupling.
+            // Ablate the wave-period estimator's input away from the leveled
+            // vertical acceleration (default), which passes through the
+            // attitude solution.  Both alternatives are measurement-only and
+            // open the tuner coupling: "body_z" is the raw proxy the frequency
+            // tracker already runs on, "complementary" levels it with a
+            // private Mahony observer.
             if (const char* src = std::getenv("W3D_WAVE_PERIOD_INPUT")) {
                 const std::string value = src;
                 if (value == "body_z") {
-                    filter.setWavePeriodInputBodyZ(true);
+                    filter.setWavePeriodInput(WavePeriodInputSource::BodyZ);
+                } else if (value == "complementary") {
+                    filter.setWavePeriodInput(
+                        WavePeriodInputSource::Complementary);
                 } else if (value != "leveled") {
                     throw std::runtime_error(
-                        "W3D_WAVE_PERIOD_INPUT must be leveled or body_z");
+                        "W3D_WAVE_PERIOD_INPUT must be leveled, body_z or "
+                        "complementary");
+                }
+            }
+
+            // Gains of that private observer, so the correction corner can be
+            // swept against the wave band it must stay below.
+            {
+                float two_kp = 0.2f, two_ki = 0.0f;
+                const bool kp = env_float("W3D_WAVE_PERIOD_MAHONY_KP", two_kp);
+                const bool ki = env_float("W3D_WAVE_PERIOD_MAHONY_KI", two_ki);
+                if (kp || ki) {
+                    filter.setWavePeriodComplementaryGains(two_kp, two_ki);
                 }
             }
 

--- a/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
+++ b/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
@@ -201,6 +201,20 @@ public:
                 }
             }
 
+            // Ablate the wave-period estimator's input from the leveled
+            // vertical acceleration (default) to the body-Z proxy the
+            // frequency tracker already runs on, which does not pass through
+            // the attitude solution and so opens the tuner coupling.
+            if (const char* src = std::getenv("W3D_WAVE_PERIOD_INPUT")) {
+                const std::string value = src;
+                if (value == "body_z") {
+                    filter.setWavePeriodInputBodyZ(true);
+                } else if (value != "leveled") {
+                    throw std::runtime_error(
+                        "W3D_WAVE_PERIOD_INPUT must be leveled or body_z");
+                }
+            }
+
             if (env_float("OU_ACC_BIAS_INIT_STD", v)) {
                 filter.mekf().set_initial_acc_bias_std(v);
             }

--- a/tests/kalman_ou_iii/kalman_ou_iii-sim.cpp
+++ b/tests/kalman_ou_iii/kalman_ou_iii-sim.cpp
@@ -204,7 +204,9 @@ public:
                 } else if (value == "complementary") {
                     filter.setWavePeriodInput(
                         WavePeriodInputSource::Complementary);
-                } else if (value != "leveled") {
+                } else if (value == "leveled") {
+                    filter.setWavePeriodInput(WavePeriodInputSource::Leveled);
+                } else {
                     throw std::runtime_error(
                         "W3D_WAVE_PERIOD_INPUT must be leveled, body_z or "
                         "complementary");

--- a/tests/kalman_ou_iii/kalman_ou_iii-sim.cpp
+++ b/tests/kalman_ou_iii/kalman_ou_iii-sim.cpp
@@ -191,6 +191,20 @@ public:
                 }
             }
 
+            // Ablate the wave-period estimator's input from the leveled
+            // vertical acceleration (default) to the body-Z proxy the
+            // frequency tracker already runs on, which does not pass through
+            // the attitude solution and so opens the tuner coupling.
+            if (const char* src = std::getenv("W3D_WAVE_PERIOD_INPUT")) {
+                const std::string value = src;
+                if (value == "body_z") {
+                    filter.setWavePeriodInputBodyZ(true);
+                } else if (value != "leveled") {
+                    throw std::runtime_error(
+                        "W3D_WAVE_PERIOD_INPUT must be leveled or body_z");
+                }
+            }
+
             if (env_float("OU_ACC_BIAS_INIT_STD", v)) {
                 filter.mekf().set_initial_acc_bias_std(v);
             }

--- a/tests/kalman_ou_iii/kalman_ou_iii-sim.cpp
+++ b/tests/kalman_ou_iii/kalman_ou_iii-sim.cpp
@@ -191,17 +191,34 @@ public:
                 }
             }
 
-            // Ablate the wave-period estimator's input from the leveled
-            // vertical acceleration (default) to the body-Z proxy the
-            // frequency tracker already runs on, which does not pass through
-            // the attitude solution and so opens the tuner coupling.
+            // Ablate the wave-period estimator's input away from the leveled
+            // vertical acceleration (default), which passes through the
+            // attitude solution.  Both alternatives are measurement-only and
+            // open the tuner coupling: "body_z" is the raw proxy the frequency
+            // tracker already runs on, "complementary" levels it with a
+            // private Mahony observer.
             if (const char* src = std::getenv("W3D_WAVE_PERIOD_INPUT")) {
                 const std::string value = src;
                 if (value == "body_z") {
-                    filter.setWavePeriodInputBodyZ(true);
+                    filter.setWavePeriodInput(WavePeriodInputSource::BodyZ);
+                } else if (value == "complementary") {
+                    filter.setWavePeriodInput(
+                        WavePeriodInputSource::Complementary);
                 } else if (value != "leveled") {
                     throw std::runtime_error(
-                        "W3D_WAVE_PERIOD_INPUT must be leveled or body_z");
+                        "W3D_WAVE_PERIOD_INPUT must be leveled, body_z or "
+                        "complementary");
+                }
+            }
+
+            // Gains of that private observer, so the correction corner can be
+            // swept against the wave band it must stay below.
+            {
+                float two_kp = 0.2f, two_ki = 0.0f;
+                const bool kp = env_float("W3D_WAVE_PERIOD_MAHONY_KP", two_kp);
+                const bool ki = env_float("W3D_WAVE_PERIOD_MAHONY_KI", two_ki);
+                if (kp || ki) {
+                    filter.setWavePeriodComplementaryGains(two_kp, two_ki);
                 }
             }
 

--- a/tests/kalman_ou_iii/tuner_coupling-test.cpp
+++ b/tests/kalman_ou_iii/tuner_coupling-test.cpp
@@ -11,25 +11,23 @@
 //    world vertical acceleration instead, which would couple the variance
 //    estimate to the very states being tuned. Asserted bit-for-bit.
 //
-// 2. The frequency channel is NOT exogenous, and that is the loop the
-//    certificate still has to account for. wave_period_ is fed
-//    direction_accel.up_ms2, the leveled vertical acceleration, which uses
-//    the attitude estimate. So delta_theta -> wave period -> tau, sigma_a,
-//    r_S -> filter gains -> delta_theta is a real feedback path. It cannot be
-//    asserted away; what is asserted is that its gain stays modest, so the
-//    small-gain reading of the interconnection keeps its premise.
+// 2. The frequency channel is exogenous too, under the default
+//    WavePeriodInputSource::Complementary. wave_period_ is fed a vertical
+//    acceleration levelled by a private Mahony observer that reads only the
+//    raw gyro and accelerometer, so displacing every estimator state leaves
+//    the reported period and the whole operating point bit-for-bit unchanged.
+//    A pure function of the measurements admits no tolerance, so that is how
+//    it is asserted. With both channels exogenous the interconnection
+//    app:iss-tuner was written around is absent, not merely small.
 //
-//    Note this reaches the linear states indirectly too: displacing v, p, S
-//    or a_w perturbs attitude through the filter's cross-covariances and so
-//    moves the tuner as well. The source comment at the wave_period_.update
-//    call says the leveled signal "depends on attitude but not on the linear
-//    block, so it does not close a loop through the quantity being tuned".
-//    That holds for the signal in isolation, not for the closed filter.
-//
-//    WavePeriodInputSource::Complementary removes this loop rather than
-//    bounding it, by levelling with a private Mahony observer that reads only
-//    the raw gyro and accelerometer. That is asserted separately, bit-for-bit,
-//    since a pure function of the measurements admits no tolerance.
+//    WavePeriodInputSource::Leveled is the older behaviour, kept for ablation,
+//    and it does close the loop: it feeds direction_accel.up_ms2, which uses
+//    the attitude estimate, so delta_theta -> wave period -> tau, sigma_a,
+//    r_S -> filter gains -> delta_theta is a real feedback path. It reaches
+//    the linear states indirectly as well, since displacing v, p, S or a_w
+//    perturbs attitude through the filter's cross-covariances. Its gain is
+//    still bounded here, because the ablation has to stay interpretable and
+//    because the bound is what any small-gain argument about it would consume.
 //
 // 3. One gate reads the attitude estimate directly and re-locks the filter
 //    above 70 degrees of tilt. It is kept out of the certified envelope only
@@ -160,12 +158,16 @@ bool test_variance_channel_input_is_exogenous() {
     return ok;
 }
 
-bool test_frequency_channel_coupling_stays_bounded() {
+bool test_leveled_ablation_coupling_stays_bounded() {
     bool ok = true;
 
     Filter nominal, displaced;
     bring_up(nominal);
     bring_up(displaced);
+    // Not the default any more, so it has to be selected: without this the
+    // test would measure the exogenous path and pass while proving nothing.
+    nominal.setWavePeriodInput(WavePeriodInputSource::Leveled);
+    displaced.setWavePeriodInput(WavePeriodInputSource::Leveled);
     run(nominal, 0, SETTLE);
     run(displaced, 0, SETTLE);
 
@@ -178,11 +180,11 @@ bool test_frequency_channel_coupling_stays_bounded() {
 
     const float ratio = displaced.getTauTarget() / nominal.getTauTarget();
 
-    // Measured 1.34 for a 0.25 rad displacement. The bound is a small-gain
+    // Measured 1.28 for a 0.25 rad displacement. The bound is a small-gain
     // guard, not a fit: it fails if the attitude-to-tuning path ever becomes
-    // strong enough that the interconnection stops being a mild perturbation.
-    // It also passes trivially if someone makes the frequency channel
-    // exogenous, which would be an improvement.
+    // strong enough that this ablation stops being a mild perturbation of the
+    // default. It is no longer load-bearing for the shipped filter, whose
+    // frequency channel is exogenous, but it keeps the comparison honest.
     constexpr float MAX_RATIO = 2.0f;
     ok &= check(ratio > 1.0f / MAX_RATIO && ratio < MAX_RATIO,
                 "attitude-to-tuning loop gain must stay modest");
@@ -193,42 +195,44 @@ bool test_frequency_channel_coupling_stays_bounded() {
     return ok;
 }
 
-// The counterpart to the test above: under WavePeriodInputSource::Complementary
-// the frequency channel joins the variance channel in being exogenous, so the
-// interconnection the certificate has to argue about is not merely small, it is
-// absent.  Asserted bit-for-bit against a displacement of *every* state, because
-// "a pure function of the measurements" admits no tolerance.
-bool test_complementary_frequency_channel_is_exogenous() {
+// The frequency channel under the *default* input source. It joins the variance
+// channel in being exogenous, so the interconnection the certificate has to
+// argue about is not merely small, it is absent. Asserted bit-for-bit against a
+// displacement of *every* state, because "a pure function of the measurements"
+// admits no tolerance. Nothing is selected here on purpose: the point is that
+// this is what the filter does out of the box.
+bool test_default_frequency_channel_is_exogenous() {
     bool ok = true;
 
     Filter nominal, displaced;
     bring_up(nominal);
     bring_up(displaced);
-    nominal.setWavePeriodInput(WavePeriodInputSource::Complementary);
-    displaced.setWavePeriodInput(WavePeriodInputSource::Complementary);
+    ok &= check(nominal.wavePeriodInput() == WavePeriodInputSource::Complementary,
+                "the default wave-period input must be the exogenous one");
     run(nominal, 0, SETTLE);
     run(displaced, 0, SETTLE);
 
     ok &= check(nominal.isAdaptiveLive(),
                 "the tuner must reach its live stage, or this test proves nothing");
     ok &= check(nominal.wavePeriodReady(),
-                "the complementary period must have settled, or the fallback is "
-                "what is being measured");
+                "the period must have settled, or the body-Z fallback is what "
+                "is being measured");
 
     displace_state(displaced, /*attitude=*/true, /*linear=*/true);
     run(nominal, SETTLE, AFTER);
     run(displaced, SETTLE, AFTER);
 
     ok &= check(nominal.getWavePeriodSec() == displaced.getWavePeriodSec(),
-                "the complementary wave period must be a function of the "
+                "the default wave period must be a function of the "
                 "measurement alone");
 
     // With both tuner inputs exogenous the whole operating point must be, too.
     ok &= check(nominal.getTauTarget() == displaced.getTauTarget(),
-                "the complementary operating point must be a function of the "
+                "the default operating point must be a function of the "
                 "measurement alone");
 
-    std::cout << "  complementary: attitude+linear displacement -> wave period "
+    std::cout << "  default (complementary): attitude+linear displacement -> "
+                 "wave period "
               << nominal.getWavePeriodSec() << " s vs "
               << displaced.getWavePeriodSec() << " s (must be identical)\n";
 
@@ -273,8 +277,8 @@ bool test_tilt_gate_stays_outside_the_certified_envelope() {
 int main() {
     bool ok = true;
     ok &= test_variance_channel_input_is_exogenous();
-    ok &= test_frequency_channel_coupling_stays_bounded();
-    ok &= test_complementary_frequency_channel_is_exogenous();
+    ok &= test_default_frequency_channel_is_exogenous();
+    ok &= test_leveled_ablation_coupling_stays_bounded();
     ok &= test_tilt_gate_stays_outside_the_certified_envelope();
 
     if (!ok) {

--- a/tests/kalman_ou_iii/tuner_coupling-test.cpp
+++ b/tests/kalman_ou_iii/tuner_coupling-test.cpp
@@ -26,6 +26,11 @@
 //    block, so it does not close a loop through the quantity being tuned".
 //    That holds for the signal in isolation, not for the closed filter.
 //
+//    WavePeriodInputSource::Complementary removes this loop rather than
+//    bounding it, by levelling with a private Mahony observer that reads only
+//    the raw gyro and accelerometer. That is asserted separately, bit-for-bit,
+//    since a pure function of the measurements admits no tolerance.
+//
 // 3. One gate reads the attitude estimate directly and re-locks the filter
 //    above 70 degrees of tilt. It is kept out of the certified envelope only
 //    by margin, so the margin is pinned.
@@ -188,6 +193,54 @@ bool test_frequency_channel_coupling_stays_bounded() {
     return ok;
 }
 
+// The counterpart to the test above: under WavePeriodInputSource::Complementary
+// the frequency channel joins the variance channel in being exogenous, so the
+// interconnection the certificate has to argue about is not merely small, it is
+// absent.  Asserted bit-for-bit against a displacement of *every* state, because
+// "a pure function of the measurements" admits no tolerance.
+bool test_complementary_frequency_channel_is_exogenous() {
+    bool ok = true;
+
+    Filter nominal, displaced;
+    bring_up(nominal);
+    bring_up(displaced);
+    nominal.setWavePeriodInput(WavePeriodInputSource::Complementary);
+    displaced.setWavePeriodInput(WavePeriodInputSource::Complementary);
+    run(nominal, 0, SETTLE);
+    run(displaced, 0, SETTLE);
+
+    ok &= check(nominal.isAdaptiveLive(),
+                "the tuner must reach its live stage, or this test proves nothing");
+    ok &= check(nominal.wavePeriodReady(),
+                "the complementary period must have settled, or the fallback is "
+                "what is being measured");
+
+    displace_state(displaced, /*attitude=*/true, /*linear=*/true);
+    run(nominal, SETTLE, AFTER);
+    run(displaced, SETTLE, AFTER);
+
+    ok &= check(nominal.getWavePeriodSec() == displaced.getWavePeriodSec(),
+                "the complementary wave period must be a function of the "
+                "measurement alone");
+
+    // With both tuner inputs exogenous the whole operating point must be, too.
+    ok &= check(nominal.getTauTarget() == displaced.getTauTarget(),
+                "the complementary operating point must be a function of the "
+                "measurement alone");
+
+    std::cout << "  complementary: attitude+linear displacement -> wave period "
+              << nominal.getWavePeriodSec() << " s vs "
+              << displaced.getWavePeriodSec() << " s (must be identical)\n";
+
+    if (!ok) {
+        std::cerr << "  The private Mahony observer has acquired a dependence on\n"
+                     "  estimator state. It exists precisely so the tuner has an\n"
+                     "  input that cannot; feeding it anything the filter computed\n"
+                     "  defeats the point.\n";
+    }
+    return ok;
+}
+
 bool test_tilt_gate_stays_outside_the_certified_envelope() {
     bool ok = true;
 
@@ -221,6 +274,7 @@ int main() {
     bool ok = true;
     ok &= test_variance_channel_input_is_exogenous();
     ok &= test_frequency_channel_coupling_stays_bounded();
+    ok &= test_complementary_frequency_channel_is_exogenous();
     ok &= test_tilt_gate_stays_outside_the_certified_envelope();
 
     if (!ok) {

--- a/tools/ou_wave_period_input_study.py
+++ b/tools/ou_wave_period_input_study.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Compare the two possible inputs to the OU-II / OU-III wave-period estimator.
+"""Compare the possible inputs to the OU-II / OU-III wave-period estimator.
 
 The adaptation tuner takes its operating point from the zero-crossing wave
 period, and that period is estimated by ``WavePeriodEstimator`` from a vertical
@@ -18,7 +18,13 @@ stability consequence:
                          band, where double integration weights the spectrum by
                          1/omega^4.
 
-This tool replays the eight reference records under both inputs, for both
+  ``complementary``      levelled with a private Mahony observer running on the
+                         raw gyro and accelerometer.  Also a pure function of
+                         the measurements, so the loop is equally open, but
+                         levelled, so the leakage is removed rather than
+                         accepted.
+
+This tool replays the eight reference records under every input, for both
 filters, and reports the RMS errors side by side.  The protocol is the
 deterministic one of ``tools/ou_sim_table.py``: one realization per record,
 default seeds, the final 900 s of a 20-minute replay.  It is not the ten-seed
@@ -33,6 +39,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import math
 import os
 import subprocess
 import sys
@@ -61,7 +68,10 @@ RECORDS = (
     ("PM-Stokes", 8.50, "wave_data_pmstokes_H8.500_L202.839_A-30.00_P72.00.csv"),
 )
 
-INPUTS = ("leveled", "body_z")
+INPUTS = ("leveled", "body_z", "complementary")
+
+# The shipped configuration, and the baseline every ratio is taken against.
+BASELINE = "leveled"
 
 # Fields pulled out of the VALIDATION_METRICS line.
 FIELDS = (
@@ -156,26 +166,52 @@ def main() -> int:
         }
         results = {key: future.result() for key, future in futures.items()}
 
+    others = [s for s in INPUTS if s != BASELINE]
+
     rows = []
     for family in families:
+        for metric, label in (("disp_z_rms_m", "vertical"), ("disp_3d_rms_m", "3D")):
+            print()
+            print(f"=== {family}: last {int(WINDOW_SEC)} s {label} RMS vs {BASELINE} ===")
+            head = f"{'record':<12}{'Hs':>6}{BASELINE:>12}"
+            for source in others:
+                head += f"{source:>14}{'delta':>8}"
+            print(head)
+            for family_label, hs, record in RECORDS:
+                base = results[(family, record, BASELINE)][metric]
+                line = f"{family_label:<12}{hs:>6.2f}{base:>12.4f}"
+                for source in others:
+                    value = results[(family, record, source)][metric]
+                    line += f"{value:>14.4f}{pct(value, base):>8}"
+                print(line)
+            # Geometric mean of the per-record ratio, a scale-free pooling of
+            # relative change across sea states that differ by 30x in Hs.
+            tail = f"{'geometric mean':<18}{'':>12}"
+            for source in others:
+                logs = [
+                    math.log(results[(family, r, source)][metric]
+                             / results[(family, r, BASELINE)][metric])
+                    for _, _, r in RECORDS
+                    if results[(family, r, BASELINE)][metric] > 0.0
+                ]
+                ratio = math.exp(sum(logs) / len(logs)) if logs else float("nan")
+                tail += f"{ratio:>13.3f}x{'':>8}"
+            print(tail)
+
         print()
-        print(f"=== {family}: last {int(WINDOW_SEC)} s RMS, wave-period input ablation ===")
-        print(
-            f"{'record':<20}{'Hs':>6} | {'Z RMS leveled':>14}{'Z RMS body_z':>14}"
-            f"{'dZ':>8} | {'3D leveled':>12}{'3D body_z':>12}{'d3D':>8} | "
-            f"{'Tz lvl':>8}{'Tz bz':>8}"
-        )
+        print(f"=== {family}: reported zero-crossing period T_z [s] ===")
+        head = f"{'record':<12}{'Hs':>6}{BASELINE:>12}"
+        for source in others:
+            head += f"{source:>14}"
+        print(head)
         for family_label, hs, record in RECORDS:
-            lvl = results[(family, record, "leveled")]
-            bz = results[(family, record, "body_z")]
-            print(
-                f"{family_label:<20}{hs:>6.2f} | "
-                f"{lvl['disp_z_rms_m']:>14.4f}{bz['disp_z_rms_m']:>14.4f}"
-                f"{pct(bz['disp_z_rms_m'], lvl['disp_z_rms_m']):>8} | "
-                f"{lvl['disp_3d_rms_m']:>12.4f}{bz['disp_3d_rms_m']:>12.4f}"
-                f"{pct(bz['disp_3d_rms_m'], lvl['disp_3d_rms_m']):>8} | "
-                f"{lvl['wave_period_s']:>8.2f}{bz['wave_period_s']:>8.2f}"
-            )
+            line = (f"{family_label:<12}{hs:>6.2f}"
+                    f"{results[(family, record, BASELINE)]['wave_period_s']:>12.2f}")
+            for source in others:
+                line += f"{results[(family, record, source)]['wave_period_s']:>14.2f}"
+            print(line)
+
+        for family_label, hs, record in RECORDS:
             for source in INPUTS:
                 row = dict(results[(family, record, source)])
                 row.update(

--- a/tools/ou_wave_period_input_study.py
+++ b/tools/ou_wave_period_input_study.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Compare the two possible inputs to the OU-II / OU-III wave-period estimator.
+
+The adaptation tuner takes its operating point from the zero-crossing wave
+period, and that period is estimated by ``WavePeriodEstimator`` from a vertical
+acceleration.  Which vertical acceleration it gets is a design choice with a
+stability consequence:
+
+  ``leveled`` (shipped)  the heading-frame up component, i.e. the accelerometer
+                         rotated by the filter's own attitude solution.  It
+                         tracks the sea state well, but attitude is a filter
+                         state, so the tuner is inside a loop.
+
+  ``body_z``             the raw body-Z proxy ``-(acc.z + g)`` that the
+                         frequency tracker already runs on.  It never touches
+                         the attitude solution, so the loop is open, but a
+                         tilting platform leaks gravity into it below the wave
+                         band, where double integration weights the spectrum by
+                         1/omega^4.
+
+This tool replays the eight reference records under both inputs, for both
+filters, and reports the RMS errors side by side.  The protocol is the
+deterministic one of ``tools/ou_sim_table.py``: one realization per record,
+default seeds, the final 900 s of a 20-minute replay.  It is not the ten-seed
+ensemble study and must not be quoted interchangeably with it.
+
+Usage:
+  tools/ou_wave_period_input_study.py
+  tools/ou_wave_period_input_study.py --family OU_III --csv out.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Trailing window the simulators score their own quality gates over.
+WINDOW_SEC = 900.0
+
+FAMILIES = {
+    "OU_II": {"subdir": "kalman_ou_ii", "binary": "kalman_ou_ii-sim"},
+    "OU_III": {"subdir": "kalman_ou_iii", "binary": "kalman_ou_iii-sim"},
+}
+
+# The eight records, in the order the historical table reports them.
+RECORDS = (
+    ("JONSWAP", 0.27, "wave_data_jonswap_H0.270_L14.047_A30.00_P60.00.csv"),
+    ("JONSWAP", 1.50, "wave_data_jonswap_H1.500_L50.710_A-30.00_P120.00.csv"),
+    ("JONSWAP", 4.00, "wave_data_jonswap_H4.000_L112.766_A30.00_P30.00.csv"),
+    ("JONSWAP", 8.50, "wave_data_jonswap_H8.500_L202.839_A-30.00_P72.00.csv"),
+    ("PM-Stokes", 0.27, "wave_data_pmstokes_H0.270_L14.047_A30.00_P60.00.csv"),
+    ("PM-Stokes", 1.50, "wave_data_pmstokes_H1.500_L50.710_A-30.00_P120.00.csv"),
+    ("PM-Stokes", 4.00, "wave_data_pmstokes_H4.000_L112.766_A30.00_P30.00.csv"),
+    ("PM-Stokes", 8.50, "wave_data_pmstokes_H8.500_L202.839_A-30.00_P72.00.csv"),
+)
+
+INPUTS = ("leveled", "body_z")
+
+# Fields pulled out of the VALIDATION_METRICS line.
+FIELDS = (
+    "disp_z_rms_m",
+    "disp_3d_rms_m",
+    "disp_z_pct_hs",
+    "disp_x_rms_m",
+    "disp_y_rms_m",
+    "roll_rms_deg",
+    "pitch_rms_deg",
+    "yaw_rms_deg",
+    "wave_period_s",
+    "period_s",
+    "tau_applied_s",
+)
+
+
+def run_one(family: str, record: str, wave_period_input: str) -> dict[str, float]:
+    """Replay one record under one input choice and parse its metrics line."""
+    spec = FAMILIES[family]
+    workdir = (ROOT / "tests" / spec["subdir"]).resolve()
+    binary = workdir / spec["binary"]
+    if not binary.exists():
+        raise SystemExit(f"missing {binary}; run `make -C {workdir} build` first")
+    path = workdir / record
+    if not path.exists():
+        raise SystemExit(f"missing record {path}; run `make fetch-sim-data` first")
+
+    env = dict(os.environ)
+    env["W3D_WRITE_TIMESERIES"] = "0"
+    # Every record has to be scored, including any that trips a historical gate;
+    # this reports what the filter did, not whether it passed.
+    env["W3D_COLLECT_ALL_GATES"] = "1"
+    env["W3D_VALIDATION_WINDOW_SEC"] = str(WINDOW_SEC)
+    env["W3D_WAVE_PERIOD_INPUT"] = wave_period_input
+
+    completed = subprocess.run(
+        [str(binary), "--input", str(path)],
+        cwd=workdir,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    line = next(
+        (l for l in completed.stdout.splitlines() if l.startswith("VALIDATION_METRICS ")),
+        None,
+    )
+    if line is None:
+        sys.stderr.write(completed.stdout[-2000:] + completed.stderr[-2000:])
+        raise SystemExit(f"no VALIDATION_METRICS for {family} {record} {wave_period_input}")
+
+    parsed = dict(
+        token.split("=", 1) for token in line.split() if "=" in token
+    )
+    out: dict[str, float] = {}
+    for field in FIELDS:
+        try:
+            out[field] = float(parsed[field])
+        except (KeyError, ValueError):
+            out[field] = float("nan")
+    return out
+
+
+def pct(new: float, old: float) -> str:
+    if not (old > 0.0):
+        return "   n/a"
+    return f"{100.0 * (new / old - 1.0):+6.1f}%"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--family", choices=sorted(FAMILIES), action="append")
+    ap.add_argument("--jobs", type=int, default=os.cpu_count() or 4)
+    ap.add_argument("--csv", type=Path, help="write the raw rows here")
+    args = ap.parse_args()
+
+    families = args.family or ["OU_II", "OU_III"]
+
+    jobs = [
+        (family, family_label, hs, record, source)
+        for family in families
+        for family_label, hs, record in RECORDS
+        for source in INPUTS
+    ]
+
+    with ThreadPoolExecutor(max_workers=max(1, args.jobs)) as pool:
+        futures = {
+            (family, record, source): pool.submit(run_one, family, record, source)
+            for family, _, _, record, source in jobs
+        }
+        results = {key: future.result() for key, future in futures.items()}
+
+    rows = []
+    for family in families:
+        print()
+        print(f"=== {family}: last {int(WINDOW_SEC)} s RMS, wave-period input ablation ===")
+        print(
+            f"{'record':<20}{'Hs':>6} | {'Z RMS leveled':>14}{'Z RMS body_z':>14}"
+            f"{'dZ':>8} | {'3D leveled':>12}{'3D body_z':>12}{'d3D':>8} | "
+            f"{'Tz lvl':>8}{'Tz bz':>8}"
+        )
+        for family_label, hs, record in RECORDS:
+            lvl = results[(family, record, "leveled")]
+            bz = results[(family, record, "body_z")]
+            print(
+                f"{family_label:<20}{hs:>6.2f} | "
+                f"{lvl['disp_z_rms_m']:>14.4f}{bz['disp_z_rms_m']:>14.4f}"
+                f"{pct(bz['disp_z_rms_m'], lvl['disp_z_rms_m']):>8} | "
+                f"{lvl['disp_3d_rms_m']:>12.4f}{bz['disp_3d_rms_m']:>12.4f}"
+                f"{pct(bz['disp_3d_rms_m'], lvl['disp_3d_rms_m']):>8} | "
+                f"{lvl['wave_period_s']:>8.2f}{bz['wave_period_s']:>8.2f}"
+            )
+            for source in INPUTS:
+                row = dict(results[(family, record, source)])
+                row.update(
+                    family=family, record=record, sea_state=family_label,
+                    hs_m=hs, wave_period_input=source,
+                )
+                rows.append(row)
+
+    if args.csv:
+        with args.csv.open("w", newline="") as handle:
+            writer = csv.DictWriter(
+                handle,
+                fieldnames=[
+                    "family", "sea_state", "hs_m", "record", "wave_period_input", *FIELDS
+                ],
+            )
+            writer.writeheader()
+            writer.writerows(rows)
+        print(f"\nwrote {args.csv}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ou_wave_period_input_study.py
+++ b/tools/ou_wave_period_input_study.py
@@ -6,10 +6,11 @@ period, and that period is estimated by ``WavePeriodEstimator`` from a vertical
 acceleration.  Which vertical acceleration it gets is a design choice with a
 stability consequence:
 
-  ``leveled`` (shipped)  the heading-frame up component, i.e. the accelerometer
+  ``leveled``            the heading-frame up component, i.e. the accelerometer
                          rotated by the filter's own attitude solution.  It
                          tracks the sea state well, but attitude is a filter
-                         state, so the tuner is inside a loop.
+                         state, so the tuner is inside a loop.  This is what
+                         the filter shipped before ``complementary``.
 
   ``body_z``             the raw body-Z proxy ``-(acc.z + g)`` that the
                          frequency tracker already runs on.  It never touches
@@ -18,11 +19,11 @@ stability consequence:
                          band, where double integration weights the spectrum by
                          1/omega^4.
 
-  ``complementary``      levelled with a private Mahony observer running on the
-                         raw gyro and accelerometer.  Also a pure function of
-                         the measurements, so the loop is equally open, but
-                         levelled, so the leakage is removed rather than
-                         accepted.
+  ``complementary``      (shipped) levelled with a private Mahony observer
+                         running on the raw gyro and accelerometer.  Also a
+                         pure function of the measurements, so the loop is
+                         equally open, but levelled, so the leakage is removed
+                         rather than accepted.
 
 This tool replays the eight reference records under every input, for both
 filters, and reports the RMS errors side by side.  The protocol is the
@@ -70,7 +71,10 @@ RECORDS = (
 
 INPUTS = ("leveled", "body_z", "complementary")
 
-# The shipped configuration, and the baseline every ratio is taken against.
+# The baseline every ratio is taken against.  This is deliberately not the
+# shipped input, which is "complementary": the question the tool exists to
+# answer is what the shipped input changed relative to attitude levelling, so
+# the old behaviour stays the denominator.
 BASELINE = "leveled"
 
 # Fields pulled out of the VALIDATION_METRICS line.


### PR DESCRIPTION
The adaptation tuner takes its operating point from WavePeriodEstimator,
which is fed the leveled vertical acceleration.  Levelling uses the
filter's own attitude solution, so the tuner sits inside a loop.  The
body-Z proxy the frequency tracker already runs on is the one input that
opens that loop completely - it never touches the attitude solution - so
it is worth measuring rather than dismissing.

Add setWavePeriodInputBodyZ(bool) to both filters, defaulting to false so
shipped behaviour is unchanged, and W3D_WAVE_PERIOD_INPUT=leveled|body_z
in both sim harnesses, following the existing W3D_TUNING_BAND pattern.
tools/ou_wave_period_input_study.py replays all eight reference records
both ways under the deterministic single-seed protocol.

Opening the loop costs far more than the loop does.  Geometric-mean
ratio body-Z / leveled over the eight records: OU-II 1.88x vertical and
1.63x 3D, OU-III 2.51x and 2.24x.  Every record degrades, monotonically
in sea state, worst in the calmest ones - which is the period error read
straight through.  The body-Z estimate is pinned near 6.8-10.0 s whatever
the sea does, reproducing the figure the OU-III note already recorded,
against a truth of 2.4-8.7 s.  Since tau is a fixed multiple of T_z, that
is the uninformative operating point wave-band tuning was introduced to
fix.  Attitude RMS is essentially unmoved either way, so the loss is the
operating point and not the attitude solution.

Record the measurement in docs/ou-iii-adaptation-and-travel-sense.md
beside the qualitative claim it confirms.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015n9AqZvcbUXXRfEGETDBPY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added measurement-only complementary attitude processing for more independent wave-period estimation.
  - Added selectable wave-period inputs: complementary, leveled, or body-axis acceleration.
  - Added controls for complementary observer gains and reset behavior.
  - Added a command-line study tool comparing input methods across reference wave records.

- **Documentation**
  - Expanded guidance on wave-period inputs, observer behavior, feedback effects, and configuration.

- **Tests**
  - Added validation for input selection, gain overrides, and stability when estimator attitude changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->