### PR TITLE
Replace numerical ISS certificate with analytical stability proof

### DIFF
--- a/doc/kalman_ou_iii/w3d-conclusion-summary.tex-part
+++ b/doc/kalman_ou_iii/w3d-conclusion-summary.tex-part
@@ -1,123 +1,124 @@
 
 The present study establishes the complete estimator recursion and verifies it
-under the simulation protocol of Sec.~\ref{sec:sim-and-eval}.  The deterministic
+under the simulation protocol of Sec.~\ref{sec:sim-and-eval}. The deterministic
 eight-case comparison retains the adaptive PII and TVG--NLO reference results,
 while the completed ten-seed study provides the inferential OU-family and
-adaptation evidence.  Across the four stationary JONSWAP seas, OU--III has a
+adaptation evidence. Across the four stationary JONSWAP seas, OU--III has a
 seed-wise mean normalized vertical error of
 $\OUValidationOUIIINormalizedMean\pm\OUValidationOUIIINormalizedStd\%$ of
 $H_s$, versus
 $\OUValidationOUIINormalizedMean\pm\OUValidationOUIINormalizedStd\%$ for
-OU--II.  Their paired difference is $\OUValidationNormalizedDifference$
+OU--II. Their paired difference is $\OUValidationNormalizedDifference$
 percentage point (bootstrap 95\% interval
 $[\OUValidationNormalizedDifferenceLow,\OUValidationNormalizedDifferenceHigh]$,
 Student-$t$ interval
 $[\OUValidationNormalizedTLow,\OUValidationNormalizedTHigh]$, with all
 $\OUValidationNormalizedSignNegative$ seed-level differences in the same
-direction).  Those are four constructions on ten paired numbers, and they
+direction). Those are four constructions on ten paired numbers, and they
 establish that the difference is stable across realizations of this simulator
-rather than that it would survive a change of simulator, sensor model, or
-sea (Sec.~\ref{par:companion-inference}).
+rather than that it would survive a change of simulator, sensor model, or sea
+(Sec.~\ref{par:companion-inference}).
 Both filters take that operating point from the same wave-band zero-crossing
 period, so the comparison isolates the additional integral-displacement state
-rather than the spectral band the two were tuned from; in earlier revisions
-only OU--III did, and about \pct{51} of the vertical advantage reported then
-was the band rather than the architecture.  OU--III 3D displacement error is
-higher in \OUValidationThreeDHigherCount{} of the
+rather than the spectral band the two were tuned from. Tuning only OU--III from
+the wave band would inflate the apparent vertical advantage by about \pct{51},
+so the matched tuning used here is necessary for an architectural comparison.
+OU--III 3D displacement error is higher in
+\OUValidationThreeDHigherCount{} of the
 \OUValidationThreeDScenarios{} scenarios and lower in the largest sea, so the
 supported claim is a vertical one throughout and a three-dimensional one only
 in that one sea: the vertical gain is otherwise paid for in the horizontal
-channels, and most visibly in $Y$.  The result extends to a second
-spectral family, with a paired PM--Stokes difference of
+channels, and most visibly in $Y$. The result extends to a second spectral
+family, with a paired PM--Stokes difference of
 $\OUValidationPMStokesDifference$ percentage point
 ($[\OUValidationPMStokesDifferenceLow,\OUValidationPMStokesDifferenceHigh]$)
-scored on the same seeds.  Adaptive tuning improves on FixedNominal at the
+scored on the same seeds. Adaptive tuning improves on FixedNominal at the
 smallest and largest stationary seas and over the controlled transition, where
 it also beats the endpoint-calibrated fixed reference; it costs a few
 hundredths of a point only at the nominal sea the frozen point was calibrated
-at.  The channel ablation locates that benefit in one parameter, and the location is
-now unambiguous: freezing $\tau$ and $\sigma_{aw}$ while $r_S$ keeps adapting
+at. The channel ablation locates that benefit in one parameter, and the location
+is unambiguous: freezing $\tau$ and $\sigma_{aw}$ while $r_S$ keeps adapting
 reproduces the adaptive result to within a few tenths of a millimetre in every
-scenario, whereas freezing $r_S$ recovers none of it.  In earlier revisions
-freezing the OU channel was \emph{better} than adapting all three, which is
-what motivated re-examining the operating point; with $\tau$ estimated in the
-wave band that gap closes.  The two readings are consistent, because $\tau$'s
-material role is setting $r_S\propto\tau^3$ rather than shaping the OU process
-covariance: what the earlier ablation measured was a $\tau$ carrying no
-sea-state information, not a $\tau$ that does not matter.  The vertical
+scenario, whereas freezing $r_S$ recovers none of it. With $\tau$ estimated in
+the wave band, there is no material accuracy gain from adapting the OU process
+parameters independently of the regularization channel. The two readings are
+consistent, because $\tau$'s material role is setting
+$r_S\propto\tau^3$ rather than shaping the OU process covariance. The vertical
 evidence therefore establishes the value of adaptive integral-state
 regularization driven by a wave-band period, not the necessity of joint
-three-parameter OU adaptation.  A matched control shows
-that the periodic covariance re-alignment accounts for at most
+three-parameter OU adaptation. A matched control shows that the periodic
+covariance re-alignment accounts for at most
 $\OUValidationCovSyncWorstDifference$ points of any of these differences, so
 the residual nominal-sea cost is the cost of estimating the operating point
-online rather than an artifact of the adaptation bookkeeping.  The simulations and embedded builds exercise the same estimator
-recursion, including the exact OU-chain transition, small-step covariance
-branch, full MEKF reset, and adaptive pseudo-measurement scaling.
+online rather than an artifact of the adaptation bookkeeping. The simulations
+and embedded builds exercise the same estimator recursion, including the exact
+OU-chain transition, small-step covariance branch, full MEKF reset, and
+adaptive pseudo-measurement scaling.
 
 The separate ten-seed robustness study in
 Sec.~\ref{sec:ou-robustness} maps both one-factor sensitivity to $\tau$,
 $\sigma_{aw}$, and $r_S$ and the coupled directions along which the deployed
 regularization law actually moves, and reports rather than excludes low-motion
-and rapid transition degradation cases.  Displacement error is dominated by
+and rapid transition degradation cases. Displacement error is dominated by
 $r_S$; the near-flat frozen-companion $\tau$ and $\sigma_{aw}$ columns reflect
 the near-saturated accelerometer observation of the latent acceleration rather
-than an unused parameter.  Over the declared multiplier range the largest
+than an unused parameter. Over the declared multiplier range the largest
 mean normalized vertical error is \OURobustnessWorstMean\% of $H_s$, while the
 $H_s=\SI{0.05}{m}$ case reaches \OURobustnessLowStressMean\% and the
-\SI{30}{s} transition reaches \OURobustnessRapidAdaptiveMean\%.  These results
+\SI{30}{s} transition reaches \OURobustnessRapidAdaptiveMean\%. These results
 bound the empirical claim to the tested parameter neighborhood, motion
 amplitudes, and transition rates.
 
-Appendix~\ref{app:iss-stability} complements the empirical results with a
-sufficient-condition proof of uniform local input-to-state stability for the
-core predict--correct recursion. The theorem is conditional on frozen-point
-Schur stability and uniform bounds on the Lyapunov family, both checked by
-sampling rather than proved.
+Appendix~\ref{app:iss-stability} gives an analytic stability treatment of the
+Live estimator core. The tuner schedule is exogenous with respect to the MEKF
+state, so no estimator--tuner small-gain loop is part of the stability problem.
+For each translational axis, the appendix derives an explicit uniform
+finite-horizon observability bound from four consecutive $S$ pseudo-measurements
+for every bounded measurable $\tau(t)$ schedule. It also shows that the
+$r_S\propto\sigma_{aw}\tau^3$ law keeps the pseudo-measurement on the natural
+stochastic scale of the triple-integral state. Once the complete scheduled
+linearization is uniformly exponentially stable, a separate perturbation
+argument gives local ISS of the nonlinear Live-state error recursion.
 
-Its slow-variation assumption is not satisfied by the running system, and
-Sec.~\ref{app:iss-switched} and Sec.~\ref{app:iss-trajectory} show why it is
-also the wrong condition to impose: roll and pitch sweep the envelope in
-seconds while the frozen mode is hours, so the governing object is the
-transition matrix over a wave period rather than any frozen Jacobian. Taken
-along a continuous trajectory, one common Lyapunov metric serves the whole
-tuning envelope across three sea states, which removes that assumption
-altogether.
-
-The interconnection with the tuner remains open. Its variance channel is
-exogenous, but the tuning frequency is derived from the leveled vertical
-acceleration and so reads the attitude estimate; the resulting loop is bounded
-by test, not analysed. The appendix therefore does not treat startup or reset
-logic, does not certify the adaptive filter as a closed loop, and does not
-convert the simulation study into an unconditional EKF convergence claim.
+The appendix does not claim that the remaining full-filter step is already
+closed. A complete 21-state proof still needs a finite-horizon Gramian bound for
+the coupled attitude--gyro-bias--translation system, a uniform
+controllability/stabilizability result for the scheduled process model, and a
+Riccati treatment compatible with the periodic acceleration-covariance
+re-alignment. The $S=0$ channel is a regularizer rather than a physical
+measurement, so an infinite-horizon stochastic result is more naturally stated
+in mean-square or finite-horizon high-probability form than as a deterministic
+sample-path bound. Startup and hard reset logic also remain outside the local
+Live-state theorem. Appendix~\ref{app:iss-recommendations} lists small
+implementation changes that make these remaining obligations substantially
+cleaner without changing the estimator architecture.
 
 The results support drift-controlled wave-state reconstruction for the tested
 conditions, while the MCU exercise establishes only functional source
-portability. They do not by themselves imply
-universal performance across spectra, update cadences, vessel speeds, or sensor
-installations, nor do they establish an embedded timing or memory margin.
-Two gaps bound the work most sharply, and neither is closed here. The only
-comparison run under the inferential protocol is against the author's own
-predecessor architecture, so the paper establishes an architectural increment
-and not a position against published practice; closing that needs a current
-published heave estimator and a conventional frequency-domain
-double-integration baseline re-implemented under the same ten-seed protocol.
-And no result is validated against an external physical displacement
-reference, so this remains a simulation and implementation study rather than a
-characterized measurement instrument; closing that needs a motion platform,
-wave tank, or instrumented deployment scored against optical, GNSS, or
-commercial-MRU truth.
+portability. They do not by themselves imply universal performance across
+spectra, update cadences, vessel speeds, or sensor installations, nor do they
+establish an embedded timing or memory margin. Two gaps bound the work most
+sharply, and neither is closed here. The only comparison run under the
+inferential protocol is against the author's own predecessor architecture, so
+the paper establishes an architectural increment and not a position against
+published practice; closing that needs a current published heave estimator and
+a conventional frequency-domain double-integration baseline re-implemented
+under the same ten-seed protocol. And no result is validated against an
+external physical displacement reference, so this remains a simulation and
+implementation study rather than a characterized measurement instrument;
+closing that needs a motion platform, wave tank, or instrumented deployment
+scored against optical, GNSS, or commercial-MRU truth.
 Future work should extend the paired ensembles to parameter interactions,
 additional spectra, and update cadences; independently vary wave height,
 period, directional spreading, heading, sensor grade, and update rate rather
 than moving them in the four linked pairs used here, and hold out sea states
-not used to fit the coefficients; reduce the estimation jitter that
-costs accuracy where a well-matched frozen point exists; replace the
-crossfade with a continuously evolving spectrum so that adaptation rate can be
-isolated from the composition of the scoring window; and add quantitative
-timing and external-reference measurements on hardware.  The high trigger rate of the realization-specific historical
-gates also motivates replacing them with separately calibrated ensemble
-acceptance criteria while retaining them as deterministic regression sentinels.
-Optional absolute-navigation fusion is kept separate in
+not used to fit the coefficients; reduce the estimation jitter that costs
+accuracy where a well-matched frozen point exists; replace the crossfade with a
+continuously evolving spectrum so that adaptation rate can be isolated from the
+composition of the scoring window; and add quantitative timing and
+external-reference measurements on hardware. The high trigger rate of the
+realization-specific gates also motivates replacing them with separately
+calibrated ensemble acceptance criteria while retaining them as deterministic
+regression sentinels. Optional absolute-navigation fusion is kept separate in
 Appendix~\ref{sec:gps_fusion} so that the oscillatory displacement state
 $\vct{p}$ is not conflated with a local or global navigation position.

--- a/doc/kalman_ou_iii/w3d-intro.tex-part
+++ b/doc/kalman_ou_iii/w3d-intro.tex-part
@@ -27,12 +27,20 @@ therefore about adaptive integral-state regularization, not about the necessity
 of joint three-parameter OU adaptation, and the paper is written around that
 narrower claim. Together with an online directional estimator, these elements
 address colored excitation and MEMS errors in an efficient, embedded-friendly
-framework. Appendix~\ref{app:iss-stability} supplies a conditional
-sufficient-condition uniform local input-to-state stability analysis for the
-core estimator, excluding startup and reset logic. Its assumptions are checked
-numerically rather than proved, and the coupling between the estimator and its
-tuner is bounded rather than analysed, so it is not an unconditional
-convergence result for the filter.
+framework. Appendix~\ref{app:iss-stability} gives an analytic stability
+analysis of the Live estimator core. Because the tuner is driven by raw IMU
+data and a private Mahony attitude solution, its schedule is exogenous with
+respect to the MEKF state. The appendix proves a uniform finite-horizon
+observability bound for each OU--III translational chain under arbitrary
+bounded variation of $\tau$, and shows how
+$r_S\propto\sigma_{aw}\tau^3$ preserves the dimensionless strength of the
+integral pseudo-measurement. The nonlinear local-ISS step is then proved once
+uniform exponential stability of the complete Live linearization is available.
+The remaining obligations for a complete 21-state proof are stated explicitly:
+a coupled attitude--bias--translation Gramian bound, a uniform scheduled
+controllability/stabilizability result, treatment of covariance re-alignment,
+the stochastic interpretation of the $S=0$ regularizer, and the excluded
+hybrid reset logic.
 
 \subsection*{From Standard Q-MEKF to Extended Kinematics}
 
@@ -158,19 +166,16 @@ The main contributions of this work are:
         adaptive integral-state regularization rather than joint
         three-parameter OU adaptation, which costs a little accuracy where a
         well-matched frozen operating point already exists.
