### PR TITLE
Add the sea-state orchestrator, and fix an r_S units bug it exposed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,3 +51,4 @@ add_executable(ou_chain_identity-test "${OCEAN_IMU_TESTS_DIR}/kalman_tfg/ou_chai
 add_executable(tfg_propagation-test "${OCEAN_IMU_TESTS_DIR}/kalman_tfg/tfg_propagation-test.cpp")
 add_executable(tfg_jacobians-test "${OCEAN_IMU_TESTS_DIR}/kalman_tfg/tfg_jacobians-test.cpp")
 add_executable(covariance_transport-test "${OCEAN_IMU_TESTS_DIR}/kalman_tfg/covariance_transport-test.cpp")
+add_executable(tfg_orchestrator-test "${OCEAN_IMU_TESTS_DIR}/kalman_tfg/tfg_orchestrator-test.cpp")

--- a/docs/tfg-design.md
+++ b/docs/tfg-design.md
@@ -406,7 +406,56 @@ the input until both blocks are exercised equally. Worth remembering
 generally: a tolerance calibrated against the largest term in a matrix says
 nothing about the smallest.
 
-## 6. What this does not claim
+## 6. r_S is a standard deviation
+
+`Kalman3D_Wave_TFG::set_RS_noise` takes a **standard deviation** and squares it
+internally, matching `Kalman3D_Wave_OU_III::set_RS_noise` exactly. The tuning
+law produces `r_S` in those units — the article calls it "the standard-deviation
+scale whose square forms the integral pseudo-measurement covariance".
+
+This is recorded because getting it wrong was expensive to diagnose. An earlier
+version of the orchestrator passed `r_S` into a setter that took a variance, so
+the applied covariance was `r_S` rather than `r_S^2` — roughly a factor of ten
+of over-tight regularization at a typical operating point.
+
+**It did not look like a units error.** The `S = 0` constraint is a high-pass,
+and over-tightening a high-pass *overshoots* rather than attenuates, so the
+symptom was a heave amplitude 37% too large and a 46% RMS error that read like a
+modelling problem. Two things made it findable:
+
+1. **Decomposing the error instead of staring at the total.** Fitting `p_z` to a
+   sinusoid at the known frequency split the 46% into gain, phase, DC and
+   residual. The residual was 0.002 m — so it was not noise, not drift, and not
+   the missing detrender. Almost all of it was gain, which points at the
+   regularizer rather than at the integration chain.
+2. **Comparing against OU-III on identical input.** That is also where the first
+   comparison misled: the harness passed `r_S^2` to OU-III, which squared it
+   again, making OU-III's regularizer far too weak and its gain look better
+   (1.05) than it is. Once both filters were given a standard deviation, OU-III
+   measured *worse* than this filter (1.23 vs 1.19).
+
+`tfg_orchestrator-test::test_rs_units_are_a_standard_deviation` guards it now.
+
+### What remains after the fix
+
+About 21% RMS on a 0.15 Hz monochromatic sea, and it is the regularizer's
+high-pass overshoot, shared with OU-III:
+
+| | 0.08 Hz | 0.10 Hz | 0.15 Hz | 0.20 Hz | 0.30 Hz |
+|---|---|---|---|---|---|
+| TFG gain | 1.54 | 1.39 | 1.19 | 1.11 | 1.04 |
+| OU-III gain | 1.62 | 1.46 | 1.23 | 1.13 | 1.05 |
+
+Monotonic in frequency, and equally monotonic in `r_S` (1.39 at `r_S = 3` down
+to 1.05 at `r_S = 100`). TFG is better than OU-III at every point measured.
+
+None of that is a performance claim. The `R_S_coeff = 0.35` law was calibrated
+against broadband JONSWAP and PM spectra, and a pure sinusoid concentrates all
+its energy at one frequency, so this synthetic case is harsher than what the
+tuning was designed for. The real measurement belongs in the paired study
+against recorded waves, not here.
+
+## 7. What this does not claim
 
 The bias-free, frozen-parameter skeleton is group-affine. The complete
 estimator is **not** shown to be, and must not be described as an InEKF or as

--- a/src/kalman_tfg/Kalman3D_Wave_TFG.h
+++ b/src/kalman_tfg/Kalman3D_Wave_TFG.h
@@ -318,6 +318,123 @@ class Kalman3D_Wave_TFG {
     [[nodiscard]] const Group& state() const { return X_; }
     [[nodiscard]] Group& state() { return X_; }
 
+    /*
+        Tilt-only initialization from a gravity reading.
+
+        At rest the accelerometer reports -g in body coordinates, so the
+        measured direction fixes roll and pitch and says nothing about yaw.
+        Yaw is left at zero here; the magnetometer sets it later, once a world
+        reference exists.
+    */
+    bool initialize_from_acc(const Vector3& acc_body) {
+        if (!acc_body.allFinite()) return false;
+        const T n = acc_body.norm();
+        if (!(n > T(1e-6))) return false;
+
+        // Body-frame "up" is the direction the specific force points at rest.
+        const Vector3 up_body = acc_body / n;
+        const Vector3 up_world(T(0), T(0), T(-1));   // NED: up is -z
+
+        // Smallest rotation carrying up_body onto up_world, as R_bw.
+        const Vector3 v = up_body.cross(up_world);
+        const T c = up_body.dot(up_world);
+        const T s2 = v.squaredNorm();
+        Matrix3 R;
+        if (s2 < T(1e-18)) {
+            // Parallel or antiparallel. Antiparallel needs a half turn about
+            // any axis orthogonal to up_body; parallel is the identity.
+            if (c > T(0)) {
+                R = Matrix3::Identity();
+            } else {
+                Vector3 axis = up_body.cross(Vector3::UnitX());
+                if (axis.norm() < T(1e-6)) axis = up_body.cross(Vector3::UnitY());
+                axis.normalize();
+                R = ocean_imu::lie::Exp<T>(Vector3(axis * T(M_PI)));
+            }
+        } else {
+            const Matrix3 V = ocean_imu::lie::skew<T>(v);
+            R = Matrix3::Identity() + V + V * V * ((T(1) - c) / s2);
+        }
+        X_.R = R;
+        reorthonormalize_();
+        return true;
+    }
+
+    /*
+        Linear-block gate.
+
+        Until the tuner has an operating point worth trusting, the world chain
+        is not propagated or corrected and the filter behaves as an
+        attitude-and-bias estimator. The accelerometer update still runs -- it
+        is what levels the filter -- but with a_w marginalized into the
+        measurement noise rather than estimated, exactly as OU-III does when
+        its linear block is off.
+    */
+    void set_linear_block_enabled(bool on) { linear_block_enabled_ = on; }
+    [[nodiscard]] bool linear_block_enabled() const { return linear_block_enabled_; }
+
+    /*
+        Re-seed the a_w covariance from the stationary OU covariance.
+
+        reset_* zeroes the cross-covariances: use it when the operating point
+        has moved so far that the old correlations are meaningless.
+
+        synchronize_*_congruent rescales instead, preserving every correlation
+        coefficient. P_aa is replaced by Sigma while each cross-covariance is
+        carried through the same congruence, so the joint stays consistent.
+        That is the gentler of the two and the one the orchestrator uses on its
+        periodic tick.
+
+        Both work on the INVARIANT tangent block, not on a_w as a free-standing
+        Euclidean state -- P's rho_a rows are expressed in the same right-
+        invariant coordinates as everything else, and treating them otherwise
+        would silently mix frames.
+    */
+    void reset_aw_covariance_to_stationary() {
+        P_.template block<3,3>(OFF_AW, OFF_AW) = Sigma_aw_;
+        for (int i = 0; i < NX; ++i) {
+            if (i >= OFF_AW && i < OFF_AW + 3) continue;
+            for (int k = 0; k < 3; ++k) {
+                P_(i, OFF_AW + k) = T(0);
+                P_(OFF_AW + k, i) = T(0);
+            }
+        }
+    }
+
+    bool synchronize_aw_covariance_to_stationary_congruent() {
+        Matrix3 P_aa = P_.template block<3,3>(OFF_AW, OFF_AW);
+        P_aa = T(0.5) * (P_aa + P_aa.transpose()).eval();
+
+        Eigen::LLT<Matrix3> llt_old(P_aa);
+        Eigen::LLT<Matrix3> llt_new(Matrix3(T(0.5) * (Sigma_aw_ + Sigma_aw_.transpose())));
+        if (llt_old.info() != Eigen::Success || llt_new.info() != Eigen::Success) {
+            reset_aw_covariance_to_stationary();
+            return false;
+        }
+        // M carries the old marginal onto the new one; applying it to the
+        // cross-covariances keeps every correlation coefficient intact.
+        const Matrix3 M = llt_new.matrixL() *
+                          Matrix3(llt_old.matrixL()).inverse();
+        if (!M.allFinite()) {
+            reset_aw_covariance_to_stationary();
+            return false;
+        }
+
+        for (int i = 0; i < NX; ++i) {
+            if (i >= OFF_AW && i < OFF_AW + 3) continue;
+            Vector3 col;
+            for (int k = 0; k < 3; ++k) col(k) = P_(OFF_AW + k, i);
+            const Vector3 scaled = M * col;
+            for (int k = 0; k < 3; ++k) {
+                P_(OFF_AW + k, i) = scaled(k);
+                P_(i, OFF_AW + k) = scaled(k);
+            }
+        }
+        P_.template block<3,3>(OFF_AW, OFF_AW) = M * P_aa * M.transpose();
+        P_ = T(0.5) * (P_ + P_.transpose()).eval();
+        return true;
+    }
+
     // ------------------------------------------------------------- tuning
 
     void set_aw_time_constant(T tau) { tau_aw_ = std::max(T(1e-3), tau); }
@@ -375,11 +492,13 @@ class Kalman3D_Wave_TFG {
         X_.R = X_.R * ocean_imu::lie::Exp<T>(Vector3(omega * Ts));
         reorthonormalize_();
 
-        Eigen::Matrix<T,4,4> Phi_axis;
-        ou_detail::IntegratedOUChain<T,3>::transition(tau_aw_, Ts, Phi_axis);
-        // Row i of X is [v_i p_i S_i a_i], so applying the per-axis 4x4 to
-        // every row at once is a right multiplication by its transpose.
-        X_.X = (X_.X * Phi_axis.transpose()).eval();
+        if (linear_block_enabled_) {
+            Eigen::Matrix<T,4,4> Phi_axis;
+            ou_detail::IntegratedOUChain<T,3>::transition(tau_aw_, Ts, Phi_axis);
+            // Row i of X is [v_i p_i S_i a_i], so applying the per-axis 4x4 to
+            // every row at once is a right multiplication by its transpose.
+            X_.X = (X_.X * Phi_axis.transpose()).eval();
+        }
     }
 
     /*
@@ -442,7 +561,11 @@ class Kalman3D_Wave_TFG {
             }
         }
 
-        // World block: the OU chain, exact, per axis.
+        // World block: the OU chain, exact, per axis. When the linear block is
+        // gated off the world states are frozen, so Phi stays the identity
+        // there and the bias coupling below is skipped with it.
+        if (!linear_block_enabled_) return;
+
         Eigen::Matrix<T,4,4> Phi_axis;
         ou_detail::IntegratedOUChain<T,3>::transition(tau_aw_, Ts, Phi_axis);
         Phi.template block<12,12>(OFF_V, OFF_V).setZero();
@@ -564,7 +687,7 @@ class Kalman3D_Wave_TFG {
         }
 
         // World block: the exact OU contribution, added on top.
-        add_ou_process_noise_(Ts, Qd);
+        if (linear_block_enabled_) add_ou_process_noise_(Ts, Qd);
 
         if constexpr (with_accel_bias) {
             Qd.template block<3,3>(OFF_BA, OFF_BA) =
@@ -815,7 +938,9 @@ class Kalman3D_Wave_TFG {
 
         H.setZero();
         H.template block<3,3>(0, OFF_PHI) = ocean_imu::lie::skew<T>(gravity_world());
-        H.template block<3,3>(0, OFF_AW)  = -Matrix3::Identity();
+        if (linear_block_enabled_) {
+            H.template block<3,3>(0, OFF_AW) = -Matrix3::Identity();
+        }
         if constexpr (with_accel_bias) {
             if (acc_bias_updates_enabled_) {
                 H.template block<3,3>(0, OFF_BA) =
@@ -826,6 +951,13 @@ class Kalman3D_Wave_TFG {
         // lives in. For isotropic Racc this is a no-op, which is worth knowing
         // when reading the anisotropic case.
         Rw = X_.R * Racc_ * X_.R.transpose();
+
+        // With the linear block frozen, a_w is not estimated -- but it is
+        // still physically present in the measurement. Marginalize it in as
+        // extra measurement noise rather than pretending it is zero, which is
+        // what OU-III does in the same situation. Sigma_aw is already a world-
+        // frame covariance, so it adds directly.
+        if (!linear_block_enabled_) Rw += Sigma_aw_;
     }
 
     /*
@@ -895,6 +1027,7 @@ class Kalman3D_Wave_TFG {
     }
 
     bool applyIntegralZeroPseudoMeas() {
+        if (!linear_block_enabled_) { last_S_diag_ = MeasDiag3{}; return false; }
         Vector3 r; Eigen::Matrix<T,3,NX> H; Matrix3 Rw;
         integral_residual(r, H, Rw);
         return apply_update3_(r, H, Rw, last_S_diag_);
@@ -1046,6 +1179,7 @@ class Kalman3D_Wave_TFG {
     T       acc_bias_limit_{T(0.5)};
     bool    acc_bias_updates_enabled_{true};
     T       nis_gate_{T(0)};
+    bool    linear_block_enabled_{true};
 
     static constexpr T kTempRefC = T(35);
 

--- a/src/kalman_tfg/Kalman3D_Wave_TFG.h
+++ b/src/kalman_tfg/Kalman3D_Wave_TFG.h
@@ -864,8 +864,26 @@ class Kalman3D_Wave_TFG {
     void set_Racc_matrix(const Matrix3& R_body) { Racc_ = T(0.5) * (R_body + R_body.transpose()); }
     void set_Rmag_std(const Vector3& std_body)  { Rmag_ = std_body.cwiseAbs2().asDiagonal(); }
     void set_Rmag(T variance) { Rmag_ = Matrix3::Identity() * std::abs(variance); }
-    void set_RS_noise(T variance) { R_S_ = Matrix3::Identity() * std::abs(variance); }
-    void set_RS_noise_vector(const Vector3& variances) { R_S_ = variances.cwiseAbs().asDiagonal(); }
+    /*
+        Integral pseudo-measurement noise, as a STANDARD DEVIATION, matching
+        Kalman3D_Wave_OU_III::set_RS_noise exactly.
+
+        The units here are a trap worth spelling out. The tuning law produces
+        r_S as a standard-deviation scale -- the article calls it "the
+        standard-deviation scale whose square forms the integral
+        pseudo-measurement covariance" -- so a setter that took a variance
+        would silently receive r_S and apply r_S instead of r_S^2. At a typical
+        operating point that is an order of magnitude of over-tight
+        regularization, and it shows up as resonant gain rather than as
+        anything that looks like a units error.
+
+        set_RS_noise_matrix takes a covariance directly, for the anisotropic
+        case where a standard deviation per axis is not enough.
+    */
+    void set_RS_noise(const Vector3& sigma_S) {
+        R_S_ = sigma_S.array().square().matrix().asDiagonal();
+    }
+    void set_RS_noise(T sigma_S) { set_RS_noise(Vector3::Constant(std::abs(sigma_S))); }
     void set_RS_noise_matrix(const Matrix3& R_S) { R_S_ = T(0.5) * (R_S + R_S.transpose()); }
 
     // World-frame magnetic reference, NED. Stored as the fixed vector the

--- a/src/kalman_tfg/SeaStateFusionFilter_TFG.h
+++ b/src/kalman_tfg/SeaStateFusionFilter_TFG.h
@@ -1,0 +1,462 @@
+#pragma once
+
+/*
+    Copyright (c) 2025-2026  Mikhail Grushinskiy
+
+    Sea-state orchestration for the two-frame Lie-group filter.
+
+    SCOPE. This is deliberately the core of what SeaStateFusionFilter_OU_III
+    does, not all of it: startup staging, the sea-state tuner, the adaptation
+    smoothers, and the update loop. The wave-direction estimator, the
+    alternative frequency trackers (KalmANF, Aranovskiy, PLL), the displacement
+    detrender and the wind-heel B' frame are NOT carried over. They are
+    orthogonal to the estimator under test, and duplicating them would mean
+    maintaining a second copy of logic whose behaviour is already established
+    and evidenced for OU-III.
+
+    What that costs is worth stating plainly: the TFG simulator is therefore
+    not feature-comparable to the OU-III one on direction and frequency
+    reporting, and any paired study has to compare the channels both filters
+    actually implement.
+
+    WHAT IS SHARED RATHER THAN COPIED
+      - ::seastate::common::runStartupGravityInit and StartupTiltObserver, for
+        the Cold-stage levelling;
+      - ::seastate::common::adaptiveSmoothingHorizonSec, for the r_S channel;
+      - SeaStateAutoTuner              (variance at the wave-band operating point)
+      - WavePeriodEstimator            (zero-crossing T_z)
+      - VerticalAccelComplementary     (its private Mahony observer)
+
+    THE TUNER STAYS OUTSIDE THE GROUP STATE. tau, sigma_aw and r_S are
+    hyperparameters here, not manifold states. The article's ablation shows
+    nearly all the vertical benefit comes from adapting the integral
+    regularization scale rather than the two OU parameters, so promoting them
+    to stochastic states would add complexity without evidence it solves the
+    problem that matters.
+
+    WHY THE WAVE-PERIOD INPUT IS THE COMPLEMENTARY OBSERVER. The tuner's
+    frequency channel must not be a function of the estimator it tunes, or the
+    loop closes on itself. VerticalAccelComplementary runs its own small Mahony
+    observer on raw gyro and accelerometer, so the period estimate is
+    independent of the filter's attitude. That is the same choice OU-III
+    settled on, and for the same reason.
+*/
+
+#ifdef EIGEN_NON_ARDUINO
+#include <Eigen/Dense>
+#else
+#include <ArduinoEigenDense.h>
+#endif
+
+#include <algorithm>
+#include <cmath>
+
+#include "kalman_common/SeaStateFusionFilterCommon.h"
+#include "kalman_tfg/Kalman3D_Wave_TFG.h"
+#include "tuner/SeaStateAutoTuner.h"
+#include "tuner/VerticalAccelComplementary.h"
+#include "tuner/WavePeriodEstimator.h"
+
+namespace ocean_imu::tfg {
+
+struct TfgTuneState {
+    float tau_applied   = 1.1f;    // s
+    float sigma_applied = 1e-2f;   // m/s^2
+    float RS_applied    = 0.5f;    // m*s
+};
+
+template <typename MekfT = ocean_imu::kalman::Kalman3D_Wave_TFG<float>>
+class SeaStateFusionFilter_TFG {
+public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+    using Mekf = MekfT;
+    using Vector3f = Eigen::Vector3f;
+
+    /*
+        Cold      -- not yet levelled. Nothing but the bootstrap tilt observer
+                     runs; the filter has no usable attitude.
+        TunerWarm -- levelled, attitude and bias estimating, but the linear
+                     block is gated off and the accelerometer bias frozen,
+                     because the tuner has no trustworthy operating point yet.
+        Live      -- linear block on, tuning applied and adapting.
+
+        The staging exists because a marine filter is switched on while already
+        moving. Enabling the wave states before the tuner knows the sea state
+        means integrating displacement against a badly wrong OU prior.
+    */
+    enum class StartupStage { Cold, TunerWarm, Live };
+
+    struct Config {
+        Vector3f sigma_a{Vector3f::Constant(0.5f)};    // accel noise std, body
+        float    gyro_noise_density = 0.005f;          // rad/sqrt(s)
+        Vector3f sigma_m{Vector3f::Constant(0.1f)};    // mag noise std, body
+        bool     with_mag = true;
+        float    mag_delay_sec = 30.0f;                // hold yaw until settled
+        bool     freeze_acc_bias_until_live = true;
+        float    Racc_warmup_std = 0.5f;               // inflated while warming
+        float    gravity_magnitude = 9.80665f;
+        float    online_tune_warmup_sec = 20.0f;
+    };
+
+    void begin(const Config& cfg) {
+        cfg_ = cfg;
+        mekf_ = Mekf(cfg.gyro_noise_density, cfg.gravity_magnitude);
+        mekf_.initialize_identity();
+        mekf_.set_Racc_std(cfg.sigma_a);
+        mekf_.set_Rmag_std(cfg.sigma_m);
+        Racc_nominal_ = cfg.sigma_a;
+
+        tuner_ = ::SeaStateAutoTuner(2.0f, 1.0f);
+        wave_period_.reset();
+        vertical_complementary_.reset();
+        bootstrap_tilt_obs_.reset();
+        bootstrap_gravity_good_sec_ = 0.0f;
+        elapsed_sec_ = 0.0f;
+        live_sec_ = 0.0f;
+        mag_elapsed_sec_ = 0.0f;
+        stage_ = StartupStage::Cold;
+
+        enterCold_();
+        applyTune_();
+        mekf_.reset_aw_covariance_to_stationary();
+    }
+
+    // ------------------------------------------------------------- stepping
+
+    void update(float dt, const Vector3f& gyro, const Vector3f& acc, float tempC = 35.0f) {
+        if (!(dt > 0.0f) || !std::isfinite(dt) || !gyro.allFinite() || !acc.allFinite()) return;
+        elapsed_sec_ += dt;
+
+        // The tuner's frequency channel runs on its own observer, always, so
+        // it is never a function of the estimator it is tuning.
+        vertical_complementary_.update(dt, gyro, acc, cfg_.gravity_magnitude);
+        const float a_up = vertical_complementary_.verticalAccelUpMs2();
+        if (vertical_complementary_.isReady()) wave_period_.update(dt, a_up);
+
+        if (stage_ == StartupStage::Cold) {
+            const bool levelled = ::seastate::common::runStartupGravityInit(
+                gyro, acc, dt, elapsed_sec_,
+                /*gravity_std*/        cfg_.gravity_magnitude,
+                /*obs_acc_tau_sec*/    0.5f,
+                /*gravity_slow_tau*/   1.0f,
+                /*align_max_sin*/      0.12f,
+                /*hold_sec*/           0.5f,
+                /*min_sec*/            0.5f,
+                /*timeout_sec*/        8.0f,
+                /*norm_frac*/          0.15f,
+                bootstrap_tilt_obs_, bootstrap_gravity_slow_lpf_,
+                bootstrap_gravity_good_sec_,
+                // The helper hands back the blended gravity vector it settled
+                // on -- the observer's direction nudged toward the slow
+                // low-pass -- rather than the raw observer state. Use it.
+                [&](const Eigen::Vector3f& g_body) {
+                    mekf_.initialize_from_acc(g_body);
+                });
+            if (!levelled) return;
+            stage_ = StartupStage::TunerWarm;
+            enterCold_();
+            applyTune_();
+            mekf_.reset_aw_covariance_to_stationary();
+            return;
+        }
+
+        mekf_.time_update(gyro, dt);
+        mekf_.measurement_update_acc_only(acc, tempC);
+
+        // Integral regularization runs on its own cadence, not every step.
+        pseudo_elapsed_ += dt;
+        if (pseudo_elapsed_ >= pseudo_period_sec_) {
+            pseudo_elapsed_ = 0.0f;
+            mekf_.applyIntegralZeroPseudoMeas();
+        }
+
+        updateTuner_(dt, a_up);
+
+        if (stage_ == StartupStage::TunerWarm) {
+            live_sec_ += dt;
+            if (live_sec_ >= cfg_.online_tune_warmup_sec && wave_period_.isReady()) {
+                enterLive_();
+            }
+        } else {
+            adaptMekf_(dt);
+            aw_sync_elapsed_ += dt;
+            if (periodic_aw_cov_sync_ && aw_sync_elapsed_ >= aw_sync_period_sec_) {
+                aw_sync_elapsed_ = 0.0f;
+                mekf_.synchronize_aw_covariance_to_stationary_congruent();
+            }
+        }
+    }
+
+    /*
+        Magnetometer.
+
+        Yaw is held until mag_delay_sec has passed, then the first accepted
+        reading defines the world reference by rotating the measured field into
+        the world frame with the current (levelled) attitude. Storing B_w
+        rather than a body-frame prediction is what keeps H_m built from a
+        fixed vector.
+    */
+    void updateMag(const Vector3f& mag_body) {
+        if (!cfg_.with_mag || !mag_body.allFinite()) return;
+        if (!(mag_body.norm() > 1e-9f)) return;
+        if (stage_ == StartupStage::Cold) return;
+        if (elapsed_sec_ < cfg_.mag_delay_sec) return;
+
+        if (!mekf_.has_magnetic_reference()) {
+            mekf_.set_magnetic_reference_world(mekf_.R_bw() * mag_body);
+            return;
+        }
+        mekf_.measurement_update_mag_only(mag_body);
+    }
+
+    // ---------------------------------------------------------- ablation API
+
+    // Pin the operating point and stop adapting. Used by the fixed-tuning arms
+    // of the paired study.
+    bool setFixedTuning(float tau_s, float sigma_a, float RS) {
+        if (!(tau_s > 0.0f) || !(sigma_a >= 0.0f) || !(RS > 0.0f)) return false;
+        if (!std::isfinite(tau_s) || !std::isfinite(sigma_a) || !std::isfinite(RS)) return false;
+        fixed_tuning_ = true;
+        tune_.tau_applied = tau_s;
+        tune_.sigma_applied = sigma_a;
+        tune_.RS_applied = RS;
+        tau_target_ = tau_s; sigma_target_ = sigma_a; RS_target_ = RS;
+        applyTune_();
+        return true;
+    }
+
+    /*
+        Freeze one adaptation channel while the other keeps running.
+
+        Freezing both is rejected rather than silently accepted: that is
+        setFixedTuning, and having two ways to express it invites a study
+        configuration that means one thing and reads as the other.
+    */
+    bool setChannelFreeze(bool freeze_ou, float tau_s, float sigma_a,
+                          bool freeze_RS, float RS) {
+        if (freeze_ou && freeze_RS) return false;
+        if (freeze_ou) {
+            if (!(tau_s > 0.0f) || !(sigma_a >= 0.0f)) return false;
+            freeze_ou_channel_ = true;
+            tune_.tau_applied = tau_s;
+            tune_.sigma_applied = sigma_a;
+        }
+        if (freeze_RS) {
+            if (!(RS > 0.0f)) return false;
+            freeze_RS_channel_ = true;
+            tune_.RS_applied = RS;
+        }
+        applyTune_();
+        return true;
+    }
+
+    void enableTuner(bool on) { enable_tuner_ = on; }
+    void enableLinearBlock(bool on) { mekf_.set_linear_block_enabled(on); }
+    void setPeriodicAwCovarianceSync(bool on) { periodic_aw_cov_sync_ = on; }
+
+    void setTauCoeff(float c)      { if (c > 0.0f && std::isfinite(c)) tau_coeff_ = c; }
+    void setSigmaCoeff(float c)    { if (c > 0.0f && std::isfinite(c)) sigma_coeff_ = c; }
+    void setRSCoeff(float c)       { if (c > 0.0f && std::isfinite(c)) R_S_coeff_ = c; }
+    void setSFactor(float s)       { if (s > 0.0f && std::isfinite(s)) S_factor_ = s; }
+    void setRSXYFactor(float k)    { if (k > 0.0f && std::isfinite(k)) R_S_xy_factor_ = k; }
+    void setAccNoiseFloorSigma(float s) { if (s >= 0.0f && std::isfinite(s)) noise_floor_sigma_ = s; }
+    void setAdaptationTimeConstants(float tau_sec) {
+        if (tau_sec > 0.0f && std::isfinite(tau_sec)) adapt_tau_sec_ = tau_sec;
+    }
+    void setRSAdaptMult(float m)     { if (m > 0.0f && std::isfinite(m)) adapt_RS_mult_ = m; }
+    void setRSAdaptSlewLog(float d)  { if (d >= 0.0f && std::isfinite(d)) adapt_RS_slew_log_ = d; }
+    void setTauBounds(float lo, float hi) { if (lo > 0.0f && hi > lo) { min_tau_ = lo; max_tau_ = hi; } }
+    void setRSBounds(float lo, float hi)  { if (lo > 0.0f && hi > lo) { min_RS_ = lo; max_RS_ = hi; } }
+    void setMaxSigmaA(float m)       { if (m > 0.0f && std::isfinite(m)) max_sigma_a_ = m; }
+
+    // ------------------------------------------------------------ accessors
+
+    [[nodiscard]] Mekf& mekf() noexcept { return mekf_; }
+    [[nodiscard]] const Mekf& mekf() const noexcept { return mekf_; }
+    [[nodiscard]] StartupStage stage() const noexcept { return stage_; }
+    [[nodiscard]] bool isLive() const noexcept { return stage_ == StartupStage::Live; }
+
+    [[nodiscard]] float getTauApplied()   const noexcept { return tune_.tau_applied; }
+    [[nodiscard]] float getSigmaApplied() const noexcept { return tune_.sigma_applied; }
+    [[nodiscard]] float getRSApplied()    const noexcept { return tune_.RS_applied; }
+    [[nodiscard]] float getTauTarget()    const noexcept { return tau_target_; }
+    [[nodiscard]] float getSigmaTarget()  const noexcept { return sigma_target_; }
+    [[nodiscard]] float getRSTarget()     const noexcept { return RS_target_; }
+    [[nodiscard]] float getWavePeriodSec() const noexcept { return wave_period_.getPeriodSec(); }
+    [[nodiscard]] bool  wavePeriodReady()  const noexcept { return wave_period_.isReady(); }
+    [[nodiscard]] float getAccelVariance() const noexcept { return tuner_.getAccelVariance(); }
+
+    [[nodiscard]] Eigen::Quaternionf quaternion() const { return mekf_.quaternion(); }
+    [[nodiscard]] Vector3f get_velocity() const { return mekf_.get_velocity(); }
+    [[nodiscard]] Vector3f get_position() const { return mekf_.get_position(); }
+    [[nodiscard]] Vector3f get_world_accel() const { return mekf_.get_world_accel(); }
+
+private:
+    void enterCold_() {
+        mekf_.set_linear_block_enabled(false);
+        if (cfg_.freeze_acc_bias_until_live) mekf_.set_acc_bias_updates_enabled(false);
+        mekf_.set_Racc_std(Vector3f::Constant(cfg_.Racc_warmup_std));
+    }
+
+    void enterLive_() {
+        stage_ = StartupStage::Live;
+        mekf_.set_linear_block_enabled(true);
+        mekf_.set_acc_bias_updates_enabled(true);
+        mekf_.set_Racc_std(Racc_nominal_);
+        applyTune_();
+        // The operating point the linear block is about to start from was
+        // chosen while it was frozen, so seed the matching a_w covariance
+        // once rather than letting the filter walk into it.
+        mekf_.reset_aw_covariance_to_stationary();
+    }
+
+    /*
+        Tuning laws, carried over from OU-III unchanged:
+
+            tau  = tau_coeff * 0.5 / f_tune       half the zero-crossing period
+            R_S  = R_S_coeff * sigma * tau^3
+
+        The cubic is an engineering normalization for a fixed update cadence
+        and a bounded family of spectra, not a physical law -- it is described
+        as such in the article and should not be read as more than that.
+    */
+    void updateTuner_(float dt, float a_up) {
+        if (!enable_tuner_) return;
+
+        const float f_hint = wave_period_.isReady() ? wave_period_.getFrequencyHz() : 0.2f;
+        tuner_.update(dt, a_up, f_hint);
+
+        if (fixed_tuning_) return;
+
+        const float f_tune = std::max(kMinTuneFreqHz,
+                                      wave_period_.isReady() ? wave_period_.getFrequencyHz()
+                                                             : kMinTuneFreqHz);
+
+        // Subtract the sensor noise floor in power, not amplitude: the tuner
+        // measures total variance, and the part that is sensor noise carries no
+        // information about the sea.
+        const float var = tuner_.getAccelVariance();
+        const float wave_var = std::max(0.0f, var - noise_floor_sigma_ * noise_floor_sigma_);
+        const float sigma_wave = std::sqrt(wave_var);
+
+        if (!freeze_ou_channel_) {
+            tau_target_ = std::min(max_tau_, std::max(min_tau_, tau_coeff_ * 0.5f / f_tune));
+            sigma_target_ = std::min(max_sigma_a_, sigma_coeff_ * sigma_wave);
+        }
+        if (!freeze_RS_channel_) {
+            const float tau_for_RS = freeze_ou_channel_ ? tune_.tau_applied : tau_target_;
+            const float sig_for_RS = freeze_ou_channel_ ? tune_.sigma_applied : sigma_target_;
+            const float raw = R_S_coeff_ * sig_for_RS * tau_for_RS * tau_for_RS * tau_for_RS;
+            RS_target_ = std::min(max_RS_, std::max(min_RS_, raw));
+        }
+    }
+
+    void adaptMekf_(float dt) {
+        if (!enable_tuner_ || fixed_tuning_) return;
+
+        if (!freeze_ou_channel_) {
+            const float a = 1.0f - std::exp(-dt / adapt_tau_sec_);
+            tune_.tau_applied   += a * (tau_target_ - tune_.tau_applied);
+            tune_.sigma_applied += a * (sigma_target_ - tune_.sigma_applied);
+        }
+        if (!freeze_RS_channel_) {
+            // The r_S channel gets its own horizon, scaled by the operating
+            // point and shortened when the target has genuinely moved rather
+            // than merely jittered.
+            const float horizon = ::seastate::common::adaptiveSmoothingHorizonSec(
+                adapt_RS_mult_, tune_.tau_applied, RS_target_, tune_.RS_applied,
+                adapt_RS_slew_log_, dt);
+            const float a = (horizon > 0.0f) ? (1.0f - std::exp(-dt / horizon)) : 1.0f;
+            tune_.RS_applied += a * (RS_target_ - tune_.RS_applied);
+        }
+        applyTune_();
+    }
+
+    void applyTune_() {
+        mekf_.set_aw_time_constant(tune_.tau_applied);
+        // Horizontal stationary acceleration is scaled relative to vertical:
+        // a following sea puts more energy into heave than into surge/sway.
+        const float sZ = tune_.sigma_applied;
+        mekf_.set_aw_stationary_std(Vector3f(sZ * S_factor_, sZ * S_factor_, sZ));
+        const float rs = tune_.RS_applied;
+        mekf_.set_RS_noise_vector(
+            Vector3f(rs * R_S_xy_factor_, rs * R_S_xy_factor_, rs));
+    }
+
+    /*
+        First-order vector low-pass, matching the one both existing
+        orchestrators keep privately. It is duplicated there too; hoisting it
+        into kalman_common would be the tidier fix, but that means touching
+        two shipped filters for a six-line helper, so it stays local here.
+    */
+    struct Vec3LPF {
+        Eigen::Vector3f state = Eigen::Vector3f::Zero();
+        bool initialized = false;
+
+        void reset() { state.setZero(); initialized = false; }
+
+        Eigen::Vector3f step(const Eigen::Vector3f& x, float dt, float tau_sec) {
+            if (!x.allFinite()) return state;
+            const float tau = std::max(1.0e-3f, tau_sec);
+            const float alpha = 1.0f - std::exp(-dt / tau);
+            if (!initialized) { state = x; initialized = true; return state; }
+            state += alpha * (x - state);
+            return state;
+        }
+    };
+
+    static constexpr float kMinTuneFreqHz = 0.03f;
+
+    Config cfg_{};
+    Mekf   mekf_{};
+    StartupStage stage_{StartupStage::Cold};
+
+    ::SeaStateAutoTuner tuner_{2.0f, 1.0f};
+    ::WavePeriodEstimator wave_period_{};
+    ::VerticalAccelComplementary vertical_complementary_{};
+
+    ::seastate::common::StartupTiltObserver bootstrap_tilt_obs_{};
+    Vec3LPF bootstrap_gravity_slow_lpf_{};
+    float bootstrap_gravity_good_sec_ = 0.0f;
+
+    TfgTuneState tune_{};
+    float tau_target_   = 1.1f;
+    float sigma_target_ = 1e-2f;
+    float RS_target_    = 0.5f;
+
+    // Defaults are OU-III's, so a paired comparison differs in the estimator
+    // rather than in how it is tuned.
+    float tau_coeff_    = 1.0f;
+    float sigma_coeff_  = 1.0f;
+    float R_S_coeff_    = 0.35f;
+    float S_factor_     = 1.87f;
+    float R_S_xy_factor_ = 1.0f;
+    float noise_floor_sigma_ = 0.12f;
+
+    float adapt_tau_sec_    = 1.8f;
+    float adapt_RS_mult_    = 3.0f;
+    float adapt_RS_slew_log_ = 0.0f;
+
+    float min_tau_ = 0.02f, max_tau_ = 12.0f;
+    float min_RS_  = 0.4f,  max_RS_  = 400.0f;
+    float max_sigma_a_ = 6.0f;
+
+    bool enable_tuner_ = true;
+    bool fixed_tuning_ = false;
+    bool freeze_ou_channel_ = false;
+    bool freeze_RS_channel_ = false;
+    bool periodic_aw_cov_sync_ = true;
+
+    Vector3f Racc_nominal_{Vector3f::Constant(0.5f)};
+
+    float elapsed_sec_ = 0.0f;
+    float live_sec_ = 0.0f;
+    float mag_elapsed_sec_ = 0.0f;
+    float pseudo_elapsed_ = 0.0f;
+    float pseudo_period_sec_ = 0.015f;
+    float aw_sync_elapsed_ = 0.0f;
+    float aw_sync_period_sec_ = 1.0f;
+};
+
+}  // namespace ocean_imu::tfg

--- a/src/kalman_tfg/SeaStateFusionFilter_TFG.h
+++ b/src/kalman_tfg/SeaStateFusionFilter_TFG.h
@@ -379,9 +379,10 @@ private:
         // a following sea puts more energy into heave than into surge/sway.
         const float sZ = tune_.sigma_applied;
         mekf_.set_aw_stationary_std(Vector3f(sZ * S_factor_, sZ * S_factor_, sZ));
+        // r_S is a standard-deviation scale, and set_RS_noise takes a
+        // standard deviation. Both halves of that sentence matter.
         const float rs = tune_.RS_applied;
-        mekf_.set_RS_noise_vector(
-            Vector3f(rs * R_S_xy_factor_, rs * R_S_xy_factor_, rs));
+        mekf_.set_RS_noise(Vector3f(rs * R_S_xy_factor_, rs * R_S_xy_factor_, rs));
     }
 
     /*

--- a/tests/kalman_tfg/Makefile
+++ b/tests/kalman_tfg/Makefile
@@ -24,7 +24,7 @@ LDFLAGS  =
 # Tell make to look for source files in src/util
 VPATH = $(REPO_ROOT)/src/util
 
-TARGETS = lie_group-test convention-test ou_chain_identity-test tfg_propagation-test tfg_jacobians-test covariance_transport-test
+TARGETS = lie_group-test convention-test ou_chain_identity-test tfg_propagation-test tfg_jacobians-test covariance_transport-test tfg_orchestrator-test
 
 all: build test
 
@@ -52,6 +52,9 @@ tfg_jacobians-test: tfg_jacobians-test.o
 	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
 
 covariance_transport-test: covariance_transport-test.o
+	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
+
+tfg_orchestrator-test: tfg_orchestrator-test.o
 	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
 
 # -MMD -MP records the headers each object depends on, so editing a group or

--- a/tests/kalman_tfg/covariance_transport-test.cpp
+++ b/tests/kalman_tfg/covariance_transport-test.cpp
@@ -89,7 +89,7 @@ void configure(F& f) {
     f.set_Q_bacc_rw(Vector3(T(2.5e-7), T(3e-7), T(2e-7)));
     f.set_Racc_std(Vector3(T(0.4), T(0.35), T(0.5)));
     f.set_Rmag_std(Vector3(T(0.1), T(0.12), T(0.09)));
-    f.set_RS_noise_vector(Vector3(T(1.5), T(1.5), T(0.8)));
+    f.set_RS_noise(Vector3(T(1.5), T(1.5), T(0.8)));
     f.set_magnetic_reference_world(Vector3(T(0.21), T(0.02), T(0.43)));
     f.initialize_from_truth(
         Eigen::Quaternion<T>(Eigen::AngleAxis<T>(

--- a/tests/kalman_tfg/run_tests.sh
+++ b/tests/kalman_tfg/run_tests.sh
@@ -6,3 +6,4 @@
 ./tfg_propagation-test
 ./tfg_jacobians-test
 ./covariance_transport-test
+./tfg_orchestrator-test

--- a/tests/kalman_tfg/tfg_jacobians-test.cpp
+++ b/tests/kalman_tfg/tfg_jacobians-test.cpp
@@ -67,7 +67,7 @@ Filter make_filter() {
     f.set_aw_stationary_std(Vector3(T(0.6), T(0.6), T(0.32)));
     f.set_Racc_std(Vector3(T(0.4), T(0.35), T(0.5)));
     f.set_Rmag_std(Vector3(T(0.1), T(0.12), T(0.09)));
-    f.set_RS_noise_vector(Vector3(T(1.5), T(1.5), T(0.8)));
+    f.set_RS_noise(Vector3(T(1.5), T(1.5), T(0.8)));
     f.set_magnetic_reference_world(Vector3(T(0.21), T(0.02), T(0.43)));
     // A genuinely rotated attitude and non-zero everything, so a term that is
     // wrong cannot pass by being multiplied into zero.
@@ -473,10 +473,14 @@ void test_measurement_noise_is_rotated_into_the_world() {
           "isotropic accelerometer noise must be unchanged by the world rotation");
 
     // R_S is already world frame and must NOT be rotated.
-    f.set_RS_noise_vector(Vector3(T(1.5), T(1.5), T(0.8)));
+    f.set_RS_noise(Vector3(T(1.5), T(1.5), T(0.8)));
     f.integral_residual(r, H, Rw);
     Matrix3 want; want.setZero();
-    want.diagonal() << T(1.5), T(1.5), T(0.8);
+    // set_RS_noise takes standard deviations, so R_S is their square. Write
+    // the squares as products rather than as literals: 0.8*0.8 is
+    // 0.6400000000000001 in double, so a literal 0.64 would fail the exact
+    // comparison below for a reason that has nothing to do with frames.
+    want.diagonal() << T(1.5)*T(1.5), T(1.5)*T(1.5), T(0.8)*T(0.8);
     check((Rw - want).cwiseAbs().maxCoeff() == T(0),
           "R_S must stay in world/NED coordinates, not be rotated by the estimate");
 }

--- a/tests/kalman_tfg/tfg_orchestrator-test.cpp
+++ b/tests/kalman_tfg/tfg_orchestrator-test.cpp
@@ -1,0 +1,455 @@
+/*
+    Copyright (c) 2025-2026  Mikhail Grushinskiy
+
+    The sea-state orchestrator: startup staging, the tuning laws, the
+    adaptation smoothers, and the MEKF gates they drive.
+
+    The tuning laws are checked against closed-form expectations on a
+    synthetic sea whose period and acceleration variance are known exactly,
+    rather than against recorded output. A regression baseline would lock in
+    whatever the code did on the day it was written; this locks in what the
+    laws in the article actually say:
+
+        tau  = tau_coeff * 0.5 / f_tune
+        R_S  = R_S_coeff * sigma * tau^3
+        sigma^2 = max(0, measured variance - noise floor^2)
+*/
+
+#define EIGEN_NON_ARDUINO
+
+#include "kalman_tfg/SeaStateFusionFilter_TFG.h"
+
+#include <cmath>
+#include <iostream>
+#include <string>
+
+namespace {
+
+using Fusion = ocean_imu::tfg::SeaStateFusionFilter_TFG<>;
+using Stage = Fusion::StartupStage;
+using Vector3f = Eigen::Vector3f;
+using Matrix3f = Eigen::Matrix3f;
+
+constexpr float kPi = 3.14159265358979f;
+constexpr float kG = 9.80665f;
+
+int failures = 0;
+
+bool check(bool condition, const std::string& message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        ++failures;
+    }
+    return condition;
+}
+
+bool near_rel(float got, float want, float rel) {
+    return std::fabs(got - want) <= rel * std::fabs(want);
+}
+
+/*
+    A synthetic sea with a known period and heave-acceleration amplitude, plus
+    a little roll so attitude is not trivially level. The accelerometer reading
+    is exact for the pose, so any error the filter shows is its own.
+*/
+struct Sea {
+    float f_hz = 0.15f;
+    float a_amp = 1.2f;        // m/s^2, vertical
+    float roll_amp = 0.08f;    // rad
+    float roll_f = 0.12f;
+
+    Matrix3f R_bw(float t) const {
+        return Eigen::AngleAxisf(roll_amp * std::sin(2.0f * kPi * roll_f * t),
+                                 Vector3f::UnitX()).toRotationMatrix();
+    }
+    Vector3f gyro(float t) const {
+        return Vector3f(roll_amp * 2.0f * kPi * roll_f *
+                            std::cos(2.0f * kPi * roll_f * t), 0.0f, 0.0f);
+    }
+    Vector3f world_accel(float t) const {
+        return Vector3f(0.0f, 0.0f, a_amp * std::sin(2.0f * kPi * f_hz * t));
+    }
+    Vector3f acc_body(float t) const {
+        return R_bw(t).transpose() * (world_accel(t) - Vector3f(0, 0, kG));
+    }
+    Vector3f mag_body(float t) const {
+        return R_bw(t).transpose() * Vector3f(0.21f, 0.0f, 0.43f);
+    }
+};
+
+Fusion::Config default_config() {
+    Fusion::Config c;
+    c.online_tune_warmup_sec = 10.0f;
+    c.mag_delay_sec = 5.0f;
+    return c;
+}
+
+// Run the sea for `seconds`, optionally recording when each stage was reached.
+void run(Fusion& f, const Sea& sea, float seconds, float dt = 0.005f,
+         float* t_warm = nullptr, float* t_live = nullptr, bool with_mag = true) {
+    const int n = static_cast<int>(seconds / dt);
+    for (int i = 0; i < n; ++i) {
+        const float t = static_cast<float>(i) * dt;
+        const Stage before = f.stage();
+        f.update(dt, sea.gyro(t), sea.acc_body(t));
+        if (with_mag && i % 5 == 0) f.updateMag(sea.mag_body(t));
+        if (before != f.stage()) {
+            if (f.stage() == Stage::TunerWarm && t_warm) *t_warm = t;
+            if (f.stage() == Stage::Live && t_live) *t_live = t;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+
+void test_staging() {
+    Fusion f;
+    f.begin(default_config());
+    check(f.stage() == Stage::Cold, "the filter must start Cold");
+    check(!f.mekf().linear_block_enabled(),
+          "the linear block must be gated off while Cold");
+
+    Sea sea;
+    float t_warm = -1.0f, t_live = -1.0f;
+    run(f, sea, 300.0f, 0.005f, &t_warm, &t_live);
+
+    check(f.stage() == Stage::Live, "the filter never reached Live");
+    check(t_warm >= 0.0f && t_warm < 5.0f,
+          "levelling should complete within a few seconds");
+    check(t_live > t_warm, "Live must come after TunerWarm");
+    check(f.mekf().linear_block_enabled(),
+          "the linear block must be enabled once Live");
+
+    // The Live gate waits on the wave-period estimator as well as the warmup
+    // clock, so it is necessarily later than the clock alone.
+    check(t_live >= 10.0f,
+          "Live was reached before the configured warmup elapsed");
+}
+
+// While warming, the accelerometer bias must stay frozen and Racc inflated:
+// a filter that has not yet levelled cannot tell bias from tilt.
+void test_warmup_gates() {
+    Fusion f;
+    auto cfg = default_config();
+    cfg.freeze_acc_bias_until_live = true;
+    f.begin(cfg);
+
+    Sea sea;
+    run(f, sea, 30.0f);
+    check(f.stage() == Stage::TunerWarm, "expected to still be warming at 30 s");
+    const Vector3f bias_warm = f.mekf().get_acc_bias();
+    check(bias_warm.norm() == 0.0f,
+          "the accelerometer bias must not move while frozen");
+
+    run(f, sea, 400.0f);
+    check(f.stage() == Stage::Live, "expected Live by 430 s");
+}
+
+/*
+    The tuning laws, against closed form.
+
+    tau  = 0.5 / f          for tau_coeff = 1
+    sigma = sqrt(var - floor^2), var = a_amp^2 / 2 for a sinusoid
+    R_S  = 0.35 * sigma * tau^3
+*/
+void test_tuning_laws() {
+    Fusion f;
+    f.begin(default_config());
+
+    Sea sea;
+    run(f, sea, 600.0f);
+    check(f.stage() == Stage::Live, "did not reach Live");
+    check(f.wavePeriodReady(), "the wave-period estimator never became ready");
+
+    const float T_true = 1.0f / sea.f_hz;
+    if (!check(near_rel(f.getWavePeriodSec(), T_true, 0.10f),
+               "the estimated wave period is off by more than 10%")) {
+        std::cerr << "  T_z = " << f.getWavePeriodSec() << " want " << T_true << '\n';
+    }
+
+    const float tau_want = 0.5f * f.getWavePeriodSec();
+    if (!check(near_rel(f.getTauApplied(), tau_want, 0.05f),
+               "tau is not half the zero-crossing period")) {
+        std::cerr << "  tau = " << f.getTauApplied() << " want " << tau_want << '\n';
+    }
+
+    // Variance of a sinusoid is amplitude^2/2; the tuner subtracts the noise
+    // floor in power, not amplitude.
+    const float var_true = sea.a_amp * sea.a_amp * 0.5f;
+    const float sigma_want = std::sqrt(std::max(0.0f, var_true - 0.12f * 0.12f));
+    if (!check(near_rel(f.getSigmaApplied(), sigma_want, 0.15f),
+               "sigma does not match the sea's acceleration std")) {
+        std::cerr << "  sigma = " << f.getSigmaApplied() << " want " << sigma_want << '\n';
+    }
+
+    const float rs_want = 0.35f * f.getSigmaApplied() *
+                          std::pow(f.getTauApplied(), 3.0f);
+    if (!check(near_rel(f.getRSApplied(), rs_want, 0.05f),
+               "R_S is not R_S_coeff * sigma * tau^3")) {
+        std::cerr << "  RS = " << f.getRSApplied() << " want " << rs_want << '\n';
+    }
+}
+
+// The coefficients must actually be the knobs the study will turn.
+void test_tuning_coefficients_are_live() {
+    Fusion a, b;
+    a.begin(default_config());
+    b.begin(default_config());
+    b.setTauCoeff(2.0f);
+
+    Sea sea;
+    run(a, sea, 600.0f);
+    run(b, sea, 600.0f);
+    check(a.stage() == Stage::Live && b.stage() == Stage::Live, "both must be Live");
+    if (!check(near_rel(b.getTauApplied(), 2.0f * a.getTauApplied(), 0.05f),
+               "doubling tau_coeff did not double the applied tau")) {
+        std::cerr << "  tau a=" << a.getTauApplied() << " b=" << b.getTauApplied() << '\n';
+    }
+}
+
+void test_ablation_hooks() {
+    Sea sea;
+
+    // Fixed tuning must pin the operating point and stop adapting.
+    {
+        Fusion f;
+        f.begin(default_config());
+        check(f.setFixedTuning(2.5f, 0.7f, 6.0f), "setFixedTuning was rejected");
+        run(f, sea, 400.0f);
+        check(f.getTauApplied() == 2.5f && f.getSigmaApplied() == 0.7f &&
+              f.getRSApplied() == 6.0f,
+              "fixed tuning drifted");
+    }
+
+    // Freezing the OU channel must leave r_S adapting, and vice versa.
+    {
+        Fusion f;
+        f.begin(default_config());
+        check(f.setChannelFreeze(true, 2.0f, 0.5f, false, 0.0f),
+              "freezing the OU channel was rejected");
+        run(f, sea, 600.0f);
+        check(f.getTauApplied() == 2.0f && f.getSigmaApplied() == 0.5f,
+              "the frozen OU channel moved");
+        check(f.getRSApplied() != 0.5f, "the r_S channel should still have adapted");
+        // And with the OU channel pinned, r_S must follow from the pinned values.
+        const float rs_want = 0.35f * 0.5f * 2.0f * 2.0f * 2.0f;
+        check(near_rel(f.getRSApplied(), rs_want, 0.2f),
+              "with the OU channel frozen, r_S must be built from the frozen tau and sigma");
+    }
+
+    // Freezing both is rejected rather than silently aliased onto fixed tuning.
+    {
+        Fusion f;
+        f.begin(default_config());
+        check(!f.setChannelFreeze(true, 2.0f, 0.5f, true, 6.0f),
+              "freezing both channels must be rejected -- that is setFixedTuning");
+    }
+
+    // Nonsense arguments must be refused, not stored.
+    {
+        Fusion f;
+        f.begin(default_config());
+        check(!f.setFixedTuning(-1.0f, 0.5f, 6.0f), "a negative tau was accepted");
+        check(!f.setFixedTuning(2.0f, 0.5f, 0.0f), "a zero R_S was accepted");
+    }
+}
+
+/*
+    The magnetic reference must be captured from the world, once, and only
+    after the delay. Capturing early means freezing yaw against an attitude
+    that has not settled.
+*/
+void test_magnetic_reference_timing() {
+    Fusion f;
+    auto cfg = default_config();
+    cfg.mag_delay_sec = 20.0f;
+    f.begin(cfg);
+
+    Sea sea;
+    run(f, sea, 10.0f);
+    check(!f.mekf().has_magnetic_reference(),
+          "the magnetic reference was captured before the delay elapsed");
+
+    run(f, sea, 60.0f);
+    check(f.mekf().has_magnetic_reference(),
+          "the magnetic reference was never captured");
+
+    // It should point roughly where the true world field does.
+    const Vector3f B = f.mekf().magnetic_reference_world();
+    const Vector3f want(0.21f, 0.0f, 0.43f);
+    check(std::fabs(B.norm() - want.norm()) <= 0.02f * want.norm(),
+          "the captured magnetic reference has the wrong magnitude");
+    const float cos_ang = B.normalized().dot(want.normalized());
+    check(cos_ang > 0.98f, "the captured magnetic reference points the wrong way");
+}
+
+void test_with_mag_disabled() {
+    Fusion f;
+    auto cfg = default_config();
+    cfg.with_mag = false;
+    f.begin(cfg);
+    Sea sea;
+    run(f, sea, 60.0f, 0.005f, nullptr, nullptr, /*with_mag=*/true);
+    check(!f.mekf().has_magnetic_reference(),
+          "a reference was captured with the magnetometer disabled");
+}
+
+// The estimator must actually track heave, not merely stay finite.
+void test_tracks_heave() {
+    Fusion f;
+    f.begin(default_config());
+    Sea sea;
+    run(f, sea, 400.0f);
+    check(f.stage() == Stage::Live, "did not reach Live");
+
+    // Score over a trailing window, after the operating point has settled.
+    const float dt = 0.005f;
+    double sq_err = 0.0, sq_ref = 0.0;
+    const float omega = 2.0f * kPi * sea.f_hz;
+    const float z_amp = sea.a_amp / (omega * omega);
+    int n = 0;
+    for (int i = 0; i < 24000; ++i) {          // 120 s
+        const float t = 400.0f + static_cast<float>(i) * dt;
+        f.update(dt, sea.gyro(t), sea.acc_body(t));
+        if (i % 5 == 0) f.updateMag(sea.mag_body(t));
+        if (i < 6000) continue;                 // let it settle first
+        const float z_true = -z_amp * std::sin(omega * t);
+        const float e = f.get_position().z() - z_true;
+        sq_err += static_cast<double>(e) * e;
+        sq_ref += static_cast<double>(z_true) * z_true;
+        ++n;
+    }
+    const double rms = std::sqrt(sq_err / n);
+    const double rms_ref = std::sqrt(sq_ref / n);
+    std::cout << "  heave RMS error " << rms << " m against " << rms_ref
+              << " m of signal (" << (100.0 * rms / rms_ref) << "%)\n";
+    check(rms < rms_ref,
+          "heave error exceeds the signal itself -- the filter is not tracking");
+    check(f.get_position().allFinite() && f.mekf().covariance_full().allFinite(),
+          "the filter went non-finite");
+}
+
+// ---------------------------------------------------------------------------
+// The MEKF gates the orchestrator drives
+// ---------------------------------------------------------------------------
+
+void test_initialize_from_acc() {
+    using Mekf = ocean_imu::kalman::Kalman3D_Wave_TFG<float>;
+    // A 20 degree roll: at rest the accelerometer reads -g rotated into body.
+    for (float roll : {0.0f, 0.35f, -0.6f, 1.2f}) {
+        const Matrix3f R_true =
+            Eigen::AngleAxisf(roll, Vector3f::UnitX()).toRotationMatrix();
+        const Vector3f acc = R_true.transpose() * Vector3f(0.0f, 0.0f, -kG);
+
+        Mekf m;
+        m.initialize_identity();
+        check(m.initialize_from_acc(acc), "initialize_from_acc rejected a valid sample");
+
+        // Gravity must come back level; yaw is unconstrained and not checked.
+        const Vector3f up_world = m.R_bw() * acc.normalized();
+        check(std::fabs(up_world.x()) < 1e-5f && std::fabs(up_world.y()) < 1e-5f &&
+              up_world.z() < -0.999f,
+              "initialize_from_acc did not level the filter");
+    }
+
+    Mekf m;
+    m.initialize_identity();
+    check(!m.initialize_from_acc(Vector3f::Zero()), "a zero sample was accepted");
+}
+
+// The congruent sync must replace the a_w marginal while preserving every
+// correlation coefficient -- that is the whole point of it over a reset.
+void test_aw_covariance_sync_preserves_correlations() {
+    using Mekf = ocean_imu::kalman::Kalman3D_Wave_TFG<float>;
+    Mekf m;
+    m.initialize_identity();
+    m.set_aw_stationary_std(Vector3f(0.4f, 0.4f, 0.25f));
+
+    // Seed a covariance with real cross-correlation between a_w and phi.
+    auto& P = m.covariance_full();
+    P.setIdentity();
+    P *= 0.05f;
+    for (int k = 0; k < 3; ++k) {
+        P(Mekf::OFF_AW + k, Mekf::OFF_AW + k) = 0.9f;
+        P(Mekf::OFF_AW + k, k) = 0.06f;
+        P(k, Mekf::OFF_AW + k) = 0.06f;
+    }
+
+    auto corr = [&](int i, int j) {
+        return P(i, j) / std::sqrt(P(i, i) * P(j, j));
+    };
+    const float c_before = corr(Mekf::OFF_AW, 0);
+
+    check(m.synchronize_aw_covariance_to_stationary_congruent(),
+          "the congruent sync failed");
+
+    const float c_after = corr(Mekf::OFF_AW, 0);
+    check(std::fabs(c_after - c_before) < 1e-4f,
+          "the congruent sync did not preserve the correlation coefficient");
+    check(std::fabs(P(Mekf::OFF_AW, Mekf::OFF_AW) - 0.4f * 0.4f) < 1e-5f,
+          "the congruent sync did not install the stationary marginal");
+
+    // A plain reset must instead zero the cross terms.
+    m.reset_aw_covariance_to_stationary();
+    check(std::fabs(P(Mekf::OFF_AW, 0)) == 0.0f,
+          "reset must clear the a_w cross-covariances");
+}
+
+// With the linear block gated off, a_w is not estimated but is still present
+// in the measurement, so it must be marginalized into the noise rather than
+// assumed zero.
+void test_linear_block_gate() {
+    using Mekf = ocean_imu::kalman::Kalman3D_Wave_TFG<float>;
+    Mekf m;
+    m.initialize_identity();
+    m.set_aw_stationary_std(Vector3f(0.5f, 0.5f, 0.5f));
+    m.set_Racc_std(Vector3f::Constant(0.4f));
+
+    Eigen::Matrix<float,3,Mekf::NX> H_on, H_off;
+    Vector3f r; Matrix3f Rw_on, Rw_off;
+    m.set_linear_block_enabled(true);
+    m.accel_residual(Vector3f(0.0f, 0.0f, -kG), 35.0f, r, H_on, Rw_on);
+    m.set_linear_block_enabled(false);
+    m.accel_residual(Vector3f(0.0f, 0.0f, -kG), 35.0f, r, H_off, Rw_off);
+
+    check(H_on.block<3,3>(0, Mekf::OFF_AW).cwiseAbs().maxCoeff() > 0.5f,
+          "a_w must appear in H_a when the linear block is on");
+    check(H_off.block<3,3>(0, Mekf::OFF_AW).cwiseAbs().maxCoeff() == 0.0f,
+          "a_w must not appear in H_a when the linear block is off");
+    check((Rw_off - Rw_on - Matrix3f::Identity() * 0.25f).cwiseAbs().maxCoeff() < 1e-6f,
+          "Sigma_aw must be marginalized into the accelerometer noise when frozen");
+
+    // The world states must not move while frozen.
+    const Vector3f p0 = m.get_position();
+    for (int i = 0; i < 200; ++i) {
+        m.time_update(Vector3f(0.01f, 0.0f, 0.0f), 0.005f);
+        m.measurement_update_acc_only(Vector3f(0.0f, 0.0f, -kG), 35.0f);
+    }
+    check((m.get_position() - p0).cwiseAbs().maxCoeff() == 0.0f,
+          "the world states moved with the linear block gated off");
+    check(!m.applyIntegralZeroPseudoMeas(),
+          "the integral pseudo-measurement must be inert with the block frozen");
+}
+
+} // namespace
+
+int main() {
+    test_initialize_from_acc();
+    test_aw_covariance_sync_preserves_correlations();
+    test_linear_block_gate();
+    test_staging();
+    test_warmup_gates();
+    test_tuning_laws();
+    test_tuning_coefficients_are_live();
+    test_ablation_hooks();
+    test_magnetic_reference_timing();
+    test_with_mag_disabled();
+    test_tracks_heave();
+
+    if (failures != 0) {
+        std::cerr << failures << " orchestrator check(s) failed\n";
+        return 1;
+    }
+    std::cout << "tfg_orchestrator-test: all checks passed\n";
+    return 0;
+}

--- a/tests/kalman_tfg/tfg_orchestrator-test.cpp
+++ b/tests/kalman_tfg/tfg_orchestrator-test.cpp
@@ -190,6 +190,34 @@ void test_tuning_laws() {
     }
 }
 
+/*
+    r_S is a STANDARD DEVIATION, and MekfT::set_RS_noise takes a standard
+    deviation. This test exists because getting that wrong cost a factor of
+    ten in regularizer strength and did not look like a units error: it
+    surfaced as a 46% heave RMS error that read like a modelling problem.
+
+    The S = 0 constraint is a high-pass, and over-tightening it overshoots
+    rather than attenuates, so the symptom was gain > 1 at the wave frequency.
+    Assert the applied covariance is the square of the applied scale.
+*/
+void test_rs_units_are_a_standard_deviation() {
+    Fusion f;
+    f.begin(default_config());
+    check(f.setFixedTuning(2.0f, 0.5f, 7.0f), "setFixedTuning was rejected");
+
+    Vector3f r; Eigen::Matrix<float,3,Fusion::Mekf::NX> H; Matrix3f Rw;
+    f.mekf().integral_residual(r, H, Rw);
+
+    const float want = 7.0f * 7.0f;
+    if (!check(std::fabs(Rw(2,2) - want) <= 1e-4f * want,
+               "R_S must be the square of the applied r_S scale")) {
+        std::cerr << "  R_S(2,2) = " << Rw(2,2) << " want " << want << '\n';
+    }
+    // And emphatically not the scale itself, which is the bug being guarded.
+    check(std::fabs(Rw(2,2) - 7.0f) > 1.0f,
+          "R_S was set to the r_S scale rather than its square");
+}
+
 // The coefficients must actually be the knobs the study will turn.
 void test_tuning_coefficients_are_live() {
     Fusion a, b;
@@ -323,8 +351,28 @@ void test_tracks_heave() {
     const double rms_ref = std::sqrt(sq_ref / n);
     std::cout << "  heave RMS error " << rms << " m against " << rms_ref
               << " m of signal (" << (100.0 * rms / rms_ref) << "%)\n";
-    check(rms < rms_ref,
-          "heave error exceeds the signal itself -- the filter is not tracking");
+
+    /*
+        About 21% on this case, and it is almost entirely amplitude gain
+        rather than noise or drift: fitting p_z to a sinusoid at the known
+        frequency leaves a residual of 0.002 m, while the fitted amplitude is
+        19% high.
+
+        That overshoot is the S = 0 regularizer's high-pass response, it is
+        monotonic in both sea frequency and r_S, and OU-III shows MORE of it
+        than this filter does at every operating point measured (1.23 vs 1.19
+        at 0.15 Hz; 1.62 vs 1.54 at 0.08 Hz). So it is a property of the
+        shared model on a monochromatic sea, not a defect here -- the r_S law
+        was calibrated against broadband JONSWAP and PM spectra, and a pure
+        sinusoid puts all its energy at one frequency.
+
+        The gate is therefore deliberately loose. A tight threshold here would
+        be a number fitted to a sea state the filter was never tuned for, and
+        the real measurement belongs in the paired study against recorded
+        waves.
+    */
+    check(rms < 0.45 * rms_ref,
+          "heave error is far worse than the regularizer overshoot explains");
     check(f.get_position().allFinite() && f.mekf().covariance_full().allFinite(),
           "the filter went non-finite");
 }
@@ -440,6 +488,7 @@ int main() {
     test_staging();
     test_warmup_gates();
     test_tuning_laws();
+    test_rs_units_are_a_standard_deviation();
     test_tuning_coefficients_are_live();
     test_ablation_hooks();
     test_magnetic_reference_timing();


### PR DESCRIPTION
Stacked on #248 (Level 2), which is not yet merged -- review that first; the
diff here will shrink once it lands.

First part of the evidence phase, plus a real bug the first end-to-end run
turned up.

## The orchestrator

`SeaStateFusionFilter_TFG` carries the startup staging, the sea-state tuner,
the adaptation smoothers and the update loop, so the filter can be driven from
recorded motion rather than from unit tests.

Scope is deliberately the core of `SeaStateFusionFilter_OU_III` rather than all
of it. The wave-direction estimator, the alternative frequency trackers, the
displacement detrender and the wind-heel B' frame are **not** carried over: they
are orthogonal to the estimator under test, and a second copy would mean
maintaining logic already established and evidenced for OU-III. The cost is
real and worth stating -- the TFG simulator will not be feature-comparable on
direction and frequency reporting, so a paired study has to compare the
channels both filters actually implement.

Shared rather than copied: `runStartupGravityInit`, `StartupTiltObserver`,
`adaptiveSmoothingHorizonSec`, and all three tuner components. The tuner stays
outside the group state. The wave-period input remains the complementary
observer, which runs its own Mahony filter on raw gyro and accelerometer so the
tuner's frequency channel is not a function of the estimator it tunes.

Three MEKF capabilities come with it. `initialize_from_acc` levels from gravity
and leaves yaw for the magnetometer. The linear-block gate freezes the world
chain before the tuner has an operating point and -- the part worth getting
right -- marginalizes `Sigma_aw` into the accelerometer noise rather than
pretending `a_w` is zero while frozen. The `a_w` covariance re-seeding comes in
both flavours, the congruent one preserving every correlation coefficient; both
operate on the invariant tangent block rather than treating `a_w` as a
free-standing Euclidean state.

Tuning laws are tested against closed form on a synthetic sea of known period
and variance, not against recorded output -- a regression baseline would only
lock in whatever the code did the day it was written. On a 0.15 Hz sea with
1.2 m/s^2 of heave acceleration: `T_z` 6.61 s against 6.67 true, `tau` 3.34,
`sigma` 0.835 against 0.840 expected, `R_S` 10.82 against 10.83.

## The bug that first run exposed

`Kalman3D_Wave_OU_III::set_RS_noise` takes a **standard deviation** and squares
it internally. The TFG setter took a **variance**, and the orchestrator fed it
`r_S`, which the tuning law produces as a standard-deviation scale. The applied
covariance was `r_S` rather than `r_S^2` -- roughly a factor of ten of
over-tight regularization. Both filters now share one convention.

Heave RMS error on the synthetic case: **46.0% -> 20.8%**.

### Why it was hard to see

`S = 0` is a high-pass, and over-tightening a high-pass *overshoots* rather
than attenuates, so the symptom was a heave amplitude 37% too **large**. That
reads as a modelling problem, not as a units conversion.

Two things found it:

**Decomposing the error rather than looking at the total.** Fitting `p_z` to a
sinusoid at the known frequency split the 46% into gain, phase, DC and
residual. The residual was 0.002 m -- so not noise, not drift, and not the
missing displacement detrender, which had been the leading hypothesis. Almost
all of it was gain, which points at the regularizer rather than the integration
chain.

**Comparing against OU-III on identical input** -- which is also where the first
comparison misled. The harness passed `r_S^2` to OU-III, which squared it
again, making OU-III's regularizer far too weak and its gain look better than
it is. Corrected, OU-III measures **1.231 against this filter's 1.188** at
0.15 Hz: worse, not better.

### What remains

About 21%, and it is the regularizer's high-pass overshoot, shared with OU-III
and monotonic in both sea frequency and `r_S`:

| f (Hz) | 0.08 | 0.10 | 0.15 | 0.20 | 0.30 |
|---|---|---|---|---|---|
| TFG | 1.54 | 1.39 | 1.19 | 1.11 | 1.04 |
| OU-III | 1.62 | 1.46 | 1.23 | 1.13 | 1.05 |

TFG is better at every point measured. **None of this is a performance claim.**
`R_S_coeff = 0.35` was calibrated against broadband JONSWAP and PM spectra, and
a monochromatic sea concentrates all its energy at one frequency, so this
synthetic case is harsher than the tuning was designed for. The real
measurement belongs in the paired study against recorded waves, and the
synthetic sinusoid has now given up everything it can tell us.

The heave gate is loosened to what the overshoot actually explains, with the
reasoning written down rather than left as a bare threshold, and
`test_rs_units_are_a_standard_deviation` guards the units directly.

## Verification

`make all` is green end to end: all eight `kalman_tfg` suites pass inside it,
and `tests/validation` reports `OK`.

## Not included

The IMU lever-arm term is still absent from the accelerometer residual,
carried forward since #247.

Remaining in this phase: `kalman_tfg-sim` on `IW3dFusionAdapter`, then
`tools/tfg_validation.py` with NEES, plots, the article, CI wiring and the
Arduino sketch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9aDUvqetsX7jojWiDumAf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added staged sea-state filtering with startup, warmup, and live operating phases.
  - Added adaptive tuning for wave period, acceleration noise, and sea-state conditions.
  - Added configurable linear-block processing, tilt-only acceleration initialization, and covariance synchronization controls.
  - Added controls for fixed tuning, channel freezing, magnetometer updates, and filter state access.

- **Improvements**
  - Standard-deviation inputs for integral measurement and process noise are now converted consistently to covariance values.

- **Documentation**
  - Documented noise interpretation, observed filter behavior, and regression coverage.

- **Tests**
  - Added comprehensive orchestration and regression tests covering startup, tuning, covariance behavior, and numerical stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->