### PR TITLE
Make OU-III local ISS theorem assumptions explicit

### DIFF
--- a/doc/kalman_ou_iii/kalman_ou-w3d.tex
+++ b/doc/kalman_ou_iii/kalman_ou-w3d.tex
@@ -234,6 +234,7 @@ extended Kalman filter, inertial navigation, IMU, marine Motion Reference Unit, 
 \input{w3d-init.tex-part}
 \input{w3d-fus-methods.tex-part}
 \input{w3d-iss-stability.tex-part}
+\input{w3d-iss-theorem-audit.tex-part}
 \input{w3d-sim-charts.tex-part}
 \input{w3d-conclusion-summary.tex-part}
 

--- a/doc/kalman_ou_iii/w3d-iss-theorem-audit.tex-part
+++ b/doc/kalman_ou_iii/w3d-iss-theorem-audit.tex-part
@@ -1,0 +1,140 @@
+\subsection{External stability theorem and hypothesis audit}
+\label{sec:iss-theorem-audit}
+
+The preceding argument is intentionally constructive up to the final Riccati
+step, but that step should not be hidden behind the phrase ``standard Kalman
+stability theory.''  The external result used in
+Theorem~\ref{thm:iss-21-ues} is the discrete-time linear time-varying (LTV)
+detectability/stabilizability theory of Anderson and Moore
+\cite{AndersonMoore1981_DetectabilityStabilizability}, together with the
+singular-transition extension of Moore and Anderson
+\cite{MooreAnderson1980_SingularTransitionStability}.  The latter is relevant
+because no nonsingularity assumption on every state-transition matrix is needed.
+For this paper, only the following specialization of those results is used.
+
+\begin{theorem}[LTV Kalman stability implication used here]
+\label{thm:iss-external-kalman}
+Consider a discrete-time LTV estimation model
+\begin{equation}
+\vct x_{k+1}=\mat F_k\vct x_k+\vct w_k,
+\qquad
+\vct y_k=\mat H_k\vct x_k+\vct v_k,
+\end{equation}
+with uniformly bounded $\mat F_k$ and $\mat H_k$.  Suppose that
+$(\mat F_k,\mat H_k)$ is uniformly detectable,
+$(\mat F_k,\mat Q_k^{1/2})$ is uniformly stabilizable, and there are constants
+$0<q_-\le q_+<\infty$ and $0<r_-\le r_+<\infty$ such that
+\begin{equation}
+q_-\mat I\preceq\mat Q_k\preceq q_+\mat I,
+\qquad
+r_-\mat I\preceq\mat R_k\preceq r_+\mat I.
+\label{eq:iss-external-kalman-hyp}
+\end{equation}
+Then the stabilizing Kalman/Riccati recursion has uniform positive lower and
+upper covariance bounds and its homogeneous estimation-error transition is
+uniformly exponentially stable: for some $M\ge1$ and $0<\rho<1$,
+\begin{equation}
+\|\Psi(k,j)\|\le M\rho^{k-j},\qquad k\ge j.
+\label{eq:iss-external-kalman-conclusion}
+\end{equation}
+\end{theorem}
+
+The statement above is the specialization of the cited LTV filtering results
+needed here, not a new independent theorem.  It makes explicit the implication
+invoked in the proof of Theorem~\ref{thm:iss-21-ues}.
+
+For OU--III, the hypotheses of
+Theorem~\ref{thm:iss-external-kalman} are witnessed on every \emph{admissible
+Live interval} as follows:
+\begin{equation}
+\boxed{\begin{aligned}
+\text{uniform detectability:}\quad
+ &\text{Lemma~\ref{lem:iss-21-detectable}},\\
+\text{uniform stabilizability:}\quad
+ &\mat Q_k^{\mathrm{eff}}\succeq q_-\mat I>0,
+   \ \text{Eq.~\eqref{eq:iss-Qeff-bounds}},\\
+\text{measurement covariance:}\quad
+ &\underline r\mat I\preceq\mat R_k\preceq\overline r\mat I,
+   \ \text{Eq.~\eqref{eq:iss-R-bounds}},\\
+\text{bounded }\mat F_k,\mat H_k:\quad
+ &\text{Eqs.~\eqref{eq:iss-step-tau-bounds},
+   \eqref{eq:iss-vector-magnitude-bounds},
+   \eqref{eq:iss-vector-geometry}}.
+\end{aligned}}
+\label{eq:iss-theorem-hypothesis-map}
+\end{equation}
+Because $\mat Q_k^{\mathrm{eff}}$ is uniformly positive definite, the process
+input is full rank at every step; this is stronger than the uniform
+stabilizability condition required by the cited LTV theorem.  Thus
+Eq.~\eqref{eq:iss-theorem-hypothesis-map} is the explicit bridge from the
+OU--III lemmas and covariance bounds to the UES conclusion
+Eq.~\eqref{eq:iss-21-ues}.
+
+\paragraph{Default implementation bounds.}
+For the default adaptive fusion wrapper with its parameter clamps enabled, the
+source code supplies concrete finite bounds for the tuning variables rather
+than merely assuming their existence.  The defaults give
+\begin{equation}
+\begin{gathered}
+\SI{0.02}{s}\le\tau_k\le\SI{12}{s},\\
+\SI{0.12}{m/s^2}\le\sigma_{z,k}\le\SI{6}{m/s^2},
+\qquad
+\sigma_{x,k}=\sigma_{y,k}=1.87\,\sigma_{z,k},\\
+0.4\le r_{S,k}\le400\ \mathrm{m\,s},
+\qquad
+\tau_b=\SI{5000}{s}.
+\end{gathered}
+\label{eq:iss-default-implementation-bounds}
+\end{equation}
+The lower acceleration scale is the default \SI{0.12}{m/s^2} tuning noise
+floor used when the OU stationary covariance is applied.  The underlying MEKF
+also clamps a directly supplied OU time constant away from zero, and the default
+legacy raw $P_{a_wa_w}$ replacement is disabled, leaving the proof-compatible
+positive-semidefinite covariance-inflation path active.
+
+At the fixed-rate validation point quoted in the proof,
+\begin{equation}
+h=\SI{5}{ms},\qquad T_S=\SI{15}{ms}=3h,
+\label{eq:iss-fixed-rate-cadence-check}
+\end{equation}
+so the four required $S$ observations occur on exact sample boundaries.  This
+checks the cadence assumption for that validation configuration; it is not a
+claim that arbitrary variable-step deployment automatically has exact
+$T_S$ spacing.
+
+\begin{table}[t]
+\caption{Audit of the conditions entering the local ISS claim.}
+\label{tab:iss-condition-audit}
+\centering
+\footnotesize
+\begin{tabular}{@{}p{0.30\columnwidth}p{0.64\columnwidth}@{}}
+\toprule
+Condition & Status in the OU--III argument \\
+\midrule
+21-state uniform detectability & Proved by Lemma~\ref{lem:iss-21-detectable}: the 18-state block is UCO and the residual accelerometer-bias OU block contracts with $\rho_b<1$. \\
+Uniform stabilizability & Proved from the full-rank positive process covariance, Eq.~\eqref{eq:iss-Qeff-bounds}. \\
+Positive bounded $R_k$ & Explicit theorem/configuration assumption, Eq.~\eqref{eq:iss-R-bounds}; callers must retain nonzero finite sensor and pseudo-measurement covariances. \\
+Bounded adaptive schedule & Enforced by the default fusion-wrapper clamps; concrete values are displayed in Eq.~\eqref{eq:iss-default-implementation-bounds}. \\
+Predictable schedule & Enforced by staging the tuner result for the following IMU sample, Eq.~\eqref{eq:iss-predictable-schedule}. \\
+Exact $S$ cadence & Satisfied by the fixed \SI{200}{Hz} validation, Eq.~\eqref{eq:iss-fixed-rate-cadence-check}; otherwise a Live-interval assumption. \\
+Vector excitation & Live-interval assumption: accepted accelerometer/magnetometer pairs must satisfy Eqs.~\eqref{eq:iss-vector-magnitude-bounds}--\eqref{eq:iss-vector-gap}. \\
+No reset/outage & Live-interval assumption; startup, hard reset, re-lock, and arbitrarily long rejection/outage patterns remain outside the theorem. \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+Consequently, the paper's statement is conditional but explicit: whenever the
+rows marked as Live-interval assumptions hold, the remaining hypotheses are
+proved or supplied by the stated default configuration, so
+Theorem~\ref{thm:iss-external-kalman} yields the UES bound and the subsequent
+local nonlinear argument yields ISS.  A field run that violates a conditional
+row is outside the proved interval rather than a counterexample to the theorem.
+
+Finally, the notion of discrete-time input-to-state stability used in
+Theorem~\ref{thm:iss-21-local} follows the framework of Jiang and Wang
+\cite{JiangWang2001_DiscreteISS}.  That citation supplies the standard
+finite-dimensional discrete-time ISS definition and Lyapunov/small-gain
+framework.  The OU--III paper does not use that result as an unshown black box:
+Eq.~\eqref{eq:iss-local-bound} is obtained directly by variation of constants
+from the UES estimate, followed by the displayed local small-gain condition
+$Mc_\varphi r/(1-\rho)<1$.

