### PR TITLE
Address OU-III publication review blockers

### DIFF
--- a/doc/kalman_ou_iii/kalman_ou-w3d.tex
+++ b/doc/kalman_ou_iii/kalman_ou-w3d.tex
@@ -237,9 +237,10 @@ extended Kalman filter, inertial navigation, IMU, marine Motion Reference Unit, 
 \input{w3d-conclusion-summary.tex-part}
 
 \appendices
+% The evaluated stability result remains in the journal manuscript.  Optional
+% wind/heel and GNSS extensions are retained in the repository as companion
+% material rather than typeset as unevaluated publication appendices.
 \input{w3d-tracker-alternatives.tex-part}
-\input{w3d-wind-heel.tex-part}
-\input{w3d-gps-fusion.tex-part}
 \input{w3d-iss-stability.tex-part}
 
 \FloatBarrier

--- a/doc/kalman_ou_iii/w3d-analytic-coeff.tex-part
+++ b/doc/kalman_ou_iii/w3d-analytic-coeff.tex-part
@@ -204,11 +204,15 @@ which is equivalently
 $\matg{Q}_{LL}=\mat{C}\otimes\matg{\Sigma}_{aw}^{\mathrm{stat}}$ for this
 ordering.
 
-The accelerometer-bias block is
+The residual accelerometer-bias block uses the same finite-$\tau_b$ process as
+the continuous model and Sec.~\ref{sec:lti-disc}:
 \[
-\Phi_{b_ab_a}=\Id,
+\matg{\Phi}_{b_ab_a}(h)=e^{-h/\tau_b}\Id,
 \qquad
-\matg{Q}_{b_ab_a}=h\matg{Q}_{ba}.
+\matg{Q}_{d,b}(h)=\frac{\tau_b}{2}
+\left(1-e^{-2h/\tau_b}\right)\matg{Q}_{ba}.
 \]
+Thus the discrete model retains the restoring factor required by the 21-state
+detectability result rather than reverting to the former random-walk block.
 The complete transition and process covariance are assembled blockwise while
 retaining all propagated cross-covariances in $\mat{P}$.

--- a/doc/kalman_ou_iii/w3d-baseline-comparison.tex-part
+++ b/doc/kalman_ou_iii/w3d-baseline-comparison.tex-part
@@ -97,10 +97,11 @@ OU--II.  The paired OU--III-minus-OU--II difference is
 $\OUValidationNormalizedDifference$ percentage point with bootstrap 95\%
 interval
 $[\OUValidationNormalizedDifferenceLow,\OUValidationNormalizedDifferenceHigh]$.
-This paired difference is the primary effect-size statement; the ten paired
-realizations establish repeatability within the stated simulator and sensor
-model, not uncertainty over alternative simulators, vessels, spectra, or update
-cadences.
+The secondary exact paired sign-flip/randomization check gives
+$p=\OUValidationNormalizedRandomizationP$.  This paired difference is the
+primary effect-size statement; the ten paired realizations establish
+repeatability within the stated simulator and sensor model, not uncertainty
+over alternative simulators, vessels, spectra, or update cadences.
 
 \paragraph{Vertical versus three-dimensional displacement}
 OU--III has lower vertical error in every stationary JONSWAP sea and in the

--- a/doc/kalman_ou_iii/w3d-conclusion-summary.tex-part
+++ b/doc/kalman_ou_iii/w3d-conclusion-summary.tex-part
@@ -31,10 +31,12 @@ the tested signal-to-noise levels and transition construction.
 
 Appendix~\ref{app:iss-stability} establishes nominal local stability of the
 21-state Live error dynamics under bounded noncollinear reference geometry,
-bounded measurement gaps, finite positive covariance bounds, and finite
-accelerometer-bias correlation time.  The result is local and applies between
-hard resets; startup, re-lock, gating, and arbitrary ocean-model mismatch are
-outside its scope.
+bounded measurement gaps, exact $T_S$ spacing for the four integral-state
+pseudo-updates used on each translational proof horizon, finite positive
+covariance bounds, and finite accelerometer-bias correlation time.  The result
+is local and applies between hard resets; startup, re-lock, gating, general
+sample-time jitter of the nominal $S$ deadlines, and arbitrary ocean-model
+mismatch are outside its scope.
 
 The present evidence remains primarily simulation based.  The only method run
 under the full paired inferential protocol is OU--II, so the paper establishes
@@ -44,6 +46,7 @@ baseline and a current published heave estimator should be evaluated under the
 same paired protocol.  The ESP32--S3 exercise establishes source portability,
 not timing, memory, power, or measurement accuracy.  Future validation should
 therefore add independent sea states and update rates, a continuously evolving
-non-stationary spectrum, quantitative embedded-resource measurements, and an
-external physical displacement reference from a motion platform, wave tank,
-GNSS/optical system, or commercial MRU.
+non-stationary spectrum, quantitative embedded-resource measurements, a
+varying-temperature calibration/lag experiment, and an external physical
+displacement reference from a motion platform, wave tank, GNSS/optical system,
+or commercial MRU.