-  \item A conditional sufficient-condition proof of uniform \emph{local} ISS for
-        the adaptive core, together with three numerical certificates of its
-        assumptions at increasing fidelity: pointwise at frozen operating
-        points, switched along an attitude orbit, and linear-time-varying along
-        a continuous trajectory. The frozen-point view turns out to understate
-        the estimator badly, because it describes a platform that never moves;
-        the trajectory certificate supplies a single common Lyapunov metric
-        over the tuning envelope and three sea states, which discharges the
-        slow-metric-variation assumption the frozen route needs. What remains
-        open is the tuner: its variance channel is exogenous but its frequency
-        channel reads the attitude estimate, so the deployed adaptive filter is
-        not certified as a closed loop. This is not an unconditional EKF
-        convergence claim.
+  \item An analytic stability treatment of the Live estimator core. For each
+        translational axis, four consecutive $S$ pseudo-measurements give a
+        uniform observability determinant bounded away from zero for every
+        bounded measurable $\tau(t)$ schedule; the
+        $r_S\propto\sigma_{aw}\tau^3$ law gives a uniform dimensionless
+        information scale. A separate local theorem shows that uniform
+        exponential stability of the complete scheduled linearization implies
+        local ISS of the nonlinear error recursion. The remaining conditions
+        needed for an unconditional 21-state result are identified explicitly
+        rather than replaced by a numerical certificate.
   \item A formulation independent of hydrodynamic equations, relying instead on
         oscillatory kinematics with slowly varying spectra and high-rate inertial measurements.
   \item A reproducible paired comparison against a published nonlinear observer

--- a/doc/kalman_ou_iii/w3d-iss-stability.tex-part
+++ b/doc/kalman_ou_iii/w3d-iss-stability.tex-part
@@ -1,8 +1,8 @@
 \section{Analytic Stability Structure and Local ISS of the Adaptive Core}
 \label{app:iss-stability}
 
-This appendix replaces a pointwise stability check by an analytic argument that
-uses the structure of the OU--III model. The analysis concerns the estimator
+This appendix analyzes the stability structure of the OU--III estimator without
+using a sampled grid of frozen Jacobians. The analysis concerns the estimator
 after entry to its normal Live state. Startup, warmup, hard attitude
 initialization, tilt re-lock, and fault-recovery logic are hybrid operations and
 are outside the theorem below.
@@ -10,7 +10,7 @@ are outside the theorem below.
 The tuning variables are treated as exogenous signals. The wave-period and
 variance estimators are driven by raw IMU measurements and by a private Mahony
 attitude solution that does not read the OU--III state or covariance.
-Consequently, for this analysis the applied schedule
+Consequently, the applied schedule
 \begin{equation}
 \vartheta(t)=\bigl(\tau(t),\sigma_{aw}(t),r_S(t)\bigr)
 \label{eq:iss-schedule}
@@ -20,12 +20,12 @@ state of the MEKF. No small-gain condition between the tuner and the estimator
 is therefore required.
 
 The key observation is that the translational subsystem is not a generic
-time-varying Kalman filter. It is a chain of three integrators driven by a
+parameter-varying filter. It is a chain of three integrators driven by a
 strictly mean-reverting OU acceleration and observed through the integral state
-$S$. That structure permits a uniform observability bound for arbitrary
-bounded variation of $\tau(t)$. The scaling
-$r_S\propto\sigma_{aw}\tau^3$ then keeps the $S$ pseudo-measurement on the
-natural stochastic scale of the triple integral.
+$S$. That structure permits a uniform observability bound for arbitrary bounded
+variation of $\tau(t)$. The scaling $r_S\propto\sigma_{aw}\tau^3$ then keeps
+the $S$ pseudo-measurement on the natural stochastic scale of the triple
+integral.
 
 \subsection{Error model and standing bounds}
 \label{app:iss-error-model}
@@ -58,7 +58,7 @@ $\vct\phi_k$ is the nonlinear Taylor remainder, and $\vct u_k$ collects
 measurement error, process/model mismatch, residual accelerometer-bias error,
 and the mismatch introduced by treating $S=0$ as a pseudo-measurement.
 
-The structural analysis assumes finite positive constants
+Assume finite positive constants
 \begin{equation}
 0<\underline\tau\le\tau(t)\le\overline\tau,\qquad
 0<\underline\sigma\le\sigma_{aw}(t)\le\overline\sigma,
@@ -69,14 +69,21 @@ and a fixed pseudo-update period $T_S>0$. Define
 \kappa(t):=\frac{r_S(t)}{\sigma_{aw}(t)\tau^3(t)}.
 \label{eq:iss-kappa-def}
 \end{equation}
-The exact cubic law gives $\kappa(t)=c_R$ away from saturation. For the
-stability result it is sufficient that
+The exact cubic law gives $\kappa(t)=c_R$ away from saturation. For stability
+it is sufficient that
 \begin{equation}
 0<\underline\kappa\le\kappa(t)\le\overline\kappa<\infty .
 \label{eq:iss-kappa-bounds}
 \end{equation}
-These bounds imply finite positive bounds on $r_S(t)$ and therefore on the
-pseudo-measurement covariance.
+Thus
+\begin{equation}
+0<\underline r_S
+:=\underline\kappa\,\underline\sigma\,\underline\tau^3
+\le r_S(t)\le
+\overline\kappa\,\overline\sigma\,\overline\tau^3
+=: \overline r_S<\infty .
+\label{eq:iss-rS-bounds}
+\end{equation}
 
 \subsection{Uniform observability of the OU--III translational chain}
 \label{app:iss-trans-observability}
@@ -90,9 +97,7 @@ $\lambda(t)=1/\tau(t)$,
 \dot a=-\lambda(t)a .
 \label{eq:iss-scalar-chain}
 \end{equation}
-The only assumption on the schedule in this subsection is
-$0<\underline\tau\le\tau(t)\le\overline\tau$; no bound on
-$\dot\tau$ is required.
+No bound on $\dot\tau$ is required.
 
 For an initial time chosen as zero, define
 \begin{equation}
@@ -104,15 +109,13 @@ A_3(t)=\frac12\int_0^t(t-s)^2E(s)\,ds .
 \end{equation}
 The homogeneous solution satisfies
 \begin{equation}
-S(t)
- =S_0+t\,p_0+\frac{t^2}{2}v_0+A_3(t)a_0 .
+S(t)=S_0+t\,p_0+\frac{t^2}{2}v_0+A_3(t)a_0 .
 \label{eq:iss-S-solution}
 \end{equation}
 
-At four consecutive pseudo-measurement times
-$t_j=jT_S$, $j=0,1,2,3$, the observation of $S$ produces the
-finite-horizon observability matrix for
-$\vct z_0=[v_0,p_0,S_0,a_0]^\top$,
+At four consecutive pseudo-measurement times $t_j=jT_S$,
+$j=0,1,2,3$, observation of $S$ gives the finite-horizon observability matrix
+for $\vct z_0=[v_0,p_0,S_0,a_0]^\top$,
 \begin{equation}
 \mat O_S=
 \begin{bmatrix}
@@ -126,33 +129,29 @@ T_S^2/2 & T_S & 1 & A_3(T_S)\\
 
 \begin{proposition}[Uniform observability of one OU--III axis]
 \label{prop:iss-ouiii-uco}
-For every measurable schedule satisfying
-Eq.~\eqref{eq:iss-tau-sigma-bounds}, the matrix
-$\mat O_S$ is nonsingular and obeys
+For every measurable $\tau(t)$ satisfying
+$0<\underline\tau\le\tau(t)\le\overline\tau$, the matrix $\mat O_S$ is
+nonsingular and obeys
 \begin{equation}
 \left|\det\mat O_S\right|
 \ge
 T_S^6\exp\!\left(-\frac{3T_S}{\underline\tau}\right)>0 .
 \label{eq:iss-det-lower}
 \end{equation}
-Hence the state $(v,p,S,a)$ is uniformly observable from four consecutive
-$S$ pseudo-measurements, independently of how rapidly $\tau(t)$ moves inside
-its admissible interval.
+Hence $(v,p,S,a)$ is uniformly observable from four consecutive $S$
+pseudo-measurements, independently of how rapidly $\tau(t)$ moves inside its
+admissible interval.
 \end{proposition}
 
 \begin{proof}
 Direct expansion of Eq.~\eqref{eq:iss-OS} gives
 \begin{equation}
-\det\mat O_S
-=-T_S^3\Delta_{T_S}^3 A_3(0),
+\det\mat O_S=-T_S^3\Delta_{T_S}^3 A_3(0),
 \label{eq:iss-det-difference}
 \end{equation}
 where $\Delta_T^3$ is the third forward difference. From
-Eq.~\eqref{eq:iss-E-A3},
-\begin{equation}
-A_3'''(t)=E(t).
-\end{equation}
-The integral representation of a third forward difference therefore gives
+Eq.~\eqref{eq:iss-E-A3}, $A_3'''(t)=E(t)$. The integral representation of a
+third forward difference therefore gives
 \begin{equation}
 \Delta_T^3 A_3(0)
 =
@@ -162,50 +161,58 @@ E(u+v+w)\,du\,dv\,dw .
 \end{equation}
 Because $\lambda(t)\le1/\underline\tau$,
 \begin{equation}
-E(t)
-=\exp\!\left[-\int_0^t\lambda(s)\,ds\right]
+E(t)=\exp\!\left[-\int_0^t\lambda(s)\,ds\right]
 \ge \exp(-t/\underline\tau).
 \end{equation}
-For $u,v,w\in[0,T_S]$ this yields
+For $u,v,w\in[0,T_S]$,
 \begin{equation}
 \Delta_{T_S}^3 A_3(0)
 \ge T_S^3\exp(-3T_S/\underline\tau),
 \end{equation}
-which substituted into Eq.~\eqref{eq:iss-det-difference} proves
-Eq.~\eqref{eq:iss-det-lower}.
+and Eq.~\eqref{eq:iss-det-lower} follows.
 
-The entries of $\mat O_S$ are also uniformly bounded because
-$0<E(t)\le1$ and therefore $0\le A_3(t)\le t^3/6$. Let
+The entries of $\mat O_S$ are uniformly bounded because $0<E(t)\le1$ and
+$0\le A_3(t)\le t^3/6$. Let
 \begin{equation}
 C_O^2(T_S)=
 \sum_{j=0}^{3}
 \left[
-\frac{(jT_S)^4}{4}
-+(jT_S)^2+1+\frac{(jT_S)^6}{36}
+\frac{(jT_S)^4}{4}+(jT_S)^2+1+\frac{(jT_S)^6}{36}
 \right].
 \label{eq:iss-CO}
 \end{equation}
-Then $\|\mat O_S\|_2\le C_O(T_S)$. Since the product of the four
-singular values equals $|\det\mat O_S|$,
+Then $\|\mat O_S\|_2\le C_O(T_S)$. Since the product of the four singular
+values equals $|\det\mat O_S|$,
 \begin{equation}
 \sigma_{\min}(\mat O_S)
 \ge
-\frac{T_S^6e^{-3T_S/\underline\tau}}
-     {C_O^3(T_S)}
->0 .
+\frac{T_S^6e^{-3T_S/\underline\tau}}{C_O^3(T_S)}
+=:s_O>0 .
 \label{eq:iss-smin-OS}
 \end{equation}
-This is a uniform finite-horizon observability bound.
+Thus $\mat O_S^\top\mat O_S\succeq s_O^2\mat I_4$ uniformly.
 \end{proof}
 
-For the three-dimensional translational subsystem, the $S$ measurement is
-applied componentwise. With isotropic $r_S$ its observability matrix is the
-Kronecker product of Eq.~\eqref{eq:iss-OS} with $\mat I_3$; with bounded
-anisotropic weights the same lower bound holds after multiplication by the
-corresponding positive measurement-information bounds. Thus the translational
-observability result is three-dimensional without requiring vessel rotation.
+Let $\mat R_{S,4}$ be the block-diagonal covariance of the four scalar
+pseudo-measurements. Equation~\eqref{eq:iss-rS-bounds} gives
+$\mat R_{S,4}\preceq\overline r_S^2\mat I_4$, so the weighted information
+matrix satisfies
+\begin{equation}
+\mat O_S^\top\mat R_{S,4}^{-1}\mat O_S
+\succeq
+\frac{s_O^2}{\overline r_S^2}\mat I_4 .
+\label{eq:iss-weighted-uco}
+\end{equation}
+This is an explicit uniform complete-observability bound over four
+pseudo-update intervals.
 
-\subsection{Why the cubic law is the natural stability scaling}
+For the three-dimensional translational subsystem, the $S$ measurement is
+applied componentwise. With isotropic weighting the observability matrix is the
+Kronecker product of Eq.~\eqref{eq:iss-OS} with $\mat I_3$; bounded positive
+anisotropic weights preserve a corresponding information lower bound. Thus the
+translational result is three-dimensional without requiring vessel rotation.
+
+\subsection{OU variance and the cubic regularization law}
 \label{app:iss-cubic-scaling}
 
 The OU diffusion used by the filter is
@@ -222,10 +229,10 @@ Under Eq.~\eqref{eq:iss-tau-sigma-bounds},
 <\infty .
 \label{eq:iss-qc-bounds}
 \end{equation}
-The stochastic forcing of the latent acceleration therefore cannot vanish or
-become unbounded within the admissible tuning set.
+The latent-acceleration forcing therefore cannot vanish or become unbounded
+inside the admissible tuning set.
 
-For fixed $\tau$ and $\sigma_{aw}$, introduce the physical scales
+For fixed $\tau$ and $\sigma_{aw}$, introduce
 \begin{equation}
 \bar a=\frac{a}{\sigma_{aw}},\qquad
 \bar v=\frac{v}{\sigma_{aw}\tau},\qquad
@@ -243,42 +250,64 @@ d\bar a=-\bar a\,ds+\sqrt2\,dW_s,\qquad
 \end{equation}
 Thus $\sigma_{aw}\tau^3$ is the intrinsic scale of the triple-integral state.
 
-The spectral calculation of Sec.~\ref{sec:adaptation} gives, for an effective
+The spectral calculation of Sec.~\ref{sec:adaptation} gives, after an effective
 nonzero low-frequency cutoff,
 \begin{equation}
 \operatorname{Var}[S]
 =c_{\mathrm{spec}}^2\,\sigma_{aw}^2\tau^6 .
 \label{eq:iss-S-variance}
 \end{equation}
-If
+With
 \begin{equation}
 r_S=\kappa\,\sigma_{aw}\tau^3,
 \label{eq:iss-rS-cubic}
 \end{equation}
