### PR TITLE
Fit OU-III publication charts to one column and move ISS proof

### DIFF
--- a/doc/kalman_ou_iii/kalman_ou-w3d.tex
+++ b/doc/kalman_ou_iii/kalman_ou-w3d.tex
@@ -233,15 +233,14 @@ extended Kalman filter, inertial navigation, IMU, marine Motion Reference Unit, 
 \input{w3d-kalm-up.tex-part}
 \input{w3d-init.tex-part}
 \input{w3d-fus-methods.tex-part}
+\input{w3d-iss-stability.tex-part}
 \input{w3d-sim-charts.tex-part}
 \input{w3d-conclusion-summary.tex-part}
 
 \appendices
-% The evaluated stability result remains in the journal manuscript.  Optional
-% wind/heel and GNSS extensions are retained in the repository as companion
-% material rather than typeset as unevaluated publication appendices.
+% Alternative tracker policies remain as companion appendix material.  The ISS
+% proof is part of the main article text immediately before the evaluation.
 \input{w3d-tracker-alternatives.tex-part}
-\input{w3d-iss-stability.tex-part}
 
 \FloatBarrier
 \section*{Acknowledgments}

--- a/doc/kalman_ou_iii/w3d-baseline-comparison.tex-part
+++ b/doc/kalman_ou_iii/w3d-baseline-comparison.tex-part
@@ -79,13 +79,13 @@ include a conventional frequency-domain double-integration heave estimator.
 }
 
 \IfFileExists{ou_validation_vertical.svg}{%
-  \begin{figure*}[t]
+  \begin{figure}[t]
     \centering
-    \includesvg[width=0.90\textwidth,inkscapelatex=false]{ou_validation_vertical}
+    \includesvg[width=\columnwidth,inkscapelatex=false]{ou_validation_vertical}
     \caption{Ten-seed normalized vertical-displacement RMS for the adaptive and
     fixed-tuning variants. Error bars are paired-bootstrap 95\% intervals.}
     \label{fig:ou_mc_vertical}
-  \end{figure*}
+  \end{figure}
 }{}
 
 Across the four stationary JONSWAP seas, the seed-wise mean normalized vertical
@@ -128,7 +128,7 @@ travel sense is correct for \OUValidationTravelCorrect\% of samples, wrong for
 vessel-frame labels and are not themselves treated as physical truth.
 
 \paragraph{Adaptation mechanism}
-Table~\ref{tab:ou_mc_adaptation} shows that online tuning strongly reduces the
+Figure~\ref{fig:ou_mc_vertical} shows that online tuning strongly reduces the
 penalty of applying the single FixedNominal operating point to off-nominal seas.
 At the nominal $H_s=\SI{1.5}{m}$ sea, where FixedNominal and FixedOracle
 coincide by construction, OU--III Adaptive is slightly worse than the matched
@@ -165,15 +165,15 @@ full covariance-control table is retained with the archived validation study
 rather than repeated in the publication view.
 
 \IfFileExists{ou_validation_transition.svg}{%
-  \begin{figure*}[t]
+  \begin{figure}[t]
     \centering
-    \includesvg[width=0.90\textwidth,inkscapelatex=false]{ou_validation_transition}
+    \includesvg[width=\columnwidth,inkscapelatex=false]{ou_validation_transition}
     \caption{One OU--III Adaptive realization of the controlled transition.
     The shaded interval is the $420$--$780$~s crossfade; the lower traces show
     the applied $\tau$, $\sigma_{aw}$, and $r_S$ relative to the two fixed
     references.}
     \label{fig:ou_transition}
-  \end{figure*}
+  \end{figure}
 }{}
 
 \input{w3d-ou-robustness.tex-part}

--- a/doc/kalman_ou_iii/w3d-conclusion-summary.tex-part
+++ b/doc/kalman_ou_iii/w3d-conclusion-summary.tex-part
@@ -29,7 +29,7 @@ at high rate, while $r_S$ governs the weakly observed low-frequency drift
 channel.  Low-motion and rapid-transition cases bound the empirical claim to
 the tested signal-to-noise levels and transition construction.
 
-Appendix~\ref{app:iss-stability} establishes nominal local stability of the
+Section~\ref{app:iss-stability} establishes nominal local stability of the
 21-state Live error dynamics under bounded noncollinear reference geometry,
 bounded measurement gaps, exact $T_S$ spacing for the four integral-state
 pseudo-updates used on each translational proof horizon, finite positive