--- a/doc/kalman_ou_iii/w3d-intro.tex-part
+++ b/doc/kalman_ou_iii/w3d-intro.tex-part
@@ -8,9 +8,22 @@ acceleration and a much slower first-order Gauss--Markov residual model for
 accelerometer bias about a deterministic temperature-calibration curve. The
 filter is designed for marine inertial sensing and wave-kinematics
 reconstruction. The proposed framework unifies attitude estimation, 3D
-kinematics, stochastic excitation modeling, and temperature-aware MEMS bias
-tracking into a single, analytically tractable structure intended for
-resource-constrained embedded estimation.
+kinematics, stochastic excitation modeling, and a finite-correlation-time
+residual bias state in an analytically tractable structure intended for
+resource-constrained embedded estimation. The temperature-centered bias model
+is used structurally by the estimator and stability analysis; the present
+experiments do not constitute a thermal-calibration validation.
+
+Recent marine heave work spans discrete-time Kalman reconstruction
+\cite{Reis2023_DiscreteKalmanHeave}, adaptive delay-free IMU filtering
+\cite{Lu2023_AdaptiveDelayFreeHeave}, and nonlinear/frequency-assisted Kalman
+approaches \cite{Li2025_HeaveCKF}.  Practical buoy studies likewise emphasize
+the error mechanisms and phase fidelity of inertial wave measurements
+\cite{YurovskyKudinov2025_IMUwaves,Hope2025_SFY}.  The contribution here is not
+a claim to replace those method classes.  It is the isolation of an adaptive
+integral-regularization mechanism inside a fully specified 21-state MEKF,
+together with exact discretization, matched OU-family ablations, and a local
+stability result at the scope stated below.
 
 Most wave measurement systems derive parameters by chaining separate motion estimation
 and spectral analysis stages, a process prone to bias and delay.
@@ -43,15 +56,17 @@ temperature model and obey a slow OU transition
 $e^{-h/\tau_b}\mat I_3$; with finite $\tau_b$ they are intrinsically uniformly
 exponentially stable, so augmenting the observable 18-state subsystem gives a
 uniformly detectable 21-state system. With uniformly bounded positive process
-and measurement covariances, bounded magnetic-update gaps, the default
-prediction-time PSD $\vct a_w$ covariance inflation, and no hard reset in the
-analysis interval, standard time-varying Kalman theory then gives bounded
+and measurement covariances, bounded magnetic-update gaps, exact $T_S$ spacing
+of the four $S$ pseudo-updates used on each translational proof horizon, the
+default prediction-time PSD $\vct a_w$ covariance inflation, and no hard reset
+in the analysis interval, standard time-varying Kalman theory then gives bounded
 Riccati solutions and UES of the homogeneous 21-state Live error dynamics. A
 quadratic-remainder argument yields local ISS for bounded temperature-model,
 sensor, pseudo-measurement, and modeling disturbances. The optional legacy raw
 $\vct a_w$ covariance replacement remains available for reproducibility but is
-outside that theorem, as are startup/re-lock resets and deterministic
-infinite-horizon claims for unbounded Gaussian sample paths.
+outside that theorem, as are startup/re-lock resets, sample-time jitter of the
+nominal $S$-update deadlines, and deterministic infinite-horizon claims for
+unbounded Gaussian sample paths.
 
 \subsection*{From Standard Q-MEKF to Extended Kinematics}
 
@@ -63,7 +78,7 @@ world-frame acceleration, velocity, oscillatory displacement, and the integral o
 oscillatory displacement in three dimensions, together with a slow residual
 accelerometer-bias state. This augmentation allows the estimator to reconstruct
 instantaneous and cumulative wave kinematics in the world frame while tracking
-MEMS bias around its calibrated temperature-dependent mean.
+a residual bias around a supplied temperature-dependent calibration mean.
 
 \subsection*{Stochastic Forcing and the OU Acceleration Model}
 
@@ -90,7 +105,9 @@ on a deliberately much slower fixed time scale. It represents only the residual
 about the deterministic temperature correction, not the total physical bias.
 The default $\tau_b=\SI{5000}{s}$ is independent of the wave tuner, and the
 continuous driving-noise density retains the historical short-time bias
-process-noise calibration.
+process-noise calibration.  In this paper that choice is chiefly a sensor-model
+and detectability assumption; a varying-temperature compensation experiment is
+left for physical validation.
 
 \subsection*{Continuous-Time Model Formulation}
 
@@ -169,7 +186,9 @@ surface motion. The simulation continues to inject the documented accelerometer
 bias random walk, so the slow-OU residual used by the estimator is also tested
 under deliberate bias-process mismatch; that mismatch is treated as an
 exogenous disturbance by the local ISS statement rather than silently removed
-from the evidence protocol.
+from the evidence protocol. Temperature itself is not swept, and calibration
+error, thermal lag, and hysteresis are not independently scored, so the
+simulation does not validate temperature compensation as a performance claim.
 
 The principal runtime bounds, gates, and time constants are tabulated in
 Sec.~\ref{sec:adapt-impl}. The complete coefficient set, fixed baseline
