### PR TITLE
Put the world vectors on the group: TFG filter at Level 1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,3 +47,5 @@ add_executable(lie_group-test "${OCEAN_IMU_TESTS_DIR}/kalman_tfg/lie_group-test.
 add_executable(convention-test "${OCEAN_IMU_TESTS_DIR}/kalman_tfg/convention-test.cpp")
 target_include_directories(lie_group-test SYSTEM PRIVATE
   "${CMAKE_CURRENT_SOURCE_DIR}/third_party/Lie-plusplus/include")
+add_executable(ou_chain_identity-test "${OCEAN_IMU_TESTS_DIR}/kalman_tfg/ou_chain_identity-test.cpp")
+add_executable(tfg_propagation-test "${OCEAN_IMU_TESTS_DIR}/kalman_tfg/tfg_propagation-test.cpp")

--- a/src/kalman_tfg/Kalman3D_Wave_TFG.h
+++ b/src/kalman_tfg/Kalman3D_Wave_TFG.h
@@ -1,0 +1,637 @@
+#pragma once
+
+/*
+    Copyright (c) 2025-2026  Mikhail Grushinskiy
+
+    Right-invariant two-frame Lie-group error-state EKF for marine wave state.
+
+    Same physics as Kalman3D_Wave_OU_III -- Ornstein-Uhlenbeck world
+    acceleration, the v -> p -> S integral chain, random-walk biases -- but
+    carried on the two-frame group in src/lie/TwoFrameGroup.h instead of a
+    quaternion MEKF with additive translational states.
+
+    CONVENTION CONTRACT (see docs/tfg-design.md; three parts, always together):
+
+        1. rotation direction : R = R_bw, body to world
+        2. error definition   : right-invariant, eta = Xhat o X^-1
+        3. correction side    : left, Xhat+ = Exp_G(dxi) o Xhat-
+
+    The public accessors keep OU-III's API. quaternion() returns body-to-world,
+    exactly as Kalman3D_Wave_OU_III::quaternion() does (it conjugates its
+    world-to-body qref to get there; this filter already stores that
+    direction). So IW3dFusionAdapter, FilterSnapshot, the plots and the
+    sketches see no change.
+
+    STATE, in OU-III's ordering so the world block stays contiguous and the
+    block structure lines up index-for-index:
+
+        xi = [ phi | delta_bg | rho_v rho_p rho_S rho_a | delta_ba ]
+               0     3          6     9     12    15      18
+
+    ------------------------------------------------------------------------
+    ERROR DYNAMICS (Level 1: world vectors on the group, additive bias errors)
+    ------------------------------------------------------------------------
+
+    Attitude. With Rdot = R [w_m - b_g - n_g]x and Rhatdot = Rhat [w_m - bhat_g]x,
+    and delta_bg = bhat_g - b_g in the body frame,
+
+        d(dR)/dt = Rhat ( [w_m - bhat_g]x - [w_m - b_g - n_g]x ) R^T
+                 = Rhat [ -delta_bg + n_g ]x R^T
+
+    and since Rhat [u]x Rhat^T = [Rhat u]x, to first order
+
+        phidot = -Rhat delta_bg + Rhat n_g                                 (1)
+
+    Note what is NOT there: no [w]x phi term. The attitude error is driftless
+    in this parameterization, which is the structural gain over the MEKF -- it
+    is why Phi_phi,phi = I here where OU-III needs an exact Rstep.
+
+    World vectors. With rho_x = xhat - dR x and d(dR)/dt = [phidot]x dR,
+
+        rho_xdot = xhatdot - [phidot]x x - dR xdot
+                 = (chain term) + [x]x phidot                              (2)
+
+    using -[u]x x = [x]x u. Substituting (1), every world vector picks up the
+    gyro bias through -[x]x Rhat. The chain terms are the OU chain itself:
+
+        rho_vdot = rho_a,  rho_pdot = rho_v,  rho_Sdot = rho_p,
+        rho_adot = -lambda rho_a
+
+    which is exactly what ou_detail::IntegratedOUChain<T,3> already
+    discretizes. That is the reuse this design is built around: the world
+    block of Phi and Qd is the OU-III code, unmodified, and
+    ou_chain_identity-test asserts it bit for bit.
+
+    ------------------------------------------------------------------------
+    DISCRETIZATION
+    ------------------------------------------------------------------------
+
+    The continuous generator is block lower triangular in (phi, delta_bg,
+    world), with A_phi,phi = 0 and A_bg,bg = 0. That makes several blocks
+    exactly integrable rather than truncated:
+
+        Phi_phi,phi   = I
+        Phi_phi,bg    = -Rbar h                        exact
+        Phi_bg,bg     = I
+        Phi_world     = Phi_OU(h, tau)                 exact, IntegratedOUChain
+        Phi_world,bg  = -Psi(h, tau) [x]x Rbar
+        Phi_world,phi = 0
+
+    where Psi(h,tau) = int_0^h Phi_OU(u) du, in closed form with Taylor
+    branches (integral_transition_axis below).
+
+    Rbar is the *average* body-to-world rotation over the step, not Rhat at
+    its start. This matters and is easy to get wrong. The attitude propagates
+    as Rhat(s) = Rhat Exp(w s) while (1) says phidot = -Rhat(s) delta_bg, so
+
+        phi(h) = phi(0) - ( int_0^h Rhat Exp(w s) ds ) delta_bg
+               = phi(0) - Rhat h J_l(w h) delta_bg
+
+    using J_l(theta) = int_0^1 Exp(u theta) du. So Rbar = Rhat J_l(w h). Using
+    Rhat alone costs a relative error of order |w| h -- 0.25% at 1 rad/s and a
+    5 ms step, small but well above the tolerance a finite-difference check
+    should be run at, and it grows with turn rate exactly when attitude and
+    bias are hardest to separate.
+
+    Doing Phi exactly rather than truncating at h^2 is what lets
+    tfg_propagation-test run at a tight tolerance and at large h, instead of
+    being loosened until it stops discriminating. Phi_world,bg keeps one
+    documented approximation: it uses the step-averaged Rbar rather than
+    correlating Rhat(s)'s variation with the Phi_OU weighting and with the
+    drift of x(s) across the step. Both neglected effects are O((|w| h)^2) and
+    O(h) on a term that is already a product of two small quantities.
+
+    Qd is assembled blockwise. The world block carries the exact OU
+    contribution from IntegratedOUChain; the attitude and bias blocks carry
+    the exactly integrated bias random-walk terms (h^2/2 and h^3/3); the gyro
+    white-noise leakage into the world vectors is first order in h. That last
+    truncation is deliberate and matches the surrounding code's standard --
+    Kalman3D_Wave_OU_III.h:1560 does the same, and Qd magnitudes are tuned
+    quantities, unlike Phi which has to match the propagation it linearizes.
+
+    ------------------------------------------------------------------------
+
+    Scalar-templated: firmware runs float, tests run double.
+*/
+
+#ifdef EIGEN_NON_ARDUINO
+#include <Eigen/Dense>
+#else
+#include <ArduinoEigenDense.h>
+#endif
+
+#include <algorithm>
+#include <cmath>
+
+#include "kalman_ou_common/KalmanOUCoreMath.h"
+#include "lie/SO3Jacobians.h"
+#include "lie/TwoFrameGroup.h"
+
+namespace ocean_imu::kalman {
+
+namespace tfg_detail {
+
+using ocean_imu::kalman::ou_detail::safe_inv_tau;
+
+/*
+    Psi(h, tau) = int_0^h Phi_OU(u) du for one axis, where Phi_OU is the 4x4
+    [v p S a] transition of IntegratedOUChain<T,3>.
+
+    Closed forms, with x = h/tau:
+
+        Psi_00 = h            Psi_10 = h^2/2        Psi_20 = h^3/6
+        Psi_11 = h            Psi_21 = h^2/2        Psi_22 = h
+        Psi_33 = -tau expm1(-x)
+        Psi_03 = tau^2 ( expm1(-x) + x )
+        Psi_13 = tau^3 ( x^2/2 - expm1(-x) - x )
+        Psi_23 = tau^4 ( x^3/6 - x^2/2 + expm1(-x) + x )
+
+    The last three cancel to O(x^2), O(x^3), O(x^4) respectively, so the
+    direct forms lose all significance for small steps -- at h/tau = 1e-3,
+    Psi_23's leading term is 1e-12 of the quantities being subtracted. Hence
+    the Taylor branch, on the same 1e-2 threshold the rest of the codebase
+    uses.
+*/
+template<typename T>
+inline void integral_transition_axis(T tau, T h, Eigen::Matrix<T,4,4>& Psi) {
+    const T inv_tau = safe_inv_tau(tau);
+    const T x = h * inv_tau;
+    const T tau2 = tau * tau;
+    const T tau3 = tau2 * tau;
+    const T tau4 = tau3 * tau;
+
+    Psi.setZero();
+    Psi(0,0) = h;
+    Psi(1,0) = T(0.5) * h * h;
+    Psi(2,0) = h * h * h / T(6);
+    Psi(1,1) = h;
+    Psi(2,1) = T(0.5) * h * h;
+    Psi(2,2) = h;
+
+    if (std::abs(x) < T(1e-2)) {
+        const T x2 = x * x, x3 = x2 * x, x4 = x3 * x, x5 = x4 * x;
+        const T x6 = x5 * x, x7 = x6 * x, x8 = x7 * x;
+        // Each series starts one power later than the one above it, so the
+        // number of terms needed to reach a given relative accuracy is the
+        // same in every case but the absolute order climbs. Psi_23's leading
+        // term is x^4/24, and its first dropped term sets the error: stopping
+        // at x^6 leaves x^3/210 relative, which is 4.6e-9 right at the 1e-2
+        // seam -- measurable, so it is carried to x^8.
+        // -tau expm1(-x) = tau (x - x^2/2 + x^3/6 - ...)
+        Psi(3,3) = tau  * (x - x2/T(2) + x3/T(6) - x4/T(24) + x5/T(120) - x6/T(720));
+        // expm1(-x) + x = x^2/2 - x^3/6 + x^4/24 - ...
+        Psi(0,3) = tau2 * (x2/T(2) - x3/T(6) + x4/T(24) - x5/T(120) + x6/T(720)
+                           - x7/T(5040));
+        // x^2/2 - expm1(-x) - x = x^3/6 - x^4/24 + ...
+        Psi(1,3) = tau3 * (x3/T(6) - x4/T(24) + x5/T(120) - x6/T(720)
+                           + x7/T(5040) - x8/T(40320));
+        // x^3/6 - x^2/2 + expm1(-x) + x = x^4/24 - x^5/120 + ...
+        Psi(2,3) = tau4 * (x4/T(24) - x5/T(120) + x6/T(720) - x7/T(5040)
+                           + x8/T(40320));
+    } else {
+        const T em1 = std::expm1(-x);
+        const T x2 = x * x, x3 = x2 * x;
+        Psi(3,3) = -tau  * em1;
+        Psi(0,3) =  tau2 * (em1 + x);
+        Psi(1,3) =  tau3 * (x2/T(2) - em1 - x);
+        Psi(2,3) =  tau4 * (x3/T(6) - x2/T(2) + em1 + x);
+    }
+}
+
+} // namespace tfg_detail
+
+/*
+    two_frame_bias selects the bias geometry:
+
+      false (Level 1) -- world vectors on SE_4(3), bias errors additive in the
+                         body frame. Implemented and tested here.
+      true  (Level 2) -- full two-frame group, beta_b = R (bhat - b).
+                         Lands in Phase D; static_asserted until then so no
+                         unverified path can be instantiated by accident.
+*/
+template <typename T = float,
+          bool with_gyro_bias = true,
+          bool with_accel_bias = true,
+          bool two_frame_bias = false>
+class Kalman3D_Wave_TFG {
+    static_assert(with_gyro_bias,
+                  "the two-frame tangent layout pins the gyro bias at offset 3; "
+                  "a no-gyro-bias variant would need its own layout");
+    static_assert(!two_frame_bias,
+                  "Level 2 (two-frame bias geometry) is not implemented yet; "
+                  "instantiate with two_frame_bias = false");
+
+  public:
+    using Group   = ocean_imu::lie::TwoFrameGroup<T, 4, with_accel_bias ? 2 : 1>;
+    using Scalar  = T;
+    using Vector3 = Eigen::Matrix<T,3,1>;
+    using Matrix3 = Eigen::Matrix<T,3,3>;
+
+    static constexpr int NX = Group::NX;               // 21, or 18 without b_a
+
+    static constexpr int OFF_PHI = Group::OFF_PHI;     // 0
+    static constexpr int OFF_BG  = Group::OFF_BG;      // 3
+    static constexpr int OFF_V   = Group::world_offset(0);   // 6
+    static constexpr int OFF_P   = Group::world_offset(1);   // 9
+    static constexpr int OFF_S   = Group::world_offset(2);   // 12
+    static constexpr int OFF_AW  = Group::world_offset(3);   // 15
+    static constexpr int OFF_BA  = with_accel_bias ? Group::OFF_BA : -1;  // 18
+
+    using MatrixNX = Eigen::Matrix<T,NX,NX>;
+    using Tangent  = Eigen::Matrix<T,NX,1>;
+
+    static constexpr T STD_GRAVITY = T(9.80665);
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+    explicit Kalman3D_Wave_TFG(T gyro_noise_density_rad_sqrt_s = T(0.005),
+                               T gravity_magnitude = STD_GRAVITY)
+        : gravity_magnitude_(gravity_magnitude) {
+        set_gyro_noise_density_rad_sqrt_s(gyro_noise_density_rad_sqrt_s);
+        P_.setIdentity();
+        P_ *= T(1e-4);
+    }
+
+    // ---------------------------------------------------------------- state
+
+    void initialize_identity() {
+        X_ = Group::Identity();
+        P_.setIdentity();
+        P_ *= T(1e-4);
+    }
+
+    // Truth injection, for tests and for the paired simulator.
+    void initialize_from_truth(const Eigen::Quaternion<T>& q_bw,
+                               const Vector3& v, const Vector3& p,
+                               const Vector3& S, const Vector3& a_w,
+                               const Vector3& b_g = Vector3::Zero(),
+                               const Vector3& b_a = Vector3::Zero()) {
+        Eigen::Quaternion<T> q = q_bw;
+        q.normalize();
+        X_.R = q.toRotationMatrix();
+        X_.X.col(0) = v;
+        X_.X.col(1) = p;
+        X_.X.col(2) = S;
+        X_.X.col(3) = a_w;
+        X_.B.col(0) = b_g;
+        if constexpr (with_accel_bias) X_.B.col(1) = b_a;
+    }
+
+    // --------------------------------------------------------- accessors
+    // Deliberately the same shapes and frames as Kalman3D_Wave_OU_III, so the
+    // two filters are drop-in comparable in the simulator and the plots.
+
+    // BODY -> WORLD, matching Kalman3D_Wave_OU_III::quaternion().
+    [[nodiscard]] Eigen::Quaternion<T> quaternion() const {
+        Eigen::Quaternion<T> q(X_.R);
+        q.normalize();
+        return q;
+    }
+    [[nodiscard]] Matrix3 R_bw() const { return X_.R; }
+    [[nodiscard]] Matrix3 R_wb() const { return X_.R.transpose(); }
+
+    [[nodiscard]] Vector3 get_velocity() const             { return X_.X.col(0); }
+    [[nodiscard]] Vector3 get_position() const             { return X_.X.col(1); }
+    [[nodiscard]] Vector3 get_integral_displacement() const{ return X_.X.col(2); }
+    [[nodiscard]] Vector3 get_world_accel() const          { return X_.X.col(3); }
+    [[nodiscard]] Vector3 gyroscope_bias() const           { return X_.B.col(0); }
+    [[nodiscard]] Vector3 get_acc_bias() const {
+        if constexpr (with_accel_bias) return X_.B.col(1);
+        else return Vector3::Zero();
+    }
+
+    [[nodiscard]] const MatrixNX& covariance_full() const { return P_; }
+    [[nodiscard]] MatrixNX& covariance_full() { return P_; }
+    [[nodiscard]] const Group& state() const { return X_; }
+    [[nodiscard]] Group& state() { return X_; }
+
+    // ------------------------------------------------------------- tuning
+
+    void set_aw_time_constant(T tau) { tau_aw_ = std::max(T(1e-3), tau); }
+    [[nodiscard]] T aw_time_constant() const { return tau_aw_; }
+
+    void set_aw_stationary_std(const Vector3& sigma) {
+        Sigma_aw_ = sigma.cwiseAbs2().asDiagonal();
+    }
+    void set_aw_stationary_cov_full(const Matrix3& Sigma) {
+        Sigma_aw_ = T(0.5) * (Sigma + Sigma.transpose());
+    }
+    [[nodiscard]] const Matrix3& aw_stationary_cov() const { return Sigma_aw_; }
+
+    void set_gyro_noise_density_rad_sqrt_s(T density) {
+        const T d = std::max(T(0), density);
+        Q_gyro_ = Matrix3::Identity() * (d * d);
+    }
+    void set_Q_bgyro_rw(const Vector3& var_per_s) {
+        Q_bg_ = var_per_s.cwiseAbs().asDiagonal();
+    }
+    void set_Q_bacc_rw(const Vector3& var_per_s) {
+        Q_ba_ = var_per_s.cwiseAbs().asDiagonal();
+    }
+
+    void set_initial_linear_uncertainty(T std_v, T std_p, T std_S, T std_aw) {
+        P_.template block<12,12>(OFF_V, OFF_V).setZero();
+        const T d[4] = {std_v*std_v, std_p*std_p, std_S*std_S, std_aw*std_aw};
+        for (int c = 0; c < 4; ++c) {
+            for (int k = 0; k < 3; ++k) P_(OFF_V + 3*c + k, OFF_V + 3*c + k) = d[c];
+        }
+    }
+
+    // --------------------------------------------------------- propagation
+
+    /*
+        Nominal (mean) propagation.
+
+            Rhat+   = Rhat Exp((w_m - bhat_g) h)
+            [v p S a_w]+ = Phi_OU applied per axis
+            biases held constant
+
+        R is body-to-world and the rate is body-frame, so the rotation
+        increment multiplies on the RIGHT here. That is not in tension with
+        the left-multiplicative *correction*: propagation moves the nominal
+        state along the trajectory, while a correction acts on the error,
+        which lives in the world frame. Mixing the two up is the single
+        easiest way to get this filter subtly wrong.
+    */
+    void propagate_mean(const Vector3& gyro_meas, T Ts) {
+        if (!(Ts > T(0)) || !std::isfinite(Ts)) return;
+
+        const Vector3 omega = gyro_meas - X_.B.col(0);
+        last_omega_ = omega;
+
+        X_.R = X_.R * ocean_imu::lie::Exp<T>(Vector3(omega * Ts));
+        reorthonormalize_();
+
+        Eigen::Matrix<T,4,4> Phi_axis;
+        ou_detail::IntegratedOUChain<T,3>::transition(tau_aw_, Ts, Phi_axis);
+        // Row i of X is [v_i p_i S_i a_i], so applying the per-axis 4x4 to
+        // every row at once is a right multiplication by its transpose.
+        X_.X = (X_.X * Phi_axis.transpose()).eval();
+    }
+
+    /*
+        Discrete transition of the right-invariant error, assembled blockwise.
+        Exposed so tfg_propagation-test can check it against finite
+        differences of the nonlinear propagation, and ou_chain_identity-test
+        can check the world block against IntegratedOUChain directly.
+    */
+    void build_transition(T Ts, const Vector3& gyro_meas, MatrixNX& Phi) const {
+        Phi.setIdentity();
+
+        // Step-averaged body-to-world rotation: (1/h) int_0^h Rhat Exp(w s) ds
+        // = Rhat J_l(w h). See the header note -- using Rhat alone is wrong at
+        // order |w| h.
+        const Vector3 omega = gyro_meas - X_.B.col(0);
+        const Matrix3 Rbar =
+            X_.R * ocean_imu::lie::left_jacobian<T>(Vector3(omega * Ts));
+
+        // Attitude <- gyro bias. Exact: A_phi,phi = 0 and A_bg,bg = 0.
+        Phi.template block<3,3>(OFF_PHI, OFF_BG) = -Rbar * Ts;
+
+        // World block: the OU chain, exact, per axis.
+        Eigen::Matrix<T,4,4> Phi_axis;
+        ou_detail::IntegratedOUChain<T,3>::transition(tau_aw_, Ts, Phi_axis);
+        Phi.template block<12,12>(OFF_V, OFF_V).setZero();
+        for (int i = 0; i < 4; ++i) {
+            for (int j = 0; j < 4; ++j) {
+                if (Phi_axis(i,j) == T(0)) continue;
+                for (int k = 0; k < 3; ++k) {
+                    Phi(OFF_V + 3*i + k, OFF_V + 3*j + k) = Phi_axis(i,j);
+                }
+            }
+        }
+
+        // World <- gyro bias:  Phi_world,bg = -Psi(h) [x]x Rbar, stacked over
+        // the world columns x in {v, p, S, a_w}. This is where rho_xdot picks
+        // up +[x]x phidot from (2).
+        Eigen::Matrix<T,4,4> Psi;
+        tfg_detail::integral_transition_axis<T>(tau_aw_, Ts, Psi);
+        Matrix3 Gx[4];
+        for (int c = 0; c < 4; ++c) {
+            Gx[c] = -ocean_imu::lie::skew<T>(Vector3(X_.X.col(c))) * Rbar;
+        }
+        for (int i = 0; i < 4; ++i) {
+            Matrix3 acc = Matrix3::Zero();
+            for (int j = 0; j < 4; ++j) {
+                if (Psi(i,j) != T(0)) acc.noalias() += Psi(i,j) * Gx[j];
+            }
+            Phi.template block<3,3>(OFF_V + 3*i, OFF_BG) = acc;
+        }
+
+        // Accelerometer bias is a pure random walk and does not enter the
+        // propagation of anything else -- it only shows up in the
+        // accelerometer measurement, which is Phase C.
+    }
+
+    /*
+        Discrete process noise.
+
+        World block: exact, from IntegratedOUChain, including the correlated
+        vector-OU assembly when Sigma_aw is not diagonal.
+
+        Attitude and gyro-bias blocks: exactly integrated, since
+        Phi_phi,bg(s) = -Rhat (h - s) is exact --
+
+            Q_phi,phi += W h + Rhat Q_bg Rhat^T h^3/3
+            Q_phi,bg   = -Rhat Q_bg h^2/2
+            Q_bg,bg    = Q_bg h                with W = Rhat Q_gyro Rhat^T
+
+        Gyro white noise leaking into the world vectors is first order in h.
+        See the header note on why that truncation is deliberate.
+    */
+    void build_process_noise(T Ts, MatrixNX& Qd) const {
+        Qd.setZero();
+        if (!(Ts > T(0)) || !std::isfinite(Ts)) return;
+
+        const Matrix3 Rhat = X_.R;
+        const Matrix3 W  = Rhat * Q_gyro_ * Rhat.transpose();   // world-frame gyro noise
+        const Matrix3 Wb = Rhat * Q_bg_   * Rhat.transpose();
+
+        const T h2 = Ts * Ts;
+        const T h3 = h2 * Ts;
+
+        // Attitude / gyro-bias.
+        Qd.template block<3,3>(OFF_PHI, OFF_PHI) = W * Ts + Wb * (h3 / T(3));
+        Qd.template block<3,3>(OFF_PHI, OFF_BG)  = -(Rhat * Q_bg_) * (h2 / T(2));
+        Qd.template block<3,3>(OFF_BG, OFF_PHI)  =
+            Qd.template block<3,3>(OFF_PHI, OFF_BG).transpose();
+        Qd.template block<3,3>(OFF_BG, OFF_BG)   = Q_bg_ * Ts;
+
+        // Gyro white noise into the world vectors, via rho_xdot = ... + [x]x phidot.
+        Matrix3 Sx[4];
+        for (int c = 0; c < 4; ++c) Sx[c] = ocean_imu::lie::skew<T>(Vector3(X_.X.col(c)));
+        for (int i = 0; i < 4; ++i) {
+            const Matrix3 SiW = Sx[i] * W;
+            Qd.template block<3,3>(OFF_PHI, OFF_V + 3*i) += (W * Sx[i].transpose()) * Ts;
+            Qd.template block<3,3>(OFF_V + 3*i, OFF_PHI) += (SiW) * Ts;
+            for (int j = 0; j < 4; ++j) {
+                Qd.template block<3,3>(OFF_V + 3*i, OFF_V + 3*j) +=
+                    (SiW * Sx[j].transpose()) * Ts;
+            }
+        }
+
+        // World block: the exact OU contribution, added on top.
+        add_ou_process_noise_(Ts, Qd);
+
+        if constexpr (with_accel_bias) {
+            Qd.template block<3,3>(OFF_BA, OFF_BA) = Q_ba_ * Ts;
+        }
+
+        Qd = T(0.5) * (Qd + Qd.transpose()).eval();
+        ou_detail::project_psd_ou_iii<T,NX>(Qd);
+    }
+
+    /*
+        Right-invariant error of this state relative to a reference, in the
+        same TANGENT coordinates that inject() consumes and that P is
+        expressed in. Exact inverse of inject().
+
+            phi        = Log(Rhat R^T)
+            rho_group  = xhat - Exp(phi) x
+            xi_rho     = J_l(phi)^-1 rho_group
+            xi_db      = bhat - b               (additive, body frame)
+
+        The J_l inverse is the part that is easy to drop, and dropping it is
+        not harmless. There are two different objects here:
+
+          - the group element eta = Xhat o X^-1, whose world components are
+            rho_group = xhat - dR x;
+          - its tangent coordinates xi = Log_G(eta), whose world components
+            are J_l(phi)^-1 rho_group.
+
+        The covariance lives on the tangent, and the retraction is Exp_G, so
+        the injection multiplies by J_l. Returning rho_group here instead
+        would make error_from and inject differ by exactly J_l -- agreeing to
+        first order, so every small-perturbation check would still pass, while
+        finite-difference Jacobians at usable step sizes and NEES at realistic
+        error magnitudes would both be quietly wrong.
+    */
+    [[nodiscard]] Tangent error_from(const Kalman3D_Wave_TFG& reference) const {
+        Tangent xi;
+        xi.setZero();
+
+        const Vector3 phi = ocean_imu::lie::Log<T>(
+            Matrix3(X_.R * reference.X_.R.transpose()));
+        const Matrix3 dR  = ocean_imu::lie::Exp<T>(phi);
+        const Matrix3 Jli = ocean_imu::lie::inv_left_jacobian<T>(phi);
+        xi.template segment<3>(OFF_PHI) = phi;
+
+        for (int c = 0; c < 4; ++c) {
+            xi.template segment<3>(OFF_V + 3*c) =
+                Jli * (X_.X.col(c) - dR * reference.X_.X.col(c));
+        }
+        xi.template segment<3>(OFF_BG) = X_.B.col(0) - reference.X_.B.col(0);
+        if constexpr (with_accel_bias) {
+            xi.template segment<3>(OFF_BA) = X_.B.col(1) - reference.X_.B.col(1);
+        }
+        return xi;
+    }
+
+    void time_update(const Vector3& gyro_meas, T Ts) {
+        if (!(Ts > T(0)) || !std::isfinite(Ts)) return;
+
+        MatrixNX Phi, Qd;
+        build_transition(Ts, gyro_meas, Phi);
+        build_process_noise(Ts, Qd);
+
+        propagate_mean(gyro_meas, Ts);
+
+        P_ = (Phi * P_ * Phi.transpose()).eval();
+        P_ += Qd;
+        P_ = T(0.5) * (P_ + P_.transpose()).eval();
+    }
+
+    // ---------------------------------------------------------- correction
+
+    /*
+        State injection, Xhat+ = Exp_G(xi) o Xhat-.
+
+        At Level 1 the world part is the group retraction and the bias part is
+        additive in the body frame. Level 2 replaces the bias line with the
+        two-frame transport in Phase D; the split is here rather than in
+        TwoFrameGroup so the group stays a pure Level-2 object.
+
+        Note what is deliberately absent: there is no MEKF-style covariance
+        reset (ou_detail::apply_left_error_reset). The invariant update already
+        leaves P in the post-update tangent frame, and applying
+        G = I + 0.5 [dtheta]x on top would double-correct it.
+    */
+    void inject(const Tangent& xi) {
+        const Vector3 phi = xi.template segment<3>(OFF_PHI);
+        const Matrix3 E_R = ocean_imu::lie::Exp<T>(phi);
+        const Matrix3 Jl  = ocean_imu::lie::left_jacobian<T>(phi);
+
+        Eigen::Matrix<T,3,4> rho;
+        for (int c = 0; c < 4; ++c) rho.col(c) = xi.template segment<3>(OFF_V + 3*c);
+
+        X_.X = (E_R * X_.X + Jl * rho).eval();
+        X_.R = (E_R * X_.R).eval();
+        reorthonormalize_();
+
+        if constexpr (!two_frame_bias) {
+            X_.B.col(0) += xi.template segment<3>(OFF_BG);
+            if constexpr (with_accel_bias) X_.B.col(1) += xi.template segment<3>(OFF_BA);
+        }
+    }
+
+  private:
+    void reorthonormalize_() {
+        // Cheaper and better conditioned than a QR: round-trip through the
+        // quaternion, which is what the surrounding filters store anyway.
+        Eigen::Quaternion<T> q(X_.R);
+        q.normalize();
+        X_.R = q.toRotationMatrix();
+    }
+
+    // Exact OU process noise for [v p S a_w], reusing OU-III's assembly
+    // including the correlated-axis Kronecker path.
+    void add_ou_process_noise_(T Ts, MatrixNX& Qd) const {
+        const bool correlated = !ou_detail::is_isotropic3<T>(Sigma_aw_) &&
+                                !is_diagonal_(Sigma_aw_);
+
+        if (correlated) {
+            Eigen::Matrix<T,4,4> Q_unit;
+            ou_detail::IntegratedOUChain<T,3>::process_covariance(tau_aw_, Ts, T(1), Q_unit);
+            Q_unit = T(0.5) * (Q_unit + Q_unit.transpose()).eval();
+            const Matrix3 Sig = T(0.5) * (Sigma_aw_ + Sigma_aw_.transpose());
+            for (int i = 0; i < 4; ++i) {
+                for (int j = 0; j < 4; ++j) {
+                    Qd.template block<3,3>(OFF_V + 3*i, OFF_V + 3*j).noalias()
+                        += Sig * Q_unit(i,j);
+                }
+            }
+        } else {
+            for (int axis = 0; axis < 3; ++axis) {
+                Eigen::Matrix<T,4,4> Q_axis;
+                ou_detail::IntegratedOUChain<T,3>::process_covariance(
+                    tau_aw_, Ts, Sigma_aw_(axis,axis), Q_axis);
+                for (int i = 0; i < 4; ++i) {
+                    for (int j = 0; j < 4; ++j) {
+                        Qd(OFF_V + 3*i + axis, OFF_V + 3*j + axis) += Q_axis(i,j);
+                    }
+                }
+            }
+        }
+    }
+
+    static bool is_diagonal_(const Matrix3& M) {
+        Matrix3 off = M;
+        off.diagonal().setZero();
+        return off.cwiseAbs().maxCoeff() <= T(1e-12) * std::max(T(1), M.cwiseAbs().maxCoeff());
+    }
+
+    T gravity_magnitude_;
+
+    Group   X_{};
+    MatrixNX P_{MatrixNX::Identity()};
+
+    T       tau_aw_{T(1.0)};
+    Matrix3 Sigma_aw_{Matrix3::Identity()};
+    Matrix3 Q_gyro_{Matrix3::Identity() * T(2.5e-5)};
+    Matrix3 Q_bg_{Matrix3::Identity() * T(1e-10)};
+    Matrix3 Q_ba_{Matrix3::Identity() * T(2.5e-7)};
+
+    Vector3 last_omega_{Vector3::Zero()};
+};
+
+} // namespace ocean_imu::kalman

--- a/tests/kalman_tfg/Makefile
+++ b/tests/kalman_tfg/Makefile
@@ -24,7 +24,7 @@ LDFLAGS  =
 # Tell make to look for source files in src/util
 VPATH = $(REPO_ROOT)/src/util
 
-TARGETS = lie_group-test convention-test
+TARGETS = lie_group-test convention-test ou_chain_identity-test tfg_propagation-test
 
 all: build test
 
@@ -40,6 +40,12 @@ lie_group-test: lie_group-test.o
 	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
 
 convention-test: convention-test.o
+	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
+
+ou_chain_identity-test: ou_chain_identity-test.o
+	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
+
+tfg_propagation-test: tfg_propagation-test.o
 	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
 
 # -MMD -MP records the headers each object depends on, so editing a group or

--- a/tests/kalman_tfg/ou_chain_identity-test.cpp
+++ b/tests/kalman_tfg/ou_chain_identity-test.cpp
@@ -1,0 +1,300 @@
+/*
+    Copyright (c) 2025-2026  Mikhail Grushinskiy
+
+    The OU chain must be *shared* with OU-III, not re-derived.
+
+    The whole argument for this filter's discretization is that the
+    right-invariant error of the world vectors obeys the same linear chain the
+    existing article already derives and validates:
+
+        rho_vdot = rho_a,  rho_pdot = rho_v,  rho_Sdot = rho_p,
+        rho_adot = -lambda rho_a
+
+    If that is true, the 12x12 world block of Phi and Qd is
+    ou_detail::IntegratedOUChain<T,3> unchanged -- the analytic coefficients,
+    the small-h/tau Maclaurin branch, the correlated-axis assembly, and the
+    PSD handling all carry over, along with the evidence already gathered for
+    them.
+
+    So this test asserts equality, not agreement-to-a-tolerance. Anything
+    looser would let the world block quietly drift into a private
+    reimplementation, which is exactly the outcome the design is meant to
+    avoid.
+*/
+
+#define EIGEN_NON_ARDUINO
+
+#include "kalman_ou_common/KalmanOUCoreMath.h"
+#include "kalman_tfg/Kalman3D_Wave_TFG.h"
+
+#include <array>
+#include <cmath>
+#include <iostream>
+#include <string>
+
+namespace detail = ocean_imu::kalman::ou_detail;
+
+namespace {
+
+using T = double;
+using Filter = ocean_imu::kalman::Kalman3D_Wave_TFG<T, true, true, false>;
+using Vector3 = Eigen::Matrix<T,3,1>;
+using Matrix3 = Eigen::Matrix<T,3,3>;
+
+int failures = 0;
+
+bool check(bool condition, const std::string& message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        ++failures;
+    }
+    return condition;
+}
+
+// Operating points spanning the Maclaurin branch boundary at h/tau = 1e-2 and
+// the ordinary regime, mirroring tests/kalman_ou_iii/kalman_ou_common-test.
+const std::array<T,4> kTaus   = {T(0.05), T(0.5), T(2.1), T(10)};
+const std::array<T,6> kRatios = {T(1e-5), T(1e-3), T(0.0099), T(0.0101), T(0.1), T(0.8)};
+
+Filter make_filter(T tau, const Matrix3& Sigma_aw) {
+    Filter f;
+    f.set_aw_time_constant(tau);
+    f.set_aw_stationary_cov_full(Sigma_aw);
+    // A non-identity attitude and non-zero world vectors, so that a world
+    // block accidentally contaminated by the attitude or bias coupling shows
+    // up here rather than passing by being multiplied by zero.
+    f.initialize_from_truth(
+        Eigen::Quaternion<T>(Eigen::AngleAxis<T>(T(0.7), Vector3(T(0.3), T(-0.5), T(0.81)).normalized())),
+        Vector3(T(0.4), T(-0.9), T(1.3)),      // v
+        Vector3(T(-2.0), T(3.1), T(0.7)),      // p
+        Vector3(T(5.0), T(-1.5), T(2.2)),      // S
+        Vector3(T(0.2), T(0.4), T(-0.6)),      // a_w
+        Vector3(T(0.01), T(-0.02), T(0.005)),  // b_g
+        Vector3(T(0.03), T(0.01), T(-0.02)));  // b_a
+    return f;
+}
+
+void test_transition_block_is_identical() {
+    for (T tau : kTaus) {
+        for (T ratio : kRatios) {
+            const T h = tau * ratio;
+            Filter f = make_filter(tau, Matrix3::Identity());
+
+            Filter::MatrixNX Phi;
+            f.build_transition(h, Vector3(T(0.1), T(-0.2), T(0.05)), Phi);
+
+            Eigen::Matrix<T,4,4> Phi_axis;
+            detail::IntegratedOUChain<T,3>::transition(tau, h, Phi_axis);
+
+            const std::string at =
+                " (tau=" + std::to_string(tau) + ", h/tau=" + std::to_string(ratio) + ")";
+
+            for (int i = 0; i < 4; ++i) {
+                for (int j = 0; j < 4; ++j) {
+                    for (int k = 0; k < 3; ++k) {
+                        const T got = Phi(Filter::OFF_V + 3*i + k, Filter::OFF_V + 3*j + k);
+                        // Bit-for-bit: the filter must be reading these out of
+                        // IntegratedOUChain, not recomputing them.
+                        if (!check(got == Phi_axis(i,j),
+                                   "world transition entry (" + std::to_string(i) + "," +
+                                   std::to_string(j) + ") axis " + std::to_string(k) +
+                                   " differs from IntegratedOUChain" + at)) {
+                            std::cerr << "  got " << got << " want " << Phi_axis(i,j) << '\n';
+                        }
+                    }
+                    // Off-axis entries must be exactly zero: the chain acts
+                    // per axis and must not couple x into y.
+                    for (int k = 0; k < 3; ++k) {
+                        for (int m = 0; m < 3; ++m) {
+                            if (k == m) continue;
+                            check(Phi(Filter::OFF_V + 3*i + k, Filter::OFF_V + 3*j + m) == T(0),
+                                  "world transition couples axes" + at);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+void test_process_noise_block_is_identical() {
+    for (T tau : kTaus) {
+        for (T ratio : kRatios) {
+            const T h = tau * ratio;
+            const Vector3 sigma(T(0.7), T(1.3), T(0.4));
+            const Matrix3 Sigma = sigma.cwiseAbs2().asDiagonal();
+
+            Filter f = make_filter(tau, Sigma);
+            // Isolate the OU contribution: with no gyro white noise and no
+            // bias random walk, the world block is the OU term alone.
+            f.set_gyro_noise_density_rad_sqrt_s(T(0));
+            f.set_Q_bgyro_rw(Vector3::Zero());
+            f.set_Q_bacc_rw(Vector3::Zero());
+
+            Filter::MatrixNX Qd;
+            f.build_process_noise(h, Qd);
+
+            const std::string at =
+                " (tau=" + std::to_string(tau) + ", h/tau=" + std::to_string(ratio) + ")";
+
+            for (int axis = 0; axis < 3; ++axis) {
+                Eigen::Matrix<T,4,4> Q_axis;
+                detail::IntegratedOUChain<T,3>::process_covariance(
+                    tau, h, Sigma(axis,axis), Q_axis);
+                for (int i = 0; i < 4; ++i) {
+                    for (int j = 0; j < 4; ++j) {
+                        const T got = Qd(Filter::OFF_V + 3*i + axis,
+                                         Filter::OFF_V + 3*j + axis);
+                        const T want = Q_axis(i,j);
+                        // project_psd_ou_iii runs over the assembled matrix and
+                        // may nudge entries, so this one is a tight tolerance
+                        // rather than exact equality -- but tight enough that a
+                        // different formula cannot hide inside it.
+                        const T tol = T(1e-13) * std::max(T(1), std::abs(want));
+                        if (!check(std::abs(got - want) <= tol,
+                                   "world process-noise entry (" + std::to_string(i) + "," +
+                                   std::to_string(j) + ") axis " + std::to_string(axis) +
+                                   " differs from IntegratedOUChain" + at)) {
+                            std::cerr << "  got " << got << " want " << want
+                                      << " diff " << (got - want) << '\n';
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// The correlated-axis path must reproduce OU-III's Kronecker assembly,
+// Q = Sigma_aw (x) Q_unit, in the same group-first ordering.
+void test_correlated_axis_assembly() {
+    Matrix3 Sigma;
+    const T s = T(0.9);
+    Sigma << s*s,            T(-0.65)*s*s*T(0.8), T(-0.65)*s*s*T(0.7),
+             T(-0.65)*s*s*T(0.8), s*s*T(1.4),     T(0.2)*s*s,
+             T(-0.65)*s*s*T(0.7), T(0.2)*s*s,     s*s*T(0.6);
+    Sigma = T(0.5) * (Sigma + Sigma.transpose()).eval();
+
+    for (T tau : kTaus) {
+        const T h = tau * T(0.1);
+        Filter f = make_filter(tau, Sigma);
+        f.set_gyro_noise_density_rad_sqrt_s(T(0));
+        f.set_Q_bgyro_rw(Vector3::Zero());
+        f.set_Q_bacc_rw(Vector3::Zero());
+
+        Filter::MatrixNX Qd;
+        f.build_process_noise(h, Qd);
+
+        Eigen::Matrix<T,4,4> Q_unit;
+        detail::IntegratedOUChain<T,3>::process_covariance(tau, h, T(1), Q_unit);
+        Q_unit = T(0.5) * (Q_unit + Q_unit.transpose()).eval();
+
+        for (int i = 0; i < 4; ++i) {
+            for (int j = 0; j < 4; ++j) {
+                const Matrix3 want = Sigma * Q_unit(i,j);
+                for (int a = 0; a < 3; ++a) {
+                    for (int b = 0; b < 3; ++b) {
+                        const T got = Qd(Filter::OFF_V + 3*i + a, Filter::OFF_V + 3*j + b);
+                        const T tol = T(1e-13) * std::max(T(1), std::abs(want(a,b)));
+                        check(std::abs(got - want(a,b)) <= tol,
+                              "correlated-axis world process noise does not match "
+                              "Sigma (x) Q_unit at tau=" + std::to_string(tau));
+                    }
+                }
+            }
+        }
+    }
+}
+
+/*
+    Psi(h,tau) = int_0^h Phi_OU(u) du, checked against Simpson quadrature of
+    the transition it integrates. This is the term that makes Phi_world,bg
+    exact rather than truncated, and it has three entries that cancel to
+    O(x^2), O(x^3), O(x^4), so its Taylor branch is load-bearing.
+
+    The quadrature reference is built from the closed form in long double
+    rather than by calling IntegratedOUChain. That is deliberate. OU-III's
+    small-x branch truncates phi_pa at x^4 and phi_Sa at x^5
+    (KalmanOUCoreMath.h:86), so near the 1e-2 seam it carries a relative error
+    of about x^3/60, roughly 2e-8. Integrating that would measure OU-III's
+    truncation rather than this function -- and Psi is the more accurate of
+    the two, so the test would fail pointing at the wrong file. The
+    truncation itself is far below anything that matters for a transition
+    coefficient and is not worth disturbing the versioned OU evidence to
+    change; it is recorded here so the next person to see an 8e-9 discrepancy
+    at the seam knows where it comes from.
+*/
+void test_psi_against_quadrature() {
+    using LD = long double;
+
+    // Exact Phi_OU for one axis, no Taylor branch, evaluated in long double.
+    auto exact_phi = [](LD tau, LD u) {
+        Eigen::Matrix<LD,4,4> Phi = Eigen::Matrix<LD,4,4>::Zero();
+        const LD x = u / tau;
+        const LD em1 = std::expm1(-x);
+        const LD tau2 = tau * tau, tau3 = tau2 * tau;
+        Phi(0,0) = LD(1);
+        Phi(0,3) = -tau * em1;
+        Phi(1,0) = u;
+        Phi(1,1) = LD(1);
+        Phi(1,3) = tau2 * (x + em1);
+        Phi(2,0) = LD(0.5) * u * u;
+        Phi(2,1) = u;
+        Phi(2,2) = LD(1);
+        Phi(2,3) = tau3 * (LD(0.5) * x * x - x - em1);
+        Phi(3,3) = std::exp(-x);
+        return Phi;
+    };
+
+    for (T tau : kTaus) {
+        for (T ratio : kRatios) {
+            const T h = tau * ratio;
+
+            Eigen::Matrix<T,4,4> Psi;
+            ocean_imu::kalman::tfg_detail::integral_transition_axis<T>(tau, h, Psi);
+
+            const int n = 4000;
+            Eigen::Matrix<LD,4,4> acc_ld = Eigen::Matrix<LD,4,4>::Zero();
+            for (int k = 0; k <= n; ++k) {
+                const LD u = static_cast<LD>(h) * static_cast<LD>(k) / static_cast<LD>(n);
+                const LD w = (k == 0 || k == n) ? LD(1) : ((k % 2 == 1) ? LD(4) : LD(2));
+                acc_ld += w * exact_phi(static_cast<LD>(tau), u);
+            }
+            acc_ld *= static_cast<LD>(h) / (LD(3) * static_cast<LD>(n));
+            const Eigen::Matrix<T,4,4> acc = acc_ld.cast<T>();
+
+            const std::string at =
+                " (tau=" + std::to_string(tau) + ", h/tau=" + std::to_string(ratio) + ")";
+            // Relative, because the entries span many orders of magnitude:
+            // Psi_23 ~ tau^4 x^4/24 is astronomically smaller than Psi_00 = h.
+            for (int i = 0; i < 4; ++i) {
+                for (int j = 0; j < 4; ++j) {
+                    const T scale = std::max(std::abs(acc(i,j)), T(1e-300));
+                    const T rel = std::abs(Psi(i,j) - acc(i,j)) / scale;
+                    if (!check(rel <= T(1e-9) || std::abs(Psi(i,j) - acc(i,j)) <= T(1e-18),
+                               "Psi entry (" + std::to_string(i) + "," + std::to_string(j) +
+                               ") disagrees with quadrature" + at)) {
+                        std::cerr << "  got " << Psi(i,j) << " want " << acc(i,j)
+                                  << " rel " << rel << '\n';
+                    }
+                }
+            }
+        }
+    }
+}
+
+} // namespace
+
+int main() {
+    test_transition_block_is_identical();
+    test_process_noise_block_is_identical();
+    test_correlated_axis_assembly();
+    test_psi_against_quadrature();
+
+    if (failures != 0) {
+        std::cerr << failures << " OU chain identity check(s) failed\n";
+        return 1;
+    }
+    std::cout << "ou_chain_identity-test: all checks passed\n";
+    return 0;
+}

--- a/tests/kalman_tfg/run_tests.sh
+++ b/tests/kalman_tfg/run_tests.sh
@@ -2,3 +2,5 @@
 
 ./lie_group-test
 ./convention-test
+./ou_chain_identity-test
+./tfg_propagation-test

--- a/tests/kalman_tfg/tfg_propagation-test.cpp
+++ b/tests/kalman_tfg/tfg_propagation-test.cpp
@@ -1,0 +1,401 @@
+/*
+    Copyright (c) 2025-2026  Mikhail Grushinskiy
+
+    The discrete transition Phi must be the Jacobian of the propagation the
+    filter actually performs -- not of the propagation someone meant to write.
+
+    So this test never compares Phi against a second closed form. It perturbs
+    the state through inject(), propagates both the perturbed and the nominal
+    state with the same measured gyro, reads the resulting right-invariant
+    error back out through error_from(), and central-differences that:
+
+        Phi[:,j] ~ ( err( f(inject(X, +h e_j)), f(X) )
+                   - err( f(inject(X, -h e_j)), f(X) ) ) / 2h
+
+    inject() and error_from() are an exact inverse pair (asserted below), so
+    this closes the loop through the same coordinates the covariance lives in.
+    A Phi that is right for the wrong parameterization fails here.
+
+    Everything runs at double. Float is exercised by the compile-only
+    instantiation at the bottom -- finite differences at float precision would
+    measure rounding, not the Jacobian.
+*/
+
+#define EIGEN_NON_ARDUINO
+
+#include "kalman_tfg/Kalman3D_Wave_TFG.h"
+
+#include <cmath>
+#include <iostream>
+#include <random>
+#include <string>
+
+namespace {
+
+using T = double;
+using Filter  = ocean_imu::kalman::Kalman3D_Wave_TFG<T, true, true, false>;
+using Vector3 = Eigen::Matrix<T,3,1>;
+using Matrix3 = Eigen::Matrix<T,3,3>;
+using Tangent = Filter::Tangent;
+using MatrixNX = Filter::MatrixNX;
+
+constexpr int NX = Filter::NX;
+
+int failures = 0;
+
+bool check(bool condition, const std::string& message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        ++failures;
+    }
+    return condition;
+}
+
+std::mt19937 rng(20260806u);
+
+Vector3 rand_vec(double scale) {
+    std::uniform_real_distribution<double> d(-scale, scale);
+    return Vector3(d(rng), d(rng), d(rng));
+}
+
+Filter make_filter(T tau = T(1.7)) {
+    Filter f;
+    f.set_aw_time_constant(tau);
+    f.set_aw_stationary_std(Vector3(T(0.6), T(0.6), T(0.32)));
+    f.set_gyro_noise_density_rad_sqrt_s(T(0.004));
+    f.set_Q_bgyro_rw(Vector3::Constant(T(1e-10)));
+    f.set_Q_bacc_rw(Vector3::Constant(T(2.5e-7)));
+    f.initialize_from_truth(
+        Eigen::Quaternion<T>(Eigen::AngleAxis<T>(
+            T(0.63), Vector3(T(0.2), T(-0.7), T(0.68)).normalized())),
+        Vector3(T(0.5), T(-0.8), T(1.1)),
+        Vector3(T(-1.7), T(2.4), T(0.9)),
+        Vector3(T(3.3), T(-2.1), T(1.4)),
+        Vector3(T(0.3), T(-0.5), T(0.7)),
+        Vector3(T(0.012), T(-0.008), T(0.004)),
+        Vector3(T(0.02), T(0.05), T(-0.01)));
+    return f;
+}
+
+// ---------------------------------------------------------------------------
+// inject() and error_from() must be exact inverses. Everything else in this
+// file depends on that, so it is checked first and on its own.
+// ---------------------------------------------------------------------------
+
+void test_inject_error_roundtrip() {
+    for (int trial = 0; trial < 50; ++trial) {
+        const Filter base = make_filter();
+
+        Tangent xi;
+        xi.setZero();
+        xi.segment<3>(Filter::OFF_PHI) = rand_vec(0.8);
+        xi.segment<3>(Filter::OFF_BG)  = rand_vec(0.05);
+        for (int c = 0; c < 4; ++c) xi.segment<3>(Filter::OFF_V + 3*c) = rand_vec(2.0);
+        xi.segment<3>(Filter::OFF_BA)  = rand_vec(0.1);
+
+        Filter perturbed = base;
+        perturbed.inject(xi);
+
+        const Tangent back = perturbed.error_from(base);
+        const T err = (back - xi).cwiseAbs().maxCoeff();
+        if (!check(err <= T(1e-12),
+                   "error_from(inject(xi)) != xi")) {
+            std::cerr << "  max|diff| = " << err << '\n';
+        }
+    }
+
+    // A zero correction must be exactly a no-op, including on the attitude.
+    Filter f = make_filter();
+    const Filter before = f;
+    f.inject(Tangent::Zero());
+    check(f.error_from(before).cwiseAbs().maxCoeff() <= T(1e-15),
+          "injecting a zero correction changed the state");
+}
+
+// ---------------------------------------------------------------------------
+// Phi against central finite differences of the real propagation.
+// ---------------------------------------------------------------------------
+
+MatrixNX numeric_transition(const Filter& base, const Vector3& gyro, T Ts, T eps) {
+    MatrixNX numeric;
+    Filter nominal = base;
+    nominal.propagate_mean(gyro, Ts);
+
+    for (int j = 0; j < NX; ++j) {
+        Tangent e = Tangent::Zero();
+
+        e(j) = eps;
+        Filter plus = base;
+        plus.inject(e);
+        plus.propagate_mean(gyro, Ts);
+
+        e(j) = -eps;
+        Filter minus = base;
+        minus.inject(e);
+        minus.propagate_mean(gyro, Ts);
+
+        numeric.col(j) = (plus.error_from(nominal) - minus.error_from(nominal)) / (T(2) * eps);
+    }
+    return numeric;
+}
+
+void compare_transition(const Filter& f, const Vector3& gyro, T Ts, T tol,
+                        const std::string& tag) {
+    MatrixNX analytic;
+    f.build_transition(Ts, gyro, analytic);
+    const MatrixNX numeric = numeric_transition(f, gyro, Ts, T(1e-6));
+
+    const T err = (analytic - numeric).cwiseAbs().maxCoeff();
+    if (!check(err <= tol, tag + ": Phi does not match finite differences")) {
+        std::cerr << "  max|diff| = " << err << " (tol " << tol << ")\n";
+        // Name the worst block, so a failure points at the derivation that
+        // broke rather than at a 21x21 wall of numbers.
+        int bi = 0, bj = 0;
+        T worst = T(0);
+        for (int i = 0; i < NX; ++i) {
+            for (int j = 0; j < NX; ++j) {
+                const T d = std::abs(analytic(i,j) - numeric(i,j));
+                if (d > worst) { worst = d; bi = i; bj = j; }
+            }
+        }
+        std::cerr << "  worst entry (" << bi << "," << bj << "): analytic "
+                  << analytic(bi,bj) << " numeric " << numeric(bi,bj) << '\n';
+    }
+}
+
+void test_transition_matches_finite_differences() {
+    // Still, moderate, and fast rotation. The turn rate is the whole point of
+    // the Rbar = Rhat J_l(w h) factor, so it has to be exercised well away
+    // from zero.
+    const Vector3 gyros[] = {
+        Vector3::Zero(),
+        Vector3(T(0.05), T(-0.03), T(0.02)),
+        Vector3(T(0.4), T(-0.7), T(0.5)),
+        Vector3(T(2.0), T(-1.5), T(3.0)),
+    };
+    const T steps[] = {T(0.001), T(0.005), T(0.02), T(0.1)};
+
+    for (const Vector3& g : gyros) {
+        for (T h : steps) {
+            Filter f = make_filter();
+            const std::string tag =
+                "|w|=" + std::to_string(g.norm()) + " h=" + std::to_string(h);
+            // The one documented approximation is in Phi_world,bg, which
+            // neglects the correlation of Rhat(s) with the Phi_OU weighting
+            // and the drift of x(s) across the step. Both are O(h) on a term
+            // already of size |x| |w| h, so the tolerance scales with h^2.
+            const T tol = T(2e-8) + T(4.0) * h * h * (T(1) + g.norm());
+            compare_transition(f, g, h, tol, tag);
+        }
+    }
+}
+
+// At zero turn rate J_l(0) = I, so Rbar reduces to Rhat exactly and the
+// attitude/bias block has no approximation left in it.
+//
+// "At rest" means the *body* is not turning, which is w = gyro - b_g = 0, so
+// the gyro must read the bias. Feeding a zero gyro instead leaves w = -b_g,
+// a real turn rate, and J_l(-b_g h) is then not the identity -- an easy way
+// to write a test that fails for a reason that has nothing to do with the
+// code under test.
+void test_attitude_bias_block_is_exact_at_rest() {
+    for (T h : {T(0.001), T(0.005), T(0.05), T(0.5)}) {
+        Filter f = make_filter();
+        MatrixNX Phi;
+        f.build_transition(h, f.gyroscope_bias(), Phi);
+
+        const Matrix3 want = -f.R_bw() * h;
+        const Matrix3 got = Phi.block<3,3>(Filter::OFF_PHI, Filter::OFF_BG);
+        check((got - want).cwiseAbs().maxCoeff() <= T(1e-15),
+              "Phi_phi,bg != -Rhat h at zero turn rate");
+
+        check((Phi.block<3,3>(Filter::OFF_PHI, Filter::OFF_PHI)
+               - Matrix3::Identity()).cwiseAbs().maxCoeff() == T(0),
+              "Phi_phi,phi must be exactly I: the right-invariant attitude "
+              "error is driftless");
+        check(Phi.block<3,12>(Filter::OFF_PHI, Filter::OFF_V).cwiseAbs().maxCoeff() == T(0),
+              "attitude error must not depend on the world vectors");
+        check(Phi.block<12,3>(Filter::OFF_V, Filter::OFF_PHI).cwiseAbs().maxCoeff() == T(0),
+              "world vectors must not couple back from phi: phidot has no phi term");
+    }
+}
+
+// The Rbar factor is not cosmetic. Rebuilding Phi with Rhat in place of
+// Rhat J_l(w h) must measurably disagree with finite differences at a
+// realistic turn rate -- otherwise the correction is untested.
+void test_average_rotation_factor_matters() {
+    const Vector3 gyro(T(1.0), T(-0.5), T(0.8));
+    const T h = T(0.02);
+    Filter f = make_filter();
+
+    MatrixNX analytic;
+    f.build_transition(h, gyro, analytic);
+    const MatrixNX numeric = numeric_transition(f, gyro, h, T(1e-6));
+
+    const Matrix3 with_Jl = analytic.block<3,3>(Filter::OFF_PHI, Filter::OFF_BG);
+    const Matrix3 naive   = -f.R_bw() * h;
+    const Matrix3 truth   = numeric.block<3,3>(Filter::OFF_PHI, Filter::OFF_BG);
+
+    const T err_correct = (with_Jl - truth).cwiseAbs().maxCoeff();
+    const T err_naive   = (naive   - truth).cwiseAbs().maxCoeff();
+
+    check(err_correct < err_naive * T(1e-2),
+          "the Rbar = Rhat J_l(w h) factor is not doing measurable work; "
+          "either the test is too weak or the factor is wrong");
+    std::cout << "  Rbar factor: |Phi_phi,bg - FD| = " << err_correct
+              << " with J_l, " << err_naive << " without\n";
+}
+
+// ---------------------------------------------------------------------------
+// Covariance propagation
+// ---------------------------------------------------------------------------
+
+bool is_psd(const MatrixNX& M, T tol) {
+    Eigen::SelfAdjointEigenSolver<MatrixNX> es(M);
+    if (es.info() != Eigen::Success) return false;
+    return es.eigenvalues().minCoeff() >= -tol;
+}
+
+void test_covariance_stays_psd_and_symmetric() {
+    Filter f = make_filter();
+    f.set_initial_linear_uncertainty(T(0.3), T(1.0), T(3.0), T(0.5));
+
+    std::normal_distribution<double> n(0.0, 0.35);
+    const T h = T(0.005);
+    for (int step = 0; step < 4000; ++step) {
+        const Vector3 gyro(n(rng), n(rng), n(rng));
+        f.time_update(gyro, h);
+    }
+
+    const MatrixNX& P = f.covariance_full();
+    check(P.allFinite(), "covariance went non-finite over a 20 s propagation");
+    check((P - P.transpose()).cwiseAbs().maxCoeff() <= T(1e-14) * P.cwiseAbs().maxCoeff(),
+          "covariance lost symmetry");
+    check(is_psd(P, T(1e-12) * std::max(T(1), P.cwiseAbs().maxCoeff())),
+          "covariance stopped being positive semi-definite");
+    check(is_psd(f.covariance_full(), T(1e-12) * std::max(T(1), P.cwiseAbs().maxCoeff())),
+          "covariance not PSD");
+
+    // Attitude uncertainty must actually grow without measurements; a Phi or Q
+    // that silently zeroed the gyro noise would still pass the PSD checks.
+    check(P(0,0) > T(1e-8), "attitude variance did not grow over 20 s of gyro-only propagation");
+}
+
+void test_process_noise_is_psd() {
+    for (T h : {T(0.001), T(0.005), T(0.05)}) {
+        Filter f = make_filter();
+        MatrixNX Qd;
+        f.build_process_noise(h, Qd);
+        check(Qd.allFinite(), "Qd non-finite");
+        check((Qd - Qd.transpose()).cwiseAbs().maxCoeff() <= T(1e-15) * std::max(T(1), Qd.cwiseAbs().maxCoeff()),
+              "Qd is not symmetric");
+        check(is_psd(Qd, T(1e-14) * std::max(T(1), Qd.cwiseAbs().maxCoeff())), "Qd is not PSD");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mean propagation
+// ---------------------------------------------------------------------------
+
+// With a perfectly known bias and no rotation, the world chain must integrate
+// the OU kinematics: p advances by v h + O(h^2), S by p h, and a_w decays.
+void test_mean_propagation_follows_the_chain() {
+    Filter f = make_filter(T(2.0));
+    f.initialize_from_truth(Eigen::Quaternion<T>::Identity(),
+                            Vector3(T(1), T(0), T(0)),     // v
+                            Vector3(T(0), T(2), T(0)),     // p
+                            Vector3(T(0), T(0), T(3)),     // S
+                            Vector3(T(0.5), T(0), T(0)),   // a_w
+                            Vector3::Zero(), Vector3::Zero());
+
+    const T h = T(0.01);
+    const Vector3 v0 = f.get_velocity();
+    const Vector3 p0 = f.get_position();
+    const Vector3 S0 = f.get_integral_displacement();
+    const Vector3 a0 = f.get_world_accel();
+
+    f.propagate_mean(Vector3::Zero(), h);
+
+    check((f.get_world_accel() - a0 * std::exp(-h / T(2.0))).cwiseAbs().maxCoeff() <= T(1e-12),
+          "a_w did not decay at the OU rate");
+    check(std::abs(f.get_position().y() - (p0.y() + v0.y()*h)) <= T(1e-12),
+          "p did not integrate v");
+    check(std::abs(f.get_integral_displacement().z() - (S0.z() + p0.z()*h)) <= T(1e-12),
+          "S did not integrate p");
+    // v gains the OU-weighted acceleration, not a naive a h.
+    check(f.get_velocity().x() > v0.x(), "v did not gain from a positive a_w");
+
+    // Attitude must be untouched by the world chain.
+    check(std::abs(f.quaternion().angularDistance(Eigen::Quaternion<T>::Identity())) <= T(1e-15),
+          "the world chain rotated the attitude");
+}
+
+// Rotation direction: R is body-to-world and the gyro is body-frame, so a
+// positive body-z rate must carry body +x toward world +y.
+void test_rotation_direction() {
+    Filter f;
+    f.initialize_from_truth(Eigen::Quaternion<T>::Identity(),
+                            Vector3::Zero(), Vector3::Zero(),
+                            Vector3::Zero(), Vector3::Zero(),
+                            Vector3::Zero(), Vector3::Zero());
+    const T rate = T(M_PI) / T(2);
+    f.propagate_mean(Vector3(T(0), T(0), rate), T(1));
+    const Vector3 mapped = f.R_bw() * Vector3::UnitX();
+    check((mapped - Vector3::UnitY()).cwiseAbs().maxCoeff() <= T(1e-12),
+          "a +90 deg/s body-z rate for 1 s must send body x to world y");
+}
+
+// Gyro bias must be subtracted, not added.
+void test_gyro_bias_is_subtracted() {
+    Filter f;
+    const Vector3 bias(T(0.1), T(-0.2), T(0.3));
+    f.initialize_from_truth(Eigen::Quaternion<T>::Identity(),
+                            Vector3::Zero(), Vector3::Zero(),
+                            Vector3::Zero(), Vector3::Zero(),
+                            bias, Vector3::Zero());
+    // Measuring exactly the bias means the body is not turning.
+    f.propagate_mean(bias, T(1.0));
+    check(std::abs(f.quaternion().angularDistance(Eigen::Quaternion<T>::Identity())) <= T(1e-12),
+          "a gyro reading equal to the bias must produce no rotation");
+}
+
+// Compile-only: the firmware instantiation must build and run.
+void test_float_instantiation() {
+    using FloatFilter = ocean_imu::kalman::Kalman3D_Wave_TFG<float, true, true, false>;
+    FloatFilter f;
+    f.set_aw_time_constant(1.5f);
+    f.set_aw_stationary_std(Eigen::Vector3f(0.5f, 0.5f, 0.3f));
+    f.initialize_identity();
+    for (int i = 0; i < 200; ++i) f.time_update(Eigen::Vector3f(0.01f, -0.02f, 0.03f), 0.005f);
+    check(f.covariance_full().allFinite() && f.state().R.allFinite(),
+          "the float instantiation went non-finite");
+
+    using NoAccelBias = ocean_imu::kalman::Kalman3D_Wave_TFG<float, true, false, false>;
+    static_assert(NoAccelBias::NX == 18, "dropping the accel bias must give 18 states");
+    NoAccelBias g;
+    g.initialize_identity();
+    g.time_update(Eigen::Vector3f(0.01f, 0.0f, 0.0f), 0.005f);
+    check(g.covariance_full().allFinite(), "the 18-state instantiation went non-finite");
+}
+
+} // namespace
+
+int main() {
+    test_inject_error_roundtrip();
+    test_attitude_bias_block_is_exact_at_rest();
+    test_transition_matches_finite_differences();
+    test_average_rotation_factor_matters();
+    test_process_noise_is_psd();
+    test_covariance_stays_psd_and_symmetric();
+    test_mean_propagation_follows_the_chain();
+    test_rotation_direction();
+    test_gyro_bias_is_subtracted();
+    test_float_instantiation();
+
+    if (failures != 0) {
+        std::cerr << failures << " propagation check(s) failed\n";
+        return 1;
+    }
+    std::cout << "tfg_propagation-test: all checks passed\n";
+    return 0;
+}


### PR DESCRIPTION
Follow-up to #245, which landed the group mathematics alone. This adds the
estimator that sits on it.

`R, v, p, S, a_w` now live on `SE_4(3)` with a right-invariant error. The
biases stay additive in the body frame for now, so a defect in the group
retraction cannot hide behind a defect in the bias geometry. Level 2 (the
full two-frame bias transport) is a later change, `static_assert`ed off
rather than shipped unverified.

## The reuse premise holds

The reason this architecture was chosen is that the right-invariant world
error obeys the chain the article already derives:

    rho_vdot = rho_a,  rho_pdot = rho_v,  rho_Sdot = rho_p,  rho_adot = -lambda rho_a

So the 12x12 world block of `Phi` and `Qd` is `IntegratedOUChain<T,3>`
unchanged -- Maclaurin branch, correlated-axis Kronecker assembly and PSD
handling included. `ou_chain_identity-test` asserts *equality*, not closeness,
so the block cannot quietly become a private reimplementation.

## Two derivations a first pass gets wrong

Both were found by building the finite-difference test rather than by
inspection, and both are now pinned.

**`Phi_phi,bg` is not `-Rhat h`.** The attitude propagates as
`Rhat(s) = Rhat Exp(w s)` while `phidot = -Rhat(s) delta_bg`, so the exact
integral is `-Rhat h J_l(w h)`. Using `Rhat` alone costs order `|w| h` --
0.25% at 1 rad/s and a 5 ms step -- and it grows with turn rate, which is
exactly when attitude and bias are hardest to separate. Against finite
differences the average-rotation factor moves the residual from `2.2e-4` to
`8.9e-11`, and a test asserts it keeps earning that.

**`error_from` must apply `J_l^-1`.** The group element `eta = Xhat X^-1` has
world components `xhat - dR x`, but its tangent coordinates -- what `P` is
expressed in and what `Exp_G` consumes -- are `J_l(phi)^-1` times those.
Omitting the inverse leaves `error_from` and `inject` differing by exactly
`J_l`. They still agree to first order, so every small-perturbation check
passes while finite-difference Jacobians at usable step sizes and NEES at
realistic error magnitudes are both quietly wrong.

## How Phi is verified

Not against a second closed form, which would only prove two derivations
agree. Perturb through `inject()`, propagate, read the error back through
`error_from()`, central-difference that. The two are an exact inverse pair
(asserted separately), so the loop closes in the coordinates the covariance
actually lives in.

Five mutations confirmed to fail: `Phi_phi,bg` sign 20 failures, world-bias
coupling sign 16, OU chain applied untransposed 17, attitude propagated on
the left 17, `inject` dropping `J_l` 50. On the chain suite, a 1e-6 relative
tweak to the world block gives 72 and the Psi truncation gives 2.

## Psi, and a note on existing coefficients

`Psi(h,tau) = int_0^h Phi_OU(u) du` in closed form is what makes the
world-to-bias coupling exact. Three of its entries cancel to `O(x^2)`,
`O(x^3)` and `O(x^4)`, so the Taylor branch is load-bearing: `Psi_23` needs
terms through `x^8`, because stopping at `x^6` leaves `x^3/210` relative,
`4.6e-9` at the seam.

Its test builds the quadrature reference from a long double closed form
rather than from `IntegratedOUChain`. That is deliberate. OU-III's small-x
branch truncates `phi_pa` at `x^4` and `phi_Sa` at `x^5`
(`KalmanOUCoreMath.h:86`), giving about `2e-8` relative error near the seam.
`Psi` is the more accurate of the two, so integrating the existing
coefficients failed while pointing at the wrong file. The truncation is far
below anything that matters for a transition coefficient and is left alone
rather than disturbing the versioned OU evidence -- it is recorded where the
next person will meet it.

## Verification

`make -C tests/kalman_tfg test` passes all four suites. `make -C tests/validation test`
passes on this base (66 tests) -- it was failing before `0508a0f` landed on
main, on a pre-existing abstract/evidence digit mismatch unrelated to this
work.

The float instantiation and the 18-state `with_accel_bias = false` variant are
both exercised, so the firmware path is covered alongside the double-precision
checks.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9aDUvqetsX7jojWiDumAf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable 3D wave-state Kalman filter with Lie-group error handling.
  - Supports state initialization, propagation, correction, covariance updates, and tuning.
  - Supports optional gyro and accelerometer bias estimation and correlated acceleration noise.

- **Tests**
  - Added comprehensive validation for state transitions, propagation, covariance behavior, rotation handling, and bias correction.
  - Added automated test targets and test-runner coverage for the new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->