-then
+we obtain
 \begin{equation}
 \frac{R_S}{\operatorname{Var}[S]}
-=
-\frac{\kappa^2}{c_{\mathrm{spec}}^2}.
+=\frac{\kappa^2}{c_{\mathrm{spec}}^2}.
 \label{eq:iss-information-ratio}
 \end{equation}
-The pseudo-measurement therefore has constant dimensionless strength when
-$\kappa$ is constant, and uniformly bounded strength under
+Hence the pseudo-measurement has constant dimensionless strength when
+$\kappa$ is constant and uniformly bounded strength under
 Eq.~\eqref{eq:iss-kappa-bounds}. This is the stability-relevant role of the
-cubic law: it prevents the drift-control information from collapsing merely
-because the wave amplitude or time scale changes.
+cubic law: the drift-control information does not collapse merely because wave
+amplitude or time scale changes.
 
-The normalization in Eq.~\eqref{eq:iss-normalized-coordinates} is used here to
-identify physical scales. It is not used as a time-varying state
-transformation when $\tau(t)$ and $\sigma_{aw}(t)$ vary, because such a
-transformation would introduce derivatives of the tuning signals. Uniform
-observability for the time-varying schedule instead follows directly from
-Proposition~\ref{prop:iss-ouiii-uco}.
+The normalization in Eq.~\eqref{eq:iss-normalized-coordinates} identifies
+physical scales; it is not used as a time-varying coordinate transformation.
+Such a transformation would introduce $\dot\tau$ and $\dot\sigma_{aw}$ terms.
+Uniform observability for arbitrary bounded $\tau(t)$ instead follows directly
+from Proposition~\ref{prop:iss-ouiii-uco}.
+
+For a frozen $\tau$, the one-axis pair is also controllable from the OU driving
+noise. With state order $[v,p,S,a]$, input $\vct B=[0,0,0,1]^\top$, and
+\begin{equation}
+\mat A(\lambda)=
+\begin{bmatrix}
+0&0&0&1\\
+1&0&0&0\\
+0&1&0&0\\
+0&0&0&-\lambda
+\end{bmatrix},
+\end{equation}
+the controllability matrix satisfies
+\begin{equation}
+\det\begin{bmatrix}
+\vct B&\mat A\vct B&\mat A^2\vct B&\mat A^3\vct B
+\end{bmatrix}=-1,
+\label{eq:iss-frozen-controllability}
+\end{equation}
+independently of $\lambda>0$. Together with Eq.~\eqref{eq:iss-qc-bounds}, this
+shows that loss of OU excitation is not a frozen-parameter singularity. A
+finite-horizon uniform controllability/stabilizability bound for an arbitrary
+measurable time-varying schedule is still required for the most direct
+application of standard Riccati theorems and is listed explicitly below.
 
 \subsection{Attitude information and the remaining linear condition}
 \label{app:iss-attitude}
 
-The accelerometer and magnetometer attitude Jacobians have the form
+The accelerometer and magnetometer attitude Jacobians are
 \begin{equation}
 \mat H_{\theta,a}=-[\widehat{\vct f}_{\mathrm{cog},b}]_\times,
 \qquad
@@ -290,11 +319,11 @@ $\vct u_f=\widehat{\vct f}_{\mathrm{cog},b}/
 \|\widehat{\vct f}_{\mathrm{cog},b}\|$
 and
 $\vct u_m=\widehat{\vct m}_b/\|\widehat{\vct m}_b\|$.
-If there are constants $f_0,m_0,\delta>0$ such that
+If constants $f_0,m_0,\delta>0$ satisfy
 \begin{equation}
 \|\widehat{\vct f}_{\mathrm{cog},b}\|\ge f_0,\qquad
 \|\widehat{\vct m}_b\|\ge m_0,\qquad
-|\vct u_f^\top\vct u_m|\le1-\delta ,
+|\vct u_f^\top\vct u_m|\le1-\delta,
 \label{eq:iss-vector-geometry}
 \end{equation}
 then, with $c_0=\min(f_0^2,m_0^2)$,
@@ -306,44 +335,38 @@ then, with $c_0=\min(f_0^2,m_0^2)$,
 \end{equation}
 Indeed,
 $[\vct x]_\times^\top[\vct x]_\times
-=\|\vct x\|^2\mat I-\vct x\vct x^\top$ and the smallest eigenvalue
-of
+=\|\vct x\|^2\mat I-\vct x\vct x^\top$, and the smallest eigenvalue of
 $2\mat I-\vct u_f\vct u_f^\top-\vct u_m\vct u_m^\top$
 is $1-|\vct u_f^\top\vct u_m|$.
 
-Equation~\eqref{eq:iss-attitude-info} supplies a simple analytic sufficient
-condition against an instantaneous attitude singularity. Gyroscope bias enters
-the attitude-error dynamics through
+Equation~\eqref{eq:iss-attitude-info} rules out the basic two-vector attitude
+singularity. Gyroscope bias enters the attitude-error dynamics through
 $\dot{\delta\vct\theta}=-[\widehat{\vct\omega}]_\times\delta\vct\theta
 +\widetilde{\vct b}_g+\cdots$, so finite-horizon attitude information also
-observes $\widetilde{\vct b}_g$ provided the reference-vector geometry remains
+observes $\widetilde{\vct b}_g$ when the reference-vector geometry remains
 nondegenerate over the observation horizon.
 
-The complete 18-state performance Jacobian is nevertheless coupled: the
-accelerometer simultaneously observes attitude and $\vct a_w$, and covariance
-cross terms couple all corrected states. Proposition~\ref{prop:iss-ouiii-uco}
-and Eq.~\eqref{eq:iss-attitude-info} establish the two principal structural
-pieces, but a formal proof of uniform complete observability of the entire
-coupled performance state still requires combining them into one finite-horizon
-Gramian bound. This is one of the remaining items in
-Sec.~\ref{app:iss-remaining}; it is not replaced here by a sampled Jacobian
-test.
+The complete performance Jacobian is nevertheless coupled: the accelerometer
+simultaneously observes attitude and $\vct a_w$, and covariance cross terms
+couple all corrected states. Proposition~\ref{prop:iss-ouiii-uco} and
+Eq.~\eqref{eq:iss-attitude-info} establish the two principal structural pieces,
+but a formal proof of uniform complete observability of the entire coupled
+performance state still requires combining them into one finite-horizon
+Gramian bound. No sampled Jacobian test is used as a substitute for that step.
 
-\subsection{From linear exponential stability to local ISS}
+\subsection{From uniform exponential stability to local ISS}
 \label{app:iss-local-theorem}
 
 Standard time-varying Kalman-filter results
-\cite{Jazwinski1970_Filtering,Maybeck1979_StochasticModels} imply uniform
-boundedness of the Riccati recursion and uniform exponential stability of the
-homogeneous estimation error when the relevant linearized pair is uniformly
-completely observable and uniformly stabilizable/controllable, with uniformly
-bounded positive measurement covariances. The OU diffusion bound
-Eq.~\eqref{eq:iss-qc-bounds}, Proposition~\ref{prop:iss-ouiii-uco}, and the
-reference-vector condition Eq.~\eqref{eq:iss-vector-geometry} are the
-structure needed to discharge those hypotheses; the remaining implementation
-qualifications are listed in Sec.~\ref{app:iss-remaining}.
+\cite{Jazwinski1970_Filtering,Maybeck1979_StochasticModels} give bounded
+Riccati solutions and uniform exponential stability under suitable uniform
+complete-observability and controllability/stabilizability conditions, with
+bounded positive measurement covariances. The results above supply analytic
+parts of those hypotheses. The remaining implementation qualifications are
+listed in Sec.~\ref{app:iss-remaining}.
 
-Accordingly, assume that the Live-state homogeneous transition satisfies
+Assume that the complete Live-state homogeneous transition has the uniform
+bound
 \begin{equation}
 \|\mat\Psi(k,j)\|
 \le M\rho^{k-j},
@@ -351,8 +374,8 @@ Accordingly, assume that the Live-state homogeneous transition satisfies
 M\ge1,\quad 0<\rho<1,
 \label{eq:iss-ues}
 \end{equation}
-uniformly for every admissible exogenous tuning schedule. This is the only
-linear stability property needed by the nonlinear ISS step.
+for every admissible exogenous tuning schedule. This is the only linear
+stability property needed by the nonlinear ISS step.
 
 \begin{theorem}[Local ISS once the Live linearization is uniformly exponentially stable]
 \label{thm:adaptive-local-iss}
@@ -365,16 +388,15 @@ $g_u>0$ such that, uniformly in $k$,
 \|\vct u_k\|\le g_u\bar d_k .
 \label{eq:iss-remainder-input}
 \end{equation}
-Then there exist $0<r\le r_e$, $C_1,C_2>0$, $0<\rho_1<1$, and
-$\bar d^\star>0$ such that, if $\|\vct e_0\|$ and
-$\sup_k\bar d_k$ are sufficiently small to keep the trajectory in the
-$r$-ball, then
+Then there exist $0<r\le r_e$, constants $C_1,C_2>0$ and
+$0<\rho_1<1$, and a disturbance threshold $\bar d^\star>0$ such that
+sufficiently small $\vct e_0$ and
+$\sup_k\bar d_k\le\bar d^\star$ imply positive invariance of the $r$-ball and
 \begin{equation}
 \|\vct e_k\|
 \le
 C_1\rho_1^k\|\vct e_0\|
-+
-C_2\sup_{0\le j<k}\bar d_j .
++C_2\sup_{0\le j<k}\bar d_j .
 \label{eq:iss-final-bound}
 \end{equation}
 Hence the Live performance state is locally input-to-state stable with respect
@@ -382,51 +404,64 @@ to the bounded disturbance channels.
 \end{theorem}
 
 \begin{proof}
-Variation of constants applied to Eq.~\eqref{eq:iss-error-recursion} and
-Eq.~\eqref{eq:iss-ues} gives
+Inside a ball of radius $r\le r_e$, write, for $\vct e_k\ne0$,
 \begin{equation}
+\mat\Delta_k
+:=\frac{\vct\phi_k(\vct e_k)\vct e_k^\top}
+        {\|\vct e_k\|^2},
+\end{equation}
+and set $\mat\Delta_k=0$ at $\vct e_k=0$. Then
+$\vct\phi_k(\vct e_k)=\mat\Delta_k\vct e_k$ and
+\begin{equation}
+\|\mat\Delta_k\|\le c_\phi r .
+\label{eq:iss-delta-bound}
+\end{equation}
+Thus, while the trajectory remains in the ball,
+\begin{equation}
+\vct e_{k+1}=(\mat A_k+\mat\Delta_k)\vct e_k+\vct u_k .
+\end{equation}
+
+Let $\widetilde{\mat\Psi}(k,j)$ denote the homogeneous transition of
+$\mat A_k+\mat\Delta_k$. Variation of constants relative to $\mat A_k$ and
+Eq.~\eqref{eq:iss-ues} give
+\begin{equation}
+\|\widetilde{\mat\Psi}(k,j)\|
+\le
+M\rho^{k-j}
++M c_\phi r
+\sum_{\ell=j}^{k-1}
+\rho^{k-1-\ell}
+\|\widetilde{\mat\Psi}(\ell,j)\| .
+\label{eq:iss-transition-perturb}
+\end{equation}
+Induction in $k-j$ yields
+\begin{equation}
+\|\widetilde{\mat\Psi}(k,j)\|
+\le M\rho_1^{k-j},
+\qquad
+\rho_1:=\rho+M c_\phi r .
+\label{eq:iss-perturbed-ues}
+\end{equation}
+Choose
+\begin{equation}
+0<r\le\min\!\left\{r_e,\frac{1-\rho}{2M c_\phi}\right\},
+\end{equation}
+so that $\rho_1<1$. A second variation-of-constants step then gives
+\begin{align}
 \|\vct e_k\|
-\le
-M\rho^k\|\vct e_0\|
-+
-M\sum_{j=0}^{k-1}
-\rho^{k-1-j}
-\left(c_\phi\|\vct e_j\|^2+g_u\bar d_j\right).
-\label{eq:iss-voc}
-\end{equation}
-Choose $r\le r_e$ such that
-\begin{equation}
-\frac{M c_\phi r}{1-\rho}\le\frac14 .
-\label{eq:iss-local-radius}
-\end{equation}
-On any interval for which $\|\vct e_j\|\le r$,
-$c_\phi\|\vct e_j\|^2\le c_\phi r\|\vct e_j\|$.
-For any fixed $\rho<\rho_1<1$, multiply Eq.~\eqref{eq:iss-voc} by
-$\rho_1^{-k}$ and take the supremum over the finite prefix $0\le k\le N$.
-The geometric convolution has gain
-\begin{equation}
-M c_\phi r
-\sum_{n=0}^{\infty}\rho^n\rho_1^{-(n+1)}
-=
-\frac{M c_\phi r}{\rho_1-\rho}.
-\end{equation}
-Reducing $r$ further so that this gain is at most $1/2$ yields
-\begin{equation}
-\sup_{0\le k\le N}\rho_1^{-k}\|\vct e_k\|
-\le
-2M\|\vct e_0\|
-+
-\frac{2Mg_u}{1-\rho}
-\sup_{0\le j<N}\bar d_j\,ho_1^{-N}.
-\end{equation}
-Returning to the unweighted norm gives constants $C_1,C_2$ for which
-Eq.~\eqref{eq:iss-final-bound} holds on the local interval. Choosing
-$\|\vct e_0\|$ and
-$\bar d=\sup_j\bar d_j$ so that the right-hand side remains strictly below
-$r$ closes the estimate by induction and proves positive invariance of the
-local ball. This is the standard local-ISS extension of a uniformly
-exponentially stable linear time-varying system with a quadratic nonlinear
-remainder.
+&\le
+M\rho_1^k\|\vct e_0\|
++M\sum_{j=0}^{k-1}\rho_1^{k-1-j}\|\vct u_j\|\\
+&\le
+M\rho_1^k\|\vct e_0\|
++\frac{M g_u}{1-\rho_1}
+\sup_{0\le j<k}\bar d_j .
+\end{align}
+Thus Eq.~\eqref{eq:iss-final-bound} holds with
+$C_1=M$ and $C_2=M g_u/(1-\rho_1)$ while the state stays in the ball.
+Choosing $\vct e_0$ and $\bar d^\star$ so that
+$M\|\vct e_0\|+C_2\bar d^\star<r$ closes the bound by induction and proves
+positive invariance. Therefore the same estimate holds for all $k\ge0$.
 \end{proof}
 
 \subsection{What remains before claiming a complete filter proof}