--- a/doc/kalman_ou_iii/w3d-intro.tex-part
+++ b/doc/kalman_ou_iii/w3d-intro.tex-part
@@ -45,10 +45,10 @@ narrower claim. Together with an online directional estimator, these elements
 address colored excitation and MEMS errors in an efficient, embedded-friendly
 framework.
 
-Appendix~\ref{app:iss-stability} gives a local 21-state stability result for the
+Section~\ref{app:iss-stability} gives a local 21-state stability result for the
 normal Live recursion under explicit operating conditions. Because the tuner is
 driven by raw IMU data and a private Mahony attitude solution, its schedule is
-exogenous with respect to the MEKF state. The appendix proves uniform
+exogenous with respect to the MEKF state. The section proves uniform
 finite-horizon observability of the OU--III translational block and of the
 attitude--gyro-bias block under bounded noncollinear accel/mag geometry. The
 formerly problematic accelerometer-bias coordinates are now residuals about the

--- a/doc/kalman_ou_iii/w3d-iss-stability.tex-part
+++ b/doc/kalman_ou_iii/w3d-iss-stability.tex-part
@@ -1,7 +1,7 @@
 \section{Analytical Observability, 21-State UES, and Local ISS}
 \label{app:iss-stability}
 
-This appendix analyzes the normal Live-state linearization of the implemented
+This section analyzes the normal Live-state linearization of the implemented
 OU--III estimator after replacing the accelerometer-bias random walk by a slow
 first-order Gauss--Markov residual about the deterministic temperature model.
 The change removes the neutral, nondecaying bias mode that prevented a

--- a/doc/kalman_ou_iii/w3d-ou-robustness.tex-part
+++ b/doc/kalman_ou_iii/w3d-ou-robustness.tex-part
@@ -14,28 +14,32 @@ change therefore gives $r_S\to c^{3}r_S$.  Two additional degradation cases
 test a low-motion $H_s=\SI{0.05}{m}$ record and a rapid \SI{30}{s} transition
 between the same endpoints used in the controlled case.
 
-\IfFileExists{w3d-ou-robustness-results-generated.tex-part}{%
-  \input{w3d-ou-robustness-results-generated.tex-part}%
-}{}
+\IfFileExists{w3d-ou-robustness-results-publication.tex-part}{%
+  \input{w3d-ou-robustness-results-publication.tex-part}%
+}{%
+  \IfFileExists{w3d-ou-robustness-results-generated.tex-part}{%
+    \input{w3d-ou-robustness-results-generated.tex-part}%
+  }{}
+}
 
 \IfFileExists{ou_robustness_sensitivity.svg}{%
-  \begin{figure*}[t]
+  \begin{figure}[t]
     \centering
-    \includesvg[width=0.82\textwidth,inkscapelatex=false]{ou_robustness_sensitivity}
+    \includesvg[width=\columnwidth,inkscapelatex=false]{ou_robustness_sensitivity}
     \caption{Ten-seed OU--III sensitivity around the nominal operating point.
     Error bars are paired-bootstrap 95\% intervals; the dashed line marks the
     frozen nominal point.}
     \label{fig:ou_robustness_sensitivity}
-  \end{figure*}
+  \end{figure}
 }{}
 
 \IfFileExists{ou_robustness_stress.svg}{%
-  \begin{figure*}[t]
+  \begin{figure}[t]
     \centering
-    \includesvg[width=0.88\textwidth,inkscapelatex=false]{ou_robustness_stress}
+    \includesvg[width=\columnwidth,inkscapelatex=false]{ou_robustness_stress}
     \caption{Low-motion and rapid-transition degradation cases.}
     \label{fig:ou_robustness_stress}
-  \end{figure*}
+  \end{figure}
 }{}
 
 Across the declared multiplier range, the largest mean normalized vertical

--- a/plots/kalman_ou_iii/draw_plots.sh
+++ b/plots/kalman_ou_iii/draw_plots.sh
@@ -63,16 +63,15 @@ cp -f ../../reports/results/ou_robustness/ou_robustness_stress.svg \
   "${DOC_DIR}/ou_robustness_stress.svg"
 
 # Keep the complete machine-generated validation tables as evidence, but make a
-# compact publication view.  Detailed covariance-control and per-scenario
-# direction tables remain in the full generated study; the main article reports
-# their load-bearing aggregate findings in prose.
+# compact publication view. Detailed covariance-control and per-scenario
+# direction tables remain in the full generated study. The adaptive/fixed
+# vertical table is also omitted from the publication because the same values
+# are already presented in Fig. ou_mc_vertical.
 python3 - <<'PY'
 from pathlib import Path
 
