### PR TITLE
Fix stale abstract validation spread

### DIFF
--- a/doc/kalman_ou_iii/kalman_ou-w3d.tex
+++ b/doc/kalman_ou_iii/kalman_ou-w3d.tex
@@ -207,7 +207,7 @@ bounded family of spectra. A ten-seed paired study scores the final
 \SI{900}{s} of four stationary JONSWAP seas, four PM--Stokes seas, and a
 controlled transition.  Over the stationary JONSWAP seas, the declared
 primary endpoint, the seed-wise mean normalized vertical-displacement RMS
-error is $4.97\pm0.25\%$ of $H_s$ for OU--III and $6.67\pm0.29\%$ for OU--II
+error is $4.97\pm0.24\%$ of $H_s$ for OU--III and $6.67\pm0.29\%$ for OU--II
 (mean $\pm$ sample standard deviation over the ten seed triplets); the paired
 difference is $-1.696$ percentage point (percentile-bootstrap 95\% interval
 $[-1.774,-1.625]$, Student-$t$ interval $[-1.787,-1.605]$, all ten seed-level


### PR DESCRIPTION
## Summary

The latest `main` build fails only in the OU evidence consistency gate. Regenerated evidence reports the OU-III stationary JONSWAP normalized vertical RMS spread as `4.97 ± 0.24%`, while the abstract still says `4.97 ± 0.25%`.

This PR updates that one stale abstract value to match the committed regenerated evidence. No filter code or validation logic is changed.

Root cause from the failing `ou-evidence / commit` job:

`AssertionError: '$4.97\\pm0.24\\%' not found ... '$4.97\\pm0.25\\%' ...`

All other reported build/test jobs in that run passed; the evidence bundle itself was already identical to the committed regenerated bundle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the reported OU–III normalized vertical-displacement RMS error to **4.97 ± 0.24% of \(H_s\)**.
  * The OU–II value remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->