--- a/doc/kalman_ou_iii/w3d-iss.bib
+++ b/doc/kalman_ou_iii/w3d-iss.bib
@@ -18,3 +18,36 @@
     year      = {2002},
     isbn      = {978-0-13-067389-3}
 }
+
+@article{MooreAnderson1980_SingularTransitionStability,
+    author  = {Moore, J. B. and Anderson, B. D. O.},
+    title   = {Coping with Singular Transition Matrices in Estimation and Control Stability Theory},
+    journal = {International Journal of Control},
+    year    = {1980},
+    volume  = {31},
+    number  = {3},
+    pages   = {571--586},
+    doi     = {10.1080/00207178008961063}
+}
+
+@article{AndersonMoore1981_DetectabilityStabilizability,
+    author  = {Anderson, B. D. O. and Moore, J. B.},
+    title   = {Detectability and Stabilizability of Time-Varying Discrete-Time Linear Systems},
+    journal = {SIAM Journal on Control and Optimization},
+    year    = {1981},
+    volume  = {19},
+    number  = {1},
+    pages   = {20--32},
+    doi     = {10.1137/0319002}
+}
+
+@article{JiangWang2001_DiscreteISS,
+    author  = {Jiang, Zhong-Ping and Wang, Yuan},
+    title   = {Input-to-State Stability for Discrete-Time Nonlinear Systems},
+    journal = {Automatica},
+    year    = {2001},
+    volume  = {37},
+    number  = {6},
+    pages   = {857--869},
+    doi     = {10.1016/S0005-1098(01)00028-0}
+}


