### PR TITLE
Fix brittle OU robustness wording assertion

### DIFF
--- a/tests/validation/test_ou_robustness.py
+++ b/tests/validation/test_ou_robustness.py
@@ -509,7 +509,8 @@ class CommittedRobustnessResultsTests(unittest.TestCase):
         # conclusion that the filter ignores its OU tuning.
         self.assertIn("coupled", source)
         self.assertIn(r"r_S\to c^{3}r_S", source)
-        self.assertIn("near saturation", source)
+        self.assertIn("latent-acceleration gain", source)
+        self.assertIn("saturation", source)
 
     def test_generated_primary_claims_match_paired_effects(self):
         effects = self.read_csv(


### PR DESCRIPTION
## Summary
- fix the single failing OU validation test from Actions run 31338964115 / job 93309977035
- replace the exact manuscript phrase assertion `near saturation` with semantic checks for `latent-acceleration gain` and `saturation`
- leave manuscript text, estimator code, generated evidence, and validation data unchanged

## Root cause
The manuscript says the latent-acceleration gain is `already close to saturation`, while the test required the exact literal phrase `near saturation`. The technical meaning is unchanged, so the exact wording check was unnecessarily brittle.

## Scope
- based on merged `main` commit `b5d64151f081c3f221738a108c3bd040d2dbfa5c`
- one file changed
- 2 additions, 1 deletion
- branch is 1 commit ahead and 0 behind `main`

The failing run had 77 tests with only this one failure (and one unrelated skipped test); all other validation tests passed before the workflow stopped.