-src = Path("../../doc/kalman_ou_iii/w3d-ou-validation-results-generated.tex-part")
-dst = Path("../../doc/kalman_ou_iii/w3d-ou-validation-results-publication.tex-part")
-text = src.read_text(encoding="utf-8")
-for label in (r"\label{tab:ou_mc_covsync}", r"\label{tab:ou_mc_direction}"):
+
+def strip_table(text: str, label: str) -> str:
     pos = text.find(label)
     if pos < 0:
         raise RuntimeError(f"supplemental table label not found: {label}")
@@ -82,7 +81,48 @@ for label in (r"\label{tab:ou_mc_covsync}", r"\label{tab:ou_mc_direction}"):
     if start < 0 or end < 0:
         raise RuntimeError(f"could not delimit supplemental table: {label}")
     end += len(end_token)
-    text = text[:start].rstrip() + "\n\n" + text[end:].lstrip()
+    return text[:start].rstrip() + "\n\n" + text[end:].lstrip()
+
+src = Path("../../doc/kalman_ou_iii/w3d-ou-validation-results-generated.tex-part")
+dst = Path("../../doc/kalman_ou_iii/w3d-ou-validation-results-publication.tex-part")
+text = src.read_text(encoding="utf-8")
+for label in (
+    r"\label{tab:ou_mc_adaptation}",
+    r"\label{tab:ou_mc_covsync}",
+    r"\label{tab:ou_mc_direction}",
+):
+    text = strip_table(text, label)
+dst.write_text(text, encoding="utf-8")
+PY
+
+# The robustness publication keeps the generated scalar macros used by the
+# prose but omits the two full-width tables because both datasets are already
+# shown by the sensitivity and degradation figures. The detailed-results
+# document continues to consume the unfiltered generated file.
+python3 - <<'PY'
+from pathlib import Path
+
+
+def strip_table(text: str, label: str) -> str:
+    pos = text.find(label)
+    if pos < 0:
+        raise RuntimeError(f"supplemental table label not found: {label}")
+    start = text.rfind(r"\begin{table*}", 0, pos)
+    end_token = r"\end{table*}"
+    end = text.find(end_token, pos)
+    if start < 0 or end < 0:
+        raise RuntimeError(f"could not delimit supplemental table: {label}")
+    end += len(end_token)
+    return text[:start].rstrip() + "\n\n" + text[end:].lstrip()
+
+src = Path("../../doc/kalman_ou_iii/w3d-ou-robustness-results-generated.tex-part")
+dst = Path("../../doc/kalman_ou_iii/w3d-ou-robustness-results-publication.tex-part")
+text = src.read_text(encoding="utf-8")
+for label in (
+    r"\label{tab:ou_robustness_sensitivity}",
+    r"\label{tab:ou_robustness_stress}",
+):
+    text = strip_table(text, label)
 dst.write_text(text, encoding="utf-8")
 PY
 


### PR DESCRIPTION
## Summary
- move the analytical observability / 21-state UES / local ISS proof from the appendix into the main OU-III article, immediately before Evaluation
- convert the publication validation/transition/robustness charts from two-column `figure*` floats to single-column `figure` floats sized to `\columnwidth`
- remove publication-view tables that duplicate plotted data while preserving the complete generated evidence for the standalone detailed-results document

## Publication table cleanup
The compact main-paper generation now omits:
- `tab:ou_mc_adaptation` because the adaptive/fixed vertical results are already shown in `fig:ou_mc_vertical`
- `tab:ou_robustness_sensitivity` because the same sweep is shown in `fig:ou_robustness_sensitivity`
- `tab:ou_robustness_stress` because the same degradation cases are shown in `fig:ou_robustness_stress`

Existing supplemental-only covariance and direction tables remain filtered from the compact publication view. The full machine-generated validation and robustness tables are not deleted and remain available to the standalone detailed-results article.

## Kept tables
The main article still retains the tables that carry information not represented by the charts, including the 3D axis comparison, the 2x2 adaptation-channel ablation, and the transition interval breakdown.

## Scope / validation
- branch was created from current `main` commit `3fce75a4e25dd544227ac2f0da9ea71cac74e6a4`
- current `main` was rechecked before opening this PR and has not advanced
- branch is 7 commits ahead and 0 behind `main`
- changes are limited to OU-III manuscript/publication-generation files; estimator and validation data are unchanged
- local GitHub CLI/network access was unavailable in the execution environment, so compile/test validation is left to the repository CI triggered by this PR