@@ -436,33 +471,41 @@ The analysis above proves a nontrivial part of the stability problem
 analytically: the OU--III translational chain is uniformly observable through
 the $S$ channel for every bounded exogenous $\tau(t)$ schedule, and the cubic
 law keeps that observation on a uniformly comparable stochastic scale.
-Theorem~\ref{thm:adaptive-local-iss} then gives local ISS once uniform
-exponential stability of the complete Live linearization has been established.
-The following items still prevent an unconditional proof of the complete
+Theorem~\ref{thm:adaptive-local-iss} gives local ISS once uniform exponential
+stability of the complete Live linearization has been established. The
+following items still prevent an unconditional proof of the complete
 implemented filter.
 
 \paragraph{Full augmented observability.}
 Equation~\eqref{eq:iss-attitude-info} rules out the basic two-vector attitude
 singularity and Proposition~\ref{prop:iss-ouiii-uco} proves translational
-observability, but the complete coupled attitude--gyro-bias--translation Gramian
-has not yet been bounded analytically. A complete proof should combine these
-two bounds over one finite observation horizon, including the actual
+observability, but the complete coupled attitude--gyro-bias--translation
+Gramian has not yet been bounded analytically. A complete proof should combine
+these bounds over one finite observation horizon, including the actual
 magnetometer cadence.
+
+\paragraph{Uniform controllability or stabilizability for the varying schedule.}
+Equation~\eqref{eq:iss-frozen-controllability} and the positive diffusion bound
+Eq.~\eqref{eq:iss-qc-bounds} remove the frozen-parameter degeneracy. The most
+direct time-varying Riccati theorem still requires a finite-horizon uniform
+controllability/stabilizability bound for the complete scheduled system. That
+bound should be proved from the same OU-chain structure rather than inferred
+from isolated operating points.
 
 \paragraph{Accelerometer-bias convergence.}
 The theorem treats residual accelerometer-bias error as an input. To claim
 convergence of all 21 error coordinates, $\widetilde{\vct b}_a$ must be placed
 inside the certified state and the augmented observability calculation must
-separate the slowly varying bias from the mean-reverting $\vct a_w$ state.
-The existing estimate projection is useful for bounded-input ISS, but by itself
-is not a convergence proof.
+separate the slowly varying bias from the mean-reverting $\vct a_w$ state. The
+existing estimate projection is useful for bounded-input ISS, but by itself is
+not a convergence proof.
 
 \paragraph{Pseudo-measurement model error.}
 $S=0$ is a regularizer rather than a physical measurement, so the physical
 $S_{\mathrm{true}}$ appears in the error system as a disturbance. The spectral
 model gives the natural second-moment scale
 $\operatorname{sd}(S_{\mathrm{true}})
-=c_{\mathrm{spec}}\sigma_{aw}\tau^3$, which is compatible with
+=c_{\mathrm{spec}}\sigma_{aw}\tau^3$, consistent with
 Eq.~\eqref{eq:iss-rS-cubic}. A deterministic infinite-horizon ISS theorem,
 however, requires a deterministic bound on this disturbance. For Gaussian
 noise and an OU prior, an infinite-horizon sample-path supremum is not
@@ -496,8 +539,8 @@ or enforced by a one-sample scheduling delay.
 \label{app:iss-recommendations}
 
 The remaining gaps do not require redesigning the estimator. The following
-small changes would make the mathematical model align much more closely with
-standard time-varying Kalman stability theory.
+small changes make the mathematical model align much more closely with standard
+time-varying Kalman stability theory.
 
 \begin{enumerate}
 \item \textbf{Compute the applied $r_S$ from the applied OU scales.}
@@ -518,8 +561,8 @@ $\sigma_{aw}$ makes this property explicit instead of leaving it implicit in a
 numerical safeguard.
 
 \item \textbf{Replace covariance overwrite by positive-semidefinite inflation.}
-If the purpose of covariance re-alignment is to prevent the
-$\vct a_w$ marginal from becoming overconfident, use an update of the form
+If covariance re-alignment is intended to prevent the $\vct a_w$ marginal from
+becoming overconfident, use an update of the form
 \begin{equation}
 \mat P^+=\mat P^-+\mat E_a\mat\Delta\mat E_a^\top,
 \qquad \mat\Delta\succeq0,
@@ -537,13 +580,13 @@ otherwise unnecessary technical issue in a stochastic proof.
 \item \textbf{State the invariant Live region explicitly.}
 Specify bounds on attitude, reference-vector noncollinearity, measurement
 availability, and validity gates under which no hard reset is invoked. The
-local theorem can then be stated on that region without relying on empirical
-trajectory coverage.
+local theorem can then be stated on that region without relying on trajectory
+coverage.
 \end{enumerate}
 
 With the first three changes, the translational part of the proof is already
 fully analytic and the remaining mathematical task is sharply defined:
-establish one finite-horizon uniform Gramian bound for the coupled
-attitude--bias--translation linearization. Once that yields
-Eq.~\eqref{eq:iss-ues}, the nonlinear ISS conclusion follows directly from
-Theorem~\ref{thm:adaptive-local-iss}.
+establish finite-horizon uniform Gramian bounds for the coupled
+attitude--bias--translation linearization and its scheduled process input.
+Once those results imply Eq.~\eqref{eq:iss-ues}, the nonlinear ISS conclusion
+follows directly from Theorem~\ref{thm:adaptive-local-iss}.

--- a/doc/kalman_ou_iii/w3d-iss-stability.tex-part
+++ b/doc/kalman_ou_iii/w3d-iss-stability.tex-part
@@ -1,27 +1,36 @@
-\section{Local Input-to-State Stability of the Adaptive Core}
+\section{Analytic Stability Structure and Local ISS of the Adaptive Core}
 \label{app:iss-stability}
 
-This appendix gives a sufficient-condition stability result for the core
-estimator and its continuous online tuning. Startup, warmup, state-reset, and
-fault-recovery logic are intentionally excluded. The result is local because
-the multiplicative attitude error and the EKF measurement model are analyzed
-in a neighborhood in which their first-order error coordinates are valid. The
-notion of input-to-state stability (ISS) follows the standard nonlinear-systems
-formulation \cite{Sontag1989_ISS,Khalil2002_NonlinearSystems}.
+This appendix replaces a pointwise stability check by an analytic argument that
+uses the structure of the OU--III model. The analysis concerns the estimator
+after entry to its normal Live state. Startup, warmup, hard attitude
+initialization, tilt re-lock, and fault-recovery logic are hybrid operations and
+are outside the theorem below.
 
-Section~\ref{app:iss-limits} reports what the pointwise numerical certificate
-actually establishes and where it falls short of the theorem's hypotheses;
-Secs.~\ref{app:iss-switched} and \ref{app:iss-trajectory} then show that the
-shortfall is an artifact of freezing the operating point, and supply
-certificates -- a switched one and, less approximately, one taken along a
-continuous trajectory -- under which the offending assumption is not needed at
-all. All three sections are part of the result.
+The tuning variables are treated as exogenous signals. The wave-period and
+variance estimators are driven by raw IMU measurements and by a private Mahony
+attitude solution that does not read the OU--III state or covariance.
+Consequently, for this analysis the applied schedule
+\begin{equation}
+\vartheta(t)=\bigl(\tau(t),\sigma_{aw}(t),r_S(t)\bigr)
+\label{eq:iss-schedule}
+\end{equation}
+is an externally supplied, bounded, measurable signal rather than a feedback
+state of the MEKF. No small-gain condition between the tuner and the estimator
+is therefore required.
 
-\subsection{Performance error and adaptive parameters}
+The key observation is that the translational subsystem is not a generic
+time-varying Kalman filter. It is a chain of three integrators driven by a
+strictly mean-reverting OU acceleration and observed through the integral state
+$S$. That structure permits a uniform observability bound for arbitrary
+bounded variation of $\tau(t)$. The scaling
+$r_S\propto\sigma_{aw}\tau^3$ then keeps the $S$ pseudo-measurement on the
+natural stochastic scale of the triple integral.
 
-The estimator contains an accelerometer-bias state to compensate slowly varying
-sensor offset. Estimating that bias is not itself an output objective of this
-work. The certified performance-error coordinate is therefore
+\subsection{Error model and standing bounds}
+\label{app:iss-error-model}
+
+Let the performance error be
 \begin{equation}
 \vct e_k=
 \begin{bmatrix}
@@ -34,634 +43,507 @@ work. The certified performance-error coordinate is therefore
 \end{bmatrix}^{\!\top}.
 \label{eq:iss-error-vector}
 \end{equation}
-The accelerometer-bias error $\widetilde{\vct b}_{a,k}$ is retained as a
-bounded nuisance input because it affects the accelerometer innovation but is
-not a quantity for which convergence is claimed.
+The accelerometer-bias error is retained as a bounded disturbance in this
+performance-state result. A proof that includes $\widetilde{\vct b}_a$ in the
+convergent state is discussed in Sec.~\ref{app:iss-remaining}.
 
-Note that $\widetilde{\vct S}$ cannot be removed from
-Eq.~\eqref{eq:iss-error-vector} the way $\widetilde{\vct b}_a$ is. Deleting the
-$\vct S$ block from the implementation Jacobian leaves a $15$-dimensional
-block whose spectral radius reaches $1.000179$ over the same envelope: the
-drift-control state is what stabilizes position, not a nuisance riding along
-with it. Any attempt to shrink the certified coordinate has to respect that.
-
-Collect the applied adaptive parameters into
-\begin{equation}
-\vct\vartheta_k=
-\begin{bmatrix}
-\tau_k & \sigma_{aw,k} & r_{S,k}
-\end{bmatrix}^{\!\top}.
-\label{eq:iss-adaptive-vector}
-\end{equation}
-For one complete predict--correct cycle, the local performance-error recursion
-can be written as
+For one complete predict--correct step the local error recursion has the form
 \begin{equation}
 \vct e_{k+1}
-=\mat F_k(\vct\vartheta_k)\vct e_k
- +\vct\phi_k(\vct e_k,\vct\vartheta_k)
- +\mat G_k\vct d_k
- +\mat B_{a,k}\widetilde{\vct b}_{a,k},
+ =\mat A_k\vct e_k+\vct\phi_k(\vct e_k)+\vct u_k ,
 \label{eq:iss-error-recursion}
 \end{equation}
-where $\vct d_k$ collects bounded sensor errors, bias-driving terms,
-linearization mismatch, and process-model mismatch.
+where $\mat A_k$ is the Jacobian of the implemented Live-state recursion,
+$\vct\phi_k$ is the nonlinear Taylor remainder, and $\vct u_k$ collects
+measurement error, process/model mismatch, residual accelerometer-bias error,
+and the mismatch introduced by treating $S=0$ as a pseudo-measurement.
 
-\begin{remark}[No separate $\Delta\vct\vartheta_k$ input channel]
-An earlier form of Eq.~\eqref{eq:iss-error-recursion} carried an additional
-additive term $\mat D_k\Delta\vct\vartheta_k$ with
-$\Delta\vct\vartheta_k=\vct\vartheta_{k+1}-\vct\vartheta_k$. It is removed
-here because it is not derivable. All dependence on the tuning at step $k$ is
-already inside $\mat F_k(\vct\vartheta_k)$, and $\Delta\vct\vartheta_k$ is a
-forward difference that cannot act on the transition from $k$ to $k+1$; the
-effect of the parameters changing is a change of the Lyapunov metric between
-consecutive steps, which is exactly what A4 accounts for. Keeping both would
-charge the same effect twice.
-
-The one construction that would justify an additive channel is a
-$\vct\vartheta$-dependent reference trajectory, since $\tau$ and $\sigma_{aw}$
-are parameters of the assumed OU plant and not only of the gain. The error
-would then be measured against a moving fixed point $\vct e^\star(\vct\vartheta)$
-and would pick up
-$-\left(\partial\vct e^\star/\partial\vct\vartheta\right)\Delta\vct\vartheta_k$.
-That derivation is not carried out here, and the coordinate in
-Eq.~\eqref{eq:iss-error-vector} is referred to a fixed point, so the term is
-dropped rather than asserted.
-\end{remark}
-
-\subsection{Assumptions}
-\label{app:iss-assumptions}
-
-\begin{description}
-\item[A1 (bounded admissible tuning set).]
-The projection, clipping, and positive covariance construction in
-Sec.~\ref{sec:adaptation} keep $\vct\vartheta_k$ in a compact set $\Theta$.
-
-\item[A2 (uniform covariance bounds).]
-The filter covariance and all applied measurement covariances remain uniformly
-positive definite and bounded on the operating set.
-
-\item[A3 (parameter-dependent quadratic contraction, on the sampled envelope).]
-For every operating point $\xi$ and $\vct\vartheta\in\Theta$ \emph{at which the
-certificate of Sec.~\ref{app:iss-limits} is evaluated}, the 18-dimensional
-performance-state Jacobian $\mat F(\xi,\vct\vartheta)$ is Schur stable.
-Consequently, there is a positive definite matrix $\mat L(\xi,\vct\vartheta)$
-satisfying
+The structural analysis assumes finite positive constants
 \begin{equation}
-\mat F^\top\mat L\mat F-\mat L=-\mat I.
-\label{eq:iss-parameter-L}
+0<\underline\tau\le\tau(t)\le\overline\tau,\qquad
+0<\underline\sigma\le\sigma_{aw}(t)\le\overline\sigma,
+\label{eq:iss-tau-sigma-bounds}
 \end{equation}
-On the compact admissible set, this Lyapunov family has uniform bounds
+and a fixed pseudo-update period $T_S>0$. Define
 \begin{equation}
-0<\underline\ell\mat I\preceq
-\mat L(\xi,\vct\vartheta)
-\preceq\overline\ell\mat I.
-\label{eq:iss-L-bounds}
+\kappa(t):=\frac{r_S(t)}{\sigma_{aw}(t)\tau^3(t)}.
+\label{eq:iss-kappa-def}
 \end{equation}
