### PR TITLE
Run the TFG filter against recorded waves

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,3 +52,4 @@ add_executable(tfg_propagation-test "${OCEAN_IMU_TESTS_DIR}/kalman_tfg/tfg_propa
 add_executable(tfg_jacobians-test "${OCEAN_IMU_TESTS_DIR}/kalman_tfg/tfg_jacobians-test.cpp")
 add_executable(covariance_transport-test "${OCEAN_IMU_TESTS_DIR}/kalman_tfg/covariance_transport-test.cpp")
 add_executable(tfg_orchestrator-test "${OCEAN_IMU_TESTS_DIR}/kalman_tfg/tfg_orchestrator-test.cpp")
+add_executable(kalman_tfg-sim "${OCEAN_IMU_TESTS_DIR}/kalman_tfg/kalman_tfg-sim.cpp" ${W3D_SIM_COMMON})

--- a/docs/tfg-design.md
+++ b/docs/tfg-design.md
@@ -455,7 +455,35 @@ its energy at one frequency, so this synthetic case is harsher than what the
 tuning was designed for. The real measurement belongs in the paired study
 against recorded waves, not here.
 
-## 7. What this does not claim
+## 7. Yaw must be anchored at magnetic lock, not merely referenced
+
+`initialize_from_acc` levels the filter but leaves yaw at zero, because gravity
+says nothing about heading. The magnetic reference is captured later, once the
+attitude has settled.
+
+Capturing it as `B_w = Rhat m` at that moment is wrong, and wrong in a way that
+is easy to miss. It bakes the arbitrary startup yaw into the reference, and the
+filter then holds yaw consistent with *its own starting frame* rather than with
+the field — a constant gauge offset. Every other channel looks healthy while
+yaw carries a fixed error.
+
+Measured on a JONSWAP H1.5 record: **12.2 degrees RMS yaw**, against roll 0.58
+and pitch 0.17. Anchoring first — rotate about world z until the measured
+field's horizontal component points north, *then* capture — gives **2.37
+degrees**, in line with OU-III's 2.2 degree gate, with every other channel
+unchanged.
+
+Capturing the canonical `(B_north, 0, B_down)` is also what makes `H_m` a
+genuinely fixed reference rather than a frame-dependent one, which is the
+property section 4 relies on.
+
+This is worth stating because the symptom points away from the cause. A large
+yaw error with clean roll and pitch reads as a magnetometer or observability
+problem; it was neither. The diagnostic that separates them is whether the
+error is a constant offset or a wander — a gauge offset is constant, and a real
+heading problem is not.
+
+## 8. What this does not claim
 
 The bias-free, frozen-parameter skeleton is group-affine. The complete
 estimator is **not** shown to be, and must not be described as an InEKF or as

--- a/src/kalman_tfg/SeaStateFusionFilter_TFG.h
+++ b/src/kalman_tfg/SeaStateFusionFilter_TFG.h
@@ -59,6 +59,15 @@
 
 namespace ocean_imu::tfg {
 
+/*
+    Yaw is held for this long before the magnetic reference is captured.
+    Deliberately the same 7 s OU-III uses (SeaStateFusionFilter_OU_III.h:128):
+    a different mag-lock time would show up in a paired study as an attitude
+    difference between the two filters that has nothing to do with either
+    estimator.
+*/
+constexpr float MAG_DELAY_SEC = 7.0f;
+
 struct TfgTuneState {
     float tau_applied   = 1.1f;    // s
     float sigma_applied = 1e-2f;   // m/s^2
@@ -92,7 +101,7 @@ public:
         float    gyro_noise_density = 0.005f;          // rad/sqrt(s)
         Vector3f sigma_m{Vector3f::Constant(0.1f)};    // mag noise std, body
         bool     with_mag = true;
-        float    mag_delay_sec = 30.0f;                // hold yaw until settled
+        float    mag_delay_sec = MAG_DELAY_SEC;         // hold yaw until settled
         bool     freeze_acc_bias_until_live = true;
         float    Racc_warmup_std = 0.5f;               // inflated while warming
         float    gravity_magnitude = 9.80665f;
@@ -204,7 +213,31 @@ public:
         if (elapsed_sec_ < cfg_.mag_delay_sec) return;
 
         if (!mekf_.has_magnetic_reference()) {
-            mekf_.set_magnetic_reference_world(mekf_.R_bw() * mag_body);
+            /*
+                Anchor yaw to magnetic north before capturing the reference.
+
+                initialize_from_acc levels the filter but leaves yaw at zero,
+                because gravity says nothing about heading. Storing
+                B_w = Rhat m at that point would bake the arbitrary yaw into
+                the reference, and the filter would then hold yaw consistent
+                with its own starting frame rather than with the field --
+                a constant gauge offset that scores as a large yaw error while
+                every other channel looks fine.
+
+                So rotate about world z until the measured field's horizontal
+                component points north, then capture. B_w comes out canonical,
+                (B_north, 0, B_down), which is also what makes H_m a genuinely
+                fixed reference rather than a frame-dependent one.
+            */
+            const Vector3f b_world = mekf_.R_bw() * mag_body;
+            const float horiz = std::hypot(b_world.x(), b_world.y());
+            if (horiz > 1e-9f) {
+                const float psi = std::atan2(b_world.y(), b_world.x());
+                const Eigen::Matrix3f Rz =
+                    Eigen::AngleAxisf(-psi, Vector3f::UnitZ()).toRotationMatrix();
+                mekf_.state().R = (Rz * mekf_.state().R).eval();
+            }
+            mekf_.set_magnetic_reference_world(Vector3f(horiz, 0.0f, b_world.z()));
             return;
         }
         mekf_.measurement_update_mag_only(mag_body);

--- a/tests/kalman_tfg/Makefile
+++ b/tests/kalman_tfg/Makefile
@@ -24,13 +24,13 @@ LDFLAGS  =
 # Tell make to look for source files in src/util
 VPATH = $(REPO_ROOT)/src/util
 
-TARGETS = lie_group-test convention-test ou_chain_identity-test tfg_propagation-test tfg_jacobians-test covariance_transport-test tfg_orchestrator-test
+TARGETS = lie_group-test convention-test ou_chain_identity-test tfg_propagation-test tfg_jacobians-test covariance_transport-test tfg_orchestrator-test kalman_tfg-sim
 
 all: build test
 
 build: $(TARGETS)
 
-test: $(TARGETS)
+test: ensure-sim-data $(TARGETS)
 	bash ./run_tests.sh
 
 ensure-sim-data:
@@ -55,6 +55,10 @@ covariance_transport-test: covariance_transport-test.o
 	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
 
 tfg_orchestrator-test: tfg_orchestrator-test.o
+	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
+
+# Needs W3dSimCommon for the shared runner, scoring and record loading.
+kalman_tfg-sim: kalman_tfg-sim.o W3dSimCommon.o
 	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
 
 # -MMD -MP records the headers each object depends on, so editing a group or

--- a/tests/kalman_tfg/kalman_tfg-sim.cpp
+++ b/tests/kalman_tfg/kalman_tfg-sim.cpp
@@ -1,0 +1,354 @@
+/*
+    Copyright (c) 2025-2026  Mikhail Grushinskiy
+
+    Simulator for the right-invariant two-frame Lie-group filter, over the same
+    recorded wave records the OU-III simulator uses, through the same
+    IW3dFusionAdapter interface and the same scoring path. Paired comparison is
+    only meaningful if both filters see identical wave realization, identical
+    sensor-error realization and identical scoring, which is what reusing
+    W3dSimulationRunner buys.
+
+    WHAT THIS FILTER DOES NOT REPORT. SeaStateFusionFilter_TFG carries the core
+    of the OU-III orchestrator and not its wave-direction estimator or its
+    alternative frequency trackers, so the direction telemetry and freq_hz stay
+    at their NaN defaults rather than being filled with a plausible-looking
+    substitute. A study comparing the two families has to compare the channels
+    both actually implement; inventing values here would make that mistake
+    invisible.
+
+    THE FAILURE LIMITS BELOW ARE REGRESSION BARS, NOT QUALITY TARGETS. They are
+    the worst values this filter actually produced over the eight JONSWAP and
+    PM-Stokes records, plus a small margin -- derived the same way OU-III's
+    were, and deliberately not copied from OU-III, because copying would
+    silently assert that a filter with different error characteristics must sit
+    inside another one's envelope.
+
+    Two of them record behaviour that is plainly poor, and they are set where
+    they are so that further regression is caught, not because the current
+    value is acceptable. See the table below.
+*/
+
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#define EIGEN_NON_ARDUINO
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#include "util/W3dSimCommon.h"
+#include "kalman_tfg/SeaStateFusionFilter_TFG.h"
+
+using Eigen::Quaternionf;
+using Eigen::Vector3f;
+
+bool add_noise = true;
+
+namespace {
+
+bool env_float(const char* name, float& out) {
+    if (const char* s = std::getenv(name)) {
+        out = static_cast<float>(std::atof(s));
+        return true;
+    }
+    return false;
+}
+
+/*
+    Tuning arms, matching the OU-III simulator's so the two can be paired arm
+    for arm in a study.
+
+      Adaptive        -- the tuner runs throughout
+      Fixed           -- pinned operating point, no adaptation
+      AdaptiveRSOnly  -- OU channel frozen, r_S keeps adapting
+      AdaptiveOUOnly  -- r_S frozen, OU channel keeps adapting
+*/
+enum class TuningMode { Adaptive, Fixed, AdaptiveRSOnly, AdaptiveOUOnly };
+
+TuningMode load_tuning_mode() {
+    const char* raw = std::getenv("TFG_TUNING");
+    if (!raw) return TuningMode::Adaptive;
+    const std::string mode(raw);
+    if (mode == "adaptive") return TuningMode::Adaptive;
+    if (mode == "fixed") return TuningMode::Fixed;
+    if (mode == "adaptive_rs_only") return TuningMode::AdaptiveRSOnly;
+    if (mode == "adaptive_ou_only") return TuningMode::AdaptiveOUOnly;
+    throw std::runtime_error("unknown TFG_TUNING mode: " + mode);
+}
+
+}  // namespace
+
+class FusionAdapter_TFG final : public IW3dFusionAdapter {
+public:
+    FusionAdapter_TFG(bool with_mag,
+                      const Vector3f& sigma_a_init,
+                      const Vector3f& sigma_g,
+                      const Vector3f& sigma_m)
+    {
+        Fusion::Config cfg;
+        cfg.with_mag = with_mag;
+        cfg.sigma_a = sigma_a_init;
+        cfg.gyro_noise_density = sigma_g.x();
+        cfg.sigma_m = sigma_m;
+        cfg.mag_delay_sec = ocean_imu::tfg::MAG_DELAY_SEC;
+        if (float v = 0.0f; env_float("SF_MAG_DELAY_SEC", v)) cfg.mag_delay_sec = v;
+        cfg.freeze_acc_bias_until_live = true;
+        cfg.Racc_warmup_std = 0.5f;
+
+        tuning_ = load_tuning_mode();
+        load_fixed_tuning_();
+
+        fusion_.begin(cfg);
+
+        // Coefficient overrides, so a sweep can move the tuning laws without
+        // recompiling. Names mirror the OU-III simulator's OU_III_* set.
+        float v = 0.0f;
+        if (env_float("TFG_TAU_COEFF", v))      fusion_.setTauCoeff(v);
+        if (env_float("TFG_SIGMA_COEFF", v))    fusion_.setSigmaCoeff(v);
+        if (env_float("TFG_R_S_COEFF", v))      fusion_.setRSCoeff(v);
+        if (env_float("TFG_S_FACTOR", v))       fusion_.setSFactor(v);
+        if (env_float("TFG_R_S_XY_FACTOR", v))  fusion_.setRSXYFactor(v);
+        if (env_float("TFG_ADAPT_TAU_SEC", v))  fusion_.setAdaptationTimeConstants(v);
+        if (env_float("TFG_ADAPT_RS_MULT", v))  fusion_.setRSAdaptMult(v);
+        if (env_float("TFG_ADAPT_RS_SLEW_LOG", v)) fusion_.setRSAdaptSlewLog(v);
+        if (env_float("TFG_ACC_NOISE_FLOOR", v))   fusion_.setAccNoiseFloorSigma(v);
+
+        if (const char* s = std::getenv("TFG_AW_COV_SYNC")) {
+            fusion_.setPeriodicAwCovarianceSync(std::string(s) != "off");
+        }
+    }
+
+    void updateMag(const Vector3f& mag_body_ned) override {
+        fusion_.updateMag(mag_body_ned);
+    }
+
+    void update(float dt,
+                const Vector3f& gyr_meas_ned,
+                const Vector3f& acc_meas_ned,
+                float temperature_c) override
+    {
+        fusion_.update(dt, gyr_meas_ned, acc_meas_ned, temperature_c);
+
+        // Fixed and frozen arms are applied once the tuner is Live, so the
+        // filter reaches its operating point the same way the adaptive arm
+        // does and only then stops moving. Applying them from cold would
+        // change the startup transient as well as the steady state, and the
+        // study could not tell the two apart.
+        if (tuning_ == TuningMode::Adaptive || fixed_tuning_applied_) return;
+        if (!fusion_.isLive()) return;
+
+        const bool ok = (tuning_ == TuningMode::Fixed)
+            ? fusion_.setFixedTuning(fixed_tau_s_, fixed_sigma_a_, fixed_RS_)
+            : fusion_.setChannelFreeze(
+                  tuning_ == TuningMode::AdaptiveRSOnly,
+                  fixed_tau_s_, fixed_sigma_a_,
+                  tuning_ == TuningMode::AdaptiveOUOnly,
+                  fixed_RS_);
+        if (!ok) throw std::runtime_error("invalid TFG tuning point");
+        fixed_tuning_applied_ = true;
+    }
+
+    FilterSnapshot snapshot() const override {
+        FilterSnapshot s;
+
+        s.disp_est_zu = ned_to_zu(fusion_.get_position());
+        s.vel_est_zu  = ned_to_zu(fusion_.get_velocity());
+        s.acc_est_zu  = ned_to_zu(fusion_.get_world_accel());
+
+        // BODY -> WORLD in NED. After magnetic lock this is the learned
+        // magnetic-NED frame, not true north: no declination model is applied,
+        // because a bare IMU does not have one.
+        const Quaternionf q_bw_ned = fusion_.quaternion().normalized();
+        float roll_deg = 0.0f, pitch_deg = 0.0f, yaw_deg = 0.0f;
+        quat_to_euler_nautical(q_bw_ned, roll_deg, pitch_deg, yaw_deg);
+        s.euler_nautical_deg = Vector3f(roll_deg, pitch_deg, wrapDeg(yaw_deg));
+
+        s.acc_bias_est_ned  = fusion_.mekf().get_acc_bias();
+        s.gyro_bias_est_ned = fusion_.mekf().gyroscope_bias();
+        // No magnetometer-bias state in this filter; left at zero rather than
+        // filled with something that would read as an estimate.
+
+        s.tau_target     = fusion_.getTauTarget();
+        s.sigma_target   = fusion_.getSigmaTarget();
+        s.tuning_target  = fusion_.getRSTarget();
+        s.tau_applied    = fusion_.getTauApplied();
+        s.sigma_applied  = fusion_.getSigmaApplied();
+        s.tuning_applied = fusion_.getRSApplied();
+
+        s.wave_period_sec = fusion_.getWavePeriodSec();
+        s.accel_variance  = fusion_.getAccelVariance();
+
+        // freq_hz, period_sec, the displacement/velocity scales and every
+        // direction field stay NaN. This filter does not compute them, and a
+        // substitute would hide that from any study reading the output.
+        return s;
+    }
+
+private:
+    using Fusion = ocean_imu::tfg::SeaStateFusionFilter_TFG<>;
+
+    void load_fixed_tuning_() {
+        if (tuning_ == TuningMode::Adaptive) return;
+        const bool need_ou = (tuning_ != TuningMode::AdaptiveOUOnly);
+        const bool need_rs = (tuning_ != TuningMode::AdaptiveRSOnly);
+
+        if (need_ou) {
+            if (!env_float("TFG_FIXED_TAU_S", fixed_tau_s_) ||
+                !env_float("TFG_FIXED_SIGMA_A", fixed_sigma_a_)) {
+                throw std::runtime_error(
+                    "TFG_TUNING requires TFG_FIXED_TAU_S and TFG_FIXED_SIGMA_A");
+            }
+        }
+        if (need_rs) {
+            if (!env_float("TFG_FIXED_RS", fixed_RS_)) {
+                throw std::runtime_error("TFG_TUNING requires TFG_FIXED_RS");
+            }
+        }
+    }
+
+    Fusion fusion_{};
+    TuningMode tuning_ = TuningMode::Adaptive;
+    bool fixed_tuning_applied_ = false;
+    float fixed_tau_s_ = 0.0f;
+    float fixed_sigma_a_ = 0.0f;
+    float fixed_RS_ = 0.0f;
+};
+
+namespace {
+
+void process_one(const std::string& filename,
+                 float dt,
+                 bool with_mag,
+                 const W3dRandomSeeds& seeds,
+                 bool write_timeseries,
+                 float validation_window_sec)
+{
+    constexpr float MAG_ODR_HZ = 25.0f;
+
+    auto result = process_wave_file_for_tracker<FusionAdapter_TFG>(
+        filename, dt, with_mag, add_noise, MAG_ODR_HZ,
+        "_fusion_tfg", "_fusion_tfg_nomag", seeds, write_timeseries);
+
+    if (!result) return;
+
+    if (validation_window_sec > 0.0f) {
+        print_validation_metrics(*result, dt, validation_window_sec, "TFG");
+    }
+
+    /*
+        Worst observed over the eight-record set, with a small margin.
+
+          channel            TFG worst   this gate   OU-III gate
+          Z RMS  jonswap        5.39        5.5          5.4
+          Z RMS  pmstokes       5.29        5.4          5.3
+          yaw                   3.19        3.3          2.2
+          3D     jonswap       30.31       30.6         21.4
+          3D     pmstokes      67.63       68.0         22.0
+          acc bias Z            9.30        9.5          5.9
+          acc bias 3D         412.29      415.0        109.4
+
+        Vertical is at parity with OU-III and six of the eight records beat its
+        worst observed value. The horizontal and bias channels are not: 3D
+        error degrades sharply on the large-wave records (H4.0 and H8.5), and
+        accelerometer-bias error is several times OU-III's.
+
+        Those last two gates are therefore recording a known deficiency rather
+        than endorsing it. They belong in the article as a finding, and the
+        cause is not yet established -- the pattern points at the horizontal
+        channels under large orbital motion, which is where OU-III's own
+        article already reports paying for its vertical gain, but that is a
+        hypothesis and not a measurement.
+    */
+    static constexpr W3dFailureLimits kRegressionBars{
+        .err_limit_percent_z_jonswap   = 5.5f,
+        .err_limit_percent_z_pmstokes  = 5.4f,
+        .err_limit_yaw_deg             = 3.3f,
+        .err_limit_percent_3d_jonswap  = 30.6f,
+        .err_limit_percent_3d_pmstokes = 68.0f,
+        .acc_z_bias_percent            = 9.5f,
+        .bias_3d_percent               = 415.0f,
+    };
+    static constexpr W3dSummaryLabels kLabels{ .target = "RS_target",
+                                               .applied = "RS_applied" };
+    print_summary_and_fail_if_needed(*result, dt, kRegressionBars, kLabels);
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+    const float dt = 1.0f / 200.0f;
+    bool with_mag = true;
+    add_noise = true;
+    std::vector<std::string> requested_files;
+
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--nomag") {
+            with_mag = false;
+        } else if (arg == "--no-noise") {
+            add_noise = false;
+        } else if (arg == "--input") {
+            if (++i >= argc) {
+                std::cerr << "ERROR: --input requires a CSV path\n";
+                return 2;
+            }
+            requested_files.emplace_back(argv[i]);
+        } else if (arg == "--help") {
+            std::cout << "Usage: " << argv[0]
+                      << " [--nomag] [--no-noise] [--input PATH]...\n";
+            return 0;
+        } else {
+            std::cerr << "ERROR: unknown argument: " << arg << "\n";
+            return 2;
+        }
+    }
+
+    W3dRandomSeeds seeds;
+    try {
+        seeds = w3d_random_seeds_from_env();
+    } catch (const std::exception& e) {
+        std::cerr << "ERROR: " << e.what() << "\n";
+        return 2;
+    }
+
+    bool write_timeseries = true;
+    if (const char* value = std::getenv("W3D_WRITE_TIMESERIES")) {
+        write_timeseries = std::string(value) != "0";
+    }
+    float validation_window_sec = 0.0f;
+    env_float("W3D_VALIDATION_WINDOW_SEC", validation_window_sec);
+
+    std::cout << "TFG simulation starting with_mag=" << (with_mag ? "true" : "false")
+              << ", mag_delay=" << ocean_imu::tfg::MAG_DELAY_SEC
+              << " sec, noise=" << (add_noise ? "true" : "false") << "\n";
+    std::cout << "RANDOM_SEEDS accel_noise=" << seeds.accel_noise
+              << " gyro_noise=" << seeds.gyro_noise
+              << " mag_noise=" << seeds.mag_noise
+              << " accel_initialization=" << seeds.accel_initialization
+              << " gyro_initialization=" << seeds.gyro_initialization
+              << " mag_initialization=" << seeds.mag_initialization << "\n";
+
+    const auto files = requested_files.empty()
+        ? collect_wave_data_files(".")
+        : requested_files;
+
+    try {
+        for (const auto& fname : files) {
+            process_one(fname, dt, with_mag, seeds, write_timeseries,
+                        validation_window_sec);
+        }
+    } catch (const std::exception& e) {
+        std::cerr << "ERROR: " << e.what() << "\n";
+        return 2;
+    }
+
+    if (std::getenv("W3D_COLLECT_ALL_GATES") && w3d_any_quality_gate_failed()) {
+        return 1;
+    }
+    return 0;
+}

--- a/tests/kalman_tfg/run_tests.sh
+++ b/tests/kalman_tfg/run_tests.sh
@@ -7,3 +7,4 @@
 ./tfg_jacobians-test
 ./covariance_transport-test
 ./tfg_orchestrator-test
+./kalman_tfg-sim


### PR DESCRIPTION
Follows #249. Adds `kalman_tfg-sim` on `IW3dFusionAdapter`, going through the
same `W3dSimulationRunner`, the same sensor-error realization and the same
scoring path as the OU-III simulator — paired comparison only means anything
if both filters see identical inputs and identical scoring.

This is the first time the filter has been measured against anything other
than synthetic input, and the results are mixed in a way that matters.

## First results

Eight JONSWAP and PM-Stokes records, against OU-III's gates:

| channel | TFG worst | OU-III gate |
|---|---|---|
| Z RMS jonswap | 5.39 | 5.4 |
| Z RMS pmstokes | 5.29 | 5.3 |
| yaw (deg) | 3.19 | 2.2 |
| 3D jonswap | 30.31 | 21.4 |
| 3D pmstokes | **67.63** | 22.0 |
| acc bias 3D | **412.29** | 109.4 |

Per record:

| record | Z %Hs | 3D % | yaw | acc-bias 3D % |
|---|---|---|---|---|
| jonswap H0.27 | 5.39 | 21.95 | 1.88 | 135.0 |
| jonswap H1.50 | 4.63 | 22.62 | 2.37 | 122.0 |
| jonswap H4.00 | 4.79 | 20.70 | 1.50 | 412.3 |
| jonswap H8.50 | 4.00 | 30.31 | 3.19 | 206.1 |
| pmstokes H0.27 | 5.29 | 22.64 | 2.45 | 90.3 |
| pmstokes H1.50 | 4.28 | 19.94 | 1.41 | 147.8 |
| pmstokes H4.00 | 4.64 | 49.17 | 2.07 | 123.5 |
| pmstokes H8.50 | 4.70 | 67.63 | 1.54 | 110.8 |

**Vertical — the primary endpoint — is at parity**, and six of the eight
records beat OU-III's worst observed value.

**Horizontal and bias are not.** 3D error degrades sharply on the large-wave
records (H4.0 and H8.5), and accelerometer-bias error is several times
OU-III's. That is a finding for the article rather than something to tune away
quietly, and **its cause is not established**. The pattern points at the
horizontal channels under large orbital motion, which is where OU-III's own
article reports paying for its vertical gain, but that is a hypothesis and not
a measurement. I would want it understood before the paired study is built on
top of it.

## The yaw bug, which only recorded waves could show

Yaw was **12.2 degrees** before the fix in this commit, against roll 0.58 and
pitch 0.17 on the same record.

`initialize_from_acc` levels the filter but leaves yaw at zero, because gravity
says nothing about heading. Capturing the reference as `B_w = Rhat m` at
magnetic lock therefore baked the arbitrary startup yaw into it, and the filter
then held yaw consistent with *its own starting frame* rather than with the
field — a constant gauge offset, with every other channel looking healthy.

Anchoring first — rotate about world z until the measured field's horizontal
component points north, then capture the canonical `(B_north, 0, B_down)` —
gives **2.37 degrees**, everything else unchanged. It also makes `H_m` a
genuinely fixed reference rather than a frame-dependent one, which is the
property the invariant formulation depends on.

A synthetic sinusoid has no heading content, so no amount of work on it would
have surfaced this. It is the argument for getting onto real records early.

## On the failure limits

They are **regression bars, not quality targets**: the worst values this filter
actually produced plus a small margin, derived the way OU-III's were rather
than copied from OU-III — copying would silently assert that a filter with
different error characteristics must sit inside another one's envelope.

Two of them record behaviour that is plainly poor. They are set where they are
so that *further* regression is caught, not because the current value is
acceptable, and the file says so.

## Smaller notes

`MAG_DELAY_SEC` is aligned to OU-III's 7 s rather than this filter's earlier
30 s default: a different mag-lock time would show up in a paired study as an
attitude difference between the two filters that has nothing to do with either
estimator.

Direction telemetry and `freq_hz` stay at their NaN defaults. This orchestrator
does not compute them, and filling them with plausible substitutes would hide
that from any study reading the output.

## Verification

All eight `kalman_tfg` suites pass on this base, and all eight simulator
records pass their gates. `make all` is running; I will follow up here with
the result.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9aDUvqetsX7jojWiDumAf)_