@@ -183,7 +202,9 @@ The main contributions of this work are:
   \item A 21-state quaternion MEKF architecture that couples an OU-driven
         latent world-acceleration prior to marine attitude and wave-motion
         estimation and models the residual accelerometer bias as a much slower
-        temperature-centered first-order Gauss--Markov process.
+        temperature-centered first-order Gauss--Markov process.  The finite
+        residual correlation time is used in the stability result; empirical
+        thermal-compensation performance is not claimed.
   \item Closed-form discrete-time transition and covariance matrices for
         the OU process and linear kinematic chain, with numerically stable
         small-step series expansions, together with the exact scalar
@@ -200,34 +221,35 @@ The main contributions of this work are:
         system. The translational and attitude--gyro-bias blocks supply the
         finite-horizon observability result; the temperature-centered residual
         bias OU block is intrinsically exponentially stable, which upgrades the
-        augmentation to uniform detectability. Under the stated cadence,
-        geometry, covariance, bounded-schedule, and no-reset conditions, this
-        yields bounded Riccati solutions and 21-state UES, followed by a local
-        ISS bound for bounded modeling and temperature-calibration disturbances.
-        The optional legacy raw $\vct a_w$ covariance-replacement mode is
-        explicitly outside that proof.
+        augmentation to uniform detectability. Under the stated exact
+        $S$-pseudo-update spacing, geometry, covariance, bounded-schedule, and
+        no-reset conditions, this yields bounded Riccati solutions and 21-state
+        UES, followed by a local ISS bound for bounded modeling and
+        temperature-calibration disturbances. The optional legacy raw
+        $\vct a_w$ covariance-replacement mode and general sample-time jitter
+        of the nominal $S$ deadlines are explicitly outside that proof.
   \item A formulation independent of hydrodynamic equations, relying instead on
         oscillatory kinematics with slowly varying spectra and high-rate inertial measurements.
-  \item A reproducible paired comparison against a published nonlinear observer
-        and two earlier author-developed observer architectures, including an
-        OU--II ablation that isolates the incremental effect of the OU--III
-        translational state structure by tuning both filters from the same
-        wave-band period.
+  \item A common-record deterministic comparison against a published nonlinear
+        observer and two earlier author-developed observer architectures,
+        together with a separate ten-seed paired OU--III/OU--II study that
+        isolates the incremental effect of the OU--III translational structure
+        while using the same wave-band period input for both filters.
   \item A versioned ten-seed paired validation on stationary and transitioning
-        directional sea spectra, including intervals from four separate
-        constructions on the declared primary endpoint, negative results, and
-        the limits of the observed OU--III advantage.
+        directional sea spectra, including a paired bootstrap interval and an
+        exact paired sign-flip check on the declared primary endpoint, negative
+        results, and the limits of the observed OU--III advantage.
 \end{itemize}
 
 The scope of the claim deserves stating once, plainly, at the outset. The
 displacement state $\vct{p}$ is oscillatory wave-induced motion, not a global
-navigation position; absolute positioning is an optional extension kept in
-Appendix~\ref{sec:gps_fusion}. The measured advantage over the matched OU--II
-architecture is a \emph{vertical} one: OU--III has higher total 3D displacement
-error in \OUValidationThreeDHigherCount{} of the
-\OUValidationThreeDScenarios{} principal scenarios, because the vertical gain
-is largely paid for in the horizontal channels
-(Sec.~\ref{sec:observer-comparison}). And every quantitative result below comes
-from simulation. The embedded exercise establishes source portability, not a
-timing or memory margin, and no result here is validated against an external
-physical displacement reference.
+navigation position; an optional absolute-position/GNSS extension is retained
+as repository companion material but is not part of the evaluated publication
+configuration. The measured advantage over the matched OU--II architecture is
+a \emph{vertical} one: OU--III has higher total 3D displacement error in
+\OUValidationThreeDHigherCount{} of the \OUValidationThreeDScenarios{}
+principal scenarios, because the vertical gain is largely paid for in the
+horizontal channels (Sec.~\ref{sec:observer-comparison}). And every quantitative
+result below comes from simulation. The embedded exercise establishes source
+portability, not a timing or memory margin, and no result here is validated
+against an external physical displacement reference.

--- a/doc/kalman_ou_iii/w3d-iss-stability.tex-part
+++ b/doc/kalman_ou_iii/w3d-iss-stability.tex-part
@@ -99,14 +99,24 @@ m_0\le\|\widehat{\vct m}_b\|\le m_1,
 \label{eq:iss-vector-geometry}
 \end{equation}
 where $\vct u_f$ and $\vct u_m$ are the corresponding unit vectors. Every
-finite proof horizon contains four consecutive $S$ pseudo-updates and two
-accepted accelerometer--magnetometer vector-update instants separated by
+finite proof horizon contains four consecutive $S$ pseudo-updates at relative
+times $0,T_S,2T_S,3T_S$ and two accepted accelerometer--magnetometer
+vector-update instants separated by
 $\Delta\in[\Delta_{\min},\Delta_{\max}]$, with
 \begin{equation}
 \overline\omega\Delta_{\max}<\frac{\pi}{2}.
 \label{eq:iss-vector-gap}
 \end{equation}
 No hard reset occurs inside the horizon.