-
-The qualifier matters. A3 is the substance of the result and it is verified by
-sampling, not proved: the certificate evaluates a grid with three values per
-swept axis, so it does not by itself establish Schur stability at the
-uncountably many intermediate points. Extending it to the continuum needs
-either a Lipschitz bound on $\xi\mapsto\rho(\mat F)$ together with a covering
-radius, or interval arithmetic. Neither is claimed here. This is a weaker
-position than a design in which the contraction is constructed rather than
-checked, as when an algebraic Riccati equation delivers a stabilizing gain
-directly.
-
-\item[A4 (bounded metric variation).]
-The operating point and adaptive parameters vary slowly enough that consecutive
-Lyapunov matrices satisfy
+The exact cubic law gives $\kappa(t)=c_R$ away from saturation. For the
+stability result it is sufficient that
 \begin{equation}
-\mat L_{k+1}\preceq(1+\delta_L)\mat L_k .
-\label{eq:iss-L-variation}
+0<\underline\kappa\le\kappa(t)\le\overline\kappa<\infty .
+\label{eq:iss-kappa-bounds}
 \end{equation}
-The admissible $\delta_L$ follows from Eq.~\eqref{eq:iss-L-bounds} and is not
-free: as shown in the proof, contraction requires
+These bounds imply finite positive bounds on $r_S(t)$ and therefore on the
+pseudo-measurement covariance.
+
+\subsection{Uniform observability of the OU--III translational chain}
+\label{app:iss-trans-observability}
+
+Consider one translational axis and omit disturbances. With
+$\lambda(t)=1/\tau(t)$,
 \begin{equation}
-\delta_L<\frac{1}{\overline\ell-1}.
-\label{eq:iss-delta-budget}
+\dot v=a,\qquad
+\dot p=v,\qquad
+\dot S=p,\qquad
+\dot a=-\lambda(t)a .
+\label{eq:iss-scalar-chain}
 \end{equation}
-Section~\ref{app:iss-limits} reports the measured value of $\delta_L$ against
-this budget. It is not met -- and Sec.~\ref{app:iss-switched} argues it is the
-wrong condition to impose here, and discharges it.
+The only assumption on the schedule in this subsection is
+$0<\underline\tau\le\tau(t)\le\overline\tau$; no bound on
+$\dot\tau$ is required.
 
-\item[A5 (local nonlinear remainder bound).]
-There exist $r_e>0$ and $c_\phi>0$ such that
-$\|\vct\phi_k(\vct e,\vct\vartheta)\|\le c_\phi\|\vct e\|^2$
-for $\|\vct e\|\le r_e$.
-
-\item[A6 (bounded input channels).]
-There are finite constants $g_d$ and $g_a$ such that
-$\|\mat G_k\|\le g_d$ and $\|\mat B_{a,k}\|\le g_a$. The residual
-accelerometer-bias error is bounded by
-$\|\widetilde{\vct b}_{a,k}\|\le\bar b_a$.
-
-The bias bound holds by construction rather than by hypothesis. The
-implementation projects the accelerometer-bias estimate onto a ball of radius
-\texttt{accel\_bias\_limit} after every state injection, so
-$\|\widehat{\vct b}_{a,k}\|\le\bar b_a^{\,\mathrm{est}}$ at all times and the
-error bound follows from the physical bias being bounded. Without that
-projection the assumption would be an unverified claim about a random-walk
-state; a covariance bound such as A2 is not a sample-path bound and does not
-supply it. The same role is played by the parameter projection in
-observer designs that confine a gyro-bias estimate to a compact ball.
-\end{description}
-
-\subsection{Uniform local ISS result}
-
-\begin{theorem}[Local ISS of the adaptive performance state]
-\label{thm:adaptive-local-iss}
-Assume A1--A6 and let
+For an initial time chosen as zero, define
 \begin{equation}
-\bar u_k=g_d\|\vct d_k\|+g_a\|\widetilde{\vct b}_{a,k}\|,
+E(t)=
+\exp\!\left[-\int_0^t\lambda(s)\,ds\right],
 \qquad
-\bar u=\sup_{j\ge 0}\bar u_j .
+A_3(t)=\frac12\int_0^t(t-s)^2E(s)\,ds .
+\label{eq:iss-E-A3}
 \end{equation}
-Then there exist a radius $0<r\le r_e$, constants $c_1,c_2>0$ and
-$0<\rho<1$, and an input threshold $\bar u^\star>0$ such that if
+The homogeneous solution satisfies
 \begin{equation}
-\|\vct e_0\|\le\frac{r}{c_1\sqrt2}
-\qquad\text{and}\qquad
-\bar u\le\bar u^\star ,
-\label{eq:iss-admissible-init}
+S(t)
+ =S_0+t\,p_0+\frac{t^2}{2}v_0+A_3(t)a_0 .
+\label{eq:iss-S-solution}
 \end{equation}
