### PR TITLE
Publish Lie-group paper PDF with releases

### DIFF
--- a/.github/workflows/kalman-tfg-paper.yml
+++ b/.github/workflows/kalman-tfg-paper.yml
@@ -1,0 +1,59 @@
+name: kalman-tfg-paper
+
+on:
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  paper:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Compile TFG LaTeX paper
+        id: latex
+        continue-on-error: true
+        uses: xu-cheng/latex-action@v4
+        with:
+          root_file: "*.tex"
+          working_directory: doc/kalman_tfg
+          work_in_root_file_dir: true
+          latexmk_use_lualatex: true
+          latexmk_shell_escape: true
+          args: "-shell-escape"
+          extra_system_packages: "inkscape ghostscript graphviz ncurses"
+
+      - name: Compile TFG LaTeX paper, retry
+        if: steps.latex.outcome == 'failure'
+        uses: xu-cheng/latex-action@v4
+        with:
+          root_file: "*.tex"
+          working_directory: doc/kalman_tfg
+          work_in_root_file_dir: true
+          latexmk_use_lualatex: true
+          latexmk_shell_escape: true
+          args: "-shell-escape"
+          extra_system_packages: "inkscape ghostscript graphviz ncurses"
+
+      - name: Upload PDF artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: latex-pdfs-kalman_tfg
+          path: doc/kalman_tfg/**/*.pdf
+          if-no-files-found: error
+
+      - name: Upload PDF to release
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: doc/kalman_tfg/*.pdf
+          tag: ${{ github.ref == 'refs/heads/main' && 'vTest' || github.ref_name }}
+          overwrite: true
+          file_glob: true

--- a/.github/workflows/tfg-validation.yml
+++ b/.github/workflows/tfg-validation.yml
@@ -6,14 +6,12 @@ on:
       - 'src/kalman_tfg/**'
       - 'src/lie/**'
       - 'tests/kalman_tfg/**'
-      - 'doc/kalman_tfg/**'
       - '.github/workflows/tfg-validation.yml'
   pull_request:
     paths:
       - 'src/kalman_tfg/**'
       - 'src/lie/**'
       - 'tests/kalman_tfg/**'
-      - 'doc/kalman_tfg/**'
       - '.github/workflows/tfg-validation.yml'
   workflow_dispatch:
 
@@ -74,25 +72,3 @@ jobs:
           W3D_WRITE_TIMESERIES: '0'
           W3D_COLLECT_ALL_GATES: '1'
         run: ./kalman_tfg-sim
-
-  paper:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Compile TFG LaTeX paper
-        uses: xu-cheng/latex-action@v4
-        with:
-          root_file: kalman_tfg.tex
-          working_directory: doc/kalman_tfg
-          work_in_root_file_dir: true
-          latexmk_use_lualatex: true
-
-      - name: Upload TFG paper PDF
-        uses: actions/upload-artifact@v6
-        with:
-          name: latex-pdfs-kalman-tfg
-          path: doc/kalman_tfg/kalman_tfg.pdf
-          if-no-files-found: error


### PR DESCRIPTION
## What changed

- adds a dedicated `kalman-tfg-paper` workflow using the same LaTeX action and release-upload convention as the repository's other papers
- publishes the Actions artifact as `latex-pdfs-kalman_tfg`
- uploads `doc/kalman_tfg/*.pdf` to the branch-named release off `main`, and to `vTest` on `main`, matching the existing repository release convention
- keeps overwrite + glob behavior consistent with the main release job
- removes the duplicate paper-build job and document-only triggers from `tfg-validation.yml`, leaving that workflow focused on mathematical/code validation

## Why

The previous implementation built the paper in `tfg-validation.yml` and uploaded only an Actions artifact. The repository's release publishing happens separately, so `kalman_tfg.pdf` never appeared in the GitHub release assets.

## Validation

The new workflow is triggered by this branch push. Its successful completion should create/update the `agent/publish-kalman-tfg-paper` release with `kalman_tfg.pdf`. After merge, pushes to `main` publish the same PDF to `vTest`.