### PR TITLE
Give the filter invariant measurement updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,3 +49,4 @@ target_include_directories(lie_group-test SYSTEM PRIVATE
   "${CMAKE_CURRENT_SOURCE_DIR}/third_party/Lie-plusplus/include")
 add_executable(ou_chain_identity-test "${OCEAN_IMU_TESTS_DIR}/kalman_tfg/ou_chain_identity-test.cpp")
 add_executable(tfg_propagation-test "${OCEAN_IMU_TESTS_DIR}/kalman_tfg/tfg_propagation-test.cpp")
+add_executable(tfg_jacobians-test "${OCEAN_IMU_TESTS_DIR}/kalman_tfg/tfg_jacobians-test.cpp")

--- a/docs/tfg-design.md
+++ b/docs/tfg-design.md
@@ -232,7 +232,106 @@ deliberately broken. A test that cannot fail is not evidence.
 | `Exp` handedness flipped | 253 fail | 516 fail |
 | `J_l` 0.1% coefficient error | 228 fail | 50 fail |
 
-## 4. What this does not claim
+## 4. Measurement updates
+
+### Sign convention
+
+One convention, stated once, used everywhere:
+
+```
+xi     is the error OF THE ESTIMATE:  eta = Xhat X^-1 = Exp_G(xi),  P = E[xi xi^T]
+r      is the innovation, measured minus predicted
+r      ~ H xi + noise                      (plus, not minus)
+K      = P H^T (H P H^T + R)^-1
+xihat  = K r                               the estimated error
+Xhat+  = Exp_G(-xihat) o Xhat              remove it
+```
+
+The correction is injected **negated**, because `xi` is the error rather than
+the correction. Half the sign bugs in filters of this shape come from mixing
+the two conventions -- deriving `H` against `r ~ -H xi` and then injecting
+`+K r`, which cancels out only if both mistakes are made together, and leaves
+a filter that works until someone fixes one of them. Here `H` is literally
+`d r / d xi`, which is what `tfg_jacobians-test` measures by finite
+differences, so there is nothing left to get backwards.
+
+### The three residuals
+
+| Update | Innovation | `H` (phi, db_g, rho_v, rho_p, rho_S, rho_a, db_a) | Noise |
+|---|---|---|---|
+| Accel | `r_a = Rhat(f_m - bhat_a) - (ahat_w - g)` | `[ [g]x, 0, 0, 0, 0, -I, -Rhat ]` | `Rhat R_a^body Rhat^T` |
+| Mag | `r_m = Rhat m_m - B_w` | `[ -[B_w]x, 0 ... ]` | `Rhat R_m^body Rhat^T` |
+| Integral | `r_S = -Shat` | `[ [Shat]x, 0, 0, 0, -I, 0, 0 ]` | `R_S`, world frame |
+
+Neither `H_a` nor `H_m` contains the estimated attitude or the estimated wave
+acceleration. They are built from **fixed** references -- gravity and the world
+magnetic vector. That is the structural gain over OU-III, whose
+`J_att = -[f_cog_b]x` is rebuilt from the current specific-force estimate on
+every step. `tfg_jacobians-test` asserts it directly: rotate the estimate by a
+large angle, move `a_w`, and the Jacobians must not change at all.
+
+### The accelerometer-bias column is `-Rhat` at Level 1
+
+Not `-I`. At Level 1 `delta_ba` is an additive **body-frame** error, so it has
+to be rotated into the world frame the residual lives in. It collapses to `-I`
+only at Level 2, where `beta_a = R(bhat_a - b_a)` is already world-referred.
+
+This is a concrete statement of what the two-frame bias geometry buys, and it
+is a trap: writing `-I` at Level 1 is wrong by a full rotation and still looks
+right at zero attitude. The test pins the value *and* asserts the test
+attitude is far enough from identity for the two to be distinguishable.
+
+### What is approximated, exactly
+
+Differentiating the accelerometer residual exactly gives
+
+```
+d r_a / d phi = -[Rhat (f_m - bhat_a)]x + [ahat_w]x = [g]x - [r_a]x
+```
+
+because `Rhat(f_m - bhat_a) = ahat_w - g + r_a` by definition. So `[g]x` is the
+exact derivative **only where the residual vanishes**, and the neglected term
+is exactly `-[r_a]x` -- first order in the innovation, vanishing as the filter
+converges. The magnetometer has the same structure: `-[B_w]x - [r_m]x`.
+
+The term is dropped deliberately. Keeping it would put the measurement and the
+estimated attitude back into the Jacobian and forfeit the one property this
+formulation exists for. It is the standard invariant-EKF choice.
+
+The tests treat it accordingly, and this is worth copying elsewhere: finite
+differences are checked at a **consistent state** where the identity is exact,
+and a **separate** test asserts that the gap at an inconsistent state equals
+`-[r]x` to `2e-8`. Asserting only that the gap is "small" would pass equally
+well if the gap were some other small thing, and would stop discriminating the
+moment a genuine error of similar size appeared. Pinning its exact structure
+means any additional error shows up immediately, however small.
+
+### Covariance
+
+Rank-3 Joseph form, `P+ = (I-KH)P(I-KH)^T + K R K^T`, in the invariant tangent
+frame. There is deliberately **no** MEKF-style covariance reset afterwards:
+`ou_detail::apply_left_error_reset`'s `G = I + 0.5[dtheta]x` exists because
+OU-III zeroes its error state after injection and has to transport `P` into the
+new linearization point. Here the update is already expressed in the
+post-update tangent frame, so applying that transport on top would
+double-correct.
+
+### Two testing notes
+
+**Finite-difference step size.** Central differences have error
+`~ h^2 f''' + eps_machine |f| / h`. Reaching for a smaller `h` past the optimum
+makes things worse, not better: at `h = 1e-9` the rounding term is
+`2.2e-16/1e-9 = 2.2e-7`, which swamps the quantity being measured. `1e-6` is
+the right order here.
+
+**Asserting that something did not happen.** Use raw state comparison, not
+`error_from`. `error_from` computes `Log(Rhat R_ref^T)`, and the floating-point
+product of a rotation with its own transpose is `I +- 1e-17` rather than
+exactly `I`, so it reports about `1e-16` of "error" between two bitwise
+identical states. For inertness checks that is noise; compare `R`, `X` and `B`
+directly.
+
+## 5. What this does not claim
 
 The bias-free, frozen-parameter skeleton is group-affine. The complete
 estimator is **not** shown to be, and must not be described as an InEKF or as

--- a/src/kalman_tfg/Kalman3D_Wave_TFG.h
+++ b/src/kalman_tfg/Kalman3D_Wave_TFG.h
@@ -574,7 +574,278 @@ class Kalman3D_Wave_TFG {
         }
     }
 
