### PR TITLE
Fix OU validation guard for analytic ISS wording

### DIFF
--- a/doc/kalman_ou_iii/w3d-intro.tex-part
+++ b/doc/kalman_ou_iii/w3d-intro.tex-part
@@ -40,7 +40,9 @@ The remaining obligations for a complete 21-state proof are stated explicitly:
 a coupled attitude--bias--translation Gramian bound, a uniform scheduled
 controllability/stabilizability result, treatment of covariance re-alignment,
 the stochastic interpretation of the $S=0$ regularizer, and the excluded
-hybrid reset logic.
+hybrid reset logic. Accordingly, the full 21-state statement remains a
+conditional sufficient-condition result, not an unconditional EKF convergence
+claim.
 
 \subsection*{From Standard Q-MEKF to Extended Kinematics}
 


### PR DESCRIPTION
## Summary

- Restores the manuscript wording expected by the OU validation methodology guard after the analytical ISS rewrite.
- Keeps the new analytical stability treatment intact.
- Explicitly states that the full 21-state conclusion remains a conditional sufficient-condition result and is not an unconditional EKF convergence claim.

## Scope

This is a one-file manuscript-only fix in `doc/kalman_ou_iii/w3d-intro.tex-part`. No filter, simulation, or validation logic changes.

## CI failure addressed

The `ou-validation` unit-test step failed because `test_the_contribution_is_framed_at_the_width_of_the_evidence` still requires the introduction to carry those two scope qualifiers. This branch restores them without reintroducing the removed numerical-certificate narrative.