+
+The exact $S$-update spacing is an explicit theorem assumption.  The production
+scheduler in Sec.~\ref{sec:measurement_model} is time based and, for general
+variable $h_k$, may apply an intended deadline on the first IMU sample after
+that deadline.  The fixed-rate validation uses $h=\SI{5}{ms}$ and the default
+$T_S=\SI{15}{ms}$, so its pseudo-updates occur every three IMU samples and
+satisfy the exact-spacing assumption.  Extending the determinant argument to
+bounded sample-time jitter would require an explicit perturbation margin for
+the finite-horizon Gramian; that extension is not claimed here.
 
 \subsection{Exact Live-state linearized structure}
 
@@ -161,7 +171,7 @@ h^2/2&h&1&\phi_{Sa}\\
 \end{bmatrix},
 \label{eq:iss-implemented-phi}
 \end{equation}
-with the coefficients derived in Sec.~\ref{sec:discretization}.
+with the coefficients derived in Sec.~\ref{sec:block-Phi-Qd}.
 
 The vector-measurement Jacobians are
 \begin{align}
@@ -213,14 +223,15 @@ T_S^2/2&T_S&1&A_3(T_S)\\
 
 \begin{lemma}[Uniform observability of one OU--III axis]
 For every measurable $\tau(t)$ satisfying
-$\underline\tau\le\tau(t)\le\overline\tau$,
+$\underline\tau\le\tau(t)\le\overline\tau$ and four consecutive $S$
+pseudo-measurements separated exactly by $T_S$,
 \begin{equation}
 |\det\mat O_S|
 \ge T_S^6\exp\!\left(-\frac{3T_S}{\underline\tau}\right)>0.
 \label{eq:iss-det-lower}
 \end{equation}
-Hence the scalar $[v,p,S,a]$ chain is uniformly observable from four
-consecutive $S$ pseudo-measurements.
+Hence the scalar $[v,p,S,a]$ chain is uniformly observable over that
+exact-cadence four-update horizon.
 \end{lemma}
 
 \begin{proof}
@@ -446,14 +457,15 @@ is not covered by the theorem.
 
 \begin{theorem}[21-state Live UES]
 \label{thm:iss-21-ues}
-Under Eqs.~\eqref{eq:iss-step-tau-bounds}--\eqref{eq:iss-vector-gap}, the
-positive process-density assumptions above, the default PSD $a_w$ covariance
-inflation (or no periodic covariance maintenance), active slow-OU residual
-accelerometer-bias estimation with finite $\overline\tau_b$, and no hard reset
-inside the analyzed Live interval, the homogeneous 21-state linearized Kalman
-estimation-error transition is uniformly exponentially stable. There exist
-constants $M\ge1$ and $0<\rho<1$, independent of the admissible exogenous tuning
-schedule, such that
+Under Eqs.~\eqref{eq:iss-step-tau-bounds}--\eqref{eq:iss-vector-gap}, including
+the exact $T_S$ spacing of the four $S$ pseudo-updates on each translational
+proof horizon, the positive process-density assumptions above, the default PSD
+$a_w$ covariance inflation (or no periodic covariance maintenance), active
+slow-OU residual accelerometer-bias estimation with finite
+$\overline\tau_b$, and no hard reset inside the analyzed Live interval, the
+homogeneous 21-state linearized Kalman estimation-error transition is uniformly
+exponentially stable. There exist constants $M\ge1$ and $0<\rho<1$,
+independent of the admissible exogenous tuning schedule, such that
 \begin{equation}
 \boxed{
 \|\Psi_{21}(k,j)\|\le M\rho^{k-j},\qquad k\ge j .}
@@ -557,5 +569,6 @@ The proof covers the default prediction-time PSD $a_w$ covariance inflation and
 the case in which periodic covariance maintenance is disabled. It does not
 cover the optional legacy raw covariance replacement, startup/re-lock/hard-reset
 maps, arbitrarily long measurement outages, collinear gravity/magnetic reference
-geometry, or the random-walk limit $\tau_b=\infty$. In particular, the finite
-upper bound on $\tau_b$ is essential for a uniform 21-state stability margin.
+geometry, sample-time jitter of the nominal $S$ pseudo-update deadlines, or the
+random-walk limit $\tau_b=\infty$. In particular, the finite upper bound on
+$\tau_b$ is essential for a uniform 21-state stability margin.

--- a/doc/kalman_ou_iii/w3d-meas.tex-part
+++ b/doc/kalman_ou_iii/w3d-meas.tex-part
@@ -42,7 +42,7 @@ With calibrated world reference $\vct{B}_w$,
 \begin{equation}
 \vct{m}_b=\Rot_{wb}\vct{B}_w+\vct{n}_m,
 \qquad
-\vct{n}_m\sim\mathcal{N}(0,\mat{R}_m),
+\vct{n}_m\sim\mathcal{N}(0,\mat{R}_m)$,
 \label{eq:mag-meas}
 \end{equation}
 and
