### PR TITLE
Sync the abstract's paired statistics to the committed manifest

### DIFF
--- a/doc/kalman_ou_iii/kalman_ou-w3d.tex
+++ b/doc/kalman_ou_iii/kalman_ou-w3d.tex
@@ -209,8 +209,8 @@ controlled transition.  Over the stationary JONSWAP seas, the declared
 primary endpoint, the seed-wise mean normalized vertical-displacement RMS
 error is $4.97\pm0.25\%$ of $H_s$ for OU--III and $6.67\pm0.29\%$ for OU--II
 (mean $\pm$ sample standard deviation over the ten seed triplets); the paired
-difference is $-1.694$ percentage point (percentile-bootstrap 95\% interval
-$[-1.774,-1.623]$, Student-$t$ interval $[-1.786,-1.603]$, all ten seed-level
+difference is $-1.696$ percentage point (percentile-bootstrap 95\% interval
+$[-1.774,-1.625]$, Student-$t$ interval $[-1.787,-1.605]$, all ten seed-level
 differences negative, exact sign and paired sign-flip tests both at their
 $n=10$ floor of $p=0.002$).  These are four readings of the same ten paired
 differences and establish repeatability within the simulator, not


### PR DESCRIPTION
Fixes the red `ou-validation` job on `main`.

## What is failing

`test_abstract_reports_committed_stationary_aggregate` asserts that the
manuscript abstract quotes the stationary aggregate recorded in
`reports/results/ou_validation/ou_validation_manifest.json`. Both are committed
files, and the workflow runs this test *before* it regenerates anything, so the
assertion is purely a consistency check between two things already in the tree.

A regeneration of the validation evidence moved three of those numbers and the
abstract was not updated with them.

| quantity | abstract | committed manifest |
| --- | --- | --- |
| mean paired difference | `-1.694` | `-1.696` |
| percentile-bootstrap 95% | `[-1.774,-1.623]` | `[-1.774,-1.625]` |
| Student-*t* 95% | `[-1.786,-1.603]` | `[-1.787,-1.605]` |

The two mean ± standard deviation figures (`4.97±0.25%`, `6.67±0.29%`) already
agreed and are untouched. No other file in `doc/` quotes these values.

## This predates PR #243

Worth stating explicitly, because the failure first became visible on that
merge commit and it would be easy to attribute it there. It reproduces at
`7d00e06^1` — `main` immediately *before* the merge — where the manifest
already formatted to `[-1.773,-1.623]` against an abstract reading
`[-1.774,-1.623]`. The regression entered with `6287f02`.

Two details confirm the diagnosis rather than a filter-behaviour change. The
mean and the Student-*t* bounds are closed-form functions of the same ten
paired differences, and they are stale in the same direction — a change in
filter output could not move the bootstrap bound while leaving those
self-consistent. And the assertion fails on a commit that contains none of
#243's code.

## The fix

Three numbers in the abstract, transcribed from the committed manifest. This is
a transcription fix, not a change of result: the values come from the evidence
bundle and only the prose lagged behind it.

## Validation

`tests/validation`: 66 tests, OK — that is the suite the CI job runs.
`make all` green.

## Note for follow-up

This will break again on the next regeneration. The abstract hardcodes numbers
that `tools/ou_validation.py` recomputes, and the test is the only thing tying
them together, after the fact rather than by construction. The repository
already has the machinery that would prevent it —
`w3d-ou-validation-macros-generated.tex-part` — but its macros cover per-record
tuning points, not the stationary aggregate. Extending the generator to emit
macros for these five values and having the abstract reference them would make
the sync automatic.

That is deliberately not done here: it changes how the manuscript sources its
prose numbers, which is an authoring decision rather than a CI fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_015n9AqZvcbUXXRfEGETDBPY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the reported OU–III versus OU–II paired difference in the abstract.
  * Updated the associated percentile-bootstrap and Student’s *t* confidence intervals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->