### PR TITLE
Add the two-frame Lie group the TFG filter will be built on

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,3 +39,11 @@ add_executable(kalman_ou_iii-sim "${OCEAN_IMU_TESTS_DIR}/kalman_ou_iii/kalman_ou
 add_executable(kalman_ou_common-test "${OCEAN_IMU_TESTS_DIR}/kalman_ou_iii/kalman_ou_common-test.cpp")
 add_executable(phi_coeff_boundary-test "${OCEAN_IMU_TESTS_DIR}/kalman_ou_iii/phi_coeff_boundary-test.cpp")
 add_executable(pii_observer-adaptive "${OCEAN_IMU_TESTS_DIR}/pii_observer/pii_observer-adaptive.cpp" ${W3D_SIM_COMMON})
+
+# Two-frame Lie-group filter. lie_group-test cross-checks the world block of
+# the group against Lie++ (third_party/Lie-plusplus), which is test-only and
+# never reaches the Arduino build.
+add_executable(lie_group-test "${OCEAN_IMU_TESTS_DIR}/kalman_tfg/lie_group-test.cpp")
+add_executable(convention-test "${OCEAN_IMU_TESTS_DIR}/kalman_tfg/convention-test.cpp")
+target_include_directories(lie_group-test SYSTEM PRIVATE
+  "${CMAKE_CURRENT_SOURCE_DIR}/third_party/Lie-plusplus/include")

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ TEST_DIRS := \
 	$(REPO_ROOT)/tests/imu_calibrate \
 	$(REPO_ROOT)/tests/kalman_ou_ii \
 	$(REPO_ROOT)/tests/kalman_ou_iii \
+	$(REPO_ROOT)/tests/kalman_tfg \
 	$(REPO_ROOT)/tests/nlo \
 	$(REPO_ROOT)/tests/pii_observer \
 	$(REPO_ROOT)/tests/spectrum \

--- a/docs/tfg-design.md
+++ b/docs/tfg-design.md
@@ -1,0 +1,250 @@
+# The two-frame Lie group: conventions and structure
+
+This is the reference for `src/lie/` and the filter built on it
+(`src/kalman_tfg/`). It exists because the single most common way a
+Lie-group estimator gets implemented backwards is by stating one convention
+choice and leaving two implicit.
+
+Everything here is pinned by `tests/kalman_tfg/lie_group-test.cpp` and
+`tests/kalman_tfg/convention-test.cpp`. If the prose and the tests ever
+disagree, the tests are right.
+
+## 1. The convention contract
+
+Three independent choices. Never state one without the other two.
+
+| # | Choice | This filter |
+|---|---|---|
+| 1 | rotation direction | `R = R_bw`, body to world |
+| 2 | error definition | right-invariant, `eta = Xhat o X^-1` |
+| 3 | correction side | left, `Xhat+ = Exp_G(dxi) o Xhat-` |
+
+**"Right-invariant" describes the error, not the side the correction lands
+on.** A right-invariant error is invariant when *both* states are multiplied
+on the right by the same group element, and such an error is applied by **left**
+multiplication. That is not a contradiction. `convention-test.cpp` asserts both
+halves, including the negative cases — the right-invariant error must *not*
+survive left multiplication, and left and right retraction must differ for a
+generic element. Without the negatives, a degenerate error definition would
+satisfy the positives trivially.
+
+The binding identity between (2) and (3): if `Xhat = Exp_G(xi) o X`, then
+`eta = Xhat o X^-1 = Exp_G(xi)` exactly, so `Log_G(Xhat o X^-1) = xi` with no
+approximation. Apply the same `xi` on the right and this fails.
+
+### Why right-invariant here
+
+The states that distinguish this filter — `v`, `p`, `S`, `a_w`, gravity, the
+magnetic reference, and the `S = 0` regularizer — are all world-frame
+quantities. A right-invariant error puts all the translational errors in a
+common world frame, which is why the accelerometer and magnetometer Jacobians
+come out built from *fixed* references rather than from the current estimate.
+
+A left-invariant error (`eta = X^-1 Xhat`, corrected on the right) would put
+translational errors in a body frame. Gravity would appear as `Rhat^T g`, north
+as `Rhat^T B_w`, the `S = 0` constraint would need transforming, and the
+NED-anisotropic `R_S` would rotate with the estimate. It has real advantages —
+body-frame sensor noise needs no rotation, and body biases are natural — but
+they do not pay for the world-frame structure this filter is built around. That
+trade would only flip if the state were redesigned around body-frame quantities.
+
+### The OU-III bridge
+
+OU-III makes a different choice on (1). It stores a **world-to-body** quaternion
+`C = R_wb` and injects on the left:
+
+```
+C+ = Exp(dtheta) C-
+```
+
+This filter stores `R = C^T = R_bw`. Transposing:
+
+```
+R+ = (C+)^T = (C-)^T Exp(-dtheta) = R- Exp(-dtheta)
+```
+
+The same physical rotation is a **right** multiplication on `R`. So "OU-III
+corrects on the left and TFG corrects on the left" is not a statement of
+agreement — the rotation directions differ.
+
+To express it as this filter's left-multiplicative correction, conjugate through
+`R Exp(u) R^T = Exp(R u)`:
+
+```
+R+ = Exp(-R- dtheta) R-        i.e.   phi = -R- dtheta
+```
+
+**The correspondence is not `phi = +-dtheta`.** It is a rotated, negated
+`dtheta`. This matters because both forms agree to first order at `R- = I`, so a
+test that only exercised small rotations near identity would never catch the
+difference. `convention-test.cpp` therefore asserts the correct bridge *and*
+asserts that both naive correspondences fail, gated on `|dtheta| > 0.2` and
+`|Log(R-)| > 0.2` so the check is only made where the forms genuinely diverge.
+
+### One more trap, in the sign of `Exp`
+
+`ocean_imu::lie::Exp` is the standard right-handed exponential: `Exp(phi)`
+rotates by `+phi` about `phi/|phi|`. `ou_detail::rot_and_B_from_wt` returns its
+**transpose**, because OU-III propagates a world-to-body quaternion. The two are
+not interchangeable; swapping them silently inverts every rotation in the
+filter. `convention-test.cpp` asserts the transpose relation directly, so the
+day someone "fixes" one of them the build goes red.
+
+`ou_detail::quat_from_delta_theta(dtheta)`, on the other hand, *does* equal
+`Exp(dtheta)` — also asserted.
+
+## 2. The group
+
+```
+X = (R, X_w, B_b)     R   = R_bw in SO(3)
+                      X_w = [v p S a_w] in R^{3x4}, world frame
+                      B_b = [b_g b_a]   in R^{3x2}, body frame
+
+(R1,X1,B1) o (R2,X2,B2) = ( R1 R2, X1 + R1 X2, B2 + R2^T B1 )
+identity                = (I, 0, 0)
+(R,X,B)^-1              = (R^T, -R^T X, -R B)
+```
+
+The asymmetry in the last slot is the whole point. World vectors are carried by
+`R`; body vectors by `R^T`, from the other side. A direct product
+`SE_4(3) x R^6` cannot express it, and that is exactly the difference between
+Level 1 and Level 2 in `Kalman3D_Wave_TFG`'s `two_frame_bias` flag.
+
+Right-invariant error in local coordinates:
+
+```
+dR     = Rhat R^T = Exp(phi)
+rho_x  = xhat - dR x       for each world column x
+beta_b = R (bhat - b)      for each body column b
+```
+
+Note that `rho_v` is **not** `vhat - v`, and `rho_p` is not `phat - p`. The
+attitude error and the translational errors share one frame, which is what makes
+a correction rotate `v, p, S, a_w` coherently instead of nudging the quaternion
+and leaving the rest behind.
+
+### Tangent layout
+
+Deliberately matches `Kalman3D_Wave_OU_III.h:40-54`, so the 12x12 world block
+stays contiguous and the scalar-loop propagation and Joseph-update block
+structure port over at the same offsets:
+
+```
+xi = [ phi | beta_g | rho_v rho_p rho_S rho_a | beta_a ]
+       0     3        6     9     12    15      18
+```
+
+`TwoFrameGroup<T, NW, NB>` is templated on the column counts; `NB = 1` drops the
+accelerometer bias and gives 18 states, matching OU-III's
+`with_accel_bias = false`. The offsets are `static_assert`ed in the test.
+
+### Group exponential
+
+```
+E_R = Exp(phi)
+E_X = J_l(phi)  [rho_v rho_p rho_S rho_a]
+E_B = J_l(-phi) [beta_g beta_a]
+```
+
+**The `J_l(-phi)` on the bias block is derived, not chosen.** The group law
+induces the one-parameter ODE
+
+```
+b'(s) = beta - [phi]x b(s)
+```
+
+whose solution at `s = 1` is `Exp(-phi) J_l(phi) beta`, and
+`Exp(-phi) J_l(phi) = J_r(phi) = J_l(-phi)`.
+
+Because Lie++ has no oracle for four world vectors plus six body-frame biases,
+this block is pinned by the **one-parameter subgroup property**,
+`Exp_G(s1 xi) o Exp_G(s2 xi) = Exp_G((s1+s2) xi)`, which only holds when the
+exponential genuinely integrates that ODE. Changing `J_l(-phi)` to `J_l(+phi)`
+fails 182 checks.
+
+### Retraction
+
+```
+Xhat+ = Exp_G(xi) o Xhat-
+
+Rhat+ = E_R Rhat-
+Xhat+ = E_R Xhat- + E_X
+Bhat+ = Bhat- + (Rhat-)^T E_B
+```
+
+### Adjoint
+
+`X Exp(xi) X^-1 = Exp(Ad_X xi)`, with
+
+```
+phi    -> R phi
+rho_i  -> R rho_i + [x_i]x R phi
+beta_j -> R beta_j + R [b_j]x phi
+```
+
+Checked at finite `xi` (so a first-order-only adjoint fails) and against central
+finite differences.
+
+## 3. How the group math is validated
+
+Two independent references, because finite differences alone share their
+assumptions with the code under test:
+
+1. **Lie++** (`third_party/Lie-plusplus`, `group::SEn3<double,4>`) — a separately
+   derived implementation by the authors of the equivariant filtering literature
+   this filter follows. Covers the world block to `1e-12` on compose, inverse,
+   `exp`, `log`, and `Adjoint`. See `third_party/Lie-plusplus/VENDORED.md` for
+   the convention correspondence and why it is test-only.
+2. **Structural identities** for what Lie++ cannot reach: the one-parameter
+   subgroup property, exp/log round trips in both directions, the exact adjoint
+   relation, `J_l = int_0^1 Exp(u phi) du` by Simpson quadrature, and
+   `retract`/`local` as an inverse pair.
+
+The whole battery runs at `double` (tight tolerances, the real check) and at
+`float` (loose, proving the firmware instantiation compiles and keeps its
+small-angle branches).
+
+### On testing the small-angle branches
+
+Every branch in `SO3Jacobians.h` switches at `|phi| = 1e-2`. It is tempting to
+test continuity by comparing `f(seam - eps)` against `f(seam + eps)` — **this
+does not work.** Those are different arguments, so the difference is dominated
+by the genuine slope of `f`, and the check fails spuriously at any useful
+tolerance.
+
+What has to hold is that *both* branches are accurate at the seam; if each is
+within `tol` there, the function is continuous across it to within `2 tol`. So
+the test compares each branch against a closed form carried in `long double`,
+which has the headroom to absorb the cancellation in `(1-cos t)/t^2` and
+`1 - (t/2)cot(t/2)` at `t = 1e-2` and still leave about 14 digits.
+
+### Mutation results
+
+Every check in these suites has been confirmed to fail when the code is
+deliberately broken. A test that cannot fail is not evidence.
+
+| Mutation | `lie_group-test` | `convention-test` |
+|---|---|---|
+| bias block uses `J_l(+phi)` | 182 fail | 50 fail |
+| adjoint bias coupling sign flipped | 50 fail | passes (does not exercise `Adjoint`) |
+| `retract` applied on the right | 200 fail | 350 fail |
+| `compose` body block not transposed | 529 fail | 150 fail |
+| `Exp` handedness flipped | 253 fail | 516 fail |
+| `J_l` 0.1% coefficient error | 228 fail | 50 fail |
+
+## 4. What this does not claim
+
+The bias-free, frozen-parameter skeleton is group-affine. The complete
+estimator is **not** shown to be, and must not be described as an InEKF or as
+having log-linear error propagation. It carries estimated body biases, OU decay,
+an online `tau`, a tuner driven by estimated signals, staged startup, yaw
+locking, resets, and a synthetic `S = 0` observation. Verifying the group-affine
+property of the fixed-parameter continuous dynamics is a prerequisite for any
+such claim, and has not been done.
+
+The accurate name is **right-invariant two-frame Lie-group error-state EKF**.
+
+A Lie-group formulation also does not cure the physical observability problem
+between tilt, horizontal acceleration, and accelerometer bias. It can represent
+that uncertainty more consistently; it cannot create information the sensors do
+not provide.

--- a/src/lie/SO3Jacobians.h
+++ b/src/lie/SO3Jacobians.h
@@ -1,0 +1,180 @@
+#pragma once
+
+/*
+    Copyright (c) 2025-2026  Mikhail Grushinskiy
+
+    SO(3) exponential, logarithm, and left Jacobians for the right-invariant
+    two-frame Lie-group filter (see src/lie/TwoFrameGroup.h).
+
+    Everything is templated on the scalar type. Firmware instantiates float;
+    the finite-difference and Lie++ cross-check tests instantiate double,
+    where the tolerances mean something. There are no hardcoded float types
+    and no literals that would force a promotion, so -Wconversion stays clean
+    at both precisions.
+
+    Small-angle branches reuse the thresholds and the fma-based expansion
+    style already established in kalman_ou_common/KalmanOUCoreMath.h. Those
+    thresholds are chosen for float and remain safe for double.
+
+    CONVENTION. This file's Exp() is the standard right-handed exponential:
+    Exp(phi) rotates by +phi about phi/|phi|, and the filter uses it to carry
+    a body-to-world rotation R = R_bw. KalmanOUCoreMath's rot_and_B_from_wt()
+    returns the *transpose* of this, because OU-III propagates a world-to-body
+    quaternion. The two are not interchangeable; swapping them silently
+    inverts every rotation in the filter.
+*/
+
+#ifdef EIGEN_NON_ARDUINO
+#include <Eigen/Dense>
+#else
+#include <ArduinoEigenDense.h>
+#endif
+
+#include <cmath>
+
+#include "kalman_ou_common/KalmanOUCoreMath.h"
+
+namespace ocean_imu::lie {
+
+// skew() and quat_from_delta_theta() already exist in the OU core math and
+// carry the expansions this file has to agree with. Alias rather than clone.
+using ocean_imu::kalman::ou_detail::skew;
+using ocean_imu::kalman::ou_detail::quat_from_delta_theta;
+
+// Angle below which the trigonometric forms lose significance and the Taylor
+// branches take over. Matches KalmanOUCoreMath.h's quat_from_delta_theta.
+template<typename T>
+inline constexpr T kSmallAngle = T(1e-2);
+
+/*
+    Exp: so(3) -> SO(3).
+
+        R = I + (sin t / t) [phi]x + ((1 - cos t) / t^2) [phi]x^2,  t = |phi|
+*/
+template<typename T>
+inline Eigen::Matrix<T,3,3> Exp(const Eigen::Matrix<T,3,1>& phi) {
+    using Matrix3 = Eigen::Matrix<T,3,3>;
+    const T t2 = phi.squaredNorm();
+    const T t = std::sqrt(t2);
+    const Matrix3 W = skew<T>(phi);
+
+    T a, b;  // coefficients of [phi]x and [phi]x^2
+    if (t < kSmallAngle<T>) {
+        const T t4 = t2 * t2;
+        // sin(t)/t
+        a = T(1);
+        a = std::fma(-t2, T(1)/T(6), a);
+        a = std::fma( t4, T(1)/T(120), a);
+        // (1-cos(t))/t^2
+        b = T(0.5);
+        b = std::fma(-t2, T(1)/T(24), b);
+        b = std::fma( t4, T(1)/T(720), b);
+    } else {
+        a = std::sin(t) / t;
+        b = (T(1) - std::cos(t)) / t2;
+    }
+    return Matrix3::Identity() + a * W + b * (W * W);
+}
+
+/*
+    Log: SO(3) -> so(3), the exact inverse of Exp above.
+
+    Recovered through the quaternion rather than from acos(trace) so the
+    near-identity case stays accurate and the near-pi case stays defined.
+*/
+template<typename T>
+inline Eigen::Matrix<T,3,1> Log(const Eigen::Matrix<T,3,3>& R) {
+    Eigen::Quaternion<T> q(R);
+    q.normalize();
+    if (q.w() < T(0)) q.coeffs() = -q.coeffs();  // shortest arc
+
+    const Eigen::Matrix<T,3,1> v(q.x(), q.y(), q.z());
+    const T sin_half = v.norm();
+    if (sin_half < kSmallAngle<T> * T(0.5)) {
+        // phi = 2 v (1 + s^2/6 + 3 s^4/40),  s = |v| = sin(t/2)
+        const T s2 = sin_half * sin_half;
+        T k = T(2);
+        k = std::fma(s2, T(2)/T(6), k);
+        k = std::fma(s2 * s2, T(6)/T(40), k);
+        return k * v;
+    }
+    const T half_angle = std::atan2(sin_half, q.w());
+    return v * (T(2) * half_angle / sin_half);
+}
+
+/*
+    Left Jacobian of SO(3).
+
+        J_l(phi) = I + ((1-cos t)/t^2) [phi]x + ((t - sin t)/t^3) [phi]x^2
+                 = int_0^1 Exp(u phi) du
+
+    This is the factor coupling an attitude correction into the world vectors
+    of the group exponential: E_X = J_l(phi) [rho_v rho_p rho_S rho_a].
+*/
+template<typename T>
+inline Eigen::Matrix<T,3,3> left_jacobian(const Eigen::Matrix<T,3,1>& phi) {
+    using Matrix3 = Eigen::Matrix<T,3,3>;
+    const T t2 = phi.squaredNorm();
+    const T t = std::sqrt(t2);
+    const Matrix3 W = skew<T>(phi);
+
+    T a, b;
+    if (t < kSmallAngle<T>) {
+        const T t4 = t2 * t2;
+        // (1-cos t)/t^2
+        a = T(0.5);
+        a = std::fma(-t2, T(1)/T(24), a);
+        a = std::fma( t4, T(1)/T(720), a);
+        // (t - sin t)/t^3
+        b = T(1)/T(6);
+        b = std::fma(-t2, T(1)/T(120), b);
+        b = std::fma( t4, T(1)/T(5040), b);
+    } else {
+        a = (T(1) - std::cos(t)) / t2;
+        b = (t - std::sin(t)) / (t2 * t);
+    }
+    return Matrix3::Identity() + a * W + b * (W * W);
+}
+
+/*
+    Inverse left Jacobian of SO(3).
+
+        J_l^-1(phi) = I - (1/2)[phi]x + c(t) [phi]x^2
+        c(t)        = (1 - (t/2) cot(t/2)) / t^2
+
+    The cotangent form is singular at t = 2 pi; the filter never retracts by
+    anything close to that, and the small-angle branch covers the other end.
+*/
+template<typename T>
+inline Eigen::Matrix<T,3,3> inv_left_jacobian(const Eigen::Matrix<T,3,1>& phi) {
+    using Matrix3 = Eigen::Matrix<T,3,3>;
+    const T t2 = phi.squaredNorm();
+    const T t = std::sqrt(t2);
+    const Matrix3 W = skew<T>(phi);
+
+    T c;
+    if (t < kSmallAngle<T>) {
+        const T t4 = t2 * t2;
+        c = T(1)/T(12);
+        c = std::fma(t2, T(1)/T(720), c);
+        c = std::fma(t4, T(1)/T(30240), c);
+    } else {
+        const T half = T(0.5) * t;
+        c = (T(1) - half * std::cos(half) / std::sin(half)) / t2;
+    }
+    return Matrix3::Identity() - T(0.5) * W + c * (W * W);
+}
+
+// Right Jacobians. J_r(phi) = J_l(-phi) = Exp(-phi) J_l(phi); this identity is
+// what the bias block of the group exponential rests on.
+template<typename T>
+inline Eigen::Matrix<T,3,3> right_jacobian(const Eigen::Matrix<T,3,1>& phi) {
+    return left_jacobian<T>(Eigen::Matrix<T,3,1>(-phi));
+}
+
+template<typename T>
+inline Eigen::Matrix<T,3,3> inv_right_jacobian(const Eigen::Matrix<T,3,1>& phi) {
+    return inv_left_jacobian<T>(Eigen::Matrix<T,3,1>(-phi));
+}
+
+} // namespace ocean_imu::lie

--- a/src/lie/TwoFrameGroup.h
+++ b/src/lie/TwoFrameGroup.h
@@ -1,0 +1,238 @@
+#pragma once
+
+/*
+    Copyright (c) 2025-2026  Mikhail Grushinskiy
+
+    The right-invariant two-frame Lie group carrying the wave-state estimator.
+
+        X = (R, X_w, B_b),   R   = R_bw in SO(3)          (body -> world)
+                             X_w = [v p S a_w] in R^{3xNW}, world frame
+                             B_b = [b_g b_a]   in R^{3xNB}, body frame
+
+    Group law:
+
+        (R1,X1,B1) o (R2,X2,B2) = ( R1 R2, X1 + R1 X2, B2 + R2^T B1 )
+        identity                = (I, 0, 0)
+        (R,X,B)^-1              = (R^T, -R^T X, -R B)
+
+    The point of the law is the asymmetry in the last slot. World vectors are
+    carried along by R; body-frame vectors are carried by R^T from the other
+    side. A direct product SE_NW(3) x R^{3 NB} cannot express that, and it is
+    precisely what makes an attitude correction rotate v, p, S, a_w coherently
+    while transporting the biases in the frame they are measured in.
+
+    CONVENTION CONTRACT. Three choices, always stated together, because two
+    implementations that look opposite can be identical if only one or two are
+    given:
+
+        1. rotation direction : R = R_bw, body to world
+        2. error definition   : right-invariant, eta = Xhat o X^-1
+        3. correction side    : left, Xhat+ = Exp_G(dxi) o Xhat-
+
+    "Right-invariant" describes the error -- it is invariant under right
+    multiplication of both states -- and such an error is applied by LEFT
+    multiplication. That is not a contradiction, and conflating the two is the
+    usual way this gets implemented backwards.
+
+    Note that OU-III stores the opposite rotation direction (world-to-body C =
+    R_wb, corrected as C+ = Exp(dtheta) C-). Because R = C^T, the same physical
+    perturbation appears there as a right multiplication:
+
+        R+ = (C+)^T = (C-)^T Exp(-dtheta) = R- Exp(-dtheta)
+
+    so "both correct on the left" is not a statement of agreement between the
+    two filters. tests/kalman_tfg/convention-test.cpp pins the equivalence.
+
+    Right-invariant error in local coordinates:
+
+        dR     = Rhat R^T = Exp(phi)
+        rho_x  = xhat - dR x        for each world column x
+        beta_b = R (bhat - b)       for each body column b
+
+    Tangent layout deliberately matches Kalman3D_Wave_OU_III.h:40-54, so the
+    world block stays contiguous and the propagation/Joseph block structure
+    ports over with the same offsets:
+
+        xi = [ phi | beta_g | rho_v rho_p rho_S rho_a | beta_a ]
+               0     3        6     9     12    15      18       (NW=4, NB=2)
+
+    Scalar-templated throughout: firmware runs float, tests run double.
+*/
+
+#ifdef EIGEN_NON_ARDUINO
+#include <Eigen/Dense>
+#else
+#include <ArduinoEigenDense.h>
+#endif
+
+#include "lie/SO3Jacobians.h"
+
+namespace ocean_imu::lie {
+
+/*
+    NW world-frame columns and NB body-frame columns.
+
+    The defaults are the OU-III state: [v p S a_w] and [b_g b_a]. NB = 1 drops
+    the accelerometer bias, matching Kalman3D_Wave_OU_III's with_accel_bias =
+    false instantiation.
+*/
+template<typename T = float, int NW = 4, int NB = 2>
+struct TwoFrameGroup {
+    static_assert(NW >= 1, "at least one world vector");
+    static_assert(NB >= 1, "at least the gyroscope bias");
+
+    static constexpr int kWorldCols = NW;
+    static constexpr int kBiasCols  = NB;
+
+    // Tangent dimension: 3 attitude + 3 per world column + 3 per bias column.
+    static constexpr int NX = 3 + 3 * NW + 3 * NB;
+
+    static constexpr int OFF_PHI = 0;
+    static constexpr int OFF_BG  = 3;               // first bias column
+    static constexpr int OFF_W   = 6;               // world block, contiguous
+    static constexpr int OFF_BA  = OFF_W + 3 * NW;  // remaining bias columns
+
+    // Tangent offset of world column i (0 = v, 1 = p, 2 = S, 3 = a_w).
+    static constexpr int world_offset(int i) { return OFF_W + 3 * i; }
+
+    // Tangent offset of bias column j. Column 0 is the gyro bias and keeps
+    // OU-III's slot right after attitude; the rest follow the world block.
+    static constexpr int bias_offset(int j) {
+        return (j == 0) ? OFF_BG : (OFF_BA + 3 * (j - 1));
+    }
+
+    using Scalar     = T;
+    using Matrix3    = Eigen::Matrix<T,3,3>;
+    using Vector3    = Eigen::Matrix<T,3,1>;
+    using WorldBlock = Eigen::Matrix<T,3,NW>;
+    using BiasBlock  = Eigen::Matrix<T,3,NB>;
+    using Tangent    = Eigen::Matrix<T,NX,1>;
+    using AdjointMat = Eigen::Matrix<T,NX,NX>;
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+    Matrix3    R{Matrix3::Identity()};
+    WorldBlock X{WorldBlock::Zero()};
+    BiasBlock  B{BiasBlock::Zero()};
+
+    TwoFrameGroup() = default;
+    TwoFrameGroup(const Matrix3& R_in, const WorldBlock& X_in, const BiasBlock& B_in)
+        : R(R_in), X(X_in), B(B_in) {}
+
+    static TwoFrameGroup Identity() { return TwoFrameGroup(); }
+
+    // (R1,X1,B1) o (R2,X2,B2) = ( R1 R2, X1 + R1 X2, B2 + R2^T B1 )
+    TwoFrameGroup compose(const TwoFrameGroup& other) const {
+        return TwoFrameGroup(R * other.R,
+                             X + R * other.X,
+                             other.B + other.R.transpose() * B);
+    }
+
+    TwoFrameGroup operator*(const TwoFrameGroup& other) const { return compose(other); }
+
+    // (R,X,B)^-1 = (R^T, -R^T X, -R B)
+    TwoFrameGroup inverse() const {
+        const Matrix3 Rt = R.transpose();
+        return TwoFrameGroup(Rt, WorldBlock(-(Rt * X)), BiasBlock(-(R * B)));
+    }
+
+    /*
+        Group exponential.
+
+            E_R = Exp(phi)
+            E_X = J_l(phi)  [rho_v rho_p rho_S rho_a]
+            E_B = J_l(-phi) [beta_g beta_a]
+
+        The J_l(-phi) on the bias block is derived, not chosen. The group law
+        induces the one-parameter ODE b'(s) = beta - [phi]x b(s), whose
+        solution at s = 1 is Exp(-phi) J_l(phi) beta, and Exp(-phi) J_l(phi)
+        is the right Jacobian J_r(phi) = J_l(-phi).
+    */
+    static TwoFrameGroup Exp_G(const Tangent& xi) {
+        const Vector3 phi = xi.template segment<3>(OFF_PHI);
+        const Matrix3 Jl  = left_jacobian<T>(phi);
+        const Matrix3 Jr  = left_jacobian<T>(Vector3(-phi));
+
+        WorldBlock rho;
+        for (int i = 0; i < NW; ++i) rho.col(i) = xi.template segment<3>(world_offset(i));
+        BiasBlock beta;
+        for (int j = 0; j < NB; ++j) beta.col(j) = xi.template segment<3>(bias_offset(j));
+
+        return TwoFrameGroup(Exp<T>(phi), WorldBlock(Jl * rho), BiasBlock(Jr * beta));
+    }
+
+    // Group logarithm, the exact inverse of Exp_G.
+    static Tangent Log_G(const TwoFrameGroup& g) {
+        const Vector3 phi = Log<T>(g.R);
+        const Matrix3 Jli = inv_left_jacobian<T>(phi);
+        const Matrix3 Jri = inv_left_jacobian<T>(Vector3(-phi));
+
+        const WorldBlock rho  = Jli * g.X;
+        const BiasBlock  beta = Jri * g.B;
+
+        Tangent xi;
+        xi.setZero();
+        xi.template segment<3>(OFF_PHI) = phi;
+        for (int i = 0; i < NW; ++i) xi.template segment<3>(world_offset(i)) = rho.col(i);
+        for (int j = 0; j < NB; ++j) xi.template segment<3>(bias_offset(j)) = beta.col(j);
+        return xi;
+    }
+
+    /*
+        Adjoint: X Exp(xi) X^-1 = Exp(Ad_X xi).
+
+            phi    -> R phi
+            rho_i  -> R rho_i + [x_i]x R phi
+            beta_j -> R beta_j + R [b_j]x phi
+
+        The off-diagonal blocks are what make an attitude uncertainty show up
+        as translational uncertainty scaled by how far the vector reaches.
+    */
+    AdjointMat Adjoint() const {
+        AdjointMat Ad;
+        Ad.setZero();
+        Ad.template block<3,3>(OFF_PHI, OFF_PHI) = R;
+
+        for (int i = 0; i < NW; ++i) {
+            const int off = world_offset(i);
+            Ad.template block<3,3>(off, off)     = R;
+            Ad.template block<3,3>(off, OFF_PHI) = skew<T>(Vector3(X.col(i))) * R;
+        }
+        for (int j = 0; j < NB; ++j) {
+            const int off = bias_offset(j);
+            Ad.template block<3,3>(off, off)     = R;
+            Ad.template block<3,3>(off, OFF_PHI) = R * skew<T>(Vector3(B.col(j)));
+        }
+        return Ad;
+    }
+
+    /*
+        Left retraction: the filter's state injection.
+
+            Xhat+ = Exp_G(xi) o Xhat-
+
+        Componentwise:
+
+            Rhat+ = E_R Rhat-
+            Xhat+ = E_R Xhat- + E_X
+            Bhat+ = Bhat- + (Rhat-)^T E_B
+
+        which is the whole point of the redesign: a correction to attitude
+        rotates v, p, S and a_w with it instead of leaving them behind.
+    */
+    TwoFrameGroup retract(const Tangent& xi) const {
+        return Exp_G(xi).compose(*this);
+    }
+
+    /*
+        Inverse of retract(): the right-invariant error of *this relative to a
+        reference, in local coordinates. local() satisfies
+
+            reference.retract(x.local(reference)) == x
+    */
+    Tangent local(const TwoFrameGroup& reference) const {
+        return Log_G(this->compose(reference.inverse()));
+    }
+};
+
+} // namespace ocean_imu::lie

--- a/tests/kalman_tfg/Makefile
+++ b/tests/kalman_tfg/Makefile
@@ -1,0 +1,53 @@
+.PHONY: all build test ensure-sim-data clean
+
+CC = g++
+TEST_DIR := $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
+REPO_ROOT := $(abspath $(TEST_DIR)/../..)
+EIGEN_DIR ?= $(REPO_ROOT)/third_party/eigen
+EIGEN_CPPFLAGS := $(if $(wildcard $(EIGEN_DIR)/Eigen/Dense),-isystem $(EIGEN_DIR),-isystem /usr/include/eigen3)
+# Lie++ is the independent oracle for the world block of the group. Test-only:
+# it never reaches the Arduino build. See third_party/Lie-plusplus/VENDORED.md.
+LIEPP_CPPFLAGS := -isystem $(REPO_ROOT)/third_party/Lie-plusplus/include
+BASEFLAGS = -O3 -std=c++20 -Wall -Wextra -Wshadow -Wconversion -funroll-loops -fno-finite-math-only -I$(REPO_ROOT)/src $(EIGEN_CPPFLAGS) $(LIEPP_CPPFLAGS) $(CPPFLAGS)
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+    CXXFLAGS = $(BASEFLAGS) -march=native
+else ifeq ($(UNAME_S),Darwin)
+    CXXFLAGS = $(BASEFLAGS) -march=native
+else
+    CXXFLAGS = $(BASEFLAGS)
+endif
+
+LDFLAGS  =
+
+# Tell make to look for source files in src/util
+VPATH = $(REPO_ROOT)/src/util
+
+TARGETS = lie_group-test convention-test
+
+all: build test
+
+build: $(TARGETS)
+
+test: $(TARGETS)
+	bash ./run_tests.sh
+
+ensure-sim-data:
+	@$(MAKE) -C "$(REPO_ROOT)" ensure-sim-data
+
+lie_group-test: lie_group-test.o
+	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
+
+convention-test: convention-test.o
+	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
+
+# -MMD -MP records the headers each object depends on, so editing a group or
+# filter header rebuilds the test instead of silently reusing a stale object.
+%.o: %.cpp
+	$(CC) $(CXXFLAGS) -MMD -MP -c $< -o $@
+
+-include $(wildcard *.d)
+
+clean:
+	rm -f *.o *.d $(TARGETS) *.exe *.csv

--- a/tests/kalman_tfg/convention-test.cpp
+++ b/tests/kalman_tfg/convention-test.cpp
@@ -1,0 +1,319 @@
+/*
+    Copyright (c) 2025-2026  Mikhail Grushinskiy
+
+    The convention contract, asserted rather than asserted-about.
+
+    Three choices get conflated constantly, and two implementations that look
+    opposite can be mathematically identical if only one or two are stated:
+
+        1. rotation direction : R = R_bw, body to world       (this filter)
+        2. error definition   : right-invariant, eta = Xhat o X^-1
+        3. correction side    : left, Xhat+ = Exp_G(dxi) o Xhat-
+
+    OU-III makes a different choice on (1): it stores a world-to-body
+    quaternion C = R_wb and corrects it as C+ = Exp(dtheta) C-. That is also a
+    left multiplication, but on the *other* rotation direction, so "both
+    correct on the left" is not a statement of agreement. This file works out
+    what the correspondence actually is and pins it numerically.
+
+    The tests here deliberately use no filter code. They are about the frames
+    and the sides, and they must stay valid before Kalman3D_Wave_TFG exists.
+    The matching assertion that the public accessor still returns a
+    world-to-body quaternion lands here in Phase B, when there is an accessor
+    to assert on.
+*/
+
+#define EIGEN_NON_ARDUINO
+
+#include "lie/SO3Jacobians.h"
+#include "lie/TwoFrameGroup.h"
+
+#include <cmath>
+#include <iostream>
+#include <random>
+#include <string>
+
+namespace lie = ocean_imu::lie;
+namespace ou_detail = ocean_imu::kalman::ou_detail;
+
+namespace {
+
+using T = double;
+using Matrix3 = Eigen::Matrix<T,3,3>;
+using Vector3 = Eigen::Matrix<T,3,1>;
+using Group = lie::TwoFrameGroup<T,4,2>;
+
+constexpr T kTol = 1e-12;
+
+int failures = 0;
+
+bool check(bool condition, const std::string& message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        ++failures;
+    }
+    return condition;
+}
+
+template<int R, int C>
+bool mat_close(const Eigen::Matrix<T,R,C>& a, const Eigen::Matrix<T,R,C>& b, T tol = kTol) {
+    return a.allFinite() && b.allFinite() && ((a - b).cwiseAbs().maxCoeff() <= tol);
+}
+
+std::mt19937 rng(20260806u);
+
+Vector3 random_vector(double scale) {
+    std::uniform_real_distribution<double> d(-scale, scale);
+    return Vector3(d(rng), d(rng), d(rng));
+}
+
+Matrix3 random_rotation() {
+    return lie::Exp<T>(random_vector(2.0));
+}
+
+Group random_group() {
+    Group g;
+    g.R = random_rotation();
+    for (int i = 0; i < Group::kWorldCols; ++i) g.X.col(i) = random_vector(5.0);
+    for (int j = 0; j < Group::kBiasCols; ++j) g.B.col(j) = random_vector(0.3);
+    return g;
+}
+
+Group::Tangent random_tangent() {
+    Group::Tangent xi;
+    xi.setZero();
+    xi.segment<3>(Group::OFF_PHI) = random_vector(0.8);
+    for (int i = 0; i < Group::kWorldCols; ++i) xi.segment<3>(Group::world_offset(i)) = random_vector(2.0);
+    for (int j = 0; j < Group::kBiasCols; ++j) xi.segment<3>(Group::bias_offset(j)) = random_vector(0.2);
+    return xi;
+}
+
+// ---------------------------------------------------------------------------
+// (1) Rotation direction: R maps body coordinates into world coordinates.
+// ---------------------------------------------------------------------------
+
+void test_rotation_direction() {
+    // A rotation of +90 degrees about world z. Under the right-handed
+    // convention this carries body +x onto world +y.
+    const Vector3 phi(T(0), T(0), T(M_PI) / T(2));
+    const Matrix3 R = lie::Exp<T>(phi);
+
+    check(mat_close<3,1>(Vector3(R * Vector3::UnitX()), Vector3::UnitY(), 1e-12),
+          "Exp is not the right-handed exponential: +90deg about z must send x to y");
+
+    // R = R_bw, so R^T is the world-to-body map OU-III stores.
+    const Vector3 v_body(T(1), T(2), T(3));
+    const Vector3 v_world = R * v_body;
+    check(mat_close<3,1>(Vector3(R.transpose() * v_world), v_body, 1e-12),
+          "R^T must map world coordinates back to body coordinates");
+
+    // The aliasing claim made in SO3Jacobians.h: OU-III's quaternion
+    // correction builds exactly this exponential.
+    for (int trial = 0; trial < 50; ++trial) {
+        const Vector3 dtheta = random_vector(1.5);
+        const Matrix3 from_quat = ou_detail::quat_from_delta_theta<T>(dtheta).toRotationMatrix();
+        check(mat_close<3,3>(from_quat, lie::Exp<T>(dtheta), 1e-12),
+              "quat_from_delta_theta must agree with Exp");
+    }
+
+    // And the warning in SO3Jacobians.h: rot_and_B_from_wt returns the
+    // transpose, because OU-III propagates a world-to-body quaternion. If this
+    // ever stops holding, every rotation in the filter silently inverts.
+    for (int trial = 0; trial < 20; ++trial) {
+        const Vector3 w = random_vector(3.0);
+        const T dt = T(0.004);
+        Matrix3 Rstep, Bstep;
+        ou_detail::rot_and_B_from_wt<T>(w, dt, Rstep, Bstep);
+        check(mat_close<3,3>(Rstep, Matrix3(lie::Exp<T>(Vector3(w * dt)).transpose()), 1e-12),
+              "rot_and_B_from_wt must be the transpose of Exp(w dt)");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// (2) Error definition: right-invariant means invariant under RIGHT
+//     multiplication of both states. Left-invariant is the other one.
+// ---------------------------------------------------------------------------
+
+void test_invariance_direction() {
+    for (int trial = 0; trial < 50; ++trial) {
+        const Group X    = random_group();
+        const Group Xhat = random_group();
+        const Group G    = random_group();
+
+        // eta_R = Xhat X^-1 is unchanged when both states are right-multiplied.
+        const Group eta_R       = Xhat.compose(X.inverse());
+        const Group eta_R_moved = Xhat.compose(G).compose(X.compose(G).inverse());
+        check(mat_close<3,3>(eta_R.R, eta_R_moved.R) &&
+              mat_close<3,Group::kWorldCols>(eta_R.X, eta_R_moved.X, 1e-11) &&
+              mat_close<3,Group::kBiasCols>(eta_R.B, eta_R_moved.B, 1e-11),
+              "the right-invariant error changed under right multiplication");
+
+        // ... and is NOT invariant under left multiplication. Asserting the
+        // negative keeps the test honest: without it, a degenerate error
+        // definition would satisfy the positive case trivially.
+        const Group eta_R_left = G.compose(Xhat).compose(G.compose(X).inverse());
+        const bool unchanged = mat_close<3,3>(eta_R.R, eta_R_left.R, 1e-9) &&
+                               mat_close<3,Group::kWorldCols>(eta_R.X, eta_R_left.X, 1e-9);
+        check(!unchanged, "the right-invariant error must not survive left multiplication");
+
+        // The mirror statement, for the convention this filter did not choose.
+        const Group eta_L       = X.inverse().compose(Xhat);
+        const Group eta_L_moved = G.compose(X).inverse().compose(G.compose(Xhat));
+        check(mat_close<3,3>(eta_L.R, eta_L_moved.R) &&
+              mat_close<3,Group::kWorldCols>(eta_L.X, eta_L_moved.X, 1e-11) &&
+              mat_close<3,Group::kBiasCols>(eta_L.B, eta_L_moved.B, 1e-11),
+              "the left-invariant error changed under left multiplication");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// (3) Correction side: a right-invariant error is applied on the LEFT.
+// ---------------------------------------------------------------------------
+
+/*
+    This is the consistency condition binding (2) to (3). If
+
+        Xhat = Exp_G(xi) o X
+
+    then the right-invariant error is exactly
+
+        eta_R = Xhat o X^-1 = Exp_G(xi),   so   Log_G(Xhat o X^-1) = xi
+
+    with no approximation. Applying the same xi on the right instead would
+    make this identity false, which is what makes it a usable test rather than
+    a restatement.
+*/
+void test_correction_side() {
+    for (int trial = 0; trial < 50; ++trial) {
+        const Group X = random_group();
+        const Group::Tangent xi = random_tangent();
+
+        const Group Xhat = X.retract(xi);
+        const Group::Tangent recovered = Group::Log_G(Xhat.compose(X.inverse()));
+        check(mat_close<Group::NX,1>(recovered, xi, 1e-10),
+              "Log_G(Xhat X^-1) != xi: the correction side does not match the error definition");
+
+        // retract() must be the left multiplication, not the right one.
+        const Group left  = Group::Exp_G(xi).compose(X);
+        const Group right = X.compose(Group::Exp_G(xi));
+        check(mat_close<3,3>(Xhat.R, left.R) &&
+              mat_close<3,Group::kWorldCols>(Xhat.X, left.X, 1e-11),
+              "retract() is not left multiplication");
+        const bool same_as_right = mat_close<3,3>(Xhat.R, right.R, 1e-9) &&
+                                   mat_close<3,Group::kWorldCols>(Xhat.X, right.X, 1e-9);
+        check(!same_as_right, "left and right retraction must differ for a generic element");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The OU-III bridge: the same physical perturbation, both conventions.
+// ---------------------------------------------------------------------------
+
+/*
+    OU-III stores C = R_wb and injects on the left:
+
+        C+ = Exp(dtheta) C-
+
+    This filter stores R = C^T = R_bw. Transposing,
+
+        R+ = (C+)^T = (C-)^T Exp(-dtheta) = R- Exp(-dtheta)
+
+    so the very same physical rotation appears as a RIGHT multiplication on R.
+    To express it as this filter's left-multiplicative correction, conjugate
+    through R- Exp(u) R-^T = Exp(R- u):
+
+        R+ = Exp(-R- dtheta) R-,     i.e.   phi = -R- dtheta
+
+    The correspondence is therefore not phi = +-dtheta. It is a rotated,
+    negated dtheta, and getting it wrong is a bug that survives every
+    small-angle test because both forms agree to first order at R- = I.
+*/
+void test_ou_iii_bridge() {
+    for (int trial = 0; trial < 100; ++trial) {
+        const Matrix3 C_minus = random_rotation();          // OU-III: world -> body
+        const Matrix3 R_minus = C_minus.transpose();        // this filter: body -> world
+        const Vector3 dtheta = random_vector(1.2);
+
+        // OU-III injection.
+        const Matrix3 C_plus = ou_detail::quat_from_delta_theta<T>(dtheta).toRotationMatrix() * C_minus;
+
+        // Same perturbation, seen as a right multiplication on R.
+        check(mat_close<3,3>(Matrix3(C_plus.transpose()),
+                             Matrix3(R_minus * lie::Exp<T>(Vector3(-dtheta))), 1e-12),
+              "R+ != R- Exp(-dtheta): the transposed injection changed sides incorrectly");
+
+        // Same perturbation, as this filter's left-multiplicative correction.
+        const Vector3 phi = -(R_minus * dtheta);
+        check(mat_close<3,3>(Matrix3(C_plus.transpose()),
+                             Matrix3(lie::Exp<T>(phi) * R_minus), 1e-12),
+              "phi = -R- dtheta does not reproduce the OU-III injection");
+
+        // Drive it through the group retraction itself, so the bridge is
+        // pinned against the code the filter will actually call.
+        Group g;
+        g.R = R_minus;
+        Group::Tangent xi;
+        xi.setZero();
+        xi.segment<3>(Group::OFF_PHI) = phi;
+        check(mat_close<3,3>(g.retract(xi).R, Matrix3(C_plus.transpose()), 1e-12),
+              "TwoFrameGroup::retract does not reproduce the OU-III attitude injection");
+
+        // The naive correspondences, which must NOT hold for a generic R-.
+        // Both agree to first order at R- = I, so a test that only ever
+        // exercised small rotations near identity would miss the error.
+        if (dtheta.norm() > 0.2 && lie::Log<T>(R_minus).norm() > 0.2) {
+            check(!mat_close<3,3>(Matrix3(C_plus.transpose()),
+                                  Matrix3(lie::Exp<T>(dtheta) * R_minus), 1e-6),
+                  "phi = +dtheta must not reproduce the injection for a generic R-");
+            check(!mat_close<3,3>(Matrix3(C_plus.transpose()),
+                                  Matrix3(lie::Exp<T>(Vector3(-dtheta)) * R_minus), 1e-6),
+                  "phi = -dtheta must not reproduce the injection for a generic R-");
+        }
+    }
+}
+
+/*
+    The physical content, stated without reference to either storage
+    convention: a fixed world direction, and a fixed body direction, must land
+    in the same place whichever filter applied the correction.
+*/
+void test_bridge_is_physical() {
+    for (int trial = 0; trial < 50; ++trial) {
+        const Matrix3 C_minus = random_rotation();
+        const Matrix3 R_minus = C_minus.transpose();
+        const Vector3 dtheta = random_vector(1.0);
+        const Vector3 v_body = random_vector(1.0);
+        const Vector3 v_world = random_vector(1.0);
+
+        const Matrix3 C_plus = ou_detail::quat_from_delta_theta<T>(dtheta).toRotationMatrix() * C_minus;
+
+        Group g;
+        g.R = R_minus;
+        Group::Tangent xi;
+        xi.setZero();
+        xi.segment<3>(Group::OFF_PHI) = -(R_minus * dtheta);
+        const Matrix3 R_plus = g.retract(xi).R;
+
+        check(mat_close<3,1>(Vector3(R_plus * v_body), Vector3(C_plus.transpose() * v_body), 1e-12),
+              "the two conventions disagree on where a body vector lands in the world");
+        check(mat_close<3,1>(Vector3(R_plus.transpose() * v_world), Vector3(C_plus * v_world), 1e-12),
+              "the two conventions disagree on where a world vector lands in the body");
+    }
+}
+
+} // namespace
+
+int main() {
+    test_rotation_direction();
+    test_invariance_direction();
+    test_correction_side();
+    test_ou_iii_bridge();
+    test_bridge_is_physical();
+
+    if (failures != 0) {
+        std::cerr << failures << " convention check(s) failed\n";
+        return 1;
+    }
+    std::cout << "convention-test: all checks passed\n";
+    return 0;
+}

--- a/tests/kalman_tfg/lie_group-test.cpp
+++ b/tests/kalman_tfg/lie_group-test.cpp
@@ -1,0 +1,666 @@
+/*
+    Copyright (c) 2025-2026  Mikhail Grushinskiy
+
+    Phase A of the right-invariant two-frame Lie-group filter: the group
+    mathematics, on its own, before any estimator code exists.
+
+    Two independent references are used, because a finite-difference check
+    alone shares its assumptions with the code under test:
+
+      1. central finite differences, for the Jacobians and the adjoint;
+      2. Lie++ (group::SEn3<double,4>, third_party/Lie-plusplus), a separately
+         derived implementation by the authors of the equivariant filtering
+         literature this filter follows.
+
+    Lie++ covers the world block only -- its SemiDirectBias is hardcoded to
+    SE_2(3) + R^6 and cannot represent four world vectors plus six bias states.
+    The bias block is therefore pinned by structural identities that a wrong
+    Jacobian cannot satisfy: the one-parameter subgroup property, the exp/log
+    round trip, and the exact adjoint relation.
+
+    The whole battery runs at double (tight tolerances, the real check) and at
+    float (loose tolerances, proving the firmware instantiation compiles and
+    keeps its small-angle branches).
+*/
+
+#define EIGEN_NON_ARDUINO
+
+#include "lie/SO3Jacobians.h"
+#include "lie/TwoFrameGroup.h"
+
+#include <groups/SEn3.hpp>
+
+#include <cmath>
+#include <cstddef>
+#include <iostream>
+#include <random>
+#include <string>
+
+namespace lie = ocean_imu::lie;
+
+namespace {
+
+int failures = 0;
+
+bool check(bool condition, const std::string& message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        ++failures;
+    }
+    return condition;
+}
+
+template<typename T>
+bool close(T a, T b, T tol) {
+    return std::abs(a - b) <= tol;
+}
+
+template<typename T, int R, int C>
+bool mat_close(const Eigen::Matrix<T,R,C>& a, const Eigen::Matrix<T,R,C>& b, T tol) {
+    return a.allFinite() && b.allFinite() && ((a - b).cwiseAbs().maxCoeff() <= tol);
+}
+
+template<typename T, int R, int C>
+void report(const Eigen::Matrix<T,R,C>& a, const Eigen::Matrix<T,R,C>& b, const std::string& what) {
+    std::cerr << "  " << what << " max|diff| = "
+              << static_cast<double>((a - b).cwiseAbs().maxCoeff()) << '\n';
+}
+
+// ---------------------------------------------------------------------------
+// Random sampling. Fixed seed: these are deterministic regressions, not a
+// fuzzing campaign.
+// ---------------------------------------------------------------------------
+
+class Sampler {
+public:
+    explicit Sampler(unsigned seed) : rng_(seed) {}
+
+    double uniform(double lo, double hi) {
+        return std::uniform_real_distribution<double>(lo, hi)(rng_);
+    }
+
+    template<typename T>
+    Eigen::Matrix<T,3,1> vector3(double scale) {
+        return Eigen::Matrix<T,3,1>(static_cast<T>(uniform(-scale, scale)),
+                                    static_cast<T>(uniform(-scale, scale)),
+                                    static_cast<T>(uniform(-scale, scale)));
+    }
+
+    // Rotation vector with a controlled magnitude, so tests can target the
+    // near-identity, moderate, and near-pi regimes on purpose.
+    template<typename T>
+    Eigen::Matrix<T,3,1> rotation_vector(double angle) {
+        Eigen::Matrix<T,3,1> axis = vector3<T>(1.0);
+        if (axis.norm() < T(1e-6)) axis = Eigen::Matrix<T,3,1>(T(1), T(0), T(0));
+        axis.normalize();
+        return axis * static_cast<T>(angle);
+    }
+
+    template<typename Group>
+    Group group_element(double angle, double scale) {
+        using T = typename Group::Scalar;
+        Group g;
+        g.R = lie::Exp<T>(rotation_vector<T>(angle));
+        for (int i = 0; i < Group::kWorldCols; ++i) g.X.col(i) = vector3<T>(scale);
+        for (int j = 0; j < Group::kBiasCols; ++j) g.B.col(j) = vector3<T>(scale * 0.1);
+        return g;
+    }
+
+    template<typename Group>
+    typename Group::Tangent tangent(double angle, double scale) {
+        using T = typename Group::Scalar;
+        typename Group::Tangent xi;
+        xi.setZero();
+        xi.template segment<3>(Group::OFF_PHI) = rotation_vector<T>(angle);
+        for (int i = 0; i < Group::kWorldCols; ++i) {
+            xi.template segment<3>(Group::world_offset(i)) = vector3<T>(scale);
+        }
+        for (int j = 0; j < Group::kBiasCols; ++j) {
+            xi.template segment<3>(Group::bias_offset(j)) = vector3<T>(scale * 0.1);
+        }
+        return xi;
+    }
+
+private:
+    std::mt19937 rng_;
+};
+
+// Angles spanning the near-identity Taylor branch, the ordinary regime, and
+// close to pi where Log's quaternion recovery has to stay well behaved.
+const double kAngles[] = {0.0, 1e-9, 1e-6, 1e-3, 0.00999, 0.01001, 0.05, 0.5, 1.5, 3.0, 3.14};
+
+// ---------------------------------------------------------------------------
+// 1. SO(3) primitives
+// ---------------------------------------------------------------------------
+
+template<typename T>
+void test_so3(Sampler& s, T tol, const std::string& tag) {
+    using Matrix3 = Eigen::Matrix<T,3,3>;
+    using Vector3 = Eigen::Matrix<T,3,1>;
+
+    for (double angle : kAngles) {
+        const Vector3 phi = s.rotation_vector<T>(angle);
+        const Matrix3 R = lie::Exp<T>(phi);
+        const std::string at = " at angle " + std::to_string(angle);
+
+        // Exp lands in SO(3).
+        check(mat_close<T,3,3>(Matrix3(R * R.transpose()), Matrix3::Identity(), tol),
+              tag + ": Exp is not orthogonal" + at);
+        check(close<T>(R.determinant(), T(1), tol),
+              tag + ": Exp determinant != 1" + at);
+
+        // Exp/Log round trip. Near pi the axis sign is ambiguous, so compare
+        // through the rotation rather than through the vector.
+        const Vector3 phi_back = lie::Log<T>(R);
+        check(mat_close<T,3,3>(lie::Exp<T>(phi_back), R, tol),
+              tag + ": Exp/Log round trip" + at);
+        if (angle < 3.0) {
+            check(mat_close<T,3,1>(phi_back, phi, tol * T(10)),
+                  tag + ": Log did not recover the rotation vector" + at);
+        }
+
+        // J_l J_l^-1 = I.
+        const Matrix3 Jl  = lie::left_jacobian<T>(phi);
+        const Matrix3 Jli = lie::inv_left_jacobian<T>(phi);
+        check(mat_close<T,3,3>(Matrix3(Jl * Jli), Matrix3::Identity(), tol * T(10)),
+              tag + ": J_l J_l^-1 != I" + at);
+
+        // J_r(phi) = J_l(-phi) = Exp(-phi) J_l(phi). This identity is what the
+        // bias block of the group exponential rests on.
+        check(mat_close<T,3,3>(lie::left_jacobian<T>(Vector3(-phi)),
+                               Matrix3(lie::Exp<T>(Vector3(-phi)) * Jl), tol * T(10)),
+              tag + ": J_l(-phi) != Exp(-phi) J_l(phi)" + at);
+        check(mat_close<T,3,3>(lie::right_jacobian<T>(phi),
+                               lie::left_jacobian<T>(Vector3(-phi)), tol),
+              tag + ": right_jacobian != J_l(-phi)" + at);
+    }
+}
+
+// J_l(phi) = int_0^1 Exp(u phi) du, by Simpson. Double only: the quadrature
+// error would swamp a float comparison.
+void test_left_jacobian_quadrature(Sampler& s) {
+    using T = double;
+    using Matrix3 = Eigen::Matrix<T,3,3>;
+
+    for (double angle : kAngles) {
+        const Eigen::Matrix<T,3,1> phi = s.rotation_vector<T>(angle);
+        const int n = 2000;
+        Matrix3 acc = Matrix3::Zero();
+        for (int k = 0; k <= n; ++k) {
+            const T u = static_cast<T>(k) / static_cast<T>(n);
+            const T w = (k == 0 || k == n) ? T(1) : ((k % 2 == 1) ? T(4) : T(2));
+            acc += w * lie::Exp<T>(Eigen::Matrix<T,3,1>(u * phi));
+        }
+        acc /= (T(3) * static_cast<T>(n));
+
+        const Matrix3 Jl = lie::left_jacobian<T>(phi);
+        if (!check(mat_close<T,3,3>(Jl, acc, 1e-10),
+                   "J_l != integral of Exp(u phi) du at angle " + std::to_string(angle))) {
+            report(Jl, acc, "J_l");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Group axioms
+// ---------------------------------------------------------------------------
+
+template<typename Group>
+void test_axioms(Sampler& s, typename Group::Scalar tol, const std::string& tag) {
+    using T = typename Group::Scalar;
+    using W = Eigen::Matrix<T,3,Group::kWorldCols>;
+    using Bm = Eigen::Matrix<T,3,Group::kBiasCols>;
+
+    auto same = [tol](const Group& a, const Group& b) {
+        return mat_close<T,3,3>(a.R, b.R, tol) &&
+               mat_close<T,3,Group::kWorldCols>(a.X, b.X, tol) &&
+               mat_close<T,3,Group::kBiasCols>(a.B, b.B, tol);
+    };
+
+    for (int trial = 0; trial < 20; ++trial) {
+        const Group a = s.group_element<Group>(s.uniform(0.0, 3.0), 5.0);
+        const Group b = s.group_element<Group>(s.uniform(0.0, 3.0), 5.0);
+        const Group c = s.group_element<Group>(s.uniform(0.0, 3.0), 5.0);
+        const Group id = Group::Identity();
+
+        check(same(a.compose(id), a), tag + ": X o I != X");
+        check(same(id.compose(a), a), tag + ": I o X != X");
+
+        // Inverse on both sides. The bias slot is what catches a law written
+        // as a plain direct product.
+        const Group ainv = a.inverse();
+        const Group prods[2] = {a.compose(ainv), ainv.compose(a)};
+        for (const Group& prod : prods) {
+            check(mat_close<T,3,3>(prod.R, Eigen::Matrix<T,3,3>::Identity(), tol) &&
+                  mat_close<T,3,Group::kWorldCols>(prod.X, W::Zero(), tol) &&
+                  mat_close<T,3,Group::kBiasCols>(prod.B, Bm::Zero(), tol),
+                  tag + ": X o X^-1 != I");
+        }
+
+        check(same(a.compose(b).compose(c), a.compose(b.compose(c))),
+              tag + ": composition is not associative");
+        check(same(a.compose(b).inverse(), b.inverse().compose(a.inverse())),
+              tag + ": (ab)^-1 != b^-1 a^-1");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 3. Exp/Log, retraction, one-parameter subgroups
+// ---------------------------------------------------------------------------
+
+template<typename Group>
+void test_exp_log(Sampler& s, typename Group::Scalar tol, const std::string& tag) {
+    using T = typename Group::Scalar;
+
+    for (double angle : kAngles) {
+        if (angle > 3.0) continue;  // Log's axis is ambiguous at pi
+        const std::string at = " at angle " + std::to_string(angle);
+        const typename Group::Tangent xi = s.tangent<Group>(angle, 2.0);
+
+        const Group g = Group::Exp_G(xi);
+        const typename Group::Tangent back = Group::Log_G(g);
+        if (!check(mat_close<T,Group::NX,1>(back, xi, tol * T(10)),
+                   tag + ": Exp_G/Log_G round trip" + at)) {
+            report(back, xi, "xi");
+        }
+
+        // Also check group -> tangent -> group, which catches an inverse
+        // Jacobian that is wrong in a way the other direction absorbs.
+        const Group h = s.group_element<Group>(angle, 3.0);
+        const Group h_back = Group::Exp_G(Group::Log_G(h));
+        check(mat_close<T,3,3>(h_back.R, h.R, tol) &&
+              mat_close<T,3,Group::kWorldCols>(h_back.X, h.X, tol * T(10)) &&
+              mat_close<T,3,Group::kBiasCols>(h_back.B, h.B, tol * T(10)),
+              tag + ": Log_G/Exp_G round trip" + at);
+    }
+
+    typename Group::Tangent zero;
+    zero.setZero();
+    const Group e = Group::Exp_G(zero);
+    check(mat_close<T,3,3>(e.R, Eigen::Matrix<T,3,3>::Identity(), tol) &&
+          mat_close<T,3,Group::kWorldCols>(e.X, Eigen::Matrix<T,3,Group::kWorldCols>::Zero(), tol) &&
+          mat_close<T,3,Group::kBiasCols>(e.B, Eigen::Matrix<T,3,Group::kBiasCols>::Zero(), tol),
+          tag + ": Exp_G(0) != I");
+}
+
+/*
+    One-parameter subgroup property:
+
+        Exp_G(s1 xi) o Exp_G(s2 xi) = Exp_G((s1 + s2) xi)
+
+    This is the structural test that pins the bias block. Lie++ cannot check it
+    -- there is no oracle for four world vectors plus six body-frame biases --
+    but a wrong J_l on the bias slot breaks it immediately, because the
+    property only holds when the exponential really does integrate the ODE
+    b'(s) = beta - [phi]x b(s) that the group law induces.
+*/
+template<typename Group>
+void test_one_parameter_subgroup(Sampler& s, typename Group::Scalar tol, const std::string& tag) {
+    using T = typename Group::Scalar;
+
+    for (int trial = 0; trial < 20; ++trial) {
+        const typename Group::Tangent xi = s.tangent<Group>(s.uniform(0.0, 1.2), 2.0);
+        const T s1 = static_cast<T>(s.uniform(-1.0, 1.0));
+        const T s2 = static_cast<T>(s.uniform(-1.0, 1.0));
+
+        const Group lhs = Group::Exp_G(typename Group::Tangent(s1 * xi))
+                              .compose(Group::Exp_G(typename Group::Tangent(s2 * xi)));
+        const Group rhs = Group::Exp_G(typename Group::Tangent((s1 + s2) * xi));
+
+        const bool ok = mat_close<T,3,3>(lhs.R, rhs.R, tol) &&
+                        mat_close<T,3,Group::kWorldCols>(lhs.X, rhs.X, tol * T(10)) &&
+                        mat_close<T,3,Group::kBiasCols>(lhs.B, rhs.B, tol * T(10));
+        if (!check(ok, tag + ": Exp_G(s1 xi) Exp_G(s2 xi) != Exp_G((s1+s2) xi)")) {
+            report(lhs.B, rhs.B, "bias block");
+        }
+    }
+}
+
+/*
+    The retraction the filter actually applies, and its inverse -- "a
+    correction followed by the inverse correction returns to where it started",
+    which is what the update step depends on and the first thing to break if
+    the injection lands on the wrong side.
+*/
+template<typename Group>
+void test_retract_local(Sampler& s, typename Group::Scalar tol, const std::string& tag) {
+    using T = typename Group::Scalar;
+    using W = Eigen::Matrix<T,3,Group::kWorldCols>;
+    using Bm = Eigen::Matrix<T,3,Group::kBiasCols>;
+
+    for (int trial = 0; trial < 20; ++trial) {
+        const Group g = s.group_element<Group>(s.uniform(0.0, 2.0), 4.0);
+        const Group x = s.group_element<Group>(s.uniform(0.0, 2.0), 4.0);
+
+        const typename Group::Tangent xi = x.local(g);
+        const Group x_back = g.retract(xi);
+        check(mat_close<T,3,3>(x_back.R, x.R, tol) &&
+              mat_close<T,3,Group::kWorldCols>(x_back.X, x.X, tol * T(20)) &&
+              mat_close<T,3,Group::kBiasCols>(x_back.B, x.B, tol * T(20)),
+              tag + ": retract(local(x)) != x");
+
+        const typename Group::Tangent eta = s.tangent<Group>(s.uniform(0.0, 1.0), 1.0);
+        const typename Group::Tangent eta_back = g.retract(eta).local(g);
+        check(mat_close<T,Group::NX,1>(eta_back, eta, tol * T(20)),
+              tag + ": retract then local did not recover the correction");
+
+        // Left injection, componentwise. This is the difference from the MEKF
+        // pattern the redesign replaces, so assert the form explicitly.
+        const Group e = Group::Exp_G(eta);
+        const Group r = g.retract(eta);
+        check(mat_close<T,3,3>(r.R, Eigen::Matrix<T,3,3>(e.R * g.R), tol),
+              tag + ": retraction is not left multiplication on R");
+        check(mat_close<T,3,Group::kWorldCols>(r.X, W(e.R * g.X + e.X), tol * T(10)),
+              tag + ": world vectors did not rotate with the attitude correction");
+        check(mat_close<T,3,Group::kBiasCols>(r.B, Bm(g.B + g.R.transpose() * e.B), tol * T(10)),
+              tag + ": bias correction was not transported into the body frame");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 4. Adjoint
+// ---------------------------------------------------------------------------
+
+/*
+    Exact relation, not a linearization:
+
+        X Exp(xi) X^-1 = Exp(Ad_X xi)
+
+    Checked at finite xi, so an adjoint that is only correct to first order
+    fails here.
+*/
+template<typename Group>
+void test_adjoint_exact(Sampler& s, typename Group::Scalar tol, const std::string& tag) {
+    using T = typename Group::Scalar;
+
+    for (int trial = 0; trial < 20; ++trial) {
+        const Group X = s.group_element<Group>(s.uniform(0.0, 2.0), 4.0);
+        const typename Group::Tangent xi = s.tangent<Group>(s.uniform(0.0, 1.0), 1.5);
+
+        const Group lhs = X.compose(Group::Exp_G(xi)).compose(X.inverse());
+        const Group rhs = Group::Exp_G(typename Group::Tangent(X.Adjoint() * xi));
+
+        const bool ok = mat_close<T,3,3>(lhs.R, rhs.R, tol * T(10)) &&
+                        mat_close<T,3,Group::kWorldCols>(lhs.X, rhs.X, tol * T(100)) &&
+                        mat_close<T,3,Group::kBiasCols>(lhs.B, rhs.B, tol * T(100));
+        if (!check(ok, tag + ": X Exp(xi) X^-1 != Exp(Ad_X xi)")) {
+            report(lhs.X, rhs.X, "world block");
+            report(lhs.B, rhs.B, "bias block");
+        }
+    }
+}
+
+// Central finite differences of the same relation. Double only.
+void test_adjoint_finite_difference(Sampler& s) {
+    using T = double;
+    using Group = lie::TwoFrameGroup<T,4,2>;
+
+    const T h = 1e-6;
+    for (int trial = 0; trial < 10; ++trial) {
+        const Group X = s.group_element<Group>(s.uniform(0.0, 2.0), 4.0);
+        const Eigen::Matrix<T,Group::NX,Group::NX> Ad = X.Adjoint();
+
+        Eigen::Matrix<T,Group::NX,Group::NX> numeric;
+        for (int col = 0; col < Group::NX; ++col) {
+            Group::Tangent e = Group::Tangent::Zero();
+            e(col) = h;
+            const Group plus  = X.compose(Group::Exp_G(e)).compose(X.inverse());
+            e(col) = -h;
+            const Group minus = X.compose(Group::Exp_G(e)).compose(X.inverse());
+            numeric.col(col) = (Group::Log_G(plus) - Group::Log_G(minus)) / (T(2) * h);
+        }
+
+        if (!check(mat_close<T,Group::NX,Group::NX>(Ad, numeric, 1e-7),
+                   "Adjoint does not match central finite differences")) {
+            report(Ad, numeric, "Ad");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 5. Lie++ cross-check of the world block
+// ---------------------------------------------------------------------------
+
+/*
+    Our world block is SE_4(3): the (R, X_w) part of the two-frame group with
+    the bias slot held at zero. Lie++'s group::SEn3<double,4> is that group,
+    independently derived. Lie++'s tangent layout is [w, t_0, t_1, ...]
+    contiguous; ours interleaves beta_g at offset 3. The world part is
+    contiguous in both, so the mapping is a pair of segment copies.
+*/
+void test_liepp_world_block(Sampler& s) {
+    using T = double;
+    using Group = lie::TwoFrameGroup<T,4,2>;
+    using Ref = group::SEn3<T,4>;
+    using Vector3 = Eigen::Matrix<T,3,1>;
+    using Matrix3 = Eigen::Matrix<T,3,3>;
+
+    auto idx = [](int i) { return static_cast<std::size_t>(i); };
+
+    auto to_ref = [&idx](const Group& g) {
+        typename Ref::IsometriesType t;
+        for (int i = 0; i < 4; ++i) t[idx(i)] = g.X.col(i);
+        return Ref(Matrix3(g.R), t);
+    };
+    auto tangent_to_ref = [](const Group::Tangent& xi) {
+        Eigen::Matrix<T,15,1> u;
+        u.segment<3>(0)  = xi.segment<3>(Group::OFF_PHI);
+        u.segment<12>(3) = xi.segment<12>(Group::OFF_W);
+        return u;
+    };
+
+    for (int trial = 0; trial < 25; ++trial) {
+        Group a = s.group_element<Group>(s.uniform(0.0, 2.5), 6.0);
+        Group b = s.group_element<Group>(s.uniform(0.0, 2.5), 6.0);
+        a.B.setZero();
+        b.B.setZero();
+
+        // Composition.
+        const Group ab = a.compose(b);
+        const Ref ab_ref = to_ref(a) * to_ref(b);
+        check(mat_close<T,3,3>(ab.R, Matrix3(ab_ref.R()), 1e-12),
+              "Lie++ disagrees on composed rotation");
+        for (int i = 0; i < 4; ++i) {
+            check(mat_close<T,3,1>(Vector3(ab.X.col(i)), Vector3(ab_ref.t()[idx(i)]), 1e-12),
+                  "Lie++ disagrees on composed world column " + std::to_string(i));
+        }
+
+        // Inverse.
+        const Group ainv = a.inverse();
+        const Ref ainv_ref = to_ref(a).inv();
+        check(mat_close<T,3,3>(ainv.R, Matrix3(ainv_ref.R()), 1e-12),
+              "Lie++ disagrees on inverse rotation");
+        for (int i = 0; i < 4; ++i) {
+            check(mat_close<T,3,1>(Vector3(ainv.X.col(i)), Vector3(ainv_ref.t()[idx(i)]), 1e-12),
+                  "Lie++ disagrees on inverse world column " + std::to_string(i));
+        }
+
+        // Exponential.
+        Group::Tangent xi = s.tangent<Group>(s.uniform(0.0, 2.0), 3.0);
+        for (int j = 0; j < Group::kBiasCols; ++j) xi.segment<3>(Group::bias_offset(j)).setZero();
+        const Group ex = Group::Exp_G(xi);
+        const Ref ex_ref = Ref::exp(tangent_to_ref(xi));
+        check(mat_close<T,3,3>(ex.R, Matrix3(ex_ref.R()), 1e-12),
+              "Lie++ disagrees on Exp rotation");
+        for (int i = 0; i < 4; ++i) {
+            check(mat_close<T,3,1>(Vector3(ex.X.col(i)), Vector3(ex_ref.t()[idx(i)]), 1e-12),
+                  "Lie++ disagrees on Exp world column " + std::to_string(i));
+        }
+
+        // Logarithm.
+        const Group::Tangent lg = Group::Log_G(a);
+        const Eigen::Matrix<T,15,1> lg_ref = Ref::log(to_ref(a));
+        check(mat_close<T,3,1>(Vector3(lg.segment<3>(Group::OFF_PHI)),
+                               Vector3(lg_ref.segment<3>(0)), 1e-12),
+              "Lie++ disagrees on Log rotation part");
+        check(mat_close<T,12,1>(Eigen::Matrix<T,12,1>(lg.segment<12>(Group::OFF_W)),
+                                Eigen::Matrix<T,12,1>(lg_ref.segment<12>(3)), 1e-11),
+              "Lie++ disagrees on Log world part");
+
+        // Adjoint, world sub-blocks.
+        const Eigen::Matrix<T,Group::NX,Group::NX> Ad = a.Adjoint();
+        const Eigen::Matrix<T,15,15> Ad_ref = to_ref(a).Adjoint();
+        check(mat_close<T,3,3>(Matrix3(Ad.block<3,3>(Group::OFF_PHI, Group::OFF_PHI)),
+                               Matrix3(Ad_ref.block<3,3>(0,0)), 1e-12),
+              "Lie++ disagrees on Adjoint attitude block");
+        check(mat_close<T,12,3>(Eigen::Matrix<T,12,3>(Ad.block<12,3>(Group::OFF_W, Group::OFF_PHI)),
+                                Eigen::Matrix<T,12,3>(Ad_ref.block<12,3>(3,0)), 1e-12),
+              "Lie++ disagrees on Adjoint world/attitude coupling");
+        check(mat_close<T,12,12>(Eigen::Matrix<T,12,12>(Ad.block<12,12>(Group::OFF_W, Group::OFF_W)),
+                                 Eigen::Matrix<T,12,12>(Ad_ref.block<12,12>(3,3)), 1e-12),
+              "Lie++ disagrees on Adjoint world block");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 6. Small-angle branch accuracy
+// ---------------------------------------------------------------------------
+
+/*
+    Every small-angle branch in SO3Jacobians.h switches at 1e-2.
+
+    Comparing f(seam - eps) against f(seam + eps) would NOT test this: those
+    are different arguments, so the difference is dominated by the genuine
+    slope of f, not by any branch mismatch. What has to hold is that *both*
+    branches are accurate at the seam -- if each is within tol there, the
+    function is continuous across it to within 2 tol.
+
+    So evaluate against a closed form carried in long double, which has the
+    headroom to absorb the cancellation in (1-cos t)/t^2 and 1 - (t/2)cot(t/2)
+    at t = 1e-2 and still leave ~14 digits.
+*/
+
+using LD = long double;
+
+Eigen::Matrix<LD,3,3> reference_exp(const Eigen::Matrix<LD,3,1>& phi) {
+    using M = Eigen::Matrix<LD,3,3>;
+    const LD t2 = phi.squaredNorm();
+    const LD t = std::sqrt(t2);
+    if (t == LD(0)) return M::Identity();
+    const M W = lie::skew<LD>(phi);
+    return M::Identity() + (std::sin(t) / t) * W + ((LD(1) - std::cos(t)) / t2) * (W * W);
+}
+
+Eigen::Matrix<LD,3,3> reference_left_jacobian(const Eigen::Matrix<LD,3,1>& phi) {
+    using M = Eigen::Matrix<LD,3,3>;
+    const LD t2 = phi.squaredNorm();
+    const LD t = std::sqrt(t2);
+    if (t == LD(0)) return M::Identity();
+    const M W = lie::skew<LD>(phi);
+    return M::Identity()
+         + ((LD(1) - std::cos(t)) / t2) * W
+         + ((t - std::sin(t)) / (t2 * t)) * (W * W);
+}
+
+Eigen::Matrix<LD,3,3> reference_inv_left_jacobian(const Eigen::Matrix<LD,3,1>& phi) {
+    using M = Eigen::Matrix<LD,3,3>;
+    const LD t2 = phi.squaredNorm();
+    const LD t = std::sqrt(t2);
+    if (t == LD(0)) return M::Identity();
+    const M W = lie::skew<LD>(phi);
+    const LD half = LD(0.5) * t;
+    const LD c = (LD(1) - half * std::cos(half) / std::sin(half)) / t2;
+    return M::Identity() - LD(0.5) * W + c * (W * W);
+}
+
+template<typename T>
+void test_branch_seam(T tol, const std::string& tag) {
+    using Vector3 = Eigen::Matrix<T,3,1>;
+    using Matrix3 = Eigen::Matrix<T,3,3>;
+
+    const Eigen::Matrix<LD,3,1> axis_ld =
+        Eigen::Matrix<LD,3,1>(LD(0.3), LD(-0.5), LD(0.81)).normalized();
+    const LD seam = static_cast<LD>(lie::kSmallAngle<T>);
+
+    // Straddle the seam tightly, and sweep the decades either side so a branch
+    // that is wrong away from the boundary is caught too.
+    const LD angles[] = {
+        LD(0), LD(1e-9), LD(1e-7), LD(1e-5), LD(1e-3),
+        seam * LD(0.999), seam * LD(0.9999), seam,
+        seam * LD(1.0001), seam * LD(1.001),
+        LD(0.1), LD(0.7), LD(2.0), LD(3.0)
+    };
+
+    auto down = [](const Eigen::Matrix<LD,3,3>& m) { return Matrix3(m.template cast<T>()); };
+
+    for (LD angle : angles) {
+        const Eigen::Matrix<LD,3,1> phi_ld = axis_ld * angle;
+        const Vector3 phi = phi_ld.cast<T>();
+        const std::string at = " at angle " + std::to_string(static_cast<double>(angle));
+
+        if (!check(mat_close<T,3,3>(lie::Exp<T>(phi), down(reference_exp(phi_ld)), tol),
+                   tag + ": Exp disagrees with the closed form" + at)) {
+            report(lie::Exp<T>(phi), down(reference_exp(phi_ld)), "Exp");
+        }
+        if (!check(mat_close<T,3,3>(lie::left_jacobian<T>(phi),
+                                    down(reference_left_jacobian(phi_ld)), tol),
+                   tag + ": left_jacobian disagrees with the closed form" + at)) {
+            report(lie::left_jacobian<T>(phi), down(reference_left_jacobian(phi_ld)), "J_l");
+        }
+        // The cotangent form is genuinely singular at t = 0; there the Taylor
+        // branch is the only truth and the reference cannot be evaluated.
+        if (angle > LD(1e-8)) {
+            if (!check(mat_close<T,3,3>(lie::inv_left_jacobian<T>(phi),
+                                        down(reference_inv_left_jacobian(phi_ld)), tol),
+                       tag + ": inv_left_jacobian disagrees with the closed form" + at)) {
+                report(lie::inv_left_jacobian<T>(phi),
+                       down(reference_inv_left_jacobian(phi_ld)), "J_l^-1");
+            }
+        }
+        check(mat_close<T,3,3>(
+                  Matrix3(lie::left_jacobian<T>(phi) * lie::inv_left_jacobian<T>(phi)),
+                  Matrix3::Identity(), tol * T(10)),
+              tag + ": J_l J_l^-1 != I" + at);
+    }
+}
+
+// ---------------------------------------------------------------------------
+
+template<typename T>
+void run_all(T tol, const std::string& tag, bool with_fd_and_oracle) {
+    Sampler s(20260806u);
+
+    using Group  = lie::TwoFrameGroup<T,4,2>;   // full state: [v p S a_w], [b_g b_a]
+    using GroupA = lie::TwoFrameGroup<T,4,1>;   // with_accel_bias = false
+
+    static_assert(Group::NX == 21, "the full two-frame state must be 21-dimensional");
+    static_assert(Group::OFF_PHI == 0 && Group::OFF_BG == 3 && Group::OFF_W == 6,
+                  "tangent layout must match Kalman3D_Wave_OU_III");
+    static_assert(Group::world_offset(0) == 6 && Group::world_offset(1) == 9 &&
+                  Group::world_offset(2) == 12 && Group::world_offset(3) == 15,
+                  "world columns must sit at the OU-III v/p/S/a_w offsets");
+    static_assert(Group::bias_offset(0) == 3 && Group::bias_offset(1) == 18,
+                  "bias columns must sit at the OU-III b_g/b_a offsets");
+    static_assert(GroupA::NX == 18, "dropping the accelerometer bias must give 18 states");
+
+    test_so3<T>(s, tol, tag);
+    test_branch_seam<T>(tol, tag);
+    test_axioms<Group>(s, tol, tag);
+    test_axioms<GroupA>(s, tol, tag + " (no accel bias)");
+    test_exp_log<Group>(s, tol, tag);
+    test_one_parameter_subgroup<Group>(s, tol, tag);
+    test_retract_local<Group>(s, tol, tag);
+    test_adjoint_exact<Group>(s, tol, tag);
+
+    if (with_fd_and_oracle) {
+        test_left_jacobian_quadrature(s);
+        test_adjoint_finite_difference(s);
+        test_liepp_world_block(s);
+    }
+}
+
+} // namespace
+
+int main() {
+    // Double is the real check. Float only has to compile, stay finite, and
+    // keep its branches -- the firmware tolerance is set accordingly.
+    run_all<double>(1e-11, "double", true);
+    run_all<float>(2e-4f, "float", false);
+
+    if (failures != 0) {
+        std::cerr << failures << " Lie group check(s) failed\n";
+        return 1;
+    }
+    std::cout << "lie_group-test: all checks passed\n";
+    return 0;
+}

--- a/tests/kalman_tfg/run_tests.sh
+++ b/tests/kalman_tfg/run_tests.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+./lie_group-test
+./convention-test

--- a/third_party/Lie-plusplus/LICENSE
+++ b/third_party/Lie-plusplus/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2023 Alessandro Fornasier
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/third_party/Lie-plusplus/VENDORED.md
+++ b/third_party/Lie-plusplus/VENDORED.md
@@ -1,0 +1,66 @@
+# Vendored: Lie++ (Lie-plusplus)
+
+Upstream: https://github.com/aau-cns/Lie-plusplus
+Commit:   ec459c38445d986b5830162ae428b8b242ce5021
+License:  Apache License 2.0 (see `LICENSE`)
+Authors:  Alessandro Fornasier, Pieter van Goor et al., Control of Networked
+          Systems (CNS), University of Klagenfurt.
+
+## Why it is here
+
+`tests/kalman_tfg/lie_group-test` uses `group::SEn3<double, 4>` as an
+**independent oracle** for the world-vector block of the two-frame group
+implemented in `src/lie/`. Checking against finite differences alone would
+leave a shared-assumption blind spot; Lie++ is a separately derived
+implementation by the authors of the equivariant filtering literature this
+filter follows.
+
+## Why it is not in `src/`
+
+Lie++ is compiled **only** by native tests, never for Arduino:
+
+- it includes `<Eigen/Dense>` directly, whereas firmware builds route through
+  `ArduinoEigenDense.h` (see `src/ArduinoOceanImu.h`);
+- it materializes dense `(3+n)x(3+n)` and `(3+3n)x(3+3n)` Eigen matrices, and
+  `src/kalman_ou_iii/Kalman3D_Wave_OU_III.h:1707` documents why this codebase
+  keeps fixed-size Eigen instantiations small (cc1plus OOM on ESP32/Windows).
+
+The firmware path uses `src/lie/`, which is scalar-templated, Arduino-safe, and
+written in the surrounding `ou_detail` style.
+
+## Scope of the copy
+
+Only the two headers the oracle needs:
+
+- `include/groups/SO3.hpp`
+- `include/groups/SEn3.hpp`  (depends on `SO3.hpp` only)
+
+Upstream `SDB.hpp` is deliberately **not** vendored: its semi-direct bias
+structure is hardcoded to `SE_2(3) + R^6`, so it cannot serve as an oracle for
+this filter's four world vectors plus six bias states. That block is validated
+by structural identities and finite differences instead.
+
+Files are copied verbatim. Do not edit them; to update, re-copy from a newer
+upstream commit and record it above.
+
+## Convention agreement
+
+Lie++'s conventions line up with `src/lie/TwoFrameGroup.h` directly, which is
+what makes the comparison meaningful rather than an exercise in re-indexing:
+
+| Operation | Lie++ `SEn3` | `TwoFrameGroup` |
+|---|---|---|
+| composition | `t_i = R1 t2_i + t1_i` | `X1 + R1 X2` |
+| inverse | `-R^T t_i` | `-R^T X` |
+| exponential | `t_i = J_l(w) u_i` | `E_X = J_l(phi) rho` |
+| adjoint | `[t_i]x R` | `[x_i]x R` |
+
+Tangent layouts differ: Lie++ packs `[w, t_0, t_1, ...]` contiguously, while
+this filter interleaves the gyro bias at offset 3 to preserve OU-III's state
+ordering. The world part is contiguous in both, so the mapping is a pair of
+segment copies.
+
+## Citation
+
+A. Fornasier et al., "Equivariant Symmetries for Inertial Navigation Systems,"
+arXiv:2309.03765, 2023.

--- a/third_party/Lie-plusplus/include/groups/SEn3.hpp
+++ b/third_party/Lie-plusplus/include/groups/SEn3.hpp
@@ -1,0 +1,590 @@
+// Copyright (C) 2023 Alessandro Fornasier.
+// Control of Networked Systems, University of Klagenfurt, Austria.
+// System Theory and Robotics Lab, Australian Centre for Robotic
+// Vision, Australian national University, Australia.
+//
+// All rights reserved.
+//
+// This software is licensed under the terms of the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with the
+// License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// You can contact the authors at <alessandro.fornasier@ieee.org>,
+// <pieter.vangoor@anu.edu.au>.
+
+#ifndef SEn3_HPP
+#define SEn3_HPP
+
+#include <array>
+
+#include "SO3.hpp"
+
+namespace group
+{
+/**
+ * @brief the Special Eucldean group with n multiple isometries (SEn3)
+ *
+ * @tparam FPType. Floating point type (float, double, long double)
+ *
+ * @note Group Formulation for Consistent Non-Linear Estiamtion
+ * @note State Estimation for Robotics [http://asrl.utias.utoronto.ca/~tdb/bib/barfoot_ser17.pdf]
+ * @note The Geometry and Kinematics of the MatrixType Lie Group SEK(3) [https://arxiv.org/abs/2012.00950]
+ */
+template <typename FPType, int n>
+class SEn3
+{
+  static_assert(n > 0, "SEn3: n needs to be grater than 0");
+
+ public:
+  using Scalar = FPType;        //!< The underlying scalar type
+  using SO3Type = SO3<FPType>;  //!< The underlying SO3 type
+  using VectorType =
+      Eigen::Matrix<FPType, 3 + 3 * n, 1>;  //!< R6 Vectorspace element type (isomorphic to Lie Algebra se3)
+  using MatrixType = Eigen::Matrix<FPType, 3 + n, 3 + n>;              //!< Lie Algebra / Lie Group matrix type
+  using TMatrixType = Eigen::Matrix<FPType, 3 + 3 * n, 3 + 3 * n>;     //!< Transformation matrix type
+  using IsometriesType = std::array<typename SO3Type::VectorType, n>;  //!< Vector of translations (Isometries)
+
+  /**
+   * @brief Construct an identity SEn3 object
+   */
+  SEn3() : C_(SO3Type()), t_() { t_.fill(SO3Type::VectorType::Zero()); }
+
+  /**
+   * @brief Construct a SEn3 object from a given normalized quaternion, and an array of vectors.
+   *
+   * @param q Quaternion
+   * @param t Array of R3 vectors
+   */
+  SEn3(const typename SO3Type::QuaternionType& q, const IsometriesType& t) : C_(q), t_(t) {}
+
+  /**
+   * @brief Construct a SEn3 object from a given rotation matrix, and an array of vectors.
+   *
+   * @param R Rotation matrix
+   * @param t Array of R3 vectors
+   */
+  SEn3(const typename SO3Type::MatrixType& R, const IsometriesType& t) : C_(R), t_(t) {}
+
+  /**
+   * @brief Construct a SEn3 object from a given SO3 object, and an array of vectors.
+   *
+   * @param C SO3 group element
+   * @param t Array of R3 vectors
+   */
+  SEn3(const SO3Type& C, const IsometriesType& t) : C_(C), t_(t) {}
+
+  /**
+   * @brief Construct a SEn3 object from a given matrix
+   *
+   * @param T SEn3 group element in matrix form
+   */
+  SEn3(const MatrixType& T) : C_(T.template block<3, 3>(0, 0)), t_()
+  {
+    for (int i = 0; i < n; ++i)
+    {
+      t_[i] = T.template block<3, 1>(0, 3 + i);
+    }
+  }
+
+  /**
+   * @brief wedge operator, transform a vector in R(3+3n) to a matrix in sen3
+   *
+   * @param u R(3+3n) vector
+   *
+   * @return SEn3 Lie algebra element in matrix form
+   */
+  [[nodiscard]] static const MatrixType wedge(const VectorType& u)
+  {
+    MatrixType U = MatrixType::Zero();
+    U.template block<3, 3>(0, 0) = SO3Type::wedge(u.template block<3, 1>(0, 0));
+    for (int i = 0; i < n; ++i)
+    {
+      U.template block<3, 1>(0, 3 + i) = u.template block<3, 1>(3 + 3 * i, 0);
+    }
+    return U;
+  }
+
+  /**
+   * @brief Transform a matrix in sen3 to a vector in R(3+3n)
+   *
+   * @param U SEn3 Lie algebra element in matrix form
+   *
+   * @return R(3+3n) vector
+   */
+  [[nodiscard]] static const VectorType vee(const MatrixType& U)
+  {
+    VectorType u = VectorType::Zero();
+    u.template block<3, 1>(0, 0) = SO3Type::vee(U.template block<3, 3>(0, 0));
+    for (int i = 0; i < n; ++i)
+    {
+      u.template block<3, 1>(3 + 3 * i, 0) = U.template block<3, 1>(0, 3 + i);
+    }
+    return u;
+  }
+
+  /**
+   * @brief sen3 adjoint matrix
+   *
+   * @param u R(3+3n) vector
+   *
+   * @return SEn3 Lie algebra adjoint matrix
+   */
+  [[nodiscard]] static const TMatrixType adjoint(const VectorType& u)
+  {
+    TMatrixType ad = TMatrixType::Zero();
+    typename SO3Type::MatrixType W = SO3Type::wedge(u.template block<3, 1>(0, 0));
+    ad.template block<3, 3>(0, 0) = W;
+    for (int i = 0; i < n; ++i)
+    {
+      ad.template block<3, 3>(3 + 3 * i, 3 + 3 * i) = W;
+      ad.template block<3, 3>(3 + 3 * i, 0) = SO3Type::wedge(u.template block<3, 1>(3 + 3 * i, 0));
+    }
+    return ad;
+  }
+
+  /**
+   * @brief SEn3 left Jacobian matrix
+   *
+   * @param u R(3+3n) vector
+   *
+   * @return SEn3 left Jacobian matrix
+   */
+  [[nodiscard]] static const TMatrixType leftJacobian(const VectorType& u)
+  {
+    typename SO3Type::VectorType w = u.template block<3, 1>(0, 0);
+    FPType ang = w.norm();
+    if (ang < eps_)
+    {
+      return TMatrixType::Identity() + 0.5 * adjoint(u);
+    }
+    typename SO3Type::MatrixType SO3JL = SO3Type::leftJacobian(w);
+    TMatrixType J = TMatrixType::Identity();
+    J.template block<3, 3>(0, 0) = SO3JL;
+    for (int i = 0; i < n; ++i)
+    {
+      typename SO3Type::VectorType x = u.template block<3, 1>(3 + 3 * i, 0);
+      J.template block<3, 3>(3 + 3 * i, 0) = SE3leftJacobianQ(w, x);
+      J.template block<3, 3>(3 + 3 * i, 3 + 3 * i) = SO3JL;
+    }
+    return J;
+  }
+
+  /**
+   * @brief SEn3 inverse left Jacobian matrix
+   *
+   * @param u R(3+3n) vector
+   *
+   * @return SEn3 inverse left Jacobian matrix
+   */
+  [[nodiscard]] static const TMatrixType invLeftJacobian(const VectorType& u)
+  {
+    typename SO3Type::VectorType w = u.template block<3, 1>(0, 0);
+    FPType ang = w.norm();
+    if (ang < eps_)
+    {
+      return TMatrixType::Identity() - 0.5 * adjoint(u);
+    }
+    typename SO3Type::MatrixType invSO3JL = SO3Type::invLeftJacobian(w);
+    TMatrixType J = TMatrixType::Identity();
+    J.template block<3, 3>(0, 0) = invSO3JL;
+    for (int i = 0; i < n; ++i)
+    {
+      typename SO3Type::VectorType x = u.template block<3, 1>(3 + 3 * i, 0);
+      J.template block<3, 3>(3 + 3 * i, 0) = -invSO3JL * SE3leftJacobianQ(w, x) * invSO3JL;
+      J.template block<3, 3>(3 + 3 * i, 3 + 3 * i) = invSO3JL;
+    }
+    return J;
+  }
+
+  /**
+   * @brief SEn3 right Jacobian matrix
+   *
+   * @param u R(3+3n) vector
+   *
+   * @return SEn3 right Jacobian matrix
+   */
+  [[nodiscard]] static const TMatrixType rightJacobian(const VectorType& u) { return leftJacobian(-u); }
+
+  /**
+   * @brief SEn3 inverse right Jacobian matrix
+   *
+   * @param u R(3+3n) vector
+   *
+   * @return SEn3 inverse right Jacobian matrix
+   */
+  [[nodiscard]] static const TMatrixType invRightJacobian(const VectorType& u) { return invLeftJacobian(-u); }
+
+  /**
+   * @brief The exponential map for SEn3.
+   * Returns a SEn3 object given a vector u in R(3+3n) (equivalent to exp(wedge(u)))
+   *
+   * @param u R(3+3n) vector
+   *
+   * @return SEn3 group element
+   */
+  [[nodiscard]] static const SEn3 exp(const VectorType& u)
+  {
+    typename SO3Type::VectorType w = u.template block<3, 1>(0, 0);
+    typename SO3Type::MatrixType SO3JL = SO3Type::leftJacobian(w);
+    IsometriesType t;
+    for (int i = 0; i < n; ++i)
+    {
+      t[i] = SO3JL * u.template block<3, 1>(3 + 3 * i, 0);
+    }
+    return SEn3(SO3Type::exp(w), t);
+  }
+
+  // /**
+  //  * @brief The exponential map for SEn3.
+  //  * Returns a SEn3 object given a matrix U in sen3
+  //  *
+  //  * @param U SEn3 Lie algebra element in matrix form
+  //  *
+  //  * @return SEn3 group element
+  //  */
+  // [[nodiscard]] static SEn3 exp(const MatrixType& U) { return exp(vee(U)); }
+
+  /**
+   * @brief The logarithmic map for SEn3.
+   * Return a vector given a SEn3 object (equivalent to vee(log(X)))
+   *
+   * @param X SEn3 group element
+   *
+   * @return R(3+3n) vector
+   */
+  [[nodiscard]] static const VectorType log(const SEn3& X)
+  {
+    VectorType u = VectorType::Zero();
+    u.template block<3, 1>(0, 0) = SO3Type::log(X.C_);
+    typename SO3Type::MatrixType invSO3JL = SO3Type::invLeftJacobian(u.template block<3, 1>(0, 0));
+    for (int i = 0; i < n; ++i)
+    {
+      u.template block<3, 1>(3 + 3 * i, 0) = invSO3JL * X.t_[i];
+    }
+    return u;
+  }
+
+  // /**
+  //  * @brief The logarithmic map for SEn3.
+  //  * Return a se3 matrix given a SEn3 object
+  //  *
+  //  * @param X SEn3 group element
+  //  *
+  //  * @return SEn3 Lie algebra element in matrix form
+  //  */
+  // [[nodiscard]] static MatrixType log(const SEn3& X) { return wedge(log(X)); }
+
+  /**
+   * @brief Operator * overloading.
+   * Implements the SEn3 composition this * other
+   *
+   * @param other SEn3 group element
+   *
+   * @return SEn3 group element
+   *
+   * @note usage: z = x * y
+   */
+  [[nodiscard]] const SEn3 operator*(const SEn3& other) const
+  {
+    IsometriesType t;
+    for (int i = 0; i < n; ++i)
+    {
+      t[i] = C_.R() * other.t_[i] + t_[i];
+    }
+    return SEn3(C_ * other.C_, t);
+  }
+
+  /**
+   * @brief Operator * overloading.
+   * Implements the SEn3 composition this * other with a SEn3 group or alegra element in matrix form
+   *
+   * @param other SE3 group or algebra element in matrix form
+   *
+   * @return SEn3 group or algebra element in matrix form
+   *
+   * @note usage: z = x * y
+   */
+  [[nodiscard]] const MatrixType operator*(const MatrixType& other) const
+  {
+    bool is_algebra = true;
+    bool is_group = true;
+
+    for (int i = 0; i < n; ++i)
+    {
+      is_algebra &= (other(3 + i, 3 + i) == 0);
+      is_group &= (other(3 + i, 3 + i) == 1);
+    }
+
+    if (!(is_algebra || is_group))
+    {
+      throw std::runtime_error(
+          "SEn3: operator* is defined only for composition with matrix form of SEn3 group or algebra elements");
+    }
+
+    MatrixType res = other;
+    res.template block<3, 3>(0, 0) = C_.R() * other.template block<3, 3>(0, 0);
+    for (int i = 0; i < n; ++i)
+    {
+      if (is_algebra)
+      {
+        res.template block<3, 1>(0, 3 + i) = C_.R() * other.template block<3, 1>(0, 3 + i);
+      }
+      else
+      {
+        res.template block<3, 1>(0, 3 + i) = C_.R() * other.template block<3, 1>(0, 3 + i) + t_[i];
+      }
+    }
+    return res;
+  }
+
+  /**
+   * @brief Operator * overloading.
+   * Implements the SE3 action on a R3 vector
+   *
+   * @param other R3 vector
+   *
+   * @return R3 vector
+   */
+  [[nodiscard]] const typename SO3Type::VectorType operator*(const typename SO3Type::VectorType& other) const
+  {
+    static_assert(n == 1, "SEn3: SE3 action on R3 (* operator overloading) available only for n = 1");
+    return C_.R() * other + t_[0];
+  }
+
+  /**
+   * @brief Implements the SEn3 composition this = this * other
+   *
+   * @param other SEn3 group element
+   *
+   * @return SEn3 group element
+   */
+  const SEn3& multiplyRight(const SEn3& other)
+  {
+    for (int i = 0; i < n; ++i)
+    {
+      t_[i] = (C_.R() * other.t_[i] + t_[i]).eval();
+    }
+    C_.multiplyRight(other.C_);  // C_ * other.C_
+    return *this;
+  }
+
+  /**
+   * @brief Implements the SEn3 composition this = other * this
+   *
+   * @param other SEn3 group element
+   *
+   * @return SEn3 group element
+   */
+  const SEn3& multiplyLeft(const SEn3& other)
+  {
+    for (int i = 0; i < n; ++i)
+    {
+      t_[i] = (other.C_.R() * t_[i] + other.t_[i]).eval();
+    }
+    C_.multiplyLeft(other.C_);  // other.C_ * th.C_
+    return *this;
+  }
+
+  /**
+   * @brief Get a constant copy of the inverse of the SEn3 object
+   *
+   * @return SEn3 group element
+   */
+  [[nodiscard]] const SEn3 inv() const
+  {
+    IsometriesType t;
+    for (int i = 0; i < n; ++i)
+    {
+      t[i] = -C_.R().transpose() * t_[i];
+    }
+    return SEn3(C_.R().transpose(), t);
+  }
+
+  /**
+   * @brief Get a constant copy of the SEn3 object as a matrix
+   *
+   * @return SEn3 group element in matrix form
+   */
+  [[nodiscard]] const MatrixType T() const
+  {
+    MatrixType T = MatrixType::Identity();
+    T.template block<3, 3>(0, 0) = C_.R();
+    for (int i = 0; i < n; ++i)
+    {
+      T.template block<3, 1>(0, 3 + i) = t_[i];
+    }
+    return T;
+  }
+
+  /**
+   * @brief Get a constant reference to the SEn3 rotation matrix
+   *
+   * @return Rotation matrix
+   */
+  [[nodiscard]] const typename SO3Type::MatrixType& R() const { return C_.R(); }
+
+  /**
+   * @brief Get a constant reference to the SEn3 normalized quaternion
+   *
+   * @return Quaternion
+   */
+  [[nodiscard]] const typename SO3Type::QuaternionType& q() const { return C_.q(); }
+
+  /**
+   * @brief Get a constant reference to the SEn3 translation vectors (isometries)
+   *
+   * @return Array of R3 vectors
+   */
+  [[nodiscard]] const IsometriesType& t() const { return t_; }
+
+  /**
+   * @brief Get a constant referece to the first isometry of SE3
+   *
+   * @note Method available only for n = 1, thus SE3
+   *
+   * @return R3 vector
+   */
+  [[nodiscard]] const typename SO3Type::VectorType& x() const
+  {
+    static_assert(n == 1, "SEn3: x() method available only for n = 1");
+    return t_[0];
+  }
+
+  /**
+   * @brief Get a constant referece to the first isometry (velocity) of SEn3 with n > 1
+   *
+   * @note Method available only for n > 1
+   *
+   * @return R3 vector
+   */
+  [[nodiscard]] const typename SO3Type::VectorType& v() const
+  {
+    static_assert(n > 1, "SEn3: v() method available only for n > 1");
+    return t_[0];
+  }
+
+  /**
+   * @brief Get a constant referece to the second isometry (position) of SEn3 with n > 1
+   *
+   * @note Method available only for n > 1
+   *
+   * @return R3 vector
+   */
+  [[nodiscard]] const typename SO3Type::VectorType& p() const
+  {
+    static_assert(n > 1, "SEn3: v() method available only for n > 1");
+    return t_[1];
+  }
+
+  /**
+   * @brief Get a constant copy of the SEn3 object as a matrix
+   *
+   * @return SEn3 group element in matrix form
+   */
+  [[nodiscard]] const MatrixType asMatrix() const { return T(); }
+
+  /**
+   * @brief Set SEn3 object value from given matrix
+   *
+   * @param T SEn3 group element in matrix form
+   */
+  void fromT(const MatrixType& T)
+  {
+    C_.fromR(T.template block<3, 3>(0, 0));
+    for (int i = 0; i < n; ++i)
+    {
+      t_[i] = T.template block<3, 1>(0, 3 + i);
+    }
+  }
+
+  /**
+   * @brief SEn3 Adjoint matrix
+   *
+   * @return SEn3 group Adjoint matrix
+   */
+  [[nodiscard]] const TMatrixType Adjoint() const
+  {
+    TMatrixType Ad = TMatrixType::Identity();
+    Ad.template block<3, 3>(0, 0) = C_.R();
+    for (int i = 0; i < n; ++i)
+    {
+      Ad.template block<3, 3>(3 + 3 * i, 3 + 3 * i) = C_.R();
+      Ad.template block<3, 3>(3 + 3 * i, 0) = SO3Type::wedge(t_[i]) * C_.R();
+    }
+    return Ad;
+  }
+
+  /**
+   * @brief SEn3 Inverse Adjoint matrix
+   *
+   * @return SEn3 group inverse Adjoint matrix
+   */
+  [[nodiscard]] const TMatrixType invAdjoint() const
+  {
+    TMatrixType Ad = TMatrixType::Identity();
+    Ad.template block<3, 3>(0, 0) = C_.R().transpose();
+    for (int i = 0; i < n; ++i)
+    {
+      Ad.template block<3, 3>(3 + 3 * i, 3 + 3 * i) = C_.R().transpose();
+      Ad.template block<3, 3>(3 + 3 * i, 0) = -C_.R().transpose() * SO3Type::wedge(t_[i]);
+    }
+    return Ad;
+  }
+
+ protected:
+  /**
+   * @brief SE3 left Jacobian Q matrix
+   *
+   * @param w R3 vector
+   * @param v R3 vector
+   *
+   * @return SE3 left Jacobian Q matrix
+   */
+  [[nodiscard]] static const typename SO3Type::MatrixType SE3leftJacobianQ(const typename SO3Type::VectorType& w,
+                                                                           const typename SO3Type::VectorType& v)
+  {
+    typename SO3Type::MatrixType p = SO3Type::wedge(w);
+    typename SO3Type::MatrixType r = SO3Type::wedge(v);
+
+    FPType ang = w.norm();
+    FPType s = sin(ang);
+    FPType c = cos(ang);
+
+    FPType ang_p2 = pow(ang, 2);
+    FPType ang_p3 = ang_p2 * ang;
+    FPType ang_p4 = ang_p3 * ang;
+    FPType ang_p5 = ang_p4 * ang;
+
+    FPType c1 = (ang - s) / ang_p3;
+    FPType c2 = (0.5 * ang_p2 + c - 1.0) / ang_p4;
+    FPType c3 = (ang * (1.0 + 0.5 * c) - 1.5 * s) / ang_p5;
+
+    typename SO3Type::MatrixType m1 = p * r + r * p + p * r * p;
+    typename SO3Type::MatrixType m2 = p * p * r + r * p * p - 3.0 * p * r * p;
+    typename SO3Type::MatrixType m3 = p * r * p * p + p * p * r * p;
+
+    return 0.5 * r + c1 * m1 + c2 * m2 + c3 * m3;
+  }
+
+  SO3Type C_;         //!< SO3 object the rotational component of SEn3
+  IsometriesType t_;  //!< R6 vector representing the n translational components of SEn3
+
+  static constexpr FPType eps_ = std::is_same_v<FPType, float> ? 1.0e-6 : 1.0e-9;  //!< Epsilon
+};
+
+using SE3d = SEn3<double, 1>;   //!< The SE3 group with double precision floating point
+using SE3f = SEn3<float, 1>;    //!< The SE3 group with single precision floating point
+using SE23d = SEn3<double, 2>;  //!< The SE23 group with double precision floating point
+using SE23f = SEn3<float, 2>;   //!< The SE23 group with single precision floating point
+
+}  // namespace group
+
+#endif  // SEn3_HPP

--- a/third_party/Lie-plusplus/include/groups/SO3.hpp
+++ b/third_party/Lie-plusplus/include/groups/SO3.hpp
@@ -1,0 +1,475 @@
+// Copyright (C) 2023 Alessandro Fornasier.
+// Control of Networked Systems, University of Klagenfurt, Austria.
+// System Theory and Robotics Lab, Australian Centre for Robotic
+// Vision, Australian national University, Australia.
+//
+// All rights reserved.
+//
+// This software is licensed under the terms of the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with the
+// License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// You can contact the authors at <alessandro.fornasier@ieee.org>,
+// <pieter.vangoor@anu.edu.au>.
+
+#ifndef SO3_HPP
+#define SO3_HPP
+
+#include <Eigen/Dense>
+
+namespace group
+{
+/**
+ * @brief The Special orthogonal group of dimension 3 (SO3) representing 3D rotations
+ *
+ * @tparam FPType. Floating point type (float, FPType, long FPType)
+ *
+ * @note Group Formulation for Consistent Non-Linear Estiamtion
+ * @note State Estimation for Robotics [http://asrl.utias.utoronto.ca/~tdb/bib/barfoot_ser17.pdf]
+ * @note The Geometry and Kinematics of the Matrix Lie Group SEK(3) [https://arxiv.org/abs/2012.00950]
+ */
+template <typename FPType>
+class SO3
+{
+ public:
+  using Scalar = FPType;                             //!< The underlying scalar type
+  using MatrixType = Eigen::Matrix<FPType, 3, 3>;    //!< Lie Algebra / Lie Group matrix type
+  using TMatrixType = Eigen::Matrix<FPType, 3, 3>;   //!< Transformation matrix type (Linear operator on R3)
+  using VectorType = Eigen::Matrix<FPType, 3, 1>;    //!< R3 Vectorspace element type (isomorphic to Lie Algebra so3)
+  using QuaternionType = Eigen::Quaternion<FPType>;  //!< Quaternion type
+  using AngleAxisType = Eigen::AngleAxis<FPType>;    //!< Angle-axis type
+
+  /**
+   * @brief Construct an identity SO3 object
+   */
+  SO3() : R_(MatrixType::Identity()), q_(QuaternionType::Identity()) {}
+
+  /**
+   * @brief Construct a SO3 object from a given normalized quaternion.
+   *
+   * @param q Quaternion
+   */
+  SO3(const QuaternionType& q) : R_(q.toRotationMatrix()), q_(q)
+  {
+    if (!isNormalized())
+    {
+      normalize();
+    }
+  }
+
+  /**
+   * @brief Construct a SO3 object from a given rotation matrix
+   *
+   * @param R Rotation matrix
+   */
+  SO3(const MatrixType& R) : R_(R), q_(R)
+  {
+    if (!isNormalized())
+    {
+      normalize();
+    }
+  }
+
+  /**
+   * @brief Construct a SO3 object from two vector such that Ru = v
+   *
+   * @param u Vector in R3
+   * @param v vector in R3
+   */
+  SO3(const VectorType& u, const VectorType& v) : R_(), q_()
+  {
+    VectorType un = u.normalized();
+    VectorType vn = v.normalized();
+
+    VectorType ax = un.cross(vn);
+    FPType s = ax.norm();
+    FPType c = un.dot(vn);
+
+    if (s == 0)
+    {
+      q_ = QuaternionType::Identity();
+      R_ = MatrixType::Identity();
+    }
+    else if (std::abs(1 + c) < eps_)
+    {
+      ax = un.cross(VectorType::Random());
+      ax.normalize();
+      q_ = QuaternionType(0.0, ax(0), ax(1), ax(2));
+      R_ = q_.toRotationMatrix();
+    }
+    else
+    {
+      R_ = MatrixType::Identity() + wedge(ax) + ((1.0 - c) / (s * s)) * (wedge(ax) * wedge(ax));
+      q_ = QuaternionType(R_);
+    }
+  }
+
+  /**
+   * @brief wedge operator, transform a vector in R3 to a matrix in so3
+   *
+   * @param u R3 vector
+   * @return SO3 Lie algebra element in matrix form
+   */
+  [[nodiscard]] static const MatrixType wedge(const VectorType& u)
+  {
+    MatrixType U;
+    U << 0.0, -u(2), u(1), u(2), 0.0, -u(0), -u(1), u(0), 0.0;
+    return (U);
+  }
+
+  /**
+   * @brief Transform a matrix in so3 to a vector in R3
+   *
+   * @param U SO3 Lie algebra element in matrix form
+   *
+   * @return R3 vector
+   */
+  [[nodiscard]] static const VectorType vee(const MatrixType& U)
+  {
+    VectorType u;
+    u << U(2, 1), U(0, 2), U(1, 0);
+    return (u);
+  }
+
+  /**
+   * @brief so3 adjoint matrix
+   *
+   * @param u R3 vector
+   *
+   * @return SO3 Lie algebra adjoint matrix
+   */
+  [[nodiscard]] static const TMatrixType adjoint(const VectorType& u) { return wedge(u); }
+
+  /**
+   * @brief SO3 Gamma2 matrix
+   *
+   * @param u R3 vector
+   *
+   * @return SO3 Gamma2 matrix
+   */
+  [[nodiscard]] static const TMatrixType Gamma2(const VectorType& u)
+  {
+    FPType ang = u.norm();
+    if (ang < eps_)
+    {
+      return 0.5 * TMatrixType::Identity() - 1 / 6 * wedge(u);
+    }
+    VectorType ax = u / ang;
+    FPType ang_p2 = pow(ang, 2);
+    FPType s = (ang - sin(ang)) / ang_p2;
+    FPType c = (1 - cos(ang)) / ang_p2;
+    return c * TMatrixType::Identity() + s * wedge(ax) + (0.5 - c) * ax * ax.transpose();
+  }
+
+  /**
+   * @brief SO3 left Jacobian matrix
+   *
+   * @param u R3 vector
+   *
+   * @return SO3 left Jacobian matrix
+   */
+  [[nodiscard]] static const TMatrixType leftJacobian(const VectorType& u)
+  {
+    FPType ang = u.norm();
+    if (ang < eps_)
+    {
+      return TMatrixType::Identity() + 0.5 * wedge(u);
+    }
+    VectorType ax = u / ang;
+    FPType s = sin(ang) / ang;
+    FPType c = cos(ang);
+    return s * TMatrixType::Identity() + ((1.0 - c) / ang) * wedge(ax) + (1.0 - s) * ax * ax.transpose();
+  }
+
+  /**
+   * @brief SO3 inverse left Jacobian matrix
+   *
+   * @param u R3 vector
+   *
+   * @return SO3 inverse left Jacobian matrix
+   */
+  [[nodiscard]] static const TMatrixType invLeftJacobian(const VectorType& u)
+  {
+    FPType ang = u.norm();
+    if (ang < eps_)
+    {
+      return TMatrixType::Identity() - 0.5 * wedge(u);
+    }
+    VectorType ax = u / ang;
+    FPType half_ang = 0.5 * ang;
+    FPType cot = 1.0 / tan(half_ang);
+    return (half_ang * cot) * TMatrixType::Identity() + (1.0 - half_ang * cot) * ax * ax.transpose() -
+           half_ang * wedge(ax);
+  }
+
+  /**
+   * @brief SO3 right Jacobian matrix
+   *
+   * @param u R3 vector
+   *
+   * @return SO3 right Jacobian matrix
+   */
+  [[nodiscard]] static const TMatrixType rightJacobian(const VectorType& u) { return leftJacobian(-u); }
+
+  /**
+   * @brief SO3 inverse right Jacobian matrix
+   *
+   * @param u R3 vector
+   *
+   * @return SO3 inverse right Jacobian matrix
+   */
+  [[nodiscard]] static const TMatrixType invRightJacobian(const VectorType& u) { return invLeftJacobian(-u); }
+
+  /**
+   * @brief The exponential map for SO3.
+   * Returns a SO3 object given a vector u in R3 (equivalent to exp(wedge(u)))
+   *
+   * @param u R3 vector
+   *
+   * @return SO3 group element
+   */
+  [[nodiscard]] static const SO3 exp(const VectorType& u)
+  {
+    FPType ang = 0.5 * u.norm();
+    QuaternionType q;
+    if (ang < eps_)
+    {
+      q.w() = 1.0;
+      q.vec() = 0.5 * u;
+    }
+    else
+    {
+      q.w() = cos(ang);
+      q.vec() = sin(ang) * u.normalized();
+    }
+    q.normalize();
+    return SO3(q);
+  }
+
+  // /**
+  //  * @brief The exponential map for SO3.
+  //  * Returns a SO3 object given a matrix U in so3
+  //  *
+  //  * @param U SO3 Lie algebra element in matrix form
+  //  *
+  //  * @return SO3 group element
+  //  */
+  // [[nodiscard]] static const SO3 exp(const MatrixType& U) { return exp(vee(U)); }
+
+  /**
+   * @brief The logarithmic map for SO3.
+   * Return a vector given a SO3 object (equivalent to vee(log(X)))
+   *
+   * @param X SO3 group element
+   *
+   * @return R3 vector
+   */
+  [[nodiscard]] static const VectorType log(const SO3& X)
+  {
+    FPType qw = X.q_.w();
+    VectorType qv = X.q_.vec();
+    FPType ang = qv.norm();
+    VectorType u;
+    if (qw < 0)
+    {
+      qw = -qw;
+      qv = -qv;
+    }
+    if (ang < eps_)
+    {
+      u = (2.0 / qw) * qv * (1.0 - (pow((ang / qw), 2) / 3));
+    }
+    else
+    {
+      u = 2 * atan2(ang, qw) * (qv / ang);
+    }
+    return u;
+  }
+
+  // /**
+  //  * @brief The logarithmic map for SO3.
+  //  * Return a so3 matrix given a SO3 object
+  //  *
+  //  * @param X SO3 group element
+  //  *
+  //  * @return SO3 Lie algebra element in matrix form
+  //  */
+  // [[nodiscard]] static const MatrixType log(const SO3& X) { return wedge(log(X)); }
+
+  /**
+   * @brief Operator * overloading.
+   * Implements the SO3 composition this * other
+   *
+   * @param other SO3 group element
+   *
+   * @return SO3 group element
+   *
+   * @note usage: z = x * y
+   */
+  [[nodiscard]] const SO3 operator*(const SO3& other) const { return SO3(q_ * other.q_); }
+
+  /**
+   * @brief Operator * overloading.
+   * Implements the SO3 composition this * other with a SO3 group or alegra element in matrix form
+   *
+   * @param other SO3 group or algebra element in matrix form
+   *
+   * @return SO3 group or algebra element in matrix form
+   *
+   * @note usage: z = x * y
+   */
+  [[nodiscard]] const MatrixType operator*(const MatrixType& other) const { return R_ * other; }
+
+  /**
+   * @brief Operator * overloading.
+   * Implements the SO3 action on a R3 vector
+   *
+   * @param other R3 vector
+   *
+   * @return R3 vector
+   */
+  [[nodiscard]] const VectorType operator*(const VectorType& other) const
+  {
+    return q_ * other;
+    // return R_ * other;
+  }
+
+  /**
+   * @brief Implements the SO3 composition this = this * other
+   *
+   * @param other SO3 group element
+   *
+   * @return SO3 group element
+   */
+  const SO3& multiplyRight(const SO3& other)
+  {
+    q_ = q_ * other.q_;
+    R_ = R_ * other.R_;
+    return *this;
+  }
+
+  /**
+   * @brief Implements the SO3 composition this = other * this
+   *
+   * @param other SO3 group element
+   *
+   * @return SO3 group element
+   */
+  const SO3& multiplyLeft(const SO3& other)
+  {
+    q_ = other.q_ * q_;
+    R_ = other.R_ * R_;
+    return *this;
+  }
+
+  /**
+   * @brief Get a constant copy of the inverse of the SO3 object
+   *
+   * @return SO3 group element
+   */
+  [[nodiscard]] const SO3 inv() const { return SO3(q_.inverse()); }
+
+  /**
+   * @brief Get a constant reference to the SO3 rotation matrix
+   *
+   * @return Rotation matrix
+   */
+  [[nodiscard]] const MatrixType& R() const { return R_; }
+
+  /**
+   * @brief Get a constant reference to the SO3 normalized quaternion
+   *
+   * @return Quaternion
+   */
+  [[nodiscard]] const QuaternionType& q() const { return q_; }
+
+  /**
+   * @brief Get a constant reference to the SO3 object as a matrix
+   *
+   * @return SO3 group element in matrix form
+   */
+  [[nodiscard]] const MatrixType& asMatrix() const { return R_; }
+
+  /**
+   * @brief Set SO3 object value from a given normalized quaternion
+   *
+   * @param q quaternion
+   */
+  void fromq(const QuaternionType& q)
+  {
+    q_ = q;
+    R_ = q.toRotationMatrix();
+
+    if (!isNormalized())
+    {
+      normalize();
+    }
+  }
+
+  /**
+   * @brief Set SO3 object value from given rotation matrix
+   *
+   * @param R rotation matrix
+   */
+  void fromR(const MatrixType& R)
+  {
+    q_ = R;
+    R_ = R;
+
+    if (!isNormalized())
+    {
+      normalize();
+    }
+  }
+
+  /**
+   * @brief SO3 Adjoint matrix
+   *
+   * @return SO3 group Adjoint matrix
+   */
+  [[nodiscard]] const TMatrixType Adjoint() const { return R_; }
+
+  /**
+   * @brief SO3 Inverse Adjoint matrix
+   *
+   * @return SO3 group inverse Adjoint matrix
+   */
+  [[nodiscard]] const TMatrixType invAdjoint() const { return R_.transpose(); }
+
+ protected:
+  /**
+   * @brief Check that q_ is a normalized quaternion
+   *
+   * @return true if q_ is normalized
+   */
+  [[nodiscard]] bool isNormalized() { return std::abs(q_.norm() - 1.0) < eps_; }
+
+  /**
+   * @brief Normalize the quaternion and update the rotation matrix
+   */
+  void normalize()
+  {
+    q_.normalize();
+    R_ = q_.toRotationMatrix();
+  }
+
+  MatrixType R_;      //!< Rotation matrix
+  QuaternionType q_;  //!< Normalized quaternion
+
+  static constexpr FPType eps_ = std::is_same_v<FPType, float> ? 1.0e-6 : 1.0e-9;  //!< Epsilon
+};
+
+using SO3d = SO3<double>;  //!< The SO3 group with double precision floating point
+using SO3f = SO3<float>;   //!< The SO3 group with single precision floating point
+
+}  // namespace group
+
+#endif  // SO3_HPP


### PR DESCRIPTION
First phase of a fourth INS estimator, sibling to OU-III: the same physics
carried on a right-invariant two-frame Lie group rather than a quaternion
MEKF with additive translational states. This lands the group mathematics
only -- no estimator code yet, so retraction defects stay separable from the
filter defects that come later.

The group puts the four world vectors and the two body-frame biases into one
structure with attitude:

    (R1,X1,B1) o (R2,X2,B2) = ( R1 R2, X1 + R1 X2, B2 + R2^T B1 )

The asymmetry in the last slot is the point. World vectors are carried by R,
body vectors by R^T from the other side, which a direct product SE_4(3) x R^6
cannot express. E_B = J_l(-phi) on the bias block is derived rather than
chosen: the law induces b'(s) = beta - [phi]x b(s), whose solution at s = 1 is
Exp(-phi) J_l(phi) = J_r(phi) = J_l(-phi).

Tangent offsets deliberately match Kalman3D_Wave_OU_III, so the 12x12 world
block stays contiguous and the scalar-loop propagation and Joseph blocks will
port over at the same indices.

Conventions are fixed as a contract of three parts, because stating fewer is
how this gets implemented backwards: R = R_bw, right-invariant error
eta = Xhat X^-1, and left-multiplicative correction. "Right-invariant"
describes the error, not the side the correction lands on. convention-test
asserts all three including the negatives -- the error must not survive left
multiplication, and left and right retraction must differ for a generic
element -- since a degenerate definition satisfies the positives trivially.

It also pins the OU-III bridge, which is sharper than a sign flip. OU-III
stores C = R_wb and injects on the left, so with R = C^T the same physical
rotation becomes R+ = R- Exp(-dtheta) = Exp(-R- dtheta) R-, giving
phi = -R- dtheta. Both naive forms agree to first order at R- = I, so the
test asserts they fail away from identity rather than only checking the
correct one.

Validation uses two independent references, since finite differences alone
share their assumptions with the code under test. Lie++ (vendored, test-only)
covers the world block to 1e-12; the bias block, which its SemiDirectBias
cannot represent, is pinned by the one-parameter subgroup property, exp/log
round trips, the exact adjoint relation, and J_l by Simpson quadrature. The
suite runs at double and at float.

Small-angle branches are checked against a long double closed form rather
than by comparing f(seam-eps) to f(seam+eps): those are different arguments,
so that comparison measures the slope of f, not a branch jump.

Every check was confirmed to fail under deliberate mutation -- bias Jacobian
sign 182 failures, retraction side 200, compose transpose 529, Exp handedness
253, a 0.1% J_l coefficient error 228.

Lie++ stays out of src/ on purpose: it includes <Eigen/Dense> directly and
materializes dense (3+3n)x(3+3n) matrices, while firmware routes through
ArduinoEigenDense.h and this codebase already keeps fixed-size Eigen
instantiations small against cc1plus OOM. A float-only proxy of the firmware
translation unit compiles to 7.7 KB of text.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01T9aDUvqetsX7jojWiDumAf