### PR DESCRIPTION
## Summary

Make the OU-III paper's local ISS argument auditable instead of relying on an unexplained "standard Kalman stability theory" step.

### What changed

- add an explicit statement of the discrete-time LTV Kalman stability implication used by the 21-state UES proof;
- cite Anderson & Moore (1981) for time-varying detectability/stabilizability and Moore & Anderson (1980) for the singular-transition filtering stability extension;
- cite Jiang & Wang (2001) for the discrete-time ISS framework;
- add a boxed mapping from each external Kalman theorem hypothesis to the corresponding OU-III lemma/equation;
- display concrete default tuning bounds (`tau`, `sigma_aw`, `r_S`, and `tau_b`) supplied by the implementation;
- explicitly check the fixed-rate `h = 5 ms`, `T_S = 15 ms = 3h` cadence used by validation;
- add a condition-audit table distinguishing what is **proved**, what is **enforced by the default implementation**, and what remains a **conditional Live-interval assumption** (measurement excitation, exact cadence outside fixed-rate validation, no reset/outage, bounded measurement covariance).

## Rigor / scope

This intentionally does **not** claim that every field run automatically satisfies the ISS theorem. In particular, accepted accel/mag updates with non-collinear geometry, bounded update gaps, no hard reset, and exact pseudo-update cadence are still assumptions of the certified Live interval. The PR makes those limitations more visible rather than weakening them.

## Validation

- branch is based on current `main` (`7151df0a59f4751a1df522a78dee6e96e6b21127`);
- changes are confined to the OU-III manuscript and bibliography;
- the repository `build` workflow and `ou-validation` workflow both trigger for this PR, including the `kalman_ou_iii` LaTeX build.

Local clone/build was not available in this tool environment because outbound DNS from the execution container is disabled, so GitHub Actions is the authoritative compilation check for the PR.