@@ -97,7 +97,10 @@ seconds rather than as every $N$ samples makes the regularization rate invariant
 to the IMU sample rate; the same $T_S$ produces the same number of updates per
 unit time at 100, 200, or 400~Hz.  The effective regularization strength still
 depends on both $\vct{r}_S$ and $T_S$, so comparisons of tuning laws assume a
-fixed pseudo-update cadence unless stated otherwise.
+fixed pseudo-update cadence unless stated otherwise.  Appendix~\ref{app:iss-stability}
+uses the narrower exact-$T_S$ spacing assumption for its translational
+observability lemma; general sample-time quantization of these deadlines under
+variable $h_k$ is not part of that theorem.
 
 \subsection{IMU lever-arm model}
 If the IMU is displaced from the center of gravity by known body-frame vector
@@ -114,6 +117,6 @@ Their second-order coupling through attitude uncertainty is neglected, so the
 state Jacobians remain those of \eqref{eq:acc-meas}.  Setting $\vct{r}_b=0$
 disables the correction.
 
-The optional steady-heel frame transform is documented in
-Appendix~\ref{sec:heel}. It is outside the evaluated configuration and is
-disabled for all results in this paper.
+The optional steady-heel frame transform is retained in the repository as
+companion material. It is outside the evaluated configuration and is disabled
+for all results in this paper.

--- a/doc/kalman_ou_iii/w3d-ou-robustness.tex-part
+++ b/doc/kalman_ou_iii/w3d-ou-robustness.tex-part
@@ -46,8 +46,7 @@ $\times\OURobustnessWorstScale$, differing from nominal by
 ($[\OURobustnessWorstDifferenceLow,\OURobustnessWorstDifferenceHigh]$).
 The sweeps also show competing objectives: changing $r_S$ can improve the
 vertical score while changing 3D displacement, and changing $\sigma_{aw}$ can
-alter pitch even when vertical displacement changes little.  Accordingly, no
-sweep point is adopted as a replacement tuning; the sweep is interpreted as
+alter pitch even when vertical displacement changes little.  Accordingly, no sweep point is adopted as a replacement tuning; the sweep is interpreted as
 local sensitivity rather than an offline search for a new operating point.
 
 \paragraph{Why the direct $\tau$ and $\sigma_{aw}$ effects are weak}

--- a/doc/kalman_ou_iii/w3d-sim-charts.tex-part
+++ b/doc/kalman_ou_iii/w3d-sim-charts.tex-part
@@ -46,6 +46,7 @@ Gauss--Markov process, so the validation includes process-model mismatch.
     \midrule
     IMU rate & \SI{200}{\hertz} & prediction and accel update \\
     Magnetometer rate & \SI{25}{\hertz} & asynchronous update \\
+    $S$ pseudo-update period & \SI{15}{\milli\second} & three IMU samples \\
     Accel white noise & \SI{0.0148}{\meter\per\second\squared} & RMS per sample \\
     Accel bias RW & \SI{5e-4}{\meter\per\second\squared\per\second\tothe{0.5}} & truth model \\
     Gyro white noise & \SI{0.00157}{\radian\per\second} & RMS per sample \\
@@ -55,6 +56,14 @@ Gauss--Markov process, so the validation includes process-model mismatch.
     \bottomrule
   \end{tabular}
 \end{table}
+
+Temperature is not varied in the scored simulations, and no separate thermal
+calibration-error, lag, or hysteresis experiment is included.  The
+finite-$\tau_b$ temperature-centered residual is therefore a structural sensor
+model used by the estimator and stability analysis, not a demonstrated
+temperature-compensation performance contribution.  Empirically, the relevant
+result here is robustness to the deliberate mismatch between that residual
+model and the random-walk accelerometer-bias truth process.
 
 All deterministic and ensemble comparisons use the final \SI{900}{s} of each
 record, excluding startup while retaining a long common scoring interval.

--- a/doc/kalman_ou_iii/w3d-sim-results-generated.tex-part
+++ b/doc/kalman_ou_iii/w3d-sim-results-generated.tex-part
@@ -54,6 +54,6 @@
   T/A/U = Toward/Away/Uncertain (\% of samples).  These are the estimator's
   own FORWARD/BACKWARD/UNCERTAIN classes, which are defined against the axis
   representative it returns and are therefore a commitment rate rather than a
-  correctness rate; the truth-referenced travel-sense correctness rate is in
-  Table~\ref{tab:ou_mc_direction}.
+  correctness rate; truth-referenced travel-sense correctness is reported
+  separately in the ten-seed direction analysis.
 \end{table}