+    // ------------------------------------------------------- measurements
+    /*
+        SIGN CONVENTION, fixed here once and used everywhere.
+
+            xi     is the error OF THE ESTIMATE:  eta = Xhat X^-1 = Exp_G(xi),
+                   and P = E[xi xi^T].
+            r      is the innovation, measured minus predicted.
+            r      ~ H xi + noise                       (note: +, not -)
+            K      = P H^T (H P H^T + R)^-1
+            xihat  = K r                                 estimated error
+            Xhat+  = Exp_G(-xihat) o Xhat                remove it
+
+        The correction is injected NEGATED, because xi is the error rather
+        than the correction. Half the sign bugs in filters like this come from
+        mixing the two conventions -- deriving H against "r ~ -H xi" and then
+        injecting +K r, which cancels out only if both mistakes are made
+        together. Here H is exactly d r / d xi, which is what
+        tfg_jacobians-test measures by finite differences, so there is nothing
+        left to get backwards.
+    */
+
+    struct MeasDiag3 {
+        Vector3 r{Vector3::Zero()};
+        Matrix3 S{Matrix3::Zero()};
+        T nis{T(0)};
+        bool accepted{false};
+    };
+
+    [[nodiscard]] const MeasDiag3& lastAccDiag() const { return last_acc_diag_; }
+    [[nodiscard]] const MeasDiag3& lastMagDiag() const { return last_mag_diag_; }
+    [[nodiscard]] const MeasDiag3& lastIntegralDiag() const { return last_S_diag_; }
+
+    void set_Racc_std(const Vector3& std_body) { Racc_ = std_body.cwiseAbs2().asDiagonal(); }
+    void set_Racc_matrix(const Matrix3& R_body) { Racc_ = T(0.5) * (R_body + R_body.transpose()); }
+    void set_Rmag_std(const Vector3& std_body)  { Rmag_ = std_body.cwiseAbs2().asDiagonal(); }
+    void set_Rmag(T variance) { Rmag_ = Matrix3::Identity() * std::abs(variance); }
+    void set_RS_noise(T variance) { R_S_ = Matrix3::Identity() * std::abs(variance); }
+    void set_RS_noise_vector(const Vector3& variances) { R_S_ = variances.cwiseAbs().asDiagonal(); }
+    void set_RS_noise_matrix(const Matrix3& R_S) { R_S_ = T(0.5) * (R_S + R_S.transpose()); }
+
+    // World-frame magnetic reference, NED. Stored as the fixed vector the
+    // magnetometer Jacobian is built from -- not as a body-frame prediction.
+    void set_magnetic_reference_world(const Vector3& B_w) {
+        if (B_w.allFinite() && B_w.norm() > T(1e-9)) {
+            B_w_ = B_w;
+            have_mag_reference_ = true;
+        }
+    }
+    [[nodiscard]] const Vector3& magnetic_reference_world() const { return B_w_; }
+    [[nodiscard]] bool has_magnetic_reference() const { return have_mag_reference_; }
+
+    void set_accel_bias_temp_coeff(const Vector3& k_a) { k_a_ = k_a; }
+    void set_accel_bias_limit(T limit) { acc_bias_limit_ = std::abs(limit); }
+    void set_acc_bias_updates_enabled(bool on) { acc_bias_updates_enabled_ = on; }
+
+    // Chi-square gate on the 3-DoF NIS. Zero disables it, which is the
+    // default and matches OU-III's behaviour of accepting every update.
+    void set_meas_gate_nis(T threshold) { nis_gate_ = std::max(T(0), threshold); }
+
+    [[nodiscard]] Vector3 gravity_world() const { return Vector3(T(0), T(0), gravity_magnitude_); }
+
+    /*
+        Accelerometer, as a world-frame invariant residual.
+
+            f_m = R^T (a_w - g) + b_a + n_a
+            r_a = Rhat (f_m - bhat_a) - (ahat_w - g)
+
+        which is zero at the true state. Linearizing with Rhat = Exp(phi) R
+        and ahat_w = rho_a + Exp(phi) a_w:
+
+            r_a ~ [g]x phi - rho_a - Rhat delta_ba + Rhat n_a
+
+        The Jacobian contains the FIXED gravity vector and nothing else --
+        no estimated attitude, no estimated wave acceleration. That is the
+        structural gain over OU-III, whose J_att = -[f_cog_b]x is rebuilt from
+        the current specific-force estimate every step.
+
+        WHAT IS APPROXIMATED, precisely. Differentiating the residual exactly
+        gives
+
+            d r_a / d phi = -[Rhat (f_m - bhat_a)]x + [ahat_w]x
+                          = [g]x - [r_a]x
+
+        because Rhat(f_m - bhat_a) = ahat_w - g + r_a by definition of r_a. So
+        [g]x is the exact derivative only where the residual vanishes, and the
+        neglected term is exactly -[r_a]x: first order in the innovation,
+        vanishing as the filter converges.
+
+        That term is dropped on purpose. Keeping it would put the measurement
+        and the estimated attitude back into the Jacobian and forfeit the one
+        property this formulation exists for. It is the standard invariant-EKF
+        choice, and tfg_jacobians-test pins its exact size and structure --
+        finite differences at a consistent state must match to 1e-8, and the
+        discrepancy at an inconsistent state must equal -[r_a]x rather than
+        merely being "small".
+
+        Note the accelerometer-bias column: -Rhat, not -I. At Level 1
+        delta_ba is an additive BODY-frame error, so it has to be rotated into
+        the world frame the residual lives in. It collapses to -I only at
+        Level 2, where beta_a = R(bhat_a - b_a) is already world-referred.
+        That difference is exactly what the two-frame bias geometry buys, and
+        tfg_jacobians-test pins both the value and the reason.
+    */
+    void accel_residual(const Vector3& acc_meas_body, T tempC,
+                        Vector3& r, Eigen::Matrix<T,3,NX>& H, Matrix3& Rw) const {
+        const Vector3 ba = accel_bias_at_(tempC);
+        r = X_.R * (acc_meas_body - ba) - (X_.X.col(3) - gravity_world());
+
+        H.setZero();
+        H.template block<3,3>(0, OFF_PHI) = ocean_imu::lie::skew<T>(gravity_world());
+        H.template block<3,3>(0, OFF_AW)  = -Matrix3::Identity();
+        if constexpr (with_accel_bias) {
+            if (acc_bias_updates_enabled_) {
+                H.template block<3,3>(0, OFF_BA) =
+                    two_frame_bias ? Matrix3(-Matrix3::Identity()) : Matrix3(-X_.R);
+            }
+        }
+        // Body-frame sensor noise, expressed in the world frame the residual
+        // lives in. For isotropic Racc this is a no-op, which is worth knowing
+        // when reading the anisotropic case.
+        Rw = X_.R * Racc_ * X_.R.transpose();
+    }
+
+    /*
+        Magnetometer.
+
+            m_m = R^T B_w + n_m
+            r_m = Rhat m_m - B_w        ~  -[B_w]x phi + Rhat n_m
+
+        Again the Jacobian is built from the fixed world reference rather than
+        from the current predicted body-frame vector.
+
+        Same approximation as the accelerometer, same structure: the exact
+        derivative is -[Rhat m_m]x = -[B_w]x - [r_m]x, so the neglected term is
+        -[r_m]x, first order in the innovation.
+    */
+    void mag_residual(const Vector3& mag_meas_body,
+                      Vector3& r, Eigen::Matrix<T,3,NX>& H, Matrix3& Rw) const {
+        r = X_.R * mag_meas_body - B_w_;
+        H.setZero();
+        H.template block<3,3>(0, OFF_PHI) = -ocean_imu::lie::skew<T>(B_w_);
+        Rw = X_.R * Rmag_ * X_.R.transpose();
+    }
+
+    /*
+        Integral pseudo-measurement, z_S = 0 = S + n_S.
+
+            r_S = 0 - Shat = -Shat       ~  [Shat]x phi - rho_S + n_S
+
+        The [Shat]x term is O(S) and vanishes at the regularization target, so
+        it is routinely dropped. It is kept because it costs one cross product
+        and makes the finite-difference check exact rather than approximate --
+        a test that has to be loosened to accommodate a term you chose not to
+        write stops discriminating against the terms you got wrong.
+
+        R_S stays in world/NED coordinates. A NED-anisotropic R_S is a
+        deliberate physical choice (heave regularized differently from surge
+        and sway), and the right-invariant error is what preserves its meaning
+        -- but it does break rotational symmetry, so the filter must not then
+        be described as invariant under arbitrary world rotations.
+    */
+    void integral_residual(Vector3& r, Eigen::Matrix<T,3,NX>& H, Matrix3& Rw) const {
+        r = -X_.X.col(2);
+        H.setZero();
+        H.template block<3,3>(0, OFF_PHI) = ocean_imu::lie::skew<T>(Vector3(X_.X.col(2)));
+        H.template block<3,3>(0, OFF_S)   = -Matrix3::Identity();
+        Rw = R_S_;
+    }
+
+    bool measurement_update_acc_only(const Vector3& acc_meas_body, T tempC = T(35)) {
+        if (!acc_meas_body.allFinite()) { last_acc_diag_ = MeasDiag3{}; return false; }
+        Vector3 r; Eigen::Matrix<T,3,NX> H; Matrix3 Rw;
+        accel_residual(acc_meas_body, tempC, r, H, Rw);
+        const bool ok = apply_update3_(r, H, Rw, last_acc_diag_);
+        if (ok) project_acc_bias_();
+        return ok;
+    }
+
+    bool measurement_update_mag_only(const Vector3& mag_meas_body) {
+        if (!have_mag_reference_ || !mag_meas_body.allFinite() ||
+            !(mag_meas_body.norm() > T(1e-9))) {
+            last_mag_diag_ = MeasDiag3{};
+            return false;
+        }
+        Vector3 r; Eigen::Matrix<T,3,NX> H; Matrix3 Rw;
+        mag_residual(mag_meas_body, r, H, Rw);
+        return apply_update3_(r, H, Rw, last_mag_diag_);
+    }
+
+    bool applyIntegralZeroPseudoMeas() {
+        Vector3 r; Eigen::Matrix<T,3,NX> H; Matrix3 Rw;
+        integral_residual(r, H, Rw);
+        return apply_update3_(r, H, Rw, last_S_diag_);
+    }
+
+    // Exposed so the covariance-transport test can drive one update in
+    // isolation and inspect what it did.
+    bool apply_update3(const Vector3& r, const Eigen::Matrix<T,3,NX>& H,
+                       const Matrix3& Rw, MeasDiag3& diag) {
+        return apply_update3_(r, H, Rw, diag);
+    }
+
   private:
