### PR TITLE
Add local ISS stability proof for OU-II

### DIFF
--- a/doc/kalman_ou_ii/kalman_ou_ii-charts.tex
+++ b/doc/kalman_ou_ii/kalman_ou_ii-charts.tex
@@ -1,6 +1,7 @@
 \documentclass[11pt,letterpaper]{article}
 \usepackage{amsmath}
 \usepackage{amssymb}
+\usepackage{amsthm}
 \usepackage{fullpage}
 \usepackage{mathrsfs}
 \usepackage{graphicx}
@@ -14,6 +15,9 @@
 \usepackage{microtype}
 \usepackage{siunitx}
 \usepackage{array,booktabs,makecell,adjustbox}
+
+\newtheorem{lemma}{Lemma}
+\newtheorem{theorem}{Theorem}
 
 % Keep this — needed by PGF outputs that reference \mathdefault
 \providecommand{\mathdefault}[1]{#1}
@@ -82,6 +86,8 @@ only at step $k+1$. Thus, for the measurement filtration $\mathcal F_k$,
 the active schedule obeys $\vartheta_k\in\mathcal F_{k-1}$. At the nominal
 \SI{200}{Hz} IMU rate the added delay is about \SI{5}{ms}, negligible beside
 the adaptation horizons.
+
+\input{ou2-iss-stability.tex-part}
 
 % PM Stokes
     \begin{figure}[H]\centering
@@ -317,5 +323,8 @@ the adaptation horizons.
     \caption{Kalman 3D filter gyroscope bias convergence — JONSWAP, high $H_s$.}
     \label{fig:w3d_ou2_jonswap_high_gyro_bias}
     \end{figure}
+
+\bibliographystyle{IEEEtran}
+\bibliography{ou2-iss}
 
 \end{document}

--- a/doc/kalman_ou_ii/ou2-iss-stability.tex-part
+++ b/doc/kalman_ou_ii/ou2-iss-stability.tex-part
@@ -1,0 +1,424 @@
+\section{Local ISS Stability of the OU--II Live Recursion}
+\label{sec:ou2-iss}
+
+This section gives a local input-to-state stability (ISS) result for the normal
+OU--II Live-state estimator implemented by
+\texttt{Kalman3D\_Wave\_OU\_II}.  The proof parallels the OU--III argument but
+uses the shorter translational chain $[v,p,a_w]$.  It applies only on an
+admissible Live interval: startup, hard attitude resets, re-lock operations,
+arbitrarily long measurement rejection/outage patterns, and the optional legacy
+raw $P_{a_wa_w}$ covariance replacement are outside the theorem.
+
+With gyro and accelerometer biases enabled, order the local error state as
+\begin{equation}
+ e=
+ \begin{bmatrix}
+ \delta\theta^\top&\widetilde b_g^\top&
+ \widetilde v^\top&\widetilde p^\top&\widetilde a_w^\top&
+ \widetilde b_a^\top
+ \end{bmatrix}^{\!\top}\in\mathbb R^{18}.
+ \label{eq:ou2-iss-state}
+\end{equation}
+The accelerometer-bias state is the stochastic residual about the deterministic
+temperature model.  In the proof-compatible Live configuration it is a slow
+first-order Gauss--Markov process with finite correlation time $\tau_b$.
+
+\subsection{Admissible Live interval and exogenous scheduling}
+
+The online tuning variables are treated as exogenous signals
+\begin{equation}
+ \vartheta_k=(\tau_k,\sigma_{aw,k},r_{p0,k},r_{v0,k}).
+ \label{eq:ou2-iss-schedule}
+\end{equation}
+As described above, the implementation stages a candidate computed after sample
+$k$ and commits it only before sample $k+1$, so
+$\vartheta_k\in\mathcal F_{k-1}$.  The deterministic stability result needs
+only bounded exogenous scheduling; the one-sample delay also supplies the usual
+predictability property for the stochastic Kalman interpretation.
+
+Assume on the analyzed interval that
+\begin{align}
+ 0<h_-\le h_k\le h_+<\infty,&\qquad
+ 0<\tau_-\le\tau_k\le\tau_+<\infty,\label{eq:ou2-iss-time-bounds}\\
+ 0<\sigma_-\le\sigma_{aw,k}\le\sigma_+<\infty,&\qquad
+ 0<\tau_{b,-}\le\tau_b\le\tau_{b,+}<\infty.\label{eq:ou2-iss-ou-bounds}
+\end{align}
+All accepted accelerometer, magnetometer, position-zero, and velocity-zero
+measurement covariances are assumed uniformly positive and finite,
+\begin{equation}
+ r_- I\preceq R_k\preceq r_+I,
+ \qquad 0<r_-\le r_+<\infty.
+ \label{eq:ou2-iss-R-bounds}
+\end{equation}
+Positive finite gyro, gyro-bias, world-acceleration OU, and residual
+accelerometer-bias process spectral densities are also assumed.
+
+For attitude observability, assume accepted accelerometer/magnetometer vector
+pairs have bounded nonzero magnitudes and uniformly non-collinear directions.
+Equivalently, for unit predicted directions $u_f,u_m$, there are constants
+$f_0,m_0,\delta>0$ such that
+\begin{equation}
+ \|\widehat f_b\|\ge f_0,\qquad
+ \|\widehat m_b\|\ge m_0,\qquad
+ |u_f^\top u_m|\le1-\delta.
+ \label{eq:ou2-iss-vector-geometry}
+\end{equation}
+Each finite attitude proof horizon contains two accepted vector-update pairs
+whose attitude/gyro-bias transition has a uniformly nonsingular bias-to-attitude
+block $B_{10}$,
+\begin{equation}
+ \sigma_{\min}(B_{10})\ge b_0>0.
+ \label{eq:ou2-iss-B-bound}
+\end{equation}
+For a constant angular rate over a gap $\Delta$, the implemented block is
+$B_{10}=\int_0^\Delta\exp(-[\omega]_\times s)\,ds$; the sufficient condition
+$\|\omega\|\Delta<\pi/2$ gives a uniform positive singular-value margin.
+Equation~\eqref{eq:ou2-iss-B-bound} is the theorem condition and also covers the
+piecewise-discrete implementation without pretending that every possible
+maneuver satisfies the constant-rate formula.
+
+Finally, every translational proof horizon contains two joint $p=0$, $v=0$
+pseudo-update instants separated by
+\begin{equation}
+ 0<T_-\le T\le T_+<\infty,
+ \label{eq:ou2-iss-pv-gap}
+\end{equation}
+and the residual accelerometer-bias OU update is active throughout the certified
+interval.  The latter qualification matters because the startup magnetometer
+lock deliberately freezes accelerometer-bias learning for a short time.
+
+\subsection{Uniform observability of the OU--II translational block}
+
+For one axis, the homogeneous translational model is
+\begin{equation}
+ \dot v=a,\qquad \dot p=v,\qquad
+ \dot a=-\lambda(t)a,\qquad \lambda(t)=1/\tau(t).
+ \label{eq:ou2-iss-scalar-chain}
+\end{equation}
+Define
+\begin{equation}
+ E(t)=\exp\!\left(-\int_0^t\lambda(s)\,ds\right),\quad
+ A_1(t)=\int_0^tE(s)\,ds,
+ \quad A_2(t)=\int_0^t(t-s)E(s)\,ds.
+\end{equation}
+Then
+\begin{equation}
+ \begin{bmatrix}v(t)\\p(t)\\a(t)\end{bmatrix}
+ =
+ \begin{bmatrix}
+ 1&0&A_1(t)\\
+ t&1&A_2(t)\\
+ 0&0&E(t)
+ \end{bmatrix}
+ \begin{bmatrix}v_0\\p_0\\a_0\end{bmatrix}.
+ \label{eq:ou2-iss-Phi-L}
+\end{equation}
+This is the continuous-time form exactly discretized per sample by the
+\texttt{IntegratedOUChain<T,2>} transition used in the source.
+
+\begin{lemma}[Uniform observability of one OU--II axis]
+\label{lem:ou2-iss-trans-uco}
+Under Eqs.~\eqref{eq:ou2-iss-time-bounds},
+\eqref{eq:ou2-iss-ou-bounds}, and \eqref{eq:ou2-iss-pv-gap}, two joint
+position/velocity pseudo-updates make the scalar $[v,p,a]$ chain uniformly
+observable over that horizon.
+\end{lemma}
+
+\begin{proof}
+At the first pseudo-update, select the direct $v$ and $p$ rows.  At the second,
+select only the propagated $v$ row.  The resulting $3\times3$ submatrix of the
+finite-horizon observation matrix is
+\begin{equation}
+ O_L(T)=
+ \begin{bmatrix}
+ 1&0&0\\
+ 0&1&0\\
+ 1&0&A_1(T)
+ \end{bmatrix},
+ \qquad \det O_L(T)=A_1(T).
+ \label{eq:ou2-iss-OL}
+\end{equation}
+Because $\tau(t)\ge\tau_-$,
+$E(s)\ge\exp(-s/\tau_-)$ and therefore, uniformly for
+$T\in[T_-,T_+]$,
+\begin{equation}
+ A_1(T)
+ \ge T_-\exp(-T_+/\tau_-)>0.
+ \label{eq:ou2-iss-A1-lower}
+\end{equation}
+All entries of $O_L$ are uniformly bounded on the compact admissible set, so
+Eq.~\eqref{eq:ou2-iss-A1-lower} gives a uniform positive lower bound on
+$\sigma_{\min}(O_L)$.  Positive bounded pseudo-measurement covariance converts
+this to a finite-horizon observability-Gramian lower bound.
+\end{proof}
+
+The three axes are independent in the homogeneous translational transition, so
+Lemma~\ref{lem:ou2-iss-trans-uco} gives uniform complete observability (UCO) of
+the nine-state $[v,p,a_w]$ block.  Notice that OU--II does not need the
+four-point finite-difference determinant used by OU--III: measuring both $p$
+and $v$ makes the shorter chain observable after only one nonzero propagation
+gap.
+
+\subsection{Attitude/gyro-bias observability and the 15-state subsystem}
+
+At an accepted vector-update instant define
+\begin{equation}
+ G_k=
+ \begin{bmatrix}
+ -[\widehat f_{b,k}]_\times\\
+ -[\widehat m_{b,k}]_\times
+ \end{bmatrix}.
+\end{equation}
+Using $[x]_\times^\top[x]_\times=\|x\|^2I-xx^\top$ and
+Eq.~\eqref{eq:ou2-iss-vector-geometry}, there is a uniform $\gamma>0$ with
+\begin{equation}
+ G_k^\top G_k\succeq\gamma I_3.
+ \label{eq:ou2-iss-G-lower}
+\end{equation}
+For two accepted vector-update pairs, the attitude/gyro-bias observation matrix
+contains
+\begin{equation}
+ O_A=
+ \begin{bmatrix}
+ G_0&0\\
+ G_1R_{10}&G_1B_{10}
+ \end{bmatrix}.
+ \label{eq:ou2-iss-OA}
+\end{equation}
+If $O_A[\delta\theta^\top,\widetilde b_g^\top]^\top=0$, the first block and
+Eq.~\eqref{eq:ou2-iss-G-lower} give $\delta\theta=0$; the second block and
+Eq.~\eqref{eq:ou2-iss-B-bound} then give $\widetilde b_g=0$.  Compactness of
+the admissible set upgrades full rank to a uniform singular-value lower bound.
+Thus the six-state attitude/gyro-bias subsystem is UCO on the stated horizon.
+
+Order the first fifteen states as translation followed by attitude/gyro bias.
+Selecting the pseudo-measurements and vector updates above gives a block
+triangular finite-horizon observation matrix
+\begin{equation}
+ O_{15}=\begin{bmatrix}O_{L,3D}&0\\D&O_A\end{bmatrix},
+\end{equation}
+where $D$ contains the legitimate $a_w$ coupling into the accelerometer
+measurement.  Both diagonal blocks have uniform positive singular-value lower
+bounds and all blocks are bounded; hence there is an $\alpha_{15}>0$ such that
+\begin{equation}
+ W_{o,15}(k,N)\succeq\alpha_{15}I_{15}.
+ \label{eq:ou2-iss-uco15}
+\end{equation}
+
+\subsection{The slow OU accelerometer-bias state and 18-state detectability}
+
+When accelerometer-bias updates are active, the source propagates the residual
+bias according to
+\begin{equation}
+ \widetilde b_{a,k+1}=\phi_{b,k}\widetilde b_{a,k},
+ \qquad \phi_{b,k}=e^{-h_k/\tau_b}.
+\end{equation}
+Thus Eqs.~\eqref{eq:ou2-iss-time-bounds} and
+\eqref{eq:ou2-iss-ou-bounds} imply
+\begin{equation}
+ 0<\phi_{b,k}\le
+ \exp(-h_-/\tau_{b,+})=: \rho_b<1.
+ \label{eq:ou2-iss-bias-contraction}
+\end{equation}
+
+\begin{lemma}[Uniform detectability of the 18-state OU--II linearization]
+\label{lem:ou2-iss-detectable}
+Under the standing assumptions, augmenting the UCO 15-state subsystem by the
+active slow residual-bias OU state gives a uniformly detectable 18-state LTV
+system.
+\end{lemma}
+
+\begin{proof}
+UCO of the first fifteen states permits a uniformly bounded observer gain whose
+homogeneous 15-state observer error is uniformly exponentially stable (UES).
+Use that correction on the first fifteen coordinates and no correction on the
+bias coordinates.  The augmented observer error transition is block upper
+triangular,
+\begin{equation}
+ \begin{bmatrix}e_{15,k+1}\\e_{b,k+1}\end{bmatrix}
+ =
+ \begin{bmatrix}
+ A^{\rm obs}_{15,k}&-L_kD_{b,k}\\
+ 0&\phi_{b,k}I_3
+ \end{bmatrix}
+ \begin{bmatrix}e_{15,k}\\e_{b,k}\end{bmatrix},
+\end{equation}
+where $D_{b,k}$ is the bounded accelerometer measurement coupling of residual
+bias.  The lower block decays as $\rho_b^{k-j}$, and the upper off-diagonal
+response is the convolution of two exponentially decaying sequences with a
+uniformly bounded multiplier.  That convolution is exponentially bounded, so
+the complete observer error is UES, which is uniform detectability.
+\end{proof}
+
+This is why the theorem explicitly requires active residual-bias OU propagation.
+During the intentional startup bias freeze the source sets $\phi_b=1$; that
+short hybrid phase is outside the certified 18-state interval.  Likewise the
+random-walk limit $\tau_b\to\infty$ is not covered by a uniform 18-state margin.
+
+\subsection{Process covariance, Riccati stability, and the external theorem}
+
+For each translational axis the continuous pair formed by
+Eq.~\eqref{eq:ou2-iss-scalar-chain} and noise injected into $a$ is controllable.
+Therefore its exact finite-time OU covariance is positive definite for every
+nonzero interval.  Positive bounded driving density, $h_k$, and $\tau_k$ give
+uniform positive finite-horizon process-Gramian bounds.  The same holds for the
+attitude/gyro-bias block under positive gyro and gyro-bias driving densities and
+for the residual-bias OU block under positive residual-bias driving density.
+Consequently $(F_k,Q_k^{1/2})$ is uniformly stabilizable and $Q_k$ is uniformly
+bounded.
+
+The default periodic $a_w$ covariance synchronization is also proof-compatible.
+The core does not overwrite the marginal in the default mode; it queues
+\begin{equation}
+ \Delta_k=\Pi_+\!\left(\Sigma_{aw,k}^{\rm stat}-P^-_{a_wa_w,k}\right)\succeq0
+\end{equation}
+and applies it in prediction as an additional bounded positive-semidefinite
+process-covariance term.  The optional legacy immediate marginal replacement is
+not an ordinary Riccati step and is excluded.
+
+The external implication used here is the discrete-time LTV Kalman stability
+theory of Anderson and Moore~\cite{AndersonMoore1981OU2}, including the
+singular-transition treatment of Moore and Anderson~\cite{MooreAnderson1980OU2}:
+uniform detectability and uniform stabilizability, together with uniformly
+bounded system matrices and positive bounded measurement covariance, yield a
+bounded stabilizing Riccati solution and UES of the homogeneous Kalman
+estimation-error transition.
+
+For clarity, the hypotheses are mapped explicitly to the OU--II argument:
+\begin{equation}
+\boxed{\begin{aligned}
+\text{uniform detectability} &:\ \text{Lemma~\ref{lem:ou2-iss-detectable}},\\
+\text{uniform stabilizability} &:\ \text{positive finite-horizon process Gramian},\\
+R_k\text{ positive/bounded} &:\ \text{Eq.~\eqref{eq:ou2-iss-R-bounds}},\\
+F_k,H_k\text{ bounded} &:\ \text{Eqs.~\eqref{eq:ou2-iss-time-bounds}--\eqref{eq:ou2-iss-vector-geometry}}.
+\end{aligned}}
+\label{eq:ou2-iss-theorem-map}
+\end{equation}
+
+\begin{theorem}[18-state OU--II Live UES]
+\label{thm:ou2-iss-ues}
+On every admissible Live interval satisfying
+Eqs.~\eqref{eq:ou2-iss-time-bounds}--\eqref{eq:ou2-iss-pv-gap}, with active
+slow-OU residual accelerometer-bias propagation, positive finite process-noise
+densities, proof-compatible $a_w$ covariance maintenance, and no hard reset,
+the homogeneous 18-state linearized OU--II Kalman estimation-error transition
+is uniformly exponentially stable.  There exist constants $M\ge1$ and
+$0<\rho<1$, independent of the admissible bounded tuning schedule, such that
+\begin{equation}
+ \boxed{\|\Psi_{18}(k,j)\|\le M\rho^{k-j},\qquad k\ge j.}
+ \label{eq:ou2-iss-ues}
+\end{equation}
+\end{theorem}
+
+\begin{proof}
+Lemma~\ref{lem:ou2-iss-detectable} supplies uniform detectability; the exact
+positive-noise discretizations give uniform stabilizability; and
+Eq.~\eqref{eq:ou2-iss-R-bounds} supplies the measurement-covariance bounds.
+The cited LTV Kalman/Riccati result therefore gives uniform covariance bounds
+and Eq.~\eqref{eq:ou2-iss-ues}.
+\end{proof}
+
+\subsection{Local nonlinear ISS}
+
+After prediction, measurement correction, quaternion error injection, and the
+MEKF reset, write the local nonlinear error recursion as
+\begin{equation}
+ e_{k+1}=A^{\rm cl}_ke_k+\varphi_k(e_k)+G_kd_k,
+ \label{eq:ou2-iss-nonlinear}
+\end{equation}
+where $A^{\rm cl}_k$ has the UES transition of
+Theorem~\ref{thm:ou2-iss-ues}.  Smoothness of the quaternion chart,
+measurement maps, and bounded scheduled coefficients on the admissible compact
+set gives constants $r_0,c_\varphi$ such that
+\begin{equation}
+ \|\varphi_k(e)\|\le c_\varphi\|e\|^2,
+ \qquad \|e\|\le r_0.
+ \label{eq:ou2-iss-remainder}
+\end{equation}
+The bounded input $d_k$ collects sensor/model mismatch, temperature-model and
+thermal-lag error, pseudo-measurement model error, and other bounded forcing
+omitted from the nominal homogeneous recursion.
+
+\begin{theorem}[Local ISS of the 18-state OU--II Live error dynamics]
+\label{thm:ou2-local-iss}
+Under Theorem~\ref{thm:ou2-iss-ues},
+Eq.~\eqref{eq:ou2-iss-remainder}, and a uniform bound
+$\|G_k\|\le\overline G$, there exist a sufficiently small invariant
+neighborhood, constants $C\ge1$, $0<\lambda<1$, and $\Gamma<\infty$ such that
+for every bounded disturbance sequence that keeps the trajectory in that
+neighborhood,
+\begin{equation}
+ \boxed{
+ \|e_k\|\le C\lambda^{k-j}\|e_j\|
+ +\Gamma\sup_{j\le i<k}\|d_i\|.}
+ \label{eq:ou2-local-iss-bound}
+\end{equation}
+\end{theorem}
+
+\begin{proof}
+Variation of constants and Eq.~\eqref{eq:ou2-iss-ues} give
+\begin{equation}
+ \|e_k\|\le M\rho^{k-j}\|e_j\|
+ +M\sum_{i=j}^{k-1}\rho^{k-1-i}
+ \left(c_\varphi\|e_i\|^2+\overline G\|d_i\|\right).
+\end{equation}
+Choose $r<r_0$ with
+$Mc_\varphi r/(1-\rho)<1$.  The quadratic convolution is then absorbed into a
+slightly slower exponential factor $\lambda\in(\rho,1)$, while the input
+convolution is bounded by
+$M\overline G(1-\rho)^{-1}\sup_i\|d_i\|$.  Shrinking the admissible initial and
+input bounds to keep the trajectory in the selected ball closes the invariant
+set argument and yields Eq.~\eqref{eq:ou2-local-iss-bound}.  This is the
+standard discrete-time ISS form; see Jiang and Wang~\cite{JiangWang2001OU2}.
+\end{proof}
+
+\subsection{Implementation-condition audit}
+
+The theorem is deliberately conditional rather than a claim of global EKF
+stability.  The current default code supplies several of its bounds directly:
+\begin{equation}
+ \begin{gathered}
+ \SI{0.02}{s}\le\tau_k\le\SI{12}{s},\qquad
+ \SI{0.12}{m/s^2}\le\sigma_{aw,z,k}\le\SI{6}{m/s^2},\\
+ \sigma_{aw,x,k}=\sigma_{aw,y,k}=1.5\,\sigma_{aw,z,k},\\
+ \SI{0.05}{m}\le r_{p0,k}\le\SI{150}{m},\qquad
+ \SI{0.01}{m/s}\le r_{v0,k}\le\SI{40}{m/s},\\
+ \tau_b=\SI{5000}{s},\qquad T_{pv}=\SI{15}{ms}\ \text{at the default cadence}.
+ \end{gathered}
+ \label{eq:ou2-iss-default-bounds}
+\end{equation}
+At the nominal \SI{200}{Hz} validation rate,
+$T_{pv}=\SI{15}{ms}=3h$, so successive joint $p/v$ pseudo-updates have a
+strictly positive, finite gap.  Unlike the OU--III four-sample determinant, the
+OU--II translational proof remains valid under bounded timing jitter as long as
+Eq.~\eqref{eq:ou2-iss-pv-gap} remains true.
+
+\begin{table}[H]
+\centering
+\small
+\caption{Audit of conditions entering the OU--II local ISS claim.}
+\label{tab:ou2-iss-audit}
+\begin{tabular}{@{}p{0.28\textwidth}p{0.66\textwidth}@{}}
+\toprule
+Condition & Status \\
+\midrule
+$[v,p,a_w]$ observability & Proved by Lemma~\ref{lem:ou2-iss-trans-uco} from the implemented joint $p=0$, $v=0$ pseudo-updates. \\
+Attitude/gyro-bias excitation & Conditional Live-interval assumption: accepted non-collinear accelerometer/magnetometer pairs and Eq.~\eqref{eq:ou2-iss-B-bound}. \\
+Residual accelerometer bias & Default model is OU with $\tau_b=\SI{5000}{s}$; the certified interval starts only after the startup bias gate has enabled its OU propagation. \\
+Adaptive schedule & Default wrapper clamps $\tau$, $\sigma_{aw}$, $r_{p0}$, and $r_{v0}$ to the finite ranges in Eq.~\eqref{eq:ou2-iss-default-bounds}. \\
+Schedule predictability & Enforced by committing the staged tuning candidate on the next IMU sample; the existing tuner-schedule regression test checks this contract. \\
+Pseudo-update gap & Default \SI{200}{Hz}/\SI{15}{ms} configuration satisfies it exactly; bounded timing jitter is also covered if Eq.~\eqref{eq:ou2-iss-pv-gap} holds. \\
+Covariance maintenance & Default prediction-time PSD $a_w$ inflation is covered; legacy immediate marginal replacement is excluded. \\
+Measurement covariance & Positive finite defaults satisfy it; custom zero/degenerate covariance settings are outside the theorem. \\
+Reset/outage behavior & Hard resets, startup/re-lock, and arbitrarily long rejected-update intervals are outside the theorem. \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+The accompanying proof-contract unit test pins the implementation details that
+are easy to regress mechanically: 18-state default dimension, finite residual
+bias OU time constant and contraction, the \SI{15}{ms} pseudo-update period,
+proof-compatible covariance policy, finite wrapper clamps, and the post-unlock
+Live bias gate.  Environmental excitation and absence of resets cannot be made
+true by a unit test; they remain explicit interval assumptions rather than being
+silently presented as properties of every deployment.

--- a/doc/kalman_ou_ii/ou2-iss.bib
+++ b/doc/kalman_ou_ii/ou2-iss.bib
@@ -1,0 +1,32 @@
+@article{MooreAnderson1980OU2,
+    author  = {Moore, J. B. and Anderson, B. D. O.},
+    title   = {Coping with Singular Transition Matrices in Estimation and Control Stability Theory},
+    journal = {International Journal of Control},
+    year    = {1980},
+    volume  = {31},
+    number  = {3},
+    pages   = {571--586},
+    doi     = {10.1080/00207178008961063}
+}
+
+@article{AndersonMoore1981OU2,
+    author  = {Anderson, B. D. O. and Moore, J. B.},
+    title   = {Detectability and Stabilizability of Time-Varying Discrete-Time Linear Systems},
+    journal = {SIAM Journal on Control and Optimization},
+    year    = {1981},
+    volume  = {19},
+    number  = {1},
+    pages   = {20--32},
+    doi     = {10.1137/0319002}
+}
+
+@article{JiangWang2001OU2,
+    author  = {Jiang, Zhong-Ping and Wang, Yuan},
+    title   = {Input-to-State Stability for Discrete-Time Nonlinear Systems},
+    journal = {Automatica},
+    year    = {2001},
+    volume  = {37},
+    number  = {6},
+    pages   = {857--869},
+    doi     = {10.1016/S0005-1098(01)00028-0}
+}

--- a/tests/kalman_ou_ii/Makefile
+++ b/tests/kalman_ou_ii/Makefile
@@ -21,7 +21,7 @@ LDFLAGS  =
 # Tell make to look for source files in src/util
 VPATH = $(REPO_ROOT)/src/util
 
-TARGETS = kalman_ou_ii-sim tuner_schedule-test
+TARGETS = kalman_ou_ii-sim tuner_schedule-test iss_contract-test
 
 all: build test
 
@@ -37,6 +37,9 @@ kalman_ou_ii-sim: kalman_ou_ii-sim.o W3dSimCommon.o
 	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
 
 tuner_schedule-test: tuner_schedule-test.o
+	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
+
+iss_contract-test: iss_contract-test.o
 	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
 
 # -MMD -MP records the headers each object depends on, so editing a filter

--- a/tests/kalman_ou_ii/iss_contract-test.cpp
+++ b/tests/kalman_ou_ii/iss_contract-test.cpp
@@ -1,0 +1,96 @@
+#define EIGEN_NON_ARDUINO
+#include <cmath>
+#include <iostream>
+#include <Eigen/Dense>
+#include <Eigen/Geometry>
+
+#define private public
+#include "kalman_ou_ii/SeaStateFusionFilter_OU_II.h"
+#undef private
+
+const float g_std = 9.80665f;
+
+using Filter = SeaStateFusionFilter_OU_II<TrackerType::KALMANF>;
+using Core = Kalman3D_Wave_OU_II<float>;
+
+static bool near(float a, float b, float rel = 2e-5f) {
+    return std::fabs(a - b) <= rel * std::max(1.0f, std::max(std::fabs(a), std::fabs(b)));
+}
+
+static int fail(const char* msg) {
+    std::cerr << "FAIL: " << msg << "\n";
+    return 1;
+}
+
+int main() {
+    Filter f(true);
+    f.initialize(Eigen::Vector3f::Constant(0.0148f),
+                 Eigen::Vector3f::Constant(0.00157f),
+                 Eigen::Vector3f::Constant(0.25f));
+    if (!f.mekf_) return fail("OU-II core was not created");
+
+    // The default template configuration used by the fusion wrapper is the
+    // 18-state proof configuration: attitude(3), gyro bias(3), v/p/a_w(9),
+    // and residual accelerometer bias(3).
+    if (f.mekf_->covariance_full().rows() != 18 ||
+        f.mekf_->covariance_full().cols() != 18) {
+        return fail("default OU-II state dimension is no longer 18");
+    }
+
+    // Pin proof-relevant default model and scheduler constants.
+    if (!near(f.mekf_->get_acc_bias_time_constant(), 5000.0f))
+        return fail("default residual accel-bias OU time constant changed");
+    if (!near(f.mekf_->get_pseudo_update_period_s(), 0.015f))
+        return fail("default p/v pseudo-update period changed");
+    if (f.mekf_->legacy_aw_covariance_replacement())
+        return fail("legacy raw a_w covariance replacement became default");
+    if (!f.periodicAwCovarianceSync())
+        return fail("default PSD a_w covariance synchronization was disabled");
+
+    if (!near(MIN_TAU_S, 0.02f) || !near(MAX_TAU_S, 12.0f) ||
+        !near(MAX_SIGMA_A, 6.0f) ||
+        !near(MIN_R_p0_std, 0.05f) || !near(MAX_R_p0_std, 150.0f) ||
+        !near(MIN_R_v0_std, 0.01f) || !near(MAX_R_v0_std, 40.0f) ||
+        !near(ACC_NOISE_FLOOR_SIGMA_DEFAULT, 0.12f)) {
+        return fail("proof-relevant OU-II wrapper clamps changed");
+    }
+    if (!near(f.P_factor_, 1.5f) || !near(f.R_p0_xy_factor_, 1.0f))
+        return fail("default OU-II anisotropy no longer matches proof audit");
+
+    // The exact source transition used by OU-II must retain a nonzero
+    // acceleration-to-velocity coefficient over one pseudo-update gap.  This
+    // is the determinant witness used by the translational UCO lemma.
+    Eigen::Matrix3f Phi;
+    Core::PhiAxis3x1_analytic(MIN_TAU_S, 0.015f, Phi);
+    if (!(Phi(0, 2) > 0.0f) || !Phi.allFinite())
+        return fail("OU-II integrated-OU transition lost translational observability witness");
+    Core::PhiAxis3x1_analytic(MAX_TAU_S, 0.015f, Phi);
+    if (!(Phi(0, 2) > 0.0f) || !Phi.allFinite())
+        return fail("OU-II transition witness failed at maximum default tau");
+
+    // Verify the residual accelerometer-bias block really contracts when its
+    // OU propagation is active.  A shorter test tau makes the contraction
+    // numerically visible while exercising the same source path.
+    f.mekf_->set_linear_block_enabled(false);
+    f.mekf_->set_acc_bias_updates_enabled(true);
+    f.mekf_->set_acc_bias_time_constant(2.0f);
+    const Eigen::Vector3f b0(0.20f, -0.10f, 0.05f);
+    f.mekf_->set_initial_acc_bias(b0);
+    f.mekf_->time_update(Eigen::Vector3f::Zero(), 0.10f);
+    const Eigen::Vector3f expected = b0 * std::exp(-0.10f / 2.0f);
+    if (!f.mekf_->get_acc_bias().isApprox(expected, 2e-6f))
+        return fail("active residual accel-bias OU block is not contractive");
+
+    // In the certified post-unlock Live regime, enterLive_ must enable the
+    // residual-bias OU state rather than leave the startup freeze in force.
+    f.accel_bias_locked_ = false;
+    f.startup_stage_ = Filter::StartupStage::TunerWarm;
+    f.enterLive_();
+    if (!f.mekf_->acc_bias_updates_enabled_)
+        return fail("post-unlock Live state did not enable accel-bias OU propagation");
+    if (!f.mekf_->linear_block_enabled())
+        return fail("default Live state did not enable the OU-II linear block");
+
+    std::cout << "OU-II ISS proof contract passed\n";
+    return 0;
+}

--- a/tests/kalman_ou_ii/run_tests.sh
+++ b/tests/kalman_ou_ii/run_tests.sh
@@ -2,3 +2,4 @@
 
 ./kalman_ou_ii-sim
 ./tuner_schedule-test
+./iss_contract-test


### PR DESCRIPTION
## Summary

Add a source-matched local ISS stability proof for the OU-II estimator and a regression test that pins the implementation assumptions used by the proof.

## Paper changes

- add an 18-state local-error model for the default OU-II configuration;
- prove uniform observability of each `[v,p,a_w]` chain from the implemented joint `p=0` and `v=0` pseudo-updates;
- prove attitude/gyro-bias finite-horizon observability under explicit accepted-vector excitation assumptions;
- combine those into UCO of the 15-state performance subsystem;
- use the finite slow-OU residual accelerometer-bias model to obtain uniform detectability of the complete 18-state linearization;
- state the process-covariance/stabilizability argument and the LTV Kalman/Riccati implication explicitly;
- derive the local nonlinear ISS bound by variation of constants plus the quadratic EKF remainder/small-gain condition;
- add an implementation-condition audit distinguishing code-enforced defaults from conditional Live-interval assumptions;
- cite Anderson & Moore (1981), Moore & Anderson (1980), and Jiang & Wang (2001).

## Important scope qualification

The theorem is intentionally **not** a global or all-modes claim. The certified 18-state interval begins only after the startup accelerometer-bias gate has enabled its OU propagation. Accepted non-collinear accel/mag updates, bounded update gaps, positive finite measurement covariances, and absence of reset/outage events remain explicit interval assumptions. No-magnetometer/no-excitation operation is outside the full 18-state UES theorem.

## Code audit / regression contract

The current OU-II production code already has the mechanisms required by the proof, so no estimator source changes were needed. A new `iss_contract-test` checks:

- default 18-state dimension;
- residual accel-bias OU time constant (`5000 s`) and actual contraction when active;
- `15 ms` joint p/v pseudo-update period;
- default proof-compatible PSD `a_w` covariance synchronization and legacy replacement disabled;
- default tuning bounds (`tau`, `sigma_aw`, `r_p0`, `r_v0`) and anisotropy;
- positive acceleration-to-velocity transition coefficient at the default tau extremes (the translational observability witness);
- post-unlock Live mode enables residual-bias OU propagation and the linear block.

The existing `tuner_schedule-test` continues to check the one-sample predictable scheduling contract.

## Validation

Branch starts from current `main` at `b1b971e0b9ce2adfdc422b9aab3b15ed661ccdbf` (the merge of PR #275). The repository build workflow will compile the OU-II tests and the OU-II LaTeX document on this PR. GitHub Actions is the authoritative build check because the local execution container cannot resolve github.com for cloning dependencies/data.