--- a/plots/kalman_ou_iii/baseline-comparison.py
+++ b/plots/kalman_ou_iii/baseline-comparison.py
@@ -85,7 +85,7 @@ def write_tables(rows, output):
     lines = [
         r"\begin{table*}[t]",
         r"  \centering",
-        r"  \caption{Paired vertical-displacement RMS error for the proposed OU--III estimator, its OU--II predecessor, the adaptive PII observer, and the published TVG--NLO baseline. All values use the same reference records and final \SI{900}{s} scoring window.}",
+        r"  \caption{Common-record deterministic vertical-displacement RMS error for the proposed OU--III estimator, its OU--II predecessor, the adaptive PII observer, and the adapted TVG--NLO baseline. All values use the same reference records and final \SI{900}{s} scoring window; this is not the ten-seed paired inferential comparison.}",
         r"  \label{tab:multi_observer_scenario_comparison}",
         r"  \footnotesize",
         r"  \setlength{\tabcolsep}{4.0pt}",
@@ -119,7 +119,7 @@ def write_tables(rows, output):
     lines += [
         r"\begin{table}[t]",
         r"  \centering",
-        r"  \caption{Aggregate comparison over all eight paired wave cases.}",
+        r"  \caption{Aggregate deterministic comparison over all eight common-record wave cases.}",
         r"  \label{tab:multi_observer_aggregate_comparison}",
         r"  \footnotesize",
         r"  \setlength{\tabcolsep}{3.0pt}",

--- a/tests/validation/Makefile
+++ b/tests/validation/Makefile
@@ -8,6 +8,7 @@ build:
 		test_ou_validation.py \
 		test_ou_robustness.py \
 		test_record_conventions.py \
+		test_publication_references.py \
 		test_workflow_contract.py \
 		test_zz_publication_contract.py
 

--- a/tests/validation/test_publication_references.py
+++ b/tests/validation/test_publication_references.py
@@ -1,10 +1,11 @@
-"""Static cross-reference audit for the OU-III publication source.
+"""Static reference audit for the OU-III publication source.
 
-LaTeX normally treats an unresolved ``\\ref`` as a warning and still produces a
-PDF.  For the publication manuscript that is too permissive: a stripped table
-or appendix can silently become ``??``.  This test walks the main manuscript's
-reachable source files and requires every source-level ref/eqref/cref target to
-have a reachable label.
+LaTeX normally treats an unresolved cross-reference or citation as a warning and
+still produces a PDF.  For the publication manuscript that is too permissive: a
+stripped table, appendix, or bibliography item can silently become ``??``.  This
+test walks the main manuscript's reachable source files and requires every
+source-level cross-reference to have a reachable label and every citation key to
+exist in the manuscript bibliography databases.
 """
 
 import re
@@ -18,7 +19,10 @@ MAIN = DOC / "kalman_ou-w3d.tex"
 
 INPUT_RE = re.compile(r"\\input\{([^}]+)\}")
 LABEL_RE = re.compile(r"\\label\{([^}]+)\}")
-REF_RE = re.compile(r"\\(?:eqref|ref|cref|Cref)\{([^}]+)\}")
+REF_RE = re.compile(r"\\(?:eqref|ref|cref|Cref|autoref|pageref)\{([^}]+)\}")
+CITE_RE = re.compile(r"\\cite(?:\[[^\]]*\])?\{([^}]+)\}")
+BIBLIOGRAPHY_RE = re.compile(r"\\bibliography\{([^}]+)\}")
+BIB_ENTRY_RE = re.compile(r"@\w+\s*\{\s*([^,\s]+)\s*,", re.I)
 COMMENT_RE = re.compile(r"(?<!\\)%.*$")
 
 
@@ -57,6 +61,17 @@ def reachable_sources() -> dict[Path, str]:
     return sources
 
 
+def bibliography_keys(main_source: str) -> set[str]:
+    keys: set[str] = set()
+    for group in BIBLIOGRAPHY_RE.findall(main_source):
+        for name in group.split(","):
+            path = DOC / f"{name.strip()}.bib"
+            if not path.is_file():
+                raise AssertionError(f"missing bibliography database: {path.name}")
+            keys.update(BIB_ENTRY_RE.findall(strip_comments(path.read_text(encoding="utf-8"))))
+    return keys
+
+
 class PublicationReferenceTests(unittest.TestCase):
     def test_every_reachable_cross_reference_has_a_reachable_label(self):
         sources = reachable_sources()
@@ -71,6 +86,17 @@ class PublicationReferenceTests(unittest.TestCase):
                 if target not in labels:
                     missing.append((path.name, target))
         self.assertEqual(missing, [], f"unresolved publication references: {missing}")
+
+    def test_every_reachable_citation_has_a_bibliography_entry(self):
+        sources = reachable_sources()
+        available = bibliography_keys(sources[MAIN])
+        missing: list[tuple[str, str]] = []
+        for path, text in sources.items():
+            for group in CITE_RE.findall(text):
+                for key in (item.strip() for item in group.split(",")):
+                    if key and key not in available:
+                        missing.append((path.name, key))
+        self.assertEqual(missing, [], f"undefined publication citations: {missing}")
 
     def test_removed_unevaluated_appendices_are_not_referenced(self):
         sources = reachable_sources()

--- a/tests/validation/test_publication_references.py
+++ b/tests/validation/test_publication_references.py
@@ -1,0 +1,83 @@
+"""Static cross-reference audit for the OU-III publication source.
+
+LaTeX normally treats an unresolved ``\\ref`` as a warning and still produces a
+PDF.  For the publication manuscript that is too permissive: a stripped table
+or appendix can silently become ``??``.  This test walks the main manuscript's
+reachable source files and requires every source-level ref/eqref/cref target to
+have a reachable label.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOC = REPO_ROOT / "doc" / "kalman_ou_iii"
+MAIN = DOC / "kalman_ou-w3d.tex"
+
+INPUT_RE = re.compile(r"\\input\{([^}]+)\}")
+LABEL_RE = re.compile(r"\\label\{([^}]+)\}")
+REF_RE = re.compile(r"\\(?:eqref|ref|cref|Cref)\{([^}]+)\}")
+COMMENT_RE = re.compile(r"(?<!\\)%.*$")
+
+
+def strip_comments(text: str) -> str:
+    return "\n".join(COMMENT_RE.sub("", line) for line in text.splitlines())
+
+
+def resolve_input(name: str) -> Path | None:
+    # The standalone *-study sources are selected only when
+    # OUStandaloneDetailedResults is defined, which the main paper never does.
+    if name.endswith("-study.tex-part"):
+        return None
+    path = DOC / name
+    if path.is_file():
+        return path
+    for suffix in (".tex", ".tex-part"):
+        candidate = DOC / f"{name}{suffix}"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def reachable_sources() -> dict[Path, str]:
+    pending = [MAIN]
+    sources: dict[Path, str] = {}
+    while pending:
+        path = pending.pop()
+        if path in sources:
+            continue
+        text = strip_comments(path.read_text(encoding="utf-8"))
+        sources[path] = text
+        for name in INPUT_RE.findall(text):
+            child = resolve_input(name)
+            if child is not None and child not in sources:
+                pending.append(child)
+    return sources
+
+
+class PublicationReferenceTests(unittest.TestCase):
+    def test_every_reachable_cross_reference_has_a_reachable_label(self):
+        sources = reachable_sources()
+        labels = {
+            label
+            for text in sources.values()
+            for label in LABEL_RE.findall(text)
+        }
+        missing: list[tuple[str, str]] = []
+        for path, text in sources.items():
+            for target in REF_RE.findall(text):
+                if target not in labels:
+                    missing.append((path.name, target))
+        self.assertEqual(missing, [], f"unresolved publication references: {missing}")
+
+    def test_removed_unevaluated_appendices_are_not_referenced(self):
+        sources = reachable_sources()
+        combined = "\n".join(sources.values())
+        for label in ("sec:heel", "sec:gps_fusion"):
+            self.assertNotIn(rf"\ref{{{label}}}", combined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/validation/test_publication_references.py
+++ b/tests/validation/test_publication_references.py
@@ -82,9 +82,10 @@ class PublicationReferenceTests(unittest.TestCase):
         }
         missing: list[tuple[str, str]] = []
         for path, text in sources.items():
-            for target in REF_RE.findall(text):
-                if target not in labels:
-                    missing.append((path.name, target))
+            for group in REF_RE.findall(text):
+                for target in (item.strip() for item in group.split(",")):
+                    if target and target not in labels:
+                        missing.append((path.name, target))
         self.assertEqual(missing, [], f"unresolved publication references: {missing}")
 
     def test_every_reachable_citation_has_a_bibliography_entry(self):

--- a/tests/validation/test_zz_publication_contract.py
+++ b/tests/validation/test_zz_publication_contract.py
@@ -2,8 +2,8 @@
 
 The numerical/statistical tests remain in ``test_ou_validation``.  The paper
 cleanup intentionally changed wording and moved some detailed tables into the
-standalone study, so six historical tests that pinned exact prose are replaced
-here with semantic assertions against the current publication structure.
+standalone study, so historical tests that pinned exact prose are replaced here
+with semantic assertions against the current publication structure.
 
 The filename is intentionally sorted after ``test_ou_validation.py``.  Unittest
 discovers the original TestCase classes first; these replacements are installed
@@ -124,6 +124,7 @@ def _inference_is_qualified_rather_than_asserted(self):
     self.assertIn("not uncertainty over alternative simulators", results)
     self.assertIn("Only OU--II is evaluated under the full paired inferential protocol", results)
     self.assertIn("frequency-domain double-integration", results)
+    self.assertIn("OUValidationNormalizedRandomizationP", results)
 
     self.assertIn("degradation result rather than a pure adaptation-rate measurement", robustness)
     self.assertIn("holds the scored sea-state composition fixed", robustness)
@@ -249,6 +250,8 @@ core.ManuscriptMethodologyTests.test_baseline_fairness_thresholds_and_hardware_l
 
 
 class PublicationContractOverrideTests(unittest.TestCase):
+    DOC = REPO_ROOT / "doc" / "kalman_ou_iii"
+
     def test_overrides_are_installed(self):
         self.assertIs(
             core.CommittedFullResultsTests.test_abstract_reports_committed_stationary_aggregate,
@@ -258,6 +261,56 @@ class PublicationContractOverrideTests(unittest.TestCase):
             core.ManuscriptMethodologyTests.test_inference_is_qualified_rather_than_asserted,
             _inference_is_qualified_rather_than_asserted,
         )
+
+    def test_bias_discretization_matches_the_stability_model(self):
+        analytic = (self.DOC / "w3d-analytic-coeff.tex-part").read_text(
+            encoding="utf-8"
+        )
+        stability = (self.DOC / "w3d-iss-stability.tex-part").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn(r"e^{-h/\tau_b}\Id", analytic)
+        self.assertIn(r"1-e^{-2h/\tau_b}", analytic)
+        self.assertNotIn(r"\Phi_{b_ab_a}=\Id", analytic)
+        self.assertIn(r"\phi_{b,k}=e^{-h_k/\tau_b}", stability)
+        self.assertIn(r"1-e^{-2h_k/\tau_b}", stability)
+
+    def test_stability_cadence_scope_matches_the_proof_matrix(self):
+        stability = (self.DOC / "w3d-iss-stability.tex-part").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("relative\ntimes $0,T_S,2T_S,3T_S$", stability)
+        self.assertIn("exact $S$-update spacing is an explicit theorem assumption", stability)
+        self.assertIn("sample-time jitter", stability)
+        self.assertIn(r"Sec.~\ref{sec:block-Phi-Qd}", stability)
+        self.assertNotIn("sec:discretization", stability)
+
+    def test_publication_does_not_reference_stripped_direction_table(self):
+        generated = (self.DOC / "w3d-sim-results-generated.tex-part").read_text(
+            encoding="utf-8"
+        )
+        generator = (REPO_ROOT / "tools" / "ou_sim_table.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertNotIn(r"\ref{tab:ou_mc_direction}", generated)
+        self.assertNotIn("Table~\\ref{tab:ou_mc_direction}", generator)
+
+    def test_external_baseline_captions_are_not_called_paired(self):
+        generator = (
+            REPO_ROOT / "plots" / "kalman_ou_iii" / "baseline-comparison.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("Common-record deterministic vertical-displacement", generator)
+        self.assertIn("Aggregate deterministic comparison", generator)
+        self.assertNotIn("Paired vertical-displacement RMS error", generator)
+        self.assertNotIn("all eight paired wave cases", generator)
+
+    def test_unevaluated_extensions_are_not_typeset_as_main_appendices(self):
+        manuscript = (self.DOC / "kalman_ou-w3d.tex").read_text(encoding="utf-8")
+        self.assertNotIn(r"\input{w3d-wind-heel.tex-part}", manuscript)
+        self.assertNotIn(r"\input{w3d-gps-fusion.tex-part}", manuscript)
+        self.assertIn(r"\input{w3d-iss-stability.tex-part}", manuscript)
+        self.assertTrue((self.DOC / "w3d-wind-heel.tex-part").is_file())
+        self.assertTrue((self.DOC / "w3d-gps-fusion.tex-part").is_file())
 
 
 if __name__ == "__main__":

--- a/tools/ou_sim_table.py
+++ b/tools/ou_sim_table.py
@@ -167,8 +167,8 @@ def format_table(rows: list[tuple[str, float, dict[str, Any]]]) -> str:
         "  T/A/U = Toward/Away/Uncertain (\\% of samples).  These are the estimator's",
         "  own FORWARD/BACKWARD/UNCERTAIN classes, which are defined against the axis",
         "  representative it returns and are therefore a commitment rate rather than a",
-        "  correctness rate; the truth-referenced travel-sense correctness rate is in",
-        "  Table~\\ref{tab:ou_mc_direction}.",
+        "  correctness rate; truth-referenced travel-sense correctness is reported",
+        "  separately in the ten-seed direction analysis.",
         "\\end{table}",
     ])
     return "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary
This is a focused manuscript/publication-readiness follow-up to PR #269.

- fixes the stale random-walk accelerometer-bias discretization so the main derivation matches the finite-`tau_b` OU model used by the implementation and stability proof
- tightens Appendix D to an explicit exact-`T_S` pseudo-update-spacing theorem; the scored 200 Hz / 15 ms configuration satisfies that assumption, while general sample-time jitter is now explicitly outside the theorem
- removes the known stripped-table and stale-section cross-reference causes and adds a static main-publication cross-reference/citation audit to validation CI
- reports the exact paired sign-flip/randomization p-value and removes the unsupported “four separate constructions” contribution wording
- labels PII/TVG-NLO tables as common-record deterministic comparisons rather than paired ensemble results
- reduces empirical prominence of the temperature-centered bias model: the paper now states that temperature is not swept and thermal compensation is not experimentally validated
- broadens modern heave/wave-estimation positioning using references already present in the bibliography
- removes the unevaluated wind/heel and GNSS appendices from the journal manuscript while retaining their source files as repository companion material

## Deliberately not done
No new numerical evidence is invented. A conventional spectral heave baseline, a stronger current published estimator under the ten-seed protocol, physical displacement-reference testing, and a varying-temperature experiment still require new experiments and remain limitations/future work. The alternative-tracker appendix is retained for now because the active method section still references those compiled alternatives; it can be moved to supplementary material in a later pure-layout pass without changing the evaluated method.

## Stack
This PR is intentionally based on `agent/fix-ou-validation-gate` / PR #269 so the manuscript-contract tests reflect the compact publication structure. After #269 lands, this PR can be retargeted to `main` without carrying the CI-gate changes in its diff.

No estimator/filter implementation or validation-number generation logic is changed.