+    [[nodiscard]] Vector3 accel_bias_at_(T tempC) const {
+        if constexpr (with_accel_bias) {
+            return X_.B.col(1) + k_a_ * (tempC - kTempRefC);
+        } else {
+            (void)tempC;
+            return Vector3::Zero();
+        }
+    }
+
+    /*
+        Rank-3 Joseph update in the invariant tangent frame.
+
+        There is deliberately NO MEKF-style covariance reset afterwards.
+        ou_detail::apply_left_error_reset's G = I + 0.5 [dtheta]x exists because
+        OU-III's error state is zeroed after injection and its covariance has
+        to be transported into the new linearization point. Here the update is
+        already formulated in the post-update tangent frame, so applying that
+        transport on top would double-correct the covariance. The
+        no-double-reset assertion lives in covariance_transport-test.
+    */
+    bool apply_update3_(const Vector3& r, const Eigen::Matrix<T,3,NX>& H,
+                        const Matrix3& Rw, MeasDiag3& diag) {
+        diag = MeasDiag3{};
+        diag.r = r;
+        if (!r.allFinite() || !H.allFinite() || !Rw.allFinite()) return false;
+
+        const Eigen::Matrix<T,NX,3> PHt = P_ * H.transpose();
+        Matrix3 S = H * PHt + Rw;
+        S = T(0.5) * (S + S.transpose()).eval();
+        diag.S = S;
+
+        Eigen::LDLT<Matrix3> ldlt(S);
+        if (ldlt.info() != Eigen::Success) return false;
+        const Vector3 Sinv_r = ldlt.solve(r);
+        if (!Sinv_r.allFinite()) return false;
+
+        diag.nis = r.dot(Sinv_r);
+        if (nis_gate_ > T(0) && !(diag.nis <= nis_gate_)) return false;
+
+        const Eigen::Matrix<T,NX,3> K = ldlt.solve(PHt.transpose()).transpose();
+        if (!K.allFinite()) return false;
+
+        const MatrixNX IKH = MatrixNX::Identity() - K * H;
+        P_ = (IKH * P_ * IKH.transpose() + K * Rw * K.transpose()).eval();
+        P_ = T(0.5) * (P_ + P_.transpose()).eval();
+
+        // xi = K r is the estimated error; remove it.
+        inject(Tangent(-(K * r)));
+
+        diag.accepted = true;
+        return true;
+    }
+
+    /*
+        Confine b_a to a ball, as OU-III does. The rationale there is the ISS
+        argument in doc/kalman_ou_iii/w3d-iss-stability.tex-part: tilt,
+        horizontal acceleration and accelerometer bias are only weakly
+        separable, so an unbounded bias state will absorb a persistent tilt
+        error and walk away. A Lie-group formulation does not change that --
+        it is a physical observability limit, not a coordinate artifact.
+    */
+    void project_acc_bias_() {
+        if constexpr (with_accel_bias) {
+            if (!(acc_bias_limit_ > T(0))) return;
+            const T n = X_.B.col(1).norm();
+            if (n > acc_bias_limit_) X_.B.col(1) *= (acc_bias_limit_ / n);
+        }
+    }
+
     void reorthonormalize_() {
         // Cheaper and better conditioned than a QR: round-trip through the
         // quaternion, which is what the surrounding filters store anyway.
@@ -630,6 +901,26 @@ class Kalman3D_Wave_TFG {
     Matrix3 Q_gyro_{Matrix3::Identity() * T(2.5e-5)};
     Matrix3 Q_bg_{Matrix3::Identity() * T(1e-10)};
     Matrix3 Q_ba_{Matrix3::Identity() * T(2.5e-7)};
+
+    // Measurement noise. Racc_ and Rmag_ are BODY frame and get rotated into
+    // the world frame per update; R_S_ is already world/NED.
+    Matrix3 Racc_{Matrix3::Identity() * T(0.16)};
+    Matrix3 Rmag_{Matrix3::Identity() * T(0.01)};
+    Matrix3 R_S_{Matrix3::Identity() * T(1.5)};
+
+    Vector3 B_w_{Vector3::UnitX()};
+    bool    have_mag_reference_{false};
+
+    Vector3 k_a_{Vector3::Zero()};
+    T       acc_bias_limit_{T(0.5)};
+    bool    acc_bias_updates_enabled_{true};
+    T       nis_gate_{T(0)};
+
+    static constexpr T kTempRefC = T(35);
+
+    MeasDiag3 last_acc_diag_{};
+    MeasDiag3 last_mag_diag_{};
+    MeasDiag3 last_S_diag_{};
 
     Vector3 last_omega_{Vector3::Zero()};
 };

--- a/tests/kalman_tfg/Makefile
+++ b/tests/kalman_tfg/Makefile
@@ -24,7 +24,7 @@ LDFLAGS  =
 # Tell make to look for source files in src/util
 VPATH = $(REPO_ROOT)/src/util
 
-TARGETS = lie_group-test convention-test ou_chain_identity-test tfg_propagation-test
+TARGETS = lie_group-test convention-test ou_chain_identity-test tfg_propagation-test tfg_jacobians-test
 
 all: build test
 
@@ -46,6 +46,9 @@ ou_chain_identity-test: ou_chain_identity-test.o
 	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
 
 tfg_propagation-test: tfg_propagation-test.o
+	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
+
+tfg_jacobians-test: tfg_jacobians-test.o
 	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
 
 # -MMD -MP records the headers each object depends on, so editing a group or

--- a/tests/kalman_tfg/run_tests.sh
+++ b/tests/kalman_tfg/run_tests.sh
@@ -4,3 +4,4 @@
 ./convention-test
 ./ou_chain_identity-test
 ./tfg_propagation-test
+./tfg_jacobians-test

--- a/tests/kalman_tfg/tfg_jacobians-test.cpp
+++ b/tests/kalman_tfg/tfg_jacobians-test.cpp
@@ -1,0 +1,656 @@
+/*
+    Copyright (c) 2025-2026  Mikhail Grushinskiy
+
+    Measurement Jacobians for the invariant residuals, verified against
+    central finite differences taken ON THE MANIFOLD.
+
+    The perturbation goes through inject(), not by adding to a state vector.
+    That matters: inject() applies Exp_G, so the derivative computed here is
+    d r / d xi in exactly the coordinates P is expressed in and the Kalman
+    gain operates in. An additive perturbation would differ by J_l and by the
+    rotation of the world vectors, and would agree only to first order --
+    passing at small steps while the real linearization is wrong.
+
+    The sign convention is the one fixed in Kalman3D_Wave_TFG:
+
+        r ~ H xi + noise,   xi the error OF THE ESTIMATE,   correction = -K r
+
+    so H is literally d r / d xi and there is nothing to get backwards.
+
+    Beyond matching finite differences, the tests assert the two properties
+    that are the point of the redesign: the accelerometer and magnetometer
+    Jacobians are built from FIXED references (gravity, the world magnetic
+    vector) and must not change when the estimated attitude or the estimated
+    wave acceleration changes.
+*/
+
+#define EIGEN_NON_ARDUINO
+
+#include "kalman_tfg/Kalman3D_Wave_TFG.h"
+
+#include <cmath>
+#include <iostream>
+#include <random>
+#include <string>
+
+namespace {
+
+using T = double;
+using Filter  = ocean_imu::kalman::Kalman3D_Wave_TFG<T, true, true, false>;
+using Vector3 = Eigen::Matrix<T,3,1>;
+using Matrix3 = Eigen::Matrix<T,3,3>;
+using Tangent = Filter::Tangent;
+
+constexpr int NX = Filter::NX;
+using JacobianT = Eigen::Matrix<T,3,NX>;
+
+int failures = 0;
+
+bool check(bool condition, const std::string& message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        ++failures;
+    }
+    return condition;
+}
+
+std::mt19937 rng(20260806u);
+
+Vector3 rand_vec(double scale) {
+    std::uniform_real_distribution<double> d(-scale, scale);
+    return Vector3(d(rng), d(rng), d(rng));
+}
+
+Filter make_filter() {
+    Filter f;
+    f.set_aw_time_constant(T(1.7));
+    f.set_aw_stationary_std(Vector3(T(0.6), T(0.6), T(0.32)));
+    f.set_Racc_std(Vector3(T(0.4), T(0.35), T(0.5)));
+    f.set_Rmag_std(Vector3(T(0.1), T(0.12), T(0.09)));
+    f.set_RS_noise_vector(Vector3(T(1.5), T(1.5), T(0.8)));
+    f.set_magnetic_reference_world(Vector3(T(0.21), T(0.02), T(0.43)));
+    // A genuinely rotated attitude and non-zero everything, so a term that is
+    // wrong cannot pass by being multiplied into zero.
+    f.initialize_from_truth(
+        Eigen::Quaternion<T>(Eigen::AngleAxis<T>(
+            T(0.83), Vector3(T(0.31), T(-0.62), T(0.72)).normalized())),
+        Vector3(T(0.5), T(-0.8), T(1.1)),      // v
+        Vector3(T(-1.7), T(2.4), T(0.9)),      // p
+        Vector3(T(3.3), T(-2.1), T(1.4)),      // S
+        Vector3(T(0.3), T(-0.5), T(0.7)),      // a_w
+        Vector3(T(0.012), T(-0.008), T(0.004)),// b_g
+        Vector3(T(0.02), T(0.05), T(-0.01)));  // b_a
+    return f;
+}
+
+// ---------------------------------------------------------------------------
+// Generic finite-difference driver: perturb the estimate through inject(),
+// recompute the residual, central-difference.
+// ---------------------------------------------------------------------------
+
+template<typename ResidualFn>
+JacobianT numeric_jacobian(const Filter& base, ResidualFn residual, T eps) {
+    JacobianT numeric;
+    for (int j = 0; j < NX; ++j) {
+        Tangent e = Tangent::Zero();
+
+        e(j) = eps;
+        Filter plus = base;
+        plus.inject(e);
+
+        e(j) = -eps;
+        Filter minus = base;
+        minus.inject(e);
+
+        numeric.col(j) = (residual(plus) - residual(minus)) / (T(2) * eps);
+    }
+    return numeric;
+}
+
+// Bitwise state comparison, for asserting that something did NOT happen.
+//
+// error_from() is the wrong instrument here: it computes Log(Rhat R_ref^T),
+// and the floating-point product of a rotation with its own transpose is
+// I +- 1e-17 rather than exactly I, so it reports ~1e-16 of "error" between
+// two bitwise-identical states. For inertness the raw comparison is both
+// exact and unambiguous.
+bool states_identical(const Filter& a, const Filter& b) {
+    return (a.state().R - b.state().R).cwiseAbs().maxCoeff() == T(0)
+        && (a.state().X - b.state().X).cwiseAbs().maxCoeff() == T(0)
+        && (a.state().B - b.state().B).cwiseAbs().maxCoeff() == T(0);
+}
+
+void compare(const JacobianT& analytic, const JacobianT& numeric, T tol,
+             const std::string& tag) {
+    const T err = (analytic - numeric).cwiseAbs().maxCoeff();
+    if (!check(err <= tol, tag + ": Jacobian does not match finite differences")) {
+        std::cerr << "  max|diff| = " << err << " (tol " << tol << ")\n";
+        int bi = 0, bj = 0;
+        T worst = T(0);
+        for (int i = 0; i < 3; ++i) {
+            for (int j = 0; j < NX; ++j) {
+                const T d = std::abs(analytic(i,j) - numeric(i,j));
+                if (d > worst) { worst = d; bi = i; bj = j; }
+            }
+        }
+        std::cerr << "  worst entry (" << bi << "," << bj << "): analytic "
+                  << analytic(bi,bj) << " numeric " << numeric(bi,bj) << '\n';
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Accelerometer
+// ---------------------------------------------------------------------------
+
+// The specific force a perfectly calibrated sensor would report for this
+// state, so the residual is evaluated near zero rather than at an arbitrary
+// offset. No temperature term: the callers leave k_a at zero, and the
+// temperature path gets its own dedicated check below.
+Vector3 consistent_accel(const Filter& f) {
+    return f.R_wb() * (f.get_world_accel() - f.gravity_world()) + f.get_acc_bias();
+}
+
+/*
+    Finite differences at a CONSISTENT state, where r_a = 0.
+
+    That is not a convenience: [g]x is the exact derivative precisely where
+    the residual vanishes. Evaluating anywhere else would measure the
+    deliberately neglected -[r_a]x term as well, and the honest way to handle
+    that is a separate test that pins its exact value -- see below -- rather
+    than a tolerance loose enough to swallow it.
+*/
+void test_accel_jacobian_at_consistent_state() {
+    const T tempC = T(35);
+    for (int trial = 0; trial < 10; ++trial) {
+        Filter f = make_filter();
+        if (trial > 0) {
+            Tangent jitter = Tangent::Zero();
+            jitter.segment<3>(Filter::OFF_PHI) = rand_vec(0.5);
+            for (int c = 0; c < 4; ++c) jitter.segment<3>(Filter::OFF_V + 3*c) = rand_vec(1.5);
+            jitter.segment<3>(Filter::OFF_BA) = rand_vec(0.05);
+            f.inject(jitter);
+        }
+        const Vector3 acc = consistent_accel(f);
+
+        Vector3 r; JacobianT H; Matrix3 Rw;
+        f.accel_residual(acc, tempC, r, H, Rw);
+        check(r.cwiseAbs().maxCoeff() <= T(1e-12),
+              "the consistent-state accelerometer sample left a residual");
+
+        const JacobianT numeric = numeric_jacobian(
+            f,
+            [&](const Filter& g) {
+                Vector3 rr; JacobianT HH; Matrix3 RR;
+                g.accel_residual(acc, tempC, rr, HH, RR);
+                return rr;
+            },
+            T(1e-6));
+
+        compare(H, numeric, T(2e-8), "accelerometer (consistent state)");
+    }
+}
+
+/*
+    Away from a consistent state the finite-difference Jacobian and the
+    analytic one must differ by EXACTLY -[r_a]x.
+
+    This is the test that makes the approximation honest. Asserting only that
+    the gap is "small" would pass equally well if the gap were some other
+    small thing, and would stop discriminating the moment a genuine error of
+    similar magnitude appeared. Asserting the gap's exact structure means any
+    additional error shows up immediately, however small.
+*/
+void test_accel_jacobian_neglected_term_is_exactly_the_innovation() {
+    const T tempC = T(35);
+    for (int trial = 0; trial < 6; ++trial) {
+        Filter f = make_filter();
+        const Vector3 acc = consistent_accel(f) + rand_vec(0.4);
+
+        Vector3 r; JacobianT H; Matrix3 Rw;
+        f.accel_residual(acc, tempC, r, H, Rw);
+        check(r.norm() > T(0.1), "the deliberate residual is too small to test with");
+
+        const JacobianT numeric = numeric_jacobian(
+            f,
+            [&](const Filter& g) {
+                Vector3 rr; JacobianT HH; Matrix3 RR;
+                g.accel_residual(acc, tempC, rr, HH, RR);
+                return rr;
+            },
+            T(1e-6));
+
+        const Matrix3 gap = numeric.block<3,3>(0, Filter::OFF_PHI)
+                          - H.block<3,3>(0, Filter::OFF_PHI);
+        const Matrix3 want = -ocean_imu::lie::skew<T>(r);
+        const T err = (gap - want).cwiseAbs().maxCoeff();
+        if (!check(err <= T(2e-8),
+                   "the accelerometer Jacobian's neglected term is not exactly -[r_a]x")) {
+            std::cerr << "  max|gap + [r]x| = " << err << ", |r| = " << r.norm() << '\n';
+        }
+
+        // Every other column must be exact regardless of the residual.
+        JacobianT rest_a = H, rest_n = numeric;
+        rest_a.block<3,3>(0, Filter::OFF_PHI).setZero();
+        rest_n.block<3,3>(0, Filter::OFF_PHI).setZero();
+        compare(rest_a, rest_n, T(2e-8), "accelerometer (non-attitude columns)");
+    }
+}
+
+// The residual must vanish at a state consistent with the measurement --
+// otherwise the Jacobian is the derivative of the wrong function.
+void test_accel_residual_is_zero_at_truth() {
+    Filter f = make_filter();
+    const T tempC = T(41);
+    f.set_accel_bias_temp_coeff(Vector3(T(1e-3), T(-2e-3), T(5e-4)));
+    const Vector3 g = f.gravity_world();
+    const Vector3 ba = f.get_acc_bias() + Vector3(T(1e-3), T(-2e-3), T(5e-4)) * (tempC - T(35));
+    const Vector3 acc = f.R_wb() * (f.get_world_accel() - g) + ba;
+
+    Vector3 r; JacobianT H; Matrix3 Rw;
+    f.accel_residual(acc, tempC, r, H, Rw);
+    check(r.cwiseAbs().maxCoeff() <= T(1e-13),
+          "accelerometer residual is not zero at a consistent state "
+          "(temperature term applied inconsistently?)");
+}
+
+/*
+    The whole argument for the invariant residual is that H_a is built from
+    the fixed gravity vector. Assert it directly: rotate the estimate, change
+    the estimated wave acceleration, and the Jacobian's attitude block must
+    not move.
+*/
+void test_accel_jacobian_is_estimate_independent() {
+    Filter a = make_filter();
+    Filter b = make_filter();
+
+    Tangent big = Tangent::Zero();
+    big.segment<3>(Filter::OFF_PHI) = Vector3(T(0.9), T(-1.2), T(0.7));
+    big.segment<3>(Filter::OFF_AW)  = Vector3(T(2.0), T(-3.0), T(1.5));
+    b.inject(big);
+
+    Vector3 ra, rb; JacobianT Ha, Hb; Matrix3 Ra, Rb;
+    a.accel_residual(Vector3(T(0.1), T(0.2), T(-9.6)), T(35), ra, Ha, Ra);
+    b.accel_residual(Vector3(T(0.1), T(0.2), T(-9.6)), T(35), rb, Hb, Rb);
+
+    check((Ha.block<3,3>(0, Filter::OFF_PHI) - Hb.block<3,3>(0, Filter::OFF_PHI))
+              .cwiseAbs().maxCoeff() == T(0),
+          "H_a attitude block changed with the estimate; it must depend only on g");
+    check((Ha.block<3,3>(0, Filter::OFF_PHI)
+           - ocean_imu::lie::skew<T>(a.gravity_world())).cwiseAbs().maxCoeff() == T(0),
+          "H_a attitude block is not [g]x");
+    check((Ha.block<3,3>(0, Filter::OFF_AW) + Matrix3::Identity()).cwiseAbs().maxCoeff() == T(0),
+          "H_a wave-acceleration block is not -I");
+}
+
+/*
+    The accelerometer-bias column is -Rhat at Level 1 and -I at Level 2.
+
+    This is not a formatting detail. delta_ba is an additive BODY-frame error,
+    so it has to be rotated into the world frame the residual lives in;
+    beta_a = R(bhat_a - b_a) is already world-referred and needs no rotation.
+    Writing -I here at Level 1 would be wrong by a full rotation, and would
+    still look plausible because it is right at zero attitude.
+*/
+void test_accel_bias_column_is_rotated_at_level_one() {
+    Filter f = make_filter();
+    Vector3 r; JacobianT H; Matrix3 Rw;
+    f.accel_residual(Vector3(T(0.1), T(0.2), T(-9.6)), T(35), r, H, Rw);
+
+    const Matrix3 got = H.block<3,3>(0, Filter::OFF_BA);
+    check((got + f.R_bw()).cwiseAbs().maxCoeff() <= T(1e-15),
+          "H_a accelerometer-bias column must be -Rhat at Level 1");
+    // And it must be genuinely different from -I, or the test above proves
+    // nothing about this state.
+    check((got + Matrix3::Identity()).cwiseAbs().maxCoeff() > T(0.3),
+          "the test attitude is too close to identity to distinguish -Rhat from -I");
+}
+
+// Freezing the accelerometer bias must remove its column entirely.
+void test_accel_bias_freeze_zeroes_the_column() {
+    Filter f = make_filter();
+    f.set_acc_bias_updates_enabled(false);
+    Vector3 r; JacobianT H; Matrix3 Rw;
+    f.accel_residual(Vector3(T(0.1), T(0.2), T(-9.6)), T(35), r, H, Rw);
+    check(H.block<3,3>(0, Filter::OFF_BA).cwiseAbs().maxCoeff() == T(0),
+          "a frozen accelerometer bias must not appear in H_a");
+}
+
+// ---------------------------------------------------------------------------
+// Magnetometer
+// ---------------------------------------------------------------------------
+
+void test_mag_jacobian_at_consistent_state() {
+    for (int trial = 0; trial < 10; ++trial) {
+        Filter f = make_filter();
+        if (trial > 0) {
+            Tangent jitter = Tangent::Zero();
+            jitter.segment<3>(Filter::OFF_PHI) = rand_vec(0.6);
+            f.inject(jitter);
+        }
+        const Vector3 mag = f.R_wb() * f.magnetic_reference_world();
+
+        Vector3 r; JacobianT H; Matrix3 Rw;
+        f.mag_residual(mag, r, H, Rw);
+
+        const JacobianT numeric = numeric_jacobian(
+            f,
+            [&](const Filter& g) {
+                Vector3 rr; JacobianT HH; Matrix3 RR;
+                g.mag_residual(mag, rr, HH, RR);
+                return rr;
+            },
+            T(1e-6));
+
+        compare(H, numeric, T(2e-8), "magnetometer (consistent state)");
+    }
+}
+
+// Same structure as the accelerometer: the gap is exactly -[r_m]x.
+void test_mag_jacobian_neglected_term_is_exactly_the_innovation() {
+    for (int trial = 0; trial < 6; ++trial) {
+        Filter f = make_filter();
+        const Vector3 mag = f.R_wb() * f.magnetic_reference_world() + rand_vec(0.05);
+
+        Vector3 r; JacobianT H; Matrix3 Rw;
+        f.mag_residual(mag, r, H, Rw);
+        check(r.norm() > T(0.01), "the deliberate magnetic residual is too small");
+
+        const JacobianT numeric = numeric_jacobian(
+            f,
+            [&](const Filter& g) {
+                Vector3 rr; JacobianT HH; Matrix3 RR;
+                g.mag_residual(mag, rr, HH, RR);
+                return rr;
+            },
+            T(1e-6));
+
+        const Matrix3 gap = numeric.block<3,3>(0, Filter::OFF_PHI)
+                          - H.block<3,3>(0, Filter::OFF_PHI);
+        const T err = (gap + ocean_imu::lie::skew<T>(r)).cwiseAbs().maxCoeff();
+        check(err <= T(2e-8),
+              "the magnetometer Jacobian's neglected term is not exactly -[r_m]x");
+    }
+}
+
+void test_mag_residual_is_zero_at_truth() {
+    Filter f = make_filter();
+    const Vector3 mag = f.R_wb() * f.magnetic_reference_world();
+    Vector3 r; JacobianT H; Matrix3 Rw;
+    f.mag_residual(mag, r, H, Rw);
+    check(r.cwiseAbs().maxCoeff() <= T(1e-14),
+          "magnetometer residual is not zero at the true attitude");
+}
+
+void test_mag_jacobian_uses_the_world_reference() {
+    Filter a = make_filter();
+    Filter b = make_filter();
+    Tangent big = Tangent::Zero();
+    big.segment<3>(Filter::OFF_PHI) = Vector3(T(1.1), T(-0.6), T(0.9));
+    b.inject(big);
+
+    Vector3 ra, rb; JacobianT Ha, Hb; Matrix3 Ra, Rb;
+    const Vector3 mag(T(0.19), T(0.05), T(0.40));
+    a.mag_residual(mag, ra, Ha, Ra);
+    b.mag_residual(mag, rb, Hb, Rb);
+
+    check((Ha - Hb).cwiseAbs().maxCoeff() == T(0),
+          "H_m changed with the estimated attitude; it must depend only on B_w");
+    check((Ha.block<3,3>(0, Filter::OFF_PHI)
+           + ocean_imu::lie::skew<T>(a.magnetic_reference_world())).cwiseAbs().maxCoeff() == T(0),
+          "H_m attitude block is not -[B_w]x");
+    check(Ha.block<3,18>(0, 3).cwiseAbs().maxCoeff() == T(0),
+          "the magnetometer must not touch anything but attitude");
+}
+
+// ---------------------------------------------------------------------------
+// Integral pseudo-measurement
+// ---------------------------------------------------------------------------
+
+void test_integral_jacobian() {
+    for (int trial = 0; trial < 10; ++trial) {
+        Filter f = make_filter();
+        if (trial > 0) {
+            Tangent jitter = Tangent::Zero();
+            jitter.segment<3>(Filter::OFF_PHI) = rand_vec(0.4);
+            jitter.segment<3>(Filter::OFF_S)   = rand_vec(2.0);
+            f.inject(jitter);
+        }
+
+        Vector3 r; JacobianT H; Matrix3 Rw;
+        f.integral_residual(r, H, Rw);
+
+        const JacobianT numeric = numeric_jacobian(
+            f,
+            [](const Filter& g) {
+                Vector3 rr; JacobianT HH; Matrix3 RR;
+                g.integral_residual(rr, HH, RR);
+                return rr;
+            },
+            T(1e-6));
+
+        // The [Shat]x term is what makes this match at a tight tolerance;
+        // dropping it would leave an O(|S| |phi|) residual.
+        compare(H, numeric, T(2e-8), "integral pseudo-measurement");
+    }
+}
+
+void test_integral_keeps_the_S_cross_term() {
+    Filter f = make_filter();
+    Vector3 r; JacobianT H; Matrix3 Rw;
+    f.integral_residual(r, H, Rw);
+
+    check((H.block<3,3>(0, Filter::OFF_PHI)
+           - ocean_imu::lie::skew<T>(f.get_integral_displacement())).cwiseAbs().maxCoeff() == T(0),
+          "H_S attitude block is not [Shat]x");
+    check((H.block<3,3>(0, Filter::OFF_S) + Matrix3::Identity()).cwiseAbs().maxCoeff() == T(0),
+          "H_S integral block is not -I");
+    check((r + f.get_integral_displacement()).cwiseAbs().maxCoeff() == T(0),
+          "integral residual is not -Shat");
+}
+
+// ---------------------------------------------------------------------------
+// Noise rotation
+// ---------------------------------------------------------------------------
+
+void test_measurement_noise_is_rotated_into_the_world() {
+    Filter f = make_filter();
+    Vector3 r; JacobianT H; Matrix3 Rw;
+
+    f.set_Racc_std(Vector3(T(0.4), T(0.2), T(0.7)));   // anisotropic
+    f.accel_residual(Vector3(T(0.1), T(0.2), T(-9.6)), T(35), r, H, Rw);
+    Matrix3 body; body.setZero();
+    body.diagonal() << T(0.16), T(0.04), T(0.49);
+    check((Rw - f.R_bw() * body * f.R_wb()).cwiseAbs().maxCoeff() <= T(1e-14),
+          "accelerometer noise is not Rhat R_body Rhat^T");
+    check((Rw - body).cwiseAbs().maxCoeff() > T(1e-3),
+          "the test attitude does not actually exercise the rotation");
+
+    // Isotropic noise must pass through unchanged -- a useful invariant, and
+    // the reason this transformation is invisible in most configurations.
+    f.set_Racc_std(Vector3::Constant(T(0.4)));
+    f.accel_residual(Vector3(T(0.1), T(0.2), T(-9.6)), T(35), r, H, Rw);
+    check((Rw - Matrix3::Identity() * T(0.16)).cwiseAbs().maxCoeff() <= T(1e-15),
+          "isotropic accelerometer noise must be unchanged by the world rotation");
+
+    // R_S is already world frame and must NOT be rotated.
+    f.set_RS_noise_vector(Vector3(T(1.5), T(1.5), T(0.8)));
+    f.integral_residual(r, H, Rw);
+    Matrix3 want; want.setZero();
+    want.diagonal() << T(1.5), T(1.5), T(0.8);
+    check((Rw - want).cwiseAbs().maxCoeff() == T(0),
+          "R_S must stay in world/NED coordinates, not be rotated by the estimate");
+}
+
+// ---------------------------------------------------------------------------
+// The updates themselves
+// ---------------------------------------------------------------------------
+
+// An update must move the state toward the measurement and shrink the
+// covariance in the observed direction.
+void test_updates_reduce_error_and_covariance() {
+    // Accelerometer: seed a wave-acceleration error and check it shrinks.
+    {
+        Filter truth = make_filter();
+        Filter f = make_filter();
+        Tangent err = Tangent::Zero();
+        err.segment<3>(Filter::OFF_AW) = Vector3(T(0.4), T(-0.3), T(0.25));
+        f.inject(err);
+        f.set_initial_linear_uncertainty(T(0.3), T(1.0), T(3.0), T(0.6));
+
+        const Vector3 acc = consistent_accel(truth);
+        const T before = f.error_from(truth).segment<3>(Filter::OFF_AW).norm();
+        const T trace_before = f.covariance_full().trace();
+        check(f.measurement_update_acc_only(acc, T(35)), "accelerometer update was rejected");
+        const T after = f.error_from(truth).segment<3>(Filter::OFF_AW).norm();
+
+        check(after < before, "the accelerometer update did not reduce the a_w error");
+        check(f.covariance_full().trace() < trace_before,
+              "the accelerometer update did not reduce covariance");
+        check(f.lastAccDiag().accepted && f.lastAccDiag().nis >= T(0),
+              "accelerometer diagnostics not populated");
+    }
+
+    // Magnetometer: seed a yaw error.
+    {
+        Filter truth = make_filter();
+        Filter f = make_filter();
+        Tangent err = Tangent::Zero();
+        err.segment<3>(Filter::OFF_PHI) = Vector3(T(0), T(0), T(0.15));
+        f.inject(err);
+
+        const Vector3 mag = truth.R_wb() * truth.magnetic_reference_world();
+        const T before = f.error_from(truth).segment<3>(Filter::OFF_PHI).norm();
+        check(f.measurement_update_mag_only(mag), "magnetometer update was rejected");
+        const T after = f.error_from(truth).segment<3>(Filter::OFF_PHI).norm();
+        check(after < before, "the magnetometer update did not reduce the attitude error");
+    }
+
+    // Integral: S must be pulled toward zero.
+    {
+        Filter f = make_filter();
+        f.set_initial_linear_uncertainty(T(0.3), T(1.0), T(3.0), T(0.6));
+        const T before = f.get_integral_displacement().norm();
+        check(f.applyIntegralZeroPseudoMeas(), "integral pseudo-measurement was rejected");
+        check(f.get_integral_displacement().norm() < before,
+              "the integral pseudo-measurement did not pull S toward zero");
+    }
+}
+
+// Covariance must stay symmetric and PSD through a long measurement sequence.
+void test_updates_keep_covariance_sane() {
+    Filter f = make_filter();
+    f.set_initial_linear_uncertainty(T(0.3), T(1.0), T(3.0), T(0.6));
+    std::normal_distribution<double> n(0.0, 0.2);
+
+    for (int step = 0; step < 3000; ++step) {
+        f.time_update(Vector3(n(rng), n(rng), n(rng)), T(0.005));
+        f.measurement_update_acc_only(
+            Vector3(f.R_wb() * (f.get_world_accel() - f.gravity_world())) + rand_vec(0.05),
+            T(35));
+        if (step % 8 == 0) {
+            f.measurement_update_mag_only(
+                Vector3(f.R_wb() * f.magnetic_reference_world()) + rand_vec(0.01));
+        }
+        if (step % 3 == 0) f.applyIntegralZeroPseudoMeas();
+    }
+
+    const auto& P = f.covariance_full();
+    check(P.allFinite(), "covariance went non-finite over a filtered run");
+    check((P - P.transpose()).cwiseAbs().maxCoeff() <= T(1e-12) * P.cwiseAbs().maxCoeff(),
+          "covariance lost symmetry under the Joseph update");
+    Eigen::SelfAdjointEigenSolver<Filter::MatrixNX> es(P);
+    check(es.info() == Eigen::Success &&
+          es.eigenvalues().minCoeff() >= -T(1e-10) * std::max(T(1), P.cwiseAbs().maxCoeff()),
+          "covariance stopped being PSD under the Joseph update");
+    check(f.state().R.allFinite() && f.get_acc_bias().norm() <= T(0.5) + T(1e-9),
+          "accelerometer bias escaped its ball");
+}
+
+// Rejected updates must leave the state and covariance completely untouched.
+void test_rejected_updates_are_inert() {
+    Filter f = make_filter();
+    f.set_meas_gate_nis(T(1e-6));   // reject essentially everything
+    const Filter before = f;
+    const auto P_before = f.covariance_full();
+
+    const bool accepted = f.measurement_update_acc_only(Vector3(T(5), T(5), T(5)), T(35));
+    check(!accepted, "the NIS gate did not reject an absurd measurement");
+    check(!f.lastAccDiag().accepted, "diagnostics claim acceptance after rejection");
+    check(states_identical(f, before), "a rejected update modified the state");
+    check((f.covariance_full() - P_before).cwiseAbs().maxCoeff() == T(0),
+          "a rejected update modified the covariance");
+
+    // A missing magnetic reference must also be inert, not a silent update
+    // against the default unit-x vector.
+    Filter g;
+    g.initialize_identity();
+    check(!g.has_magnetic_reference(), "magnetic reference should start unset");
+    const auto Pg = g.covariance_full();
+    check(!g.measurement_update_mag_only(Vector3(T(0.2), T(0), T(0.4))),
+          "magnetometer update ran without a world reference");
+    check((g.covariance_full() - Pg).cwiseAbs().maxCoeff() == T(0),
+          "an update without a magnetic reference modified the covariance");
+}
+
+// Non-finite input must not poison the filter.
+void test_non_finite_input_is_ignored() {
+    Filter f = make_filter();
+    const auto P_before = f.covariance_full();
+    const Filter before = f;
+    const T nan = std::numeric_limits<T>::quiet_NaN();
+    check(!f.measurement_update_acc_only(Vector3(nan, T(0), T(0)), T(35)),
+          "a NaN accelerometer sample was accepted");
+    check(!f.measurement_update_mag_only(Vector3(nan, T(0), T(0))),
+          "a NaN magnetometer sample was accepted");
+    check(states_identical(f, before) &&
+          (f.covariance_full() - P_before).cwiseAbs().maxCoeff() == T(0),
+          "a NaN sample perturbed the filter");
+}
+
+void test_float_instantiation() {
+    using FloatFilter = ocean_imu::kalman::Kalman3D_Wave_TFG<float, true, true, false>;
+    FloatFilter f;
+    f.initialize_identity();
+    f.set_magnetic_reference_world(Eigen::Vector3f(0.21f, 0.02f, 0.43f));
+    for (int i = 0; i < 400; ++i) {
+        f.time_update(Eigen::Vector3f(0.01f, -0.02f, 0.03f), 0.005f);
+        f.measurement_update_acc_only(Eigen::Vector3f(0.0f, 0.0f, -9.80665f), 35.0f);
+        f.measurement_update_mag_only(Eigen::Vector3f(0.21f, 0.02f, 0.43f));
+        f.applyIntegralZeroPseudoMeas();
+    }
+    check(f.covariance_full().allFinite() && f.state().R.allFinite(),
+          "the float instantiation went non-finite under measurement updates");
+}
+
+} // namespace
+
+int main() {
+    test_accel_residual_is_zero_at_truth();
+    test_accel_jacobian_at_consistent_state();
+    test_accel_jacobian_neglected_term_is_exactly_the_innovation();
+    test_accel_jacobian_is_estimate_independent();
+    test_accel_bias_column_is_rotated_at_level_one();
+    test_accel_bias_freeze_zeroes_the_column();
+
+    test_mag_residual_is_zero_at_truth();
+    test_mag_jacobian_at_consistent_state();
+    test_mag_jacobian_neglected_term_is_exactly_the_innovation();
+    test_mag_jacobian_uses_the_world_reference();
+
+    test_integral_jacobian();
+    test_integral_keeps_the_S_cross_term();
+
+    test_measurement_noise_is_rotated_into_the_world();
+    test_updates_reduce_error_and_covariance();
+    test_updates_keep_covariance_sane();
+    test_rejected_updates_are_inert();
+    test_non_finite_input_is_ignored();
+    test_float_instantiation();
+
+    if (failures != 0) {
+        std::cerr << failures << " Jacobian check(s) failed\n";
+        return 1;
+    }
+    std::cout << "tfg_jacobians-test: all checks passed\n";
+    return 0;
+}


### PR DESCRIPTION
Third phase, following #245 (the group) and #246 (the world vectors on it).
The accelerometer, magnetometer and integral-zero pseudo-measurement now run
as world-frame invariant residuals, with a rank-3 Joseph update in the
invariant tangent frame.

```
r_a = Rhat(f_m - bhat_a) - (ahat_w - g)    H_a = [ [g]x .. -I .. -Rhat ]
r_m = Rhat m_m - B_w                       H_m = [ -[B_w]x .. ]
r_S = -Shat                                H_S = [ [Shat]x .. -I .. ]
```

## The structural gain

Neither `H_a` nor `H_m` contains the estimated attitude or the estimated wave
acceleration. Both are built from fixed references -- gravity and the world
magnetic vector -- where OU-III's `J_att = -[f_cog_b]x` is rebuilt from the
current specific-force estimate on every step. A test asserts this directly
rather than by inspection: rotate the estimate by a large angle, move `a_w`,
and the Jacobians must not change at all.

## The accelerometer-bias column is `-Rhat`, not `-I`

At Level 1 `delta_ba` is an additive **body-frame** error, so it has to be
rotated into the world frame the residual lives in. It collapses to `-I` only
at Level 2, where `beta_a = R(bhat_a - b_a)` is already world-referred.

That is a concrete measure of what the two-frame bias geometry buys, and it is
a trap: `-I` is wrong by a full rotation and still looks right at zero
attitude. The test pins the value *and* asserts the test attitude is far
enough from identity for the two to be distinguishable.

## One sign convention

```
xi     is the error OF THE ESTIMATE,  eta = Xhat X^-1 = Exp_G(xi),  P = E[xi xi^T]
r      ~ H xi + noise                 (plus, not minus)
xihat  = K r                          the estimated error
Xhat+  = Exp_G(-xihat) o Xhat         remove it
```

The correction is injected negated. Deriving `H` against `r ~ -H xi` and then
injecting `+K r` cancels out only if both mistakes are made together, and
leaves a filter that works until someone fixes one of them. `H` here is
literally `d r / d xi`, which is exactly what the finite differences measure.

## What is approximated, and how it is tested

Differentiating the accelerometer residual exactly gives

```
d r_a / d phi = -[Rhat (f_m - bhat_a)]x + [ahat_w]x = [g]x - [r_a]x
```

so `[g]x` is the exact derivative only where the residual vanishes, and the
neglected term is exactly `-[r_a]x` -- first order in the innovation. Dropping
it is deliberate: keeping it would put the measurement and the estimated
attitude back into the Jacobian and forfeit the property this formulation
exists for. The magnetometer has the same structure.

My first finite-difference run failed by 2-3% for exactly this reason. Rather
than loosen the tolerance until it accommodated the term, the tests now check
finite differences at a **consistent state** to `2e-8`, and **separately**
assert that the gap at an inconsistent state equals `-[r]x`. Asserting a gap
is merely "small" would pass equally well if the gap were some other small
thing, and would stop discriminating the moment a genuine error of similar
size appeared.

## No covariance reset

`apply_left_error_reset` exists because OU-III zeroes its error state after
injection and has to transport `P` into the new linearization point. Here the
update is already expressed in the post-update tangent frame, so applying that
transport on top would double-correct. Its absence is deliberate and
documented at the call site.

## Verification

Six mutations confirmed to fail: un-negated correction 7 failures, `H_a`
attitude sign 17, `-I` bias column 18, dropped `[Shat]x` term 11, unrotated
measurement noise 2, flipped magnetometer residual 17.

`make -C tests/kalman_tfg test` passes all five suites. **The repo-wide
`make all` was still running when this PR was opened** -- the change is
additive to a new component and its own suite is green and mutation-verified,
but that wider check is not yet confirmed. I will follow up here with the
result and push a fix if it is red.

Two of my own test bugs, worth recording since both are easy to repeat: a
`1e-9` finite-difference step is *worse* than `1e-6` (rounding is
`eps_machine / h ~ 2e-7`, which swamped the quantity being measured), and
`error_from` is the wrong instrument for "nothing happened" assertions,
because the floating-point product of a rotation with its own transpose is
`I +- 1e-17` rather than exactly `I`.

Firmware footprint, since template bloat was the standing ESP32 concern: the
float-only proxy is 104 KB text and 2.4 KB bss, against OU-III's 108 KB and
5.7 KB.

## Not included

The IMU lever-arm term (`alpha x r + omega x (omega x r)`) is absent from the
accelerometer residual. It needs its own gyro-bias Jacobian coupling and
belongs with dedicated finite-difference coverage, rather than being added
alongside three other new residuals in one change.

Level 2 -- the two-frame bias geometry, where `-Rhat` becomes `-I` and the
`beta` rotation coupling enters the propagation -- remains `static_assert`ed
off and is the next phase.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9aDUvqetsX7jojWiDumAf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added measurement updates for accelerometer, magnetometer, and integral pseudo-measurements.
  * Added configurable measurement noise, magnetic references, bias compensation and limits, diagnostic reporting, and NIS-based gating.
  * Added covariance-stable updates with validation and rejection of invalid measurements.

* **Documentation**
  * Documented measurement-update behavior, Jacobians, noise models, covariance handling, and testing guidance.

* **Tests**
  * Added comprehensive Jacobian and measurement-update coverage, including finite-difference validation, covariance stability, rejection handling, and floating-point support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->