-then $\|\vct e_k\|\le r$ for all $k\ge0$ and
+
+At four consecutive pseudo-measurement times
+$t_j=jT_S$, $j=0,1,2,3$, the observation of $S$ produces the
+finite-horizon observability matrix for
+$\vct z_0=[v_0,p_0,S_0,a_0]^\top$,
+\begin{equation}
+\mat O_S=
+\begin{bmatrix}
+0 & 0 & 1 & 0\\
+T_S^2/2 & T_S & 1 & A_3(T_S)\\
+(2T_S)^2/2 & 2T_S & 1 & A_3(2T_S)\\
+(3T_S)^2/2 & 3T_S & 1 & A_3(3T_S)
+\end{bmatrix}.
+\label{eq:iss-OS}
+\end{equation}
+
+\begin{proposition}[Uniform observability of one OU--III axis]
+\label{prop:iss-ouiii-uco}
+For every measurable schedule satisfying
+Eq.~\eqref{eq:iss-tau-sigma-bounds}, the matrix
+$\mat O_S$ is nonsingular and obeys
+\begin{equation}
+\left|\det\mat O_S\right|
+\ge
+T_S^6\exp\!\left(-\frac{3T_S}{\underline\tau}\right)>0 .
+\label{eq:iss-det-lower}
+\end{equation}
+Hence the state $(v,p,S,a)$ is uniformly observable from four consecutive
+$S$ pseudo-measurements, independently of how rapidly $\tau(t)$ moves inside
+its admissible interval.
+\end{proposition}
+
+\begin{proof}
+Direct expansion of Eq.~\eqref{eq:iss-OS} gives
+\begin{equation}
+\det\mat O_S
+=-T_S^3\Delta_{T_S}^3 A_3(0),
+\label{eq:iss-det-difference}
+\end{equation}
+where $\Delta_T^3$ is the third forward difference. From
+Eq.~\eqref{eq:iss-E-A3},
+\begin{equation}
+A_3'''(t)=E(t).
+\end{equation}
+The integral representation of a third forward difference therefore gives
+\begin{equation}
+\Delta_T^3 A_3(0)
+=
+\int_0^T\!\int_0^T\!\int_0^T
+E(u+v+w)\,du\,dv\,dw .
+\label{eq:iss-forward-integral}
+\end{equation}
+Because $\lambda(t)\le1/\underline\tau$,
+\begin{equation}
+E(t)
+=\exp\!\left[-\int_0^t\lambda(s)\,ds\right]
+\ge \exp(-t/\underline\tau).
+\end{equation}
+For $u,v,w\in[0,T_S]$ this yields
+\begin{equation}
+\Delta_{T_S}^3 A_3(0)
+\ge T_S^3\exp(-3T_S/\underline\tau),
+\end{equation}
+which substituted into Eq.~\eqref{eq:iss-det-difference} proves
+Eq.~\eqref{eq:iss-det-lower}.
+
+The entries of $\mat O_S$ are also uniformly bounded because
+$0<E(t)\le1$ and therefore $0\le A_3(t)\le t^3/6$. Let
+\begin{equation}
+C_O^2(T_S)=
+\sum_{j=0}^{3}
+\left[
+\frac{(jT_S)^4}{4}
++(jT_S)^2+1+\frac{(jT_S)^6}{36}
+\right].
+\label{eq:iss-CO}
+\end{equation}
+Then $\|\mat O_S\|_2\le C_O(T_S)$. Since the product of the four
+singular values equals $|\det\mat O_S|$,
+\begin{equation}
+\sigma_{\min}(\mat O_S)
+\ge
+\frac{T_S^6e^{-3T_S/\underline\tau}}
+     {C_O^3(T_S)}
+>0 .
+\label{eq:iss-smin-OS}
+\end{equation}
+This is a uniform finite-horizon observability bound.
+\end{proof}
+
+For the three-dimensional translational subsystem, the $S$ measurement is
+applied componentwise. With isotropic $r_S$ its observability matrix is the
+Kronecker product of Eq.~\eqref{eq:iss-OS} with $\mat I_3$; with bounded
+anisotropic weights the same lower bound holds after multiplication by the
+corresponding positive measurement-information bounds. Thus the translational
+observability result is three-dimensional without requiring vessel rotation.
+
+\subsection{Why the cubic law is the natural stability scaling}
+\label{app:iss-cubic-scaling}
+
+The OU diffusion used by the filter is
+\begin{equation}
+q_c(t)=\frac{2\sigma_{aw}^2(t)}{\tau(t)}.
+\label{eq:iss-qc}
+\end{equation}
+Under Eq.~\eqref{eq:iss-tau-sigma-bounds},
+\begin{equation}
+0<
+\frac{2\underline\sigma^2}{\overline\tau}
+\le q_c(t)\le
+\frac{2\overline\sigma^2}{\underline\tau}
+<\infty .
+\label{eq:iss-qc-bounds}
+\end{equation}
+The stochastic forcing of the latent acceleration therefore cannot vanish or
+become unbounded within the admissible tuning set.
+
+For fixed $\tau$ and $\sigma_{aw}$, introduce the physical scales
+\begin{equation}
+\bar a=\frac{a}{\sigma_{aw}},\qquad
+\bar v=\frac{v}{\sigma_{aw}\tau},\qquad
+\bar p=\frac{p}{\sigma_{aw}\tau^2},\qquad
+\bar S=\frac{S}{\sigma_{aw}\tau^3},
+\label{eq:iss-normalized-coordinates}
+\end{equation}
+and dimensionless time $s=t/\tau$. The OU--III chain becomes
+\begin{equation}
+d\bar a=-\bar a\,ds+\sqrt2\,dW_s,\qquad
+\frac{d\bar v}{ds}=\bar a,\qquad
+\frac{d\bar p}{ds}=\bar v,\qquad
+\frac{d\bar S}{ds}=\bar p .
+\label{eq:iss-normalized-chain}
+\end{equation}
+Thus $\sigma_{aw}\tau^3$ is the intrinsic scale of the triple-integral state.
+
+The spectral calculation of Sec.~\ref{sec:adaptation} gives, for an effective
+nonzero low-frequency cutoff,
+\begin{equation}
+\operatorname{Var}[S]
+=c_{\mathrm{spec}}^2\,\sigma_{aw}^2\tau^6 .
+\label{eq:iss-S-variance}
+\end{equation}
+If
+\begin{equation}
+r_S=\kappa\,\sigma_{aw}\tau^3,
+\label{eq:iss-rS-cubic}
+\end{equation}
+then
+\begin{equation}
+\frac{R_S}{\operatorname{Var}[S]}
+=
+\frac{\kappa^2}{c_{\mathrm{spec}}^2}.
+\label{eq:iss-information-ratio}
+\end{equation}
+The pseudo-measurement therefore has constant dimensionless strength when
+$\kappa$ is constant, and uniformly bounded strength under
+Eq.~\eqref{eq:iss-kappa-bounds}. This is the stability-relevant role of the
+cubic law: it prevents the drift-control information from collapsing merely
+because the wave amplitude or time scale changes.
+
+The normalization in Eq.~\eqref{eq:iss-normalized-coordinates} is used here to
+identify physical scales. It is not used as a time-varying state
+transformation when $\tau(t)$ and $\sigma_{aw}(t)$ vary, because such a
+transformation would introduce derivatives of the tuning signals. Uniform
+observability for the time-varying schedule instead follows directly from
+Proposition~\ref{prop:iss-ouiii-uco}.
+
+\subsection{Attitude information and the remaining linear condition}
+\label{app:iss-attitude}
+
+The accelerometer and magnetometer attitude Jacobians have the form
+\begin{equation}
+\mat H_{\theta,a}=-[\widehat{\vct f}_{\mathrm{cog},b}]_\times,
+\qquad
+\mat H_{\theta,m}=-[\widehat{\vct m}_b]_\times .
+\label{eq:iss-attitude-H}
+\end{equation}
+Let
+$\vct u_f=\widehat{\vct f}_{\mathrm{cog},b}/
+\|\widehat{\vct f}_{\mathrm{cog},b}\|$
+and
+$\vct u_m=\widehat{\vct m}_b/\|\widehat{\vct m}_b\|$.
+If there are constants $f_0,m_0,\delta>0$ such that
+\begin{equation}
+\|\widehat{\vct f}_{\mathrm{cog},b}\|\ge f_0,\qquad
+\|\widehat{\vct m}_b\|\ge m_0,\qquad
+|\vct u_f^\top\vct u_m|\le1-\delta ,
+\label{eq:iss-vector-geometry}
+\end{equation}
+then, with $c_0=\min(f_0^2,m_0^2)$,
+\begin{equation}
+\mat H_{\theta,a}^\top\mat H_{\theta,a}
++\mat H_{\theta,m}^\top\mat H_{\theta,m}
+\succeq c_0\delta\,\mat I_3 .
+\label{eq:iss-attitude-info}
+\end{equation}
+Indeed,
+$[\vct x]_\times^\top[\vct x]_\times
+=\|\vct x\|^2\mat I-\vct x\vct x^\top$ and the smallest eigenvalue
+of
+$2\mat I-\vct u_f\vct u_f^\top-\vct u_m\vct u_m^\top$
+is $1-|\vct u_f^\top\vct u_m|$.
+
+Equation~\eqref{eq:iss-attitude-info} supplies a simple analytic sufficient
+condition against an instantaneous attitude singularity. Gyroscope bias enters
+the attitude-error dynamics through
+$\dot{\delta\vct\theta}=-[\widehat{\vct\omega}]_\times\delta\vct\theta
++\widetilde{\vct b}_g+\cdots$, so finite-horizon attitude information also
+observes $\widetilde{\vct b}_g$ provided the reference-vector geometry remains
+nondegenerate over the observation horizon.
+
+The complete 18-state performance Jacobian is nevertheless coupled: the
+accelerometer simultaneously observes attitude and $\vct a_w$, and covariance
+cross terms couple all corrected states. Proposition~\ref{prop:iss-ouiii-uco}
+and Eq.~\eqref{eq:iss-attitude-info} establish the two principal structural
+pieces, but a formal proof of uniform complete observability of the entire
+coupled performance state still requires combining them into one finite-horizon
+Gramian bound. This is one of the remaining items in
+Sec.~\ref{app:iss-remaining}; it is not replaced here by a sampled Jacobian
+test.
+
+\subsection{From linear exponential stability to local ISS}
+\label{app:iss-local-theorem}
+
+Standard time-varying Kalman-filter results
+\cite{Jazwinski1970_Filtering,Maybeck1979_StochasticModels} imply uniform
+boundedness of the Riccati recursion and uniform exponential stability of the
+homogeneous estimation error when the relevant linearized pair is uniformly
+completely observable and uniformly stabilizable/controllable, with uniformly
+bounded positive measurement covariances. The OU diffusion bound
+Eq.~\eqref{eq:iss-qc-bounds}, Proposition~\ref{prop:iss-ouiii-uco}, and the
+reference-vector condition Eq.~\eqref{eq:iss-vector-geometry} are the
+structure needed to discharge those hypotheses; the remaining implementation
+qualifications are listed in Sec.~\ref{app:iss-remaining}.
+
+Accordingly, assume that the Live-state homogeneous transition satisfies
+\begin{equation}
+\|\mat\Psi(k,j)\|
+\le M\rho^{k-j},
+\qquad k\ge j,\qquad
+M\ge1,\quad 0<\rho<1,
+\label{eq:iss-ues}
+\end{equation}
+uniformly for every admissible exogenous tuning schedule. This is the only
+linear stability property needed by the nonlinear ISS step.
+
+\begin{theorem}[Local ISS once the Live linearization is uniformly exponentially stable]
+\label{thm:adaptive-local-iss}
+Assume Eq.~\eqref{eq:iss-ues}. Suppose there are $r_e>0$, $c_\phi>0$ and
+$g_u>0$ such that, uniformly in $k$,
+\begin{equation}
+\|\vct\phi_k(\vct e)\|\le c_\phi\|\vct e\|^2
+\quad\text{for }\|\vct e\|\le r_e,
+\qquad
+\|\vct u_k\|\le g_u\bar d_k .
+\label{eq:iss-remainder-input}
+\end{equation}
+Then there exist $0<r\le r_e$, $C_1,C_2>0$, $0<\rho_1<1$, and
+$\bar d^\star>0$ such that, if $\|\vct e_0\|$ and
+$\sup_k\bar d_k$ are sufficiently small to keep the trajectory in the
+$r$-ball, then
 \begin{equation}
 \|\vct e_k\|
-\le c_1\rho^k\|\vct e_0\|
-+c_2\sup_{0\le j<k}\bar u_j .
+\le
+C_1\rho_1^k\|\vct e_0\|
++
+C_2\sup_{0\le j<k}\bar d_j .
 \label{eq:iss-final-bound}
 \end{equation}
-Thus the estimator variables relevant to attitude and wave reconstruction are
-locally ISS with respect to physical/model disturbances and residual
-accelerometer-bias error.
+Hence the Live performance state is locally input-to-state stable with respect
+to the bounded disturbance channels.
 \end{theorem}
 
 \begin{proof}
-Let
+Variation of constants applied to Eq.~\eqref{eq:iss-error-recursion} and
+Eq.~\eqref{eq:iss-ues} gives
 \begin{equation}
-V_k=\vct e_k^\top\mat L_k\vct e_k,
-\qquad
-\underline\ell\|\vct e_k\|^2
-\le V_k\le\overline\ell\|\vct e_k\|^2 .
-\label{eq:iss-lyapunov}
+\|\vct e_k\|
+\le
+M\rho^k\|\vct e_0\|
++
+M\sum_{j=0}^{k-1}
+\rho^{k-1-j}
+\left(c_\phi\|\vct e_j\|^2+g_u\bar d_j\right).
+\label{eq:iss-voc}
 \end{equation}
-Write $\vct u_k=\mat G_k\vct d_k+\mat B_{a,k}\widetilde{\vct b}_{a,k}$, so that
-$\|\vct u_k\|\le\bar u_k$.
-
-\emph{Frozen decrease.} With A3 and Eq.~\eqref{eq:iss-parameter-L},
-$\mat F_k^\top\mat L_k\mat F_k=\mat L_k-\mat I$, so for the unforced linear
-part
+Choose $r\le r_e$ such that
 \begin{equation}
-(\mat F_k\vct e_k)^\top\mat L_k(\mat F_k\vct e_k)=V_k-\|\vct e_k\|^2
-\le\left(1-\tfrac{1}{\overline\ell}\right)V_k .
+\frac{M c_\phi r}{1-\rho}\le\frac14 .
+\label{eq:iss-local-radius}
 \end{equation}
-
-\emph{Metric variation.} By A4,
-$V_{k+1}\le(1+\delta_L)\,\vct e_{k+1}^\top\mat L_k\vct e_{k+1}$, so the
-unforced bound becomes
-$(1+\delta_L)\bigl(1-1/\overline\ell\bigr)V_k$. This is a contraction exactly
-when Eq.~\eqref{eq:iss-delta-budget} holds, which is where that budget comes
-from. Write $\eta_0=(1+\delta_L)(1-1/\overline\ell)<1$.
-
-\emph{Remainder and inputs.} Expanding
-$\vct e_{k+1}=\mat F_k\vct e_k+\vct\phi_k+\vct u_k$ and applying
-Cauchy--Schwarz and Young's inequality with a free parameter $\epsilon>0$,
+On any interval for which $\|\vct e_j\|\le r$,
+$c_\phi\|\vct e_j\|^2\le c_\phi r\|\vct e_j\|$.
+For any fixed $\rho<\rho_1<1$, multiply Eq.~\eqref{eq:iss-voc} by
+$\rho_1^{-k}$ and take the supremum over the finite prefix $0\le k\le N$.
+The geometric convolution has gain
 \begin{equation}
-V_{k+1}\le(1+\epsilon)\eta_0 V_k
-+\left(1+\tfrac{1}{\epsilon}\right)(1+\delta_L)\overline\ell\,
-\bigl(c_\phi\|\vct e_k\|^2+\bar u_k\bigr)^2 .
+M c_\phi r
+\sum_{n=0}^{\infty}\rho^n\rho_1^{-(n+1)}
+=
+\frac{M c_\phi r}{\rho_1-\rho}.
 \end{equation}
-Using A5 on $\|\vct e_k\|\le r$ gives
-$c_\phi\|\vct e_k\|^2\le c_\phi r\|\vct e_k\|\le c_\phi r\sqrt{V_k/\underline\ell}$.
-Choose $\epsilon$ with $(1+\epsilon)\eta_0<1$, then choose
+Reducing $r$ further so that this gain is at most $1/2$ yields
 \begin{equation}
-r\le\min\!\left\{r_e,\;
-\frac{\sqrt{\underline\ell}\,\bigl(1-(1+\epsilon)\eta_0\bigr)}
-{4c_\phi\left(1+\tfrac1\epsilon\right)(1+\delta_L)\overline\ell}\right\},
+\sup_{0\le k\le N}\rho_1^{-k}\|\vct e_k\|
+\le
+2M\|\vct e_0\|
++
+\frac{2Mg_u}{1-\rho}
+\sup_{0\le j<N}\bar d_j\,ho_1^{-N}.
 \end{equation}
-so that the quadratic remainder is absorbed. This yields constants
-$0<\eta<1$ and $\sigma>0$ with
-\begin{equation}
-V_{k+1}\le\eta V_k+\sigma\bar u_k^{\,2}
-\label{eq:iss-V-recursion}
-\end{equation}
-for every $k$ with $\|\vct e_k\|\le r$.
-
-\emph{Invariance.} Equation~\eqref{eq:iss-V-recursion} is only valid while the
-trajectory stays in the ball, so that has to be established rather than
-assumed. Set
-\begin{equation}
-\bar u^\star=\sqrt{\frac{(1-\eta)\,\underline\ell\, r^2}{2\sigma}} .
-\end{equation}
-Suppose $V_k\le\underline\ell r^2/2$. Then by
-Eq.~\eqref{eq:iss-V-recursion} and $\bar u\le\bar u^\star$,
-\begin{equation}
-V_{k+1}\le\eta\,\frac{\underline\ell r^2}{2}
-+(1-\eta)\frac{\underline\ell r^2}{2}
-=\frac{\underline\ell r^2}{2},
-\end{equation}
-and $\|\vct e_{k+1}\|^2\le V_{k+1}/\underline\ell\le r^2/2<r^2$. The
-hypothesis on $\|\vct e_0\|$ in Eq.~\eqref{eq:iss-admissible-init} gives
-$V_0\le\overline\ell\|\vct e_0\|^2\le\underline\ell r^2/2$, so the induction
-starts, and $\|\vct e_k\|\le r$ for all $k$.
-
-\emph{Conclusion.} Iterating Eq.~\eqref{eq:iss-V-recursion},
-$V_k\le\eta^k V_0+\sigma\bar u^2/(1-\eta)$, and applying
-Eq.~\eqref{eq:iss-lyapunov} with $\sqrt{a+b}\le\sqrt a+\sqrt b$ gives
-Eq.~\eqref{eq:iss-final-bound} with
-\begin{equation}
-c_1=\sqrt{\overline\ell/\underline\ell},
-\qquad
-\rho=\sqrt\eta,
-\qquad
-c_2=\sqrt{\frac{\sigma}{\underline\ell(1-\eta)}} .
-\label{eq:iss-constants}
-\end{equation}
-Note $\rho=\sqrt\eta$: the geometric factor $\eta$ acts on $V$, and the bound
-in Eq.~\eqref{eq:iss-final-bound} is on $\|\vct e_k\|$.
+Returning to the unweighted norm gives constants $C_1,C_2$ for which
+Eq.~\eqref{eq:iss-final-bound} holds on the local interval. Choosing
+$\|\vct e_0\|$ and
+$\bar d=\sup_j\bar d_j$ so that the right-hand side remains strictly below
+$r$ closes the estimate by induction and proves positive invariance of the
+local ball. This is the standard local-ISS extension of a uniformly
+exponentially stable linear time-varying system with a quadratic nonlinear
+remainder.
 \end{proof}
 
-\begin{remark}[Role of the accelerometer-bias state]
-The implementation continues to estimate accelerometer bias because doing so
-reduces slow sensor drift in practice. Excluding its estimation error from
-Eq.~\eqref{eq:iss-error-vector} does not remove the state from the filter or
-assume it is zero. Its residual influence remains explicitly in the ISS bound
-through $\mat B_{a,k}\widetilde{\vct b}_{a,k}$, and Sec.~\ref{app:iss-limits}
-reports the size of that channel, which is not small.
-\end{remark}
+\subsection{What remains before claiming a complete filter proof}
+\label{app:iss-remaining}
 
-\subsection{What the certificate establishes, and what it does not}
-\label{app:iss-limits}
+The analysis above proves a nontrivial part of the stability problem
+analytically: the OU--III translational chain is uniformly observable through
+the $S$ channel for every bounded exogenous $\tau(t)$ schedule, and the cubic
+law keeps that observation on a uniformly comparable stochastic scale.
+Theorem~\ref{thm:adaptive-local-iss} then gives local ISS once uniform
+exponential stability of the complete Live linearization has been established.
+The following items still prevent an unconditional proof of the complete
+implemented filter.
 
-The accompanying verifier computes finite-difference Jacobians from the actual
-OU--III implementation over a $1458$-point envelope, extracts the
-18-dimensional performance block, checks strict Schur stability at every
-generated point, solves the corresponding discrete Lyapunov equation, and
-verifies each residual. Those checks pass. Four caveats bound what that means.
+\paragraph{Full augmented observability.}
+Equation~\eqref{eq:iss-attitude-info} rules out the basic two-vector attitude
+singularity and Proposition~\ref{prop:iss-ouiii-uco} proves translational
+observability, but the complete coupled attitude--gyro-bias--translation Gramian
+has not yet been bounded analytically. A complete proof should combine these
+two bounds over one finite observation horizon, including the actual
+magnetometer cadence.
 
-\paragraph{The certified rate is very slow.}
-The worst spectral radius is $\rho(\mat F)=1-7.3\cdot10^{-7}$, a continuous-time
-mode of about $1.6$ hours. The corresponding eigenvector is supported almost
-entirely on one translational axis of the $(\vct S,\vct p,\vct v,\vct a_w)$
-chain, so the slow mode is the drift-control loop. That loop is deliberately
-weak, because a drift correction stiff enough to converge quickly would also
-distort the wave band it is supposed to preserve; the slowness is a design
-choice, not a defect. But the theorem inherits it, and the constants of
-Eq.~\eqref{eq:iss-constants} become
-$c_1\approx2.8\cdot10^{5}$ with an $e$-folding time of order $10^{8}$~s. Read
-literally, Eq.~\eqref{eq:iss-final-bound} is true and says nothing useful.
+\paragraph{Accelerometer-bias convergence.}
+The theorem treats residual accelerometer-bias error as an input. To claim
+convergence of all 21 error coordinates, $\widetilde{\vct b}_a$ must be placed
+inside the certified state and the augmented observability calculation must
+separate the slowly varying bias from the mean-reverting $\vct a_w$ state.
+The existing estimate projection is useful for bounded-input ISS, but by itself
+is not a convergence proof.
 
-Two things soften this without repairing it. Roughly an order of magnitude of
-$c_1$ is an artifact of measuring $\|\vct e\|$ in mixed units: recomputing the
-same conditioning in physically scaled coordinates gives
-$c_1\approx1.7\cdot10^{4}$. And the quadratic-bound constant is far more
-conservative than the true transient: the worst point has
-$\sup_k\|\mat F^k\|_2\approx2.6\cdot10^{2}$, which is the amplification a
-trajectory can actually see. The gap between $2.6\cdot10^{2}$ and
-$2.8\cdot10^{5}$ is slack in the Lyapunov bound, not in the system.
+\paragraph{Pseudo-measurement model error.}
+$S=0$ is a regularizer rather than a physical measurement, so the physical
+$S_{\mathrm{true}}$ appears in the error system as a disturbance. The spectral
+model gives the natural second-moment scale
+$\operatorname{sd}(S_{\mathrm{true}})
+=c_{\mathrm{spec}}\sigma_{aw}\tau^3$, which is compatible with
+Eq.~\eqref{eq:iss-rS-cubic}. A deterministic infinite-horizon ISS theorem,
+however, requires a deterministic bound on this disturbance. For Gaussian
+noise and an OU prior, an infinite-horizon sample-path supremum is not
+deterministically bounded. A mean-square ISS theorem, or a finite-horizon
+high-probability result, is therefore the more natural stochastic statement.
 
-\paragraph{A4 is not satisfied.}
-With $\overline\ell\approx8.1\cdot10^{10}$, the budget in
-Eq.~\eqref{eq:iss-delta-budget} is
-$\delta_L<1.2\cdot10^{-11}$ per step. The verifier measures the metric ratio
-between adjacent envelope points and reports, per swept parameter, worst-case
-single-step values of order $4\cdot10^{1}$ for $r_S$, $8\cdot10^{2}$ for
-$\tau$, $5\cdot10^{4}$ for $\sigma_{aw}$, and $10^{7}$ for roll and pitch.
-Even amortized over a realistic traversal time, the implied per-step
-$\delta_L$ exceeds the budget by more than ten orders of magnitude.
+\paragraph{Periodic covariance re-alignment.}
+The implementation periodically re-aligns the posterior $\vct a_w$ covariance
+marginal with the prescribed stationary covariance while retaining learned
+cross-covariances. That operation is not a standard Riccati prediction or
+measurement update, so the usual uniform Riccati theorems do not apply to it
+automatically. Its positivity and its effect on the Riccati bounds must either
+be proved explicitly or the operation must be changed.
 
-The dominant contribution is not the adaptation at all: it is roll and pitch,
-which on a vessel move over the whole envelope in a few seconds. The
-separation of timescales the frozen-point argument needs is therefore
-inverted. The certified mode is slower than the operating-point variation by
-several orders of magnitude, which is the opposite of the slowly varying
-regime.
+\paragraph{Hybrid Live-state exits.}
+Hard initialization, tilt re-lock, gating, and fault recovery are discrete
+state resets. The theorem applies on an invariant Live region in which those
+branches do not fire. A global result that includes them requires a hybrid
+Lyapunov argument or reset maps that can be shown not to increase the chosen
+storage function.
 
-\paragraph{The common-metric route is not available.}
-The natural repair is to drop A4 by finding a single $\mat L\succ0$ with
-$\mat F^\top\mat L\mat F-\mat L\preceq-\epsilon\mat I$ for all sampled
-$(\xi,\vct\vartheta)$, which would give $\delta_L=0$. This was attempted as a
-semidefinite feasibility problem in scaled coordinates. It is infeasible: a
-common quadratic Lyapunov function does not exist for as few as three of the
-worst-case matrices. The problem is in any case numerically degenerate at
-$\rho\to1$, where $1-\rho^2\approx1.5\cdot10^{-6}$ leaves no room above solver
-tolerance. So the slowly varying route cannot simply be replaced by a common
-metric while the near-marginal mode is present.
+\paragraph{Stochastic adaptedness of the gain schedule.}
+For deterministic ISS, exogeneity of $\vartheta(t)$ with respect to the MEKF
+state is sufficient. For a strict stochastic Kalman proof, it is also
+convenient for the gain schedule used at step $k$ to be measurable with respect
+to data available before the innovation at that step. If the tuner and MEKF
+consume the same current IMU sample, this property should be stated carefully
+or enforced by a one-sample scheduling delay.
 
-\paragraph{The excluded bias channel is not small.}
-The worst $\|\mat F_{e b_a}\|_2$ is $0.998$, i.e. close to unit gain per step
-into the performance state. Combined with $1-\eta\approx10^{-11}$, the ISS
-gain $c_2$ from a persistent bias error is correspondingly large. The
-projection added under A6 bounds that input, which is what makes the bound
-meaningful at all, but it does not make the channel weak.
+\subsection{Small implementation changes that make the proof substantially cleaner}
+\label{app:iss-recommendations}
 
-\paragraph{Status of the pointwise certificate.}
-Taken together: Theorem~\ref{thm:adaptive-local-iss} is correct under its
-hypotheses, and the certificate verifies A3 on a sampled envelope, but A4 is
-not met. Read on its own, the pointwise certificate is a necessary-condition
-screen on the frozen dynamics -- it would catch a design in which some
-operating point is outright unstable -- and not a proof of closed-loop
-stability. Section~\ref{app:iss-switched} supplies the missing argument.
+The remaining gaps do not require redesigning the estimator. The following
+small changes would make the mathematical model align much more closely with
+standard time-varying Kalman stability theory.
 
-\subsection{The motion is what stabilizes it: a switched certificate}
-\label{app:iss-switched}
-
-A4 is the wrong assumption for this system, and not merely an unmet one. It
-asks the operating point to move \emph{slowly} relative to the estimator
-dynamics. On a vessel the opposite holds by an enormous margin: roll and pitch
-sweep the envelope in seconds while the frozen mode is hours. That is the
-fast-variation regime, in which the object governing stability is the
-transition matrix over a cycle rather than any frozen Jacobian.
-
-Computing that object changes the conclusion completely. Multiplying
-implementation Jacobians along a closed orbit in attitude -- the envelope
-corners $(\phi,\theta)=(-0.70,0)\to(0,0.45)\to(0.70,0)\to(0,-0.45)$,
-traversed once per wave period -- gives the monodromy $\mat\Phi$ over that
-period. Over the shipped envelope,
+\begin{enumerate}
+\item \textbf{Compute the applied $r_S$ from the applied OU scales.}
+After smoothing and clipping the applied $\tau$ and $\sigma_{aw}$, set
 \begin{equation}
-\rho(\mat\Phi)\in[0.18,\;0.50]
+r_S=\operatorname{clip}
+\!\left(c_R\sigma_{aw}\tau^3,\,
+r_{S,\min},r_{S,\max}\right)
 \end{equation}
-for a $10$~s period: the error contracts by a factor of two to five
-\emph{per wave}. Held still at the same tuning, the same estimator has
-$\rho=1-1.5\cdot10^{-5}$ per step, an $e$-folding of $274$~s. The frozen
-analysis is not conservative, it is describing a different system, one that
-never moves.
+rather than smoothing $r_S$ as an independent state. This makes
+Eq.~\eqref{eq:iss-kappa-def} algebraic. In the unsaturated region,
+$\kappa=c_R$ exactly; under saturation it remains bounded by construction.
 
-The effect is not an artifact of the particular orbit. Sweeping roll alone,
-pitch alone, a two-point alternation, and twenty randomly ordered four-point
-orbits all give $\rho(\mat\Phi)\in[0.40,0.60]$ over $10$~s, against
-$0.994$ for the static control. What is happening is ordinary: rotation makes
-directions observable that are unobservable at any fixed attitude, and the
-near-marginal drift mode of Sec.~\ref{app:iss-limits} is exactly such a
-direction.
+\item \textbf{Expose an explicit positive $\sigma_{aw,\min}$.}
+The theorem needs the lower diffusion bound in
+Eq.~\eqref{eq:iss-qc-bounds}. A named positive floor on the applied
+$\sigma_{aw}$ makes this property explicit instead of leaving it implicit in a
+numerical safeguard.
 
-Because the monodromies sit well inside the unit circle, the common-metric
-route that failed in Sec.~\ref{app:iss-limits} now succeeds. Bisecting for the
-least $\gamma$ admitting a single $\mat L\succeq\mat I$ with
-$\mat\Phi^\top\mat L\mat\Phi\preceq\gamma\mat L$ for every monodromy in
-the envelope gives
+\item \textbf{Replace covariance overwrite by positive-semidefinite inflation.}
+If the purpose of covariance re-alignment is to prevent the
+$\vct a_w$ marginal from becoming overconfident, use an update of the form
 \begin{equation}
-\gamma=0.246,\qquad
-c_1=\sqrt{\overline\ell/\underline\ell}=3.2\cdot10^{2},
+\mat P^+=\mat P^-+\mat E_a\mat\Delta\mat E_a^\top,
+\qquad \mat\Delta\succeq0,
 \end{equation}
-an $e$-folding of about $14$~s. Since one metric serves every cell,
-$\delta_L=0$ identically and A4 is not needed: Theorem~\ref{thm:adaptive-local-iss}
-goes through with $\mat L_k\equiv\mat L$ and the per-period contraction
-$\gamma$ in place of the per-step one. The constants improve by three orders
-of magnitude in $c_1$ and seven in the rate.
+or disable periodic re-alignment in the configuration for which the theorem is
+claimed. Positive-semidefinite inflation preserves covariance ordering and is
+much easier to incorporate into Riccati bounds than replacement of a principal
+block while retaining arbitrary cross-covariances.
 
-\begin{remark}[This model overstates the rate]
-Each factor of $\mat\Phi$ above is a frozen-point Jacobian whose covariance
-was settled at that operating point and which is then held for a dwell
-interval, whereas the real filter's covariance evolves continuously along the
-trajectory. Holding an extreme attitude for a quarter of a wave period is also
-far more exciting than a smooth oscillation that merely passes through it.
+\item \textbf{Optionally delay applied tuning by one IMU step.}
+Using $\vartheta_{k-1}$ for the measurement update at step $k$ makes the gain
+schedule predictable with respect to the current innovation and removes an
+otherwise unnecessary technical issue in a stochastic proof.
 
-Section~\ref{app:iss-trajectory} redoes the calculation without either
-approximation and finds a contraction some $26$ times weaker. The switched
-numbers are kept here because they isolate the mechanism cleanly, but the
-trajectory result is the one to quote.
-\end{remark}
+\item \textbf{State the invariant Live region explicitly.}
+Specify bounds on attitude, reference-vector noncollinearity, measurement
+availability, and validity gates under which no hard reset is invoked. The
+local theorem can then be stated on that region without relying on empirical
+trajectory coverage.
+\end{enumerate}
 
-\subsection{Trajectory certificate}
-\label{app:iss-trajectory}
-
-The least approximate version drops both idealizations. The filter is flown
-along a continuous quasi-periodic wave trajectory -- roll and pitch sweeping
-the same envelope, plus a second harmonic and a slow yaw so the motion is not
-a single tone -- and the one-step Jacobian is taken at every step against the
-filter's own running covariance. No operating point is frozen and no
-covariance is settled anywhere. The per-step Jacobians are accumulated into
-transition matrices $\mat\Phi(k+N,k)$ over windows of one wave period, which
-is the object a linear-time-varying argument needs.
-
-After the covariance settles on the path, the windows converge to
-\begin{equation}
-\rho\bigl(\mat\Phi\bigr)=0.973
-\end{equation}
-per $10$~s window, a spectral time constant of $360$~s. A single quadratic
-Lyapunov function serves every window,
-\begin{equation}
-\gamma=0.946,\qquad
-c_1=1.96\cdot10^{2},
-\end{equation}
-an $e$-folding of $363$~s. Because one metric works for all of them,
-$\delta_L=0$ and A4 is discharged for the real trajectory, not only for the
-switched caricature: Theorem~\ref{thm:adaptive-local-iss} holds with
-$\mat L_k\equiv\mat L$ and the per-window contraction $\gamma$.
-
-The within-window transient is $\sup_k\|\mat\Phi\|_2\approx2.7\cdot10^{2}$,
-consistent with the $2.6\cdot10^{2}$ measured pointwise, so that amplification
-is a real property of the estimator rather than slack in either bound.
-
-\begin{table}[t]
-\centering
-\caption{The three certificates, in increasing order of fidelity.}
-\label{tab:iss-three-certificates}
-\begin{tabular}{lccc}
-\toprule
-& rate & $c_1$ & needs A4? \\
-\midrule
-Frozen, worst envelope point & $5.7\cdot10^{3}$~s spectral & $2.8\cdot10^{5}$ & yes, violated $10^{14}\times$ \\
-Switched, dwell model        & $14$~s                      & $3.2\cdot10^{2}$ & no \\
-Trajectory, LTV              & $363$~s                     & $2.0\cdot10^{2}$ & no \\
-\bottomrule
-\end{tabular}
-\end{table}
-
-Table~\ref{tab:iss-three-certificates} summarizes. Two conclusions survive all
-three, and one does not.
-
-What survives is the structural result. A common metric exists along the real
-trajectory, so the slowly varying assumption is not needed at all, and the
-constants become usable: $c_1$ falls from $2.8\cdot10^{5}$ to
-$2.0\cdot10^{2}$, a factor of $1.4\cdot10^{3}$, and the certified rate
-improves from the frozen worst point by a factor of $16$ spectrally and by
-six orders of magnitude against the frozen ISS bound.
-
-What does not survive is the size of the benefit from motion. The switched
-model suggested that moving through the envelope buys two orders of magnitude
-in rate; along a real trajectory it buys about $16\times$ against the worst
-frozen point, and the converged rate of $363$~s is in fact slightly slower
-than the $274$~s of the best frozen point at the same tuning. Motion removes
-the near-marginal $1.6$~h mode, which is the important part, but it does not
-make the estimator fast.
-
-\paragraph{Over the whole tuning grid and three sea states.}
-Repeating the construction for every combination of
-$\tau\in\{0.55,1.8,4.0\}$, $\sigma_{aw}\in\{0.12,0.9,2.8\}$,
-$r_S\in\{0.35,1.5,6.0\}$ and wave period $\{6,10,16\}$~s gives $81$
-trajectories. Running the settling phase without building Jacobians costs one
-filter cycle per step instead of $43$, which makes the sweep take seconds per
-cell rather than minutes.
-
-Every cell contracts, and by nearly the same amount:
-\begin{equation}
-\rho(\mat\Phi)\in[0.952,\;0.981],
-\qquad
-\text{spectral time constant }322\text{--}522~\mathrm{s},
-\end{equation}
-with no cell reaching $\rho\ge1$. The insensitivity is itself informative:
-the certified rate is set by the drift-control loop, which is what the tuning
-knobs in $\vct\vartheta$ barely touch.
-
-A single quadratic Lyapunov function serves all $81$ windows at once:
-\begin{equation}
-\gamma=0.963\ \text{per window},\qquad
-c_1=2.1\cdot10^{3}.
-\end{equation}
-Because the windows are one wave period long and the periods differ, the
-per-second rate implied by $\gamma$ depends on which sea state it is read
-against; the conservative figure is the one from the $16$~s windows, an
-$e$-folding of $841$~s, against $315$~s from the $6$~s windows. The
-single-cell metric of Sec.~\ref{app:iss-trajectory} is naturally tighter,
-$c_1=1.96\cdot10^{2}$ and $363$~s, since it has only one sea state to cover.
-
-So A4 is discharged not just at one operating condition but uniformly over the
-declared tuning envelope and across the wave-period range, which is what the
-original assumption was reaching for and could not deliver.
-
-\subsection{How the tuner couples to the estimator}
-\label{app:iss-tuner}
-
-The remaining worry was the adaptation: if $\vct\vartheta_k$ were computed
-from the estimator's own output, estimator and tuner would form a feedback
-interconnection needing a composite Lyapunov function with a small-gain
-condition, as in observer designs that carry separate attitude and translation
-stages.
-
-The answer is split. The tuner has two input channels and only one of them is
-exogenous.
-
-\paragraph{The variance channel is exogenous.}
-\texttt{update\_tuner} is handed
-\begin{equation}
-a_{\text{proxy}}=-\bigl(a_{z,\text{body}}^{\text{meas}}+g\bigr),
-\end{equation}
-the raw accelerometer body-$z$ channel. Displacing every estimator state,
-attitude and linear block alike, leaves it bit-for-bit unchanged; this is
-asserted in \texttt{tests/kalman\_ou\_iii/tuner\_coupling-test.cpp}.
-
-\paragraph{The frequency channel was not, and now is.}
-The tuning frequency does not come from the raw tracker. It comes from
-\texttt{wave\_period\_}, and what that estimator is fed decides the question.
-
-Fed \texttt{direction\_accel.up\_ms2}, the vertical acceleration levelled with
-the \emph{attitude estimate}, it closed a loop. Since $\tau=c_\tau/2f$ and
-$r_S=c_R\sigma_a\tau^3$, the path
-\begin{equation}
-\delta\vct\theta\;\longrightarrow\;f\;\longrightarrow\;
-\vct\vartheta\;\longrightarrow\;\text{gains}\;\longrightarrow\;\delta\vct\theta
-\end{equation}
-was a genuine feedback loop: a $0.25$~rad attitude displacement moved the
-estimated wave period from $8.05$ to $10.1$~s and $\tau$ by a factor $1.25$.
-It reached the linear states indirectly as well, since displacing $\vct v$,
-$\vct p$, $\vct S$ or $\vct a_w$ perturbs attitude through the filter's
-cross-covariances: a displacement of $0.02$ in each linear state shifted
-$\tau$ from $4.07$ to $4.53$.
-
-Levelling is not what caused this; levelling \emph{with an estimator state}
-was. The estimator needs a levelled input, because double integration weights
-a spectrum by $\omega^{-4}$ and the sub-band gravity a tilting platform leaks
-into the raw body-$z$ proxy then dominates the elevation proxy --- fed that
-proxy the estimator reports $6.8$--$10.0$~s whatever the sea does, against a
-truth of $2.4$--$8.7$~s, and vertical RMS degrades by a factor $2.5$. Both
-requirements are met at once by levelling with a \emph{private} attitude
-solution: \texttt{src/tuner/VerticalAccelComplementary.h} runs a Mahony
-observer on the raw gyro and accelerometer, reading no calibrated value and no
-filter state, and reports $-\bigl((\mat R\vct f)_z+g\bigr)$ from its own
-quaternion. Its correction corner is placed an order of magnitude below the
-wave band ($\approx0.016$~Hz against $0.11$--$0.42$~Hz) so that the gyro
-carries attitude through the band and the accelerometer only trims drift; a
-faster corner chases horizontal orbital acceleration into tilt and reproduces
-the body-$z$ failure.
-
-This is the deployed default, and it costs nothing: over the eight reference
-records it reproduces the attitude-levelled input to within $0.2\%$ of vertical
-RMS and $0.1\%$ of 3D RMS, geometric-mean ratio $1.000$ on both OU-II and
-OU-III, with the reported $T_z$ matching to $0.01$~s. Displacing every
-estimator state now leaves the reported period \emph{and} $\vct\vartheta$
-bit-for-bit unchanged, asserted alongside the variance channel in the same
-test. The older attitude-levelled input remains selectable for ablation, and
-the test still bounds its gain at $2$ so the comparison stays interpretable.
-
-\paragraph{One further state-dependent branch.}
-A gate reads the attitude estimate and re-locks the filter above $70^\circ$
-of tilt. It cannot fire on the certified envelope, whose worst combined tilt
-is $\arccos(\cos 0.70\cos 0.45)=46.5^\circ$, or on the trajectories used
-here, which peak at $54^\circ$. The margin is pinned by the same test.
-
-\paragraph{What this means for the certificate.}
-With both channels exogenous, $\vct\vartheta$ is a function of the measured
-signals alone and the deployed schedule is an externally supplied one. That is
-exactly the hypothesis Secs.~\ref{app:iss-trajectory} and the sweep assume, so
-the gap between what is certified and what is deployed closes: no composite
-Lyapunov function and no small-gain condition is needed, because there is no
-interconnection to bound.
-
-This is a change of configuration, not a change of proof. The earlier text
-recorded the loop as this appendix's open item and offered two routes to close
-it --- include $\vct\vartheta$'s generator in the certified coordinate, or
-bound the $\delta\vct\theta\to\vct\vartheta$ gain against the estimator's own
-contraction. Removing the dependence is the third, and the bit-for-bit
-assertion is what makes it checkable rather than argued. Two caveats survive.
-The claim is conditional on the input source: selecting the attitude-levelled
-ablation reinstates the loop and with it the earlier, narrower scope. And the
-private observer's corner is fixed while the wave band moves down as the sea
-grows, so the order-of-magnitude margin quoted above is a property of the
-reference records, not a theorem.
-
-The exogenous-schedule results below therefore now speak directly to the
-deployed filter: the estimator tolerates $\vct\vartheta$ moving anywhere in
-$\Theta$, arbitrarily fast.
-
-\paragraph{An exogenous schedule is not automatically harmless either.}
-Set the coupling aside and ask what an arbitrary bounded schedule can do. A
-schedule that moves fast enough can destabilize a system every frozen version
-of which is stable, and this one is no exception. Sweeping $\vct\vartheta$
-over the whole box $\tau\in[0.55,4.0]$, $\sigma_{aw}\in[0.12,2.8]$,
-$r_S\in[0.35,6.0]$, log-spaced and out of phase per axis, and far faster than
-the real tuner slews, one window of a $6$~s sea against a $20$~s sweep gives
-\begin{equation}
-\rho(\mat\Phi)=1.099>1 .
-\end{equation}
-It is a genuine resonance, not noise: it recurs exactly every $60$~s, the beat
-period of the $20$~s schedule against the $6$~s wave.
-
-It does not imply instability, and the reason is worth stating because it is a
-trap in the method. Per-window contraction is sufficient but not necessary.
-Taking the product over the full beat period, $10$ windows, gives
-$\rho=0.83$ and a time constant of $325$~s -- the same rate as everywhere
-else. The bad window is a transient amplification at one phase alignment,
-absorbed within the repeat period. A certificate that demands every single
-window contract will therefore report a false failure whenever the schedule
-and the sea beat against each other, and the window has to be at least the
-beat period. The verifier takes a \texttt{-{}-group} argument for exactly this,
-and groups within a trajectory rather than across them.
-
-\paragraph{With that, the schedule itself is discharged.}
-Across sweeps of $20$, $60$ and $200$~s against seas of $6$, $10$ and $16$~s,
-grouped to four windows, every product contracts and one common metric serves
-all of them:
-\begin{equation}
-\gamma=0.869\ \text{per group},\qquad
-c_1=3.9\cdot10^{1},
-\end{equation}
-a worst-case $e$-folding of $910$~s read against the $64$~s groups, $341$~s
-against the $24$~s groups. The rate is unchanged from the fixed-tuning case: the schedule
-moves the gains around inside a set on which the estimator contracts anyway.
-This covers any exogenous schedule in $\Theta$; it does not by itself cover
-the state-dependent part of the deployed one.
-
-\begin{remark}[Remaining scope]
-What is left is smaller than what has been closed. The attitude paths are
-synthetic sums of sinusoids rather than recorded sea states, and measurements
-are generated from the filter's own prediction, so the linearization runs
-without injected noise. The
-$\delta\vct\theta\to\vct\vartheta$ loop above is bounded by test but not
-analysed, so the deployed adaptive filter is still not certified as a closed
-loop. And the whole construction remains a numerical certificate over sampled
-trajectories, not a proof: A3 is checked on a grid, the metrics come from an
-LMI solved at floating-point tolerance, and A2 is still assumed outright.
-\end{remark}
+With the first three changes, the translational part of the proof is already
+fully analytic and the remaining mathematical task is sharply defined:
+establish one finite-horizon uniform Gramian bound for the coupled
+attitude--bias--translation linearization. Once that yields
+Eq.~\eqref{eq:iss-ues}, the nonlinear ISS conclusion follows directly from
+Theorem~\ref{thm:adaptive-local-iss}.

--- a/doc/kalman_ou_iii/w3d-iss-stability.tex-part
+++ b/doc/kalman_ou_iii/w3d-iss-stability.tex-part
@@ -127,8 +127,8 @@ T_S^2/2 & T_S & 1 & A_3(T_S)\\
 \label{eq:iss-OS}
 \end{equation}
 
-\begin{proposition}[Uniform observability of one OU--III axis]
-\label{prop:iss-ouiii-uco}
+\begin{lemma}[Uniform observability of one OU--III axis]
+\label{lem:iss-ouiii-uco}
 For every measurable $\tau(t)$ satisfying
 $0<\underline\tau\le\tau(t)\le\overline\tau$, the matrix $\mat O_S$ is
 nonsingular and obeys
@@ -141,7 +141,7 @@ T_S^6\exp\!\left(-\frac{3T_S}{\underline\tau}\right)>0 .
 Hence $(v,p,S,a)$ is uniformly observable from four consecutive $S$
 pseudo-measurements, independently of how rapidly $\tau(t)$ moves inside its
 admissible interval.
-\end{proposition}
+\end{lemma}
 
 \begin{proof}
 Direct expansion of Eq.~\eqref{eq:iss-OS} gives
@@ -278,7 +278,7 @@ The normalization in Eq.~\eqref{eq:iss-normalized-coordinates} identifies
 physical scales; it is not used as a time-varying coordinate transformation.
 Such a transformation would introduce $\dot\tau$ and $\dot\sigma_{aw}$ terms.
 Uniform observability for arbitrary bounded $\tau(t)$ instead follows directly
-from Proposition~\ref{prop:iss-ouiii-uco}.
+from Lemma~\ref{lem:iss-ouiii-uco}.
 
 For a frozen $\tau$, the one-axis pair is also controllable from the OU driving
 noise. With state order $[v,p,S,a]$, input $\vct B=[0,0,0,1]^\top$, and
@@ -348,7 +348,7 @@ nondegenerate over the observation horizon.
 
 The complete performance Jacobian is nevertheless coupled: the accelerometer
 simultaneously observes attitude and $\vct a_w$, and covariance cross terms
-couple all corrected states. Proposition~\ref{prop:iss-ouiii-uco} and
+couple all corrected states. Lemma~\ref{lem:iss-ouiii-uco} and
 Eq.~\eqref{eq:iss-attitude-info} establish the two principal structural pieces,
 but a formal proof of uniform complete observability of the entire coupled
 performance state still requires combining them into one finite-horizon
@@ -478,7 +478,7 @@ implemented filter.
 
 \paragraph{Full augmented observability.}
 Equation~\eqref{eq:iss-attitude-info} rules out the basic two-vector attitude
-singularity and Proposition~\ref{prop:iss-ouiii-uco} proves translational
+singularity and Lemma~\ref{lem:iss-ouiii-uco} proves translational
 observability, but the complete coupled attitude--gyro-bias--translation
 Gramian has not yet been bounded analytically. A complete proof should combine
 these bounds over one finite observation horizon, including the actual


### PR DESCRIPTION
## What changed

- Rewrote `doc/kalman_ou_iii/w3d-iss-stability.tex-part` around an analytical stability route rather than sampled Jacobian/LMI certificates.
- Treats `tau`, `sigma_aw`, and `r_S` as an exogenous bounded schedule because the tuner uses the private Mahony vertical-acceleration proxy and does not depend on OU-III state estimates.
- Proves finite-horizon uniform observability of each scalar OU-III translational chain from four consecutive `S=0` pseudo-measurements, including an explicit lower bound on the observability determinant and minimum singular value.
- Uses `q_c = 2 sigma_aw^2 / tau` and the `r_S = kappa sigma_aw tau^3` scaling to show bounded OU excitation and bounded dimensionless regularization strength.
- Adds the corresponding 3D translational extension and an analytical attitude-information condition based on non-collinearity of accelerometer and magnetometer reference directions.
- Replaces the old grid-based ISS argument with the standard route `UCO/UCC -> bounded Riccati recursion -> UES -> local ISS`, and makes the remaining unproved bridge explicit instead of hiding it in a sampled Schur-stability assumption.
- Removes the historical numerical-certificate narrative, frozen/switching/trajectory experiments, and obsolete discussion of an estimator-to-tuner feedback loop.
- Updates the introduction and conclusion so they describe the analytical result consistently.

## Remaining formal-proof gaps called out in the paper

The rewrite does not claim a complete unconditional 21-state EKF convergence proof. It explicitly identifies the remaining items: full coupled attitude/bias/translation UCO, uniform scheduled controllability/stabilizability, the accelerometer-bias state, the `S=0` pseudo-measurement mismatch, covariance re-alignment outside the ordinary Riccati recursion, hybrid reset/re-lock logic, and the stochastic adaptedness issue from sharing IMU samples between tuner and estimator.

## Recommended small filter corrections

The appendix recommends:

- derive applied `r_S` algebraically from applied `sigma_aw` and `tau`;
- enforce an explicit positive `sigma_aw,min`;
- replace direct `P_awaw` block overwrite with an explicitly PSD covariance-inflation operation;
- optionally apply tuner updates with a one-sample delay for a cleaner stochastic proof;
- state a Live-state invariant region that excludes reset/re-lock branches.

## Validation

The branch was pushed as `agent/analytic-iss-proof`. The repository build workflow was triggered by the push; this PR is left as a draft pending CI and review of the analytical assumptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the OU–III estimator stability analysis with analytic observability, scheduled linear stability, and local input-to-state stability results.
  - Documented tuning schedules, disturbance handling, covariance alignment, measurement scaling, and implementation safeguards.
  - Clarified the distinction between demonstrated results and remaining requirements for a complete 21-state proof.
  - Updated the introduction and conclusion to reflect multi-seed validation, ablation findings, performance comparisons, and realization-specific acceptance gates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->