### PR TITLE
Derive the OU-III sigma tau cubed law from JONSWAP similarity

### DIFF
--- a/doc/kalman_ou_iii/w3d-fus-methods.tex-part
+++ b/doc/kalman_ou_iii/w3d-fus-methods.tex-part
@@ -154,27 +154,7 @@ $c_{\mathrm{spec}}\approx0.227$.  Under the equivalent one-sided convention,
 the PSD and normalization both change consistently and produce the same
 physical variance.
 
-\subsection{Practical pseudo-measurement scale}
-
-A physically scaled Gaussian design is
-\begin{equation}
-r_S(\sigma_{aw},\tau)
-=k_i\sigma_S
-=k_i c_{\mathrm{spec}}(u_{\min})\sigma_{aw}\tau^3,
-\label{eq:Rs-from-sigmaS}
-\end{equation}
-where $k_i>0$ is dimensionless.  The selected spectral-shape and cutoff
-calibration are represented by a single coefficient $c_R$, giving
-\begin{equation}
-r_{S,\star}=c_R\sigma_{aw,\star}\tau_\star^3.
-\label{eq:Rs-sigmaa-tau3}
-\end{equation}
-This is an engineering normalization, not an exact sea-state invariance result.
-For a fixed pseudo-update period $T_S$ and a bounded family of spectral shapes
-and cutoffs, it keeps the regularizer on approximately comparable physical
-scales as wave amplitude and period change.  Changing $T_S$, spectral bandwidth,
-or low-frequency contamination changes the effective regularization and may
-require retuning $c_R$.
+\input{w3d-rs-scale-theorem.tex-part}
 
 \subsection{Online Adaptation}
 \label{sec:adapt-impl}

--- a/doc/kalman_ou_iii/w3d-rs-scale-theorem.tex-part
+++ b/doc/kalman_ou_iii/w3d-rs-scale-theorem.tex-part
@@ -1,0 +1,198 @@
+\subsection{Scale-equivariant cubic law for the $S$ pseudo-measurement}
+\label{sec:rs-scale-theorem}
+
+Equation~\eqref{eq:sigmaS-scaling} shows from the acceleration spectrum that
+$\sigma_{aw}\tau^3$ is the natural physical scale of the triple-integral state.
+The following result is stronger than dimensional consistency: for the
+integrated OU--III similarity family, the same factor is required for the
+normalized Kalman regularization itself to remain unchanged as the acceleration
+and time scales vary.
+
+\begin{theorem}[Scale-equivariant OU--III integral regularization]
+\label{thm:rs-scale-equivariance}
+Consider one translational axis of the OU--III model
+\begin{equation}
+\begin{aligned}
+  dv &= a\,dt, & dp &= v\,dt, & dS &= p\,dt,\\
+  da &= -\frac{1}{\tau}a\,dt
+        +\sqrt{\frac{2\sigma_{aw}^{2}}{\tau}}\,dW,
+\end{aligned}
+\label{eq:rs-scale-ou3-sde}
+\end{equation}
+with $\tau>0$, $\sigma_{aw}>0$, and stationary
+$\Var[a]=\sigma_{aw}^{2}$.  Let the drift regularizer be
+\begin{equation}
+  y_S=0=S+n_S,\qquad n_S\sim\mathcal N(0,r_S^2).
+\label{eq:rs-scale-pseudomeas}
+\end{equation}
+Define the dimensionless measurement strength
+\begin{equation}
+  \kappa_S:=\frac{r_S}{\sigma_{aw}\tau^3}.
+\label{eq:kappaS-def}
+\end{equation}
+Assume that sampling and pseudo-update instants, the initial covariance, and
+all other process/measurement noise terms are held fixed after normalization by
+the natural OU--III state and time scales.  Then the normalized OU--III
+prediction and $S$-update depend on $(\sigma_{aw},\tau,r_S)$ only through
+$\kappa_S$.  Hence two members of this similarity family with the same
+$\kappa_S$ have identical normalized Kalman recursions.  Conversely, any
+positive law $r_S=g(\sigma_{aw},\tau)$ that preserves the same normalized
+$S$-regularization for every $\sigma_{aw},\tau>0$ must have the form
+\begin{equation}
+  g(\sigma_{aw},\tau)=\kappa_S\sigma_{aw}\tau^3
+\label{eq:rs-cubic-necessary}
+\end{equation}
+for a dimensionless constant $\kappa_S$ (or, if additional dimensionless
+parameters are allowed to vary, for a dimensionless function of those
+parameters).
+\end{theorem}
+
+\begin{proof}
+Set the dimensionless time $s=t/\tau$ and normalize the states by successive
+integration of the stationary acceleration scale,
+\begin{equation}
+  a=\sigma_{aw}\bar a,\qquad
+  v=\sigma_{aw}\tau\bar v,\qquad
+  p=\sigma_{aw}\tau^2\bar p,\qquad
+  S=\sigma_{aw}\tau^3\bar S.
+\label{eq:rs-natural-scales}
+\end{equation}
+Brownian scaling gives $dW(t)=\sqrt{\tau}\,d\bar W(s)$.  Substitution into
+\eqref{eq:rs-scale-ou3-sde} yields
+\begin{equation}
+\begin{aligned}
+  d\bar v &= \bar a\,ds, &
+  d\bar p &= \bar v\,ds, &
+  d\bar S &= \bar p\,ds,\\
+  d\bar a &= -\bar a\,ds+\sqrt{2}\,d\bar W.
+\end{aligned}
+\label{eq:rs-normalized-ou3}
+\end{equation}
+Thus $\sigma_{aw}$ and $\tau$ disappear from the normalized process model.
+Equivalently, for
+\[
+  \vct{x}=\begin{bmatrix}v&p&S&a\end{bmatrix}^{\top},\qquad
+  \mat D_{\sigma,\tau}
+  =\diag(\sigma_{aw}\tau,\sigma_{aw}\tau^2,
+         \sigma_{aw}\tau^3,\sigma_{aw}),
+\]
+we have $\vct{x}=\mat D_{\sigma,\tau}\bar{\vct{x}}$ and
+$\mat P=\mat D_{\sigma,\tau}\bar{\mat P}\mat D_{\sigma,\tau}^{\top}$.
+
+Now divide the pseudo-measurement~\eqref{eq:rs-scale-pseudomeas} by the natural
+$S$ scale $d_S=\sigma_{aw}\tau^3$:
+\begin{equation}
+  0=\bar S+\bar n_S,
+  \qquad
+  \bar n_S:=\frac{n_S}{\sigma_{aw}\tau^3},
+  \qquad
+  \Var[\bar n_S]=\kappa_S^2.
+\label{eq:rs-normalized-meas}
+\end{equation}
+With $\mat H_S=\begin{bmatrix}0&0&1&0\end{bmatrix}$, the normalized Kalman
+update is therefore
+\begin{equation}
+\begin{aligned}
+ \bar{\mat K}_S
+ &=\bar{\mat P}^{-}\mat H_S^{\top}
+   \left(\mat H_S\bar{\mat P}^{-}\mat H_S^{\top}
+   +\kappa_S^2\right)^{-1},\\
+ \bar{\vct{x}}^{+}
+ &=\bar{\vct{x}}^{-}
+   +\bar{\mat K}_S\left(0-\mat H_S\bar{\vct{x}}^{-}\right).
+\end{aligned}
+\label{eq:rs-normalized-kalman-update}
+\end{equation}
+The prediction from~\eqref{eq:rs-normalized-ou3}, its normalized process
+covariance, and the update~\eqref{eq:rs-normalized-kalman-update} contain no
+separate dependence on $\sigma_{aw}$, $\tau$, or $r_S$: their only
+pseudo-measurement combination is $\kappa_S$.  This proves sufficiency.
+
+For necessity, suppose $r_S=g(\sigma_{aw},\tau)$ preserves the same normalized
+$S$-regularization for every positive pair $(\sigma_{aw},\tau)$.  The normalized
+measurement variance in~\eqref{eq:rs-normalized-meas} must then be invariant, so
+\[
+  \frac{g(\sigma_{aw},\tau)^2}
+       {\sigma_{aw}^2\tau^6}=\kappa_S^2.
+\]
+Positivity of the standard-deviation scale gives
+$g(\sigma_{aw},\tau)=\kappa_S\sigma_{aw}\tau^3$, proving
+\eqref{eq:rs-cubic-necessary}.
+\end{proof}
+
+\begin{theorem}[Performance-optimal cubic law]
+\label{thm:rs-performance-cubic}
+Under the assumptions of Theorem~\ref{thm:rs-scale-equivariance}, let a
+normalized estimation criterion be
+\begin{equation}
+  \bar J=\mathcal J(\kappa_S;\vct\eta),
+\label{eq:rs-normalized-cost}
+\end{equation}
+where $\vct\eta$ contains only dimensionless quantities such as normalized
+sampling and pseudo-update periods and normalized sensor-noise levels.  If, for
+fixed $\vct\eta$, the criterion has a minimizer
+$\kappa_S^{\star}(\vct\eta)$, then every dimensional minimizer satisfies
+\begin{equation}
+  r_S^{\star}
+  =\sigma_{aw}\tau^3\kappa_S^{\star}(\vct\eta).
+\label{eq:Rs-sigmaa-tau3}
+\end{equation}
+In particular, if $\vct\eta$ is fixed across the similarity family, the
+performance-optimal coefficient is dimensionless and constant, and the
+$\sigma_{aw}\tau^3$ factor is necessary for scale-independent optimal tuning.
+If $\mat R_S$ denotes measurement variance rather than standard deviation, the
+corresponding scalar law is
+\begin{equation}
+  R_S^{\star}
+  =\left(\kappa_S^{\star}\right)^2\sigma_{aw}^2\tau^6.
+\label{eq:RS-variance-sixth-law}
+\end{equation}
+\end{theorem}
+
+\begin{proof}
+Theorem~\ref{thm:rs-scale-equivariance} reduces every member of the similarity
+family to the same normalized filtering problem, with $r_S$ entering only as
+$\kappa_S=r_S/(\sigma_{aw}\tau^3)$.  Therefore minimizing the dimensional
+criterion is equivalent, after its natural normalization, to minimizing
+$\mathcal J$ over $\kappa_S$.  At a minimizer,
+$\kappa_S=\kappa_S^{\star}(\vct\eta)$; solving the definition of $\kappa_S$
+for $r_S$ gives~\eqref{eq:Rs-sigmaa-tau3}.  Squaring this standard-deviation
+law gives~\eqref{eq:RS-variance-sixth-law}.
+\end{proof}
+
+The spectral argument above and Theorems~\ref{thm:rs-scale-equivariance}--
+\ref{thm:rs-performance-cubic} have complementary roles.  Equation
+\eqref{eq:sigmaS-scaling} relates the natural $S$ fluctuation level to a
+specified acceleration spectrum and low-frequency cutoff; the theorems show
+that, independent of that particular spectral calculation, preserving the same
+normalized OU--III regularization forces the outer $\sigma_{aw}\tau^3$ scale.
+The remaining coefficient is dimensionless and may depend on dimensionless
+sampling, bandwidth, and noise ratios.
+
+A physically scaled Gaussian design can therefore be written
+\begin{equation}
+  r_S(\sigma_{aw},\tau)
+  =k_i\sigma_S
+  =k_i c_{\mathrm{spec}}(u_{\min})\sigma_{aw}\tau^3,
+\label{eq:Rs-from-sigmaS}
+\end{equation}
+or, after absorbing spectral-shape and performance calibration into one
+coefficient,
+\begin{equation}
+  r_{S,\star}=c_R\sigma_{aw,\star}\tau_\star^3.
+\label{eq:rs-practical-cubic-law}
+\end{equation}
+The deployed $c_R$ is therefore a dimensionless calibration; the cubic outer
+scaling is the structural part of the law.  Exact scale equivariance is broken
+when physical-rate sampling, clipping, gating, or other dimensionless ratios
+change with the sea state.  In that more general case the optimum has the form
+$c_R=c_R(\vct\eta)$, while the mandatory outer scale remains
+$\sigma_{aw}\tau^3$.
+
+A fixed dimensional $r_S$ illustrates why the law matters.  If $\tau$ doubles
+while $\sigma_{aw}$ is unchanged, then
+$\kappa_S=r_S/(\sigma_{aw}\tau^3)$ falls by a factor of eight and the normalized
+measurement variance $\kappa_S^2$ falls by a factor of $64$.  Thus a fixed
+$r_S$ makes the same pseudo-measurement dramatically stronger in normalized
+terms as the characteristic period grows; scaling $r_S\propto\sigma_{aw}\tau^3$
+removes that artificial change.

--- a/doc/kalman_ou_iii/w3d-rs-scale-theorem.tex-part
+++ b/doc/kalman_ou_iii/w3d-rs-scale-theorem.tex-part
@@ -1,198 +1,288 @@
-\subsection{Scale-equivariant cubic law for the $S$ pseudo-measurement}
+\subsection{JONSWAP similarity law for the three tuner targets}
 \label{sec:rs-scale-theorem}
 
-Equation~\eqref{eq:sigmaS-scaling} shows from the acceleration spectrum that
-$\sigma_{aw}\tau^3$ is the natural physical scale of the triple-integral state.
-The following result is stronger than dimensional consistency: for the
-integrated OU--III similarity family, the same factor is required for the
-normalized Kalman regularization itself to remain unchanged as the acceleration
-and time scales vary.
+The preceding generic spectral calculation identifies the dimensions of the
+third-integral state, but it does not by itself justify a universal
+$r_S\propto\sigma_{aw}\tau^3$ law for an integrated OU process.  In particular,
+a stationary OU acceleration has nonzero spectral density at zero frequency,
+so its third integral is not stationary.  The scaling used by the deployed
+tuner is instead justified below for the wave family that motivates the
+estimator: a fixed-shape JONSWAP sea.  The result also exposes the condition
+that the acceleration variance entering the law must be a \emph{wave-band}
+quantity, not an unbounded-band fourth spectral moment.
 
-\begin{theorem}[Scale-equivariant OU--III integral regularization]
-\label{thm:rs-scale-equivariance}
-Consider one translational axis of the OU--III model
+For $\omega>0$, write a JONSWAP elevation spectrum with fixed peakedness
+parameter $\gamma$ in normalized form
 \begin{equation}
-\begin{aligned}
-  dv &= a\,dt, & dp &= v\,dt, & dS &= p\,dt,\\
-  da &= -\frac{1}{\tau}a\,dt
-        +\sqrt{\frac{2\sigma_{aw}^{2}}{\tau}}\,dW,
-\end{aligned}
-\label{eq:rs-scale-ou3-sde}
+ S_\eta^{(2)}(\omega;H_s,\omega_p,\gamma)
+ =\frac{H_s^2}{\omega_p}\,
+   \Phi_\gamma\!\left(\frac{\omega}{\omega_p}\right),
+\label{eq:jonswap-similarity-form}
 \end{equation}
-with $\tau>0$, $\sigma_{aw}>0$, and stationary
-$\Var[a]=\sigma_{aw}^{2}$.  Let the drift regularizer be
+where $\Phi_\gamma$ is the dimensionless JONSWAP shape
+\cite{Hasselmann1973_JONSWAP}.  With the two-sided PSD convention used above,
+define the dimensionless shape moments
 \begin{equation}
-  y_S=0=S+n_S,\qquad n_S\sim\mathcal N(0,r_S^2).
-\label{eq:rs-scale-pseudomeas}
+ C_n(\gamma;a,b)
+ :=\frac{1}{\pi}\int_a^b x^n\Phi_\gamma(x)\,dx,
+\qquad
+ C_n(\gamma):=C_n(\gamma;0,\infty).
+\label{eq:jonswap-shape-moments}
 \end{equation}
-Define the dimensionless measurement strength
-\begin{equation}
-  \kappa_S:=\frac{r_S}{\sigma_{aw}\tau^3}.
-\label{eq:kappaS-def}
-\end{equation}
-Assume that sampling and pseudo-update instants, the initial covariance, and
-all other process/measurement noise terms are held fixed after normalization by
-the natural OU--III state and time scales.  Then the normalized OU--III
-prediction and $S$-update depend on $(\sigma_{aw},\tau,r_S)$ only through
-$\kappa_S$.  Hence two members of this similarity family with the same
-$\kappa_S$ have identical normalized Kalman recursions.  Conversely, any
-positive law $r_S=g(\sigma_{aw},\tau)$ that preserves the same normalized
-$S$-regularization for every $\sigma_{aw},\tau>0$ must have the form
-\begin{equation}
-  g(\sigma_{aw},\tau)=\kappa_S\sigma_{aw}\tau^3
-\label{eq:rs-cubic-necessary}
-\end{equation}
-for a dimensionless constant $\kappa_S$ (or, if additional dimensionless
-parameters are allowed to vary, for a dimensionless function of those
-parameters).
-\end{theorem}
+The $H_s$ normalization gives $C_0=1/16$ for the usual linear-Gaussian
+relation $H_s=4\sqrt{m_0}$.
 
-\begin{proof}
-Set the dimensionless time $s=t/\tau$ and normalize the states by successive
-integration of the stationary acceleration scale,
+\begin{theorem}[JONSWAP similarity of the OU--III integral scale]
+\label{thm:jonswap-rs-similarity}
+Consider a fixed-$\gamma$ JONSWAP family of the form
+\eqref{eq:jonswap-similarity-form}.  Let
 \begin{equation}
-  a=\sigma_{aw}\bar a,\qquad
-  v=\sigma_{aw}\tau\bar v,\qquad
-  p=\sigma_{aw}\tau^2\bar p,\qquad
-  S=\sigma_{aw}\tau^3\bar S.
-\label{eq:rs-natural-scales}
+ m_n(a,b)
+ :=\frac{1}{\pi}\int_{a\omega_p}^{b\omega_p}
+      \omega^n S_\eta^{(2)}(\omega)\,d\omega.
+\label{eq:jonswap-band-moment}
 \end{equation}
-Brownian scaling gives $dW(t)=\sqrt{\tau}\,d\bar W(s)$.  Substitution into
-\eqref{eq:rs-scale-ou3-sde} yields
+Assume linear wave kinematics, so
+$a(\omega)=-\omega^2\eta(\omega)$.  Let the acceleration scale supplied to the
+OU tuner be the RMS acceleration in a fixed dimensionless wave band
+$B=[\lambda_-,\lambda_+]$ with
+$0\le\lambda_-<\lambda_+<\infty$,
 \begin{equation}
-\begin{aligned}
-  d\bar v &= \bar a\,ds, &
-  d\bar p &= \bar v\,ds, &
-  d\bar S &= \bar p\,ds,\\
-  d\bar a &= -\bar a\,ds+\sqrt{2}\,d\bar W.
-\end{aligned}
-\label{eq:rs-normalized-ou3}
+ \sigma_{a,B}:=\sqrt{m_4(\lambda_-,\lambda_+)},
+ \qquad
+ \sigma_{aw,\star}=c_\sigma\sigma_{a,B},
+\label{eq:jonswap-band-acc-scale}
 \end{equation}
-Thus $\sigma_{aw}$ and $\tau$ disappear from the normalized process model.
-Equivalently, for
-\[
-  \vct{x}=\begin{bmatrix}v&p&S&a\end{bmatrix}^{\top},\qquad
-  \mat D_{\sigma,\tau}
-  =\diag(\sigma_{aw}\tau,\sigma_{aw}\tau^2,
-         \sigma_{aw}\tau^3,\sigma_{aw}),
-\]
-we have $\vct{x}=\mat D_{\sigma,\tau}\bar{\vct{x}}$ and
-$\mat P=\mat D_{\sigma,\tau}\bar{\mat P}\mat D_{\sigma,\tau}^{\top}$.
-
-Now divide the pseudo-measurement~\eqref{eq:rs-scale-pseudomeas} by the natural
-$S$ scale $d_S=\sigma_{aw}\tau^3$:
+and let the OU time-scale target be
 \begin{equation}
-  0=\bar S+\bar n_S,
-  \qquad
-  \bar n_S:=\frac{n_S}{\sigma_{aw}\tau^3},
-  \qquad
-  \Var[\bar n_S]=\kappa_S^2.
-\label{eq:rs-normalized-meas}
+ \tau_\star=c_\tau\frac{T_z}{2},
+ \qquad
+ T_z=2\pi\sqrt{\frac{m_0}{m_2}}.
+\label{eq:jonswap-tau-target}
 \end{equation}
-With $\mat H_S=\begin{bmatrix}0&0&1&0\end{bmatrix}$, the normalized Kalman
-update is therefore
+Then the RMS physical scale of the OU--III third-integral state satisfies
 \begin{equation}
-\begin{aligned}
- \bar{\mat K}_S
- &=\bar{\mat P}^{-}\mat H_S^{\top}
-   \left(\mat H_S\bar{\mat P}^{-}\mat H_S^{\top}
-   +\kappa_S^2\right)^{-1},\\
- \bar{\vct{x}}^{+}
- &=\bar{\vct{x}}^{-}
-   +\bar{\mat K}_S\left(0-\mat H_S\bar{\vct{x}}^{-}\right).
-\end{aligned}
-\label{eq:rs-normalized-kalman-update}
+ \sigma_S
+ =K_J(\gamma,B,c_\sigma,c_\tau)\,
+  \sigma_{aw,\star}\tau_\star^3,
+\label{eq:jonswap-sigmaS-cubic}
 \end{equation}
-The prediction from~\eqref{eq:rs-normalized-ou3}, its normalized process
-covariance, and the update~\eqref{eq:rs-normalized-kalman-update} contain no
-separate dependence on $\sigma_{aw}$, $\tau$, or $r_S$: their only
-pseudo-measurement combination is $\kappa_S$.  This proves sufficiency.
-
-For necessity, suppose $r_S=g(\sigma_{aw},\tau)$ preserves the same normalized
-$S$-regularization for every positive pair $(\sigma_{aw},\tau)$.  The normalized
-measurement variance in~\eqref{eq:rs-normalized-meas} must then be invariant, so
-\[
-  \frac{g(\sigma_{aw},\tau)^2}
-       {\sigma_{aw}^2\tau^6}=\kappa_S^2.
-\]
-Positivity of the standard-deviation scale gives
-$g(\sigma_{aw},\tau)=\kappa_S\sigma_{aw}\tau^3$, proving
-\eqref{eq:rs-cubic-necessary}.
-\end{proof}
-
-\begin{theorem}[Performance-optimal cubic law]
-\label{thm:rs-performance-cubic}
-Under the assumptions of Theorem~\ref{thm:rs-scale-equivariance}, let a
-normalized estimation criterion be
+where $K_J$ is dimensionless and independent of $H_s$ and $\omega_p$.
+Consequently, any pseudo-measurement standard deviation chosen as a fixed
+multiple of the natural $S$ scale,
+$r_{S,\star}=k_i\sigma_S$, has the form
 \begin{equation}
-  \bar J=\mathcal J(\kappa_S;\vct\eta),
-\label{eq:rs-normalized-cost}
-\end{equation}
-where $\vct\eta$ contains only dimensionless quantities such as normalized
-sampling and pseudo-update periods and normalized sensor-noise levels.  If, for
-fixed $\vct\eta$, the criterion has a minimizer
-$\kappa_S^{\star}(\vct\eta)$, then every dimensional minimizer satisfies
-\begin{equation}
-  r_S^{\star}
-  =\sigma_{aw}\tau^3\kappa_S^{\star}(\vct\eta).
+ \boxed{\displaystyle
+ r_{S,\star}=c_R\sigma_{aw,\star}\tau_\star^3},
+ \qquad c_R=k_iK_J,
 \label{eq:Rs-sigmaa-tau3}
 \end{equation}
-In particular, if $\vct\eta$ is fixed across the similarity family, the
-performance-optimal coefficient is dimensionless and constant, and the
-$\sigma_{aw}\tau^3$ factor is necessary for scale-independent optimal tuning.
-If $\mat R_S$ denotes measurement variance rather than standard deviation, the
-corresponding scalar law is
-\begin{equation}
-  R_S^{\star}
-  =\left(\kappa_S^{\star}\right)^2\sigma_{aw}^2\tau^6.
-\label{eq:RS-variance-sixth-law}
-\end{equation}
+with a dimensionless coefficient $c_R$.
 \end{theorem}
 
 \begin{proof}
-Theorem~\ref{thm:rs-scale-equivariance} reduces every member of the similarity
-family to the same normalized filtering problem, with $r_S$ entering only as
-$\kappa_S=r_S/(\sigma_{aw}\tau^3)$.  Therefore minimizing the dimensional
-criterion is equivalent, after its natural normalization, to minimizing
-$\mathcal J$ over $\kappa_S$.  At a minimizer,
-$\kappa_S=\kappa_S^{\star}(\vct\eta)$; solving the definition of $\kappa_S$
-for $r_S$ gives~\eqref{eq:Rs-sigmaa-tau3}.  Squaring this standard-deviation
-law gives~\eqref{eq:RS-variance-sixth-law}.
+Substituting $x=\omega/\omega_p$ into
+\eqref{eq:jonswap-band-moment} gives the similarity identity
+\begin{equation}
+ m_n(a,b)
+ =H_s^2\omega_p^n C_n(\gamma;a,b).
+\label{eq:jonswap-moment-similarity}
+\end{equation}
+First consider the third-integral state.  Since
+$a(\omega)=-\omega^2\eta(\omega)$ and
+$S(\omega)=a(\omega)/(j\omega)^3$, its variance is
+\begin{equation}
+ \sigma_S^2
+ =\frac{1}{\pi}\int_0^\infty
+   \frac{S_\eta^{(2)}(\omega)}{\omega^2}\,d\omega
+ =m_{-2}.
+\label{eq:jonswap-S-variance}
+\end{equation}
+The JONSWAP low-frequency factor decays exponentially in $\omega^{-4}$, while
+its high-frequency elevation tail is proportional to $\omega^{-5}$; therefore
+$m_{-2}$ is finite.  Equation~\eqref{eq:jonswap-moment-similarity} yields
+\begin{equation}
+ \sigma_S
+ =\frac{H_s}{\omega_p}\sqrt{C_{-2}(\gamma)}.
+\label{eq:jonswap-S-scale}
+\end{equation}
+Thus the natural third-integral scale varies as $H_s/\omega_p$.
+
+For the acceleration channel, the fixed dimensionless band $B$ gives
+\begin{equation}
+ \sigma_{a,B}
+ =H_s\omega_p^2
+   \sqrt{C_4(\gamma;\lambda_-,\lambda_+)}.
+\label{eq:jonswap-acc-scale}
+\end{equation}
+The finite upper band edge is essential.  Ideal JONSWAP has an
+$\omega^{-5}$ elevation tail, so its unbounded fourth elevation moment behaves
+as $\int^\infty\omega^{-1}d\omega$ and does not exist.  A physical IMU always
+has finite bandwidth, but a constant coefficient across sea states follows
+from JONSWAP similarity only when that effective wave band is fixed in units
+of $\omega_p$ (or an equivalent characteristic wave frequency).
+
+The zero-crossing period follows from
+\eqref{eq:jonswap-moment-similarity}:
+\begin{equation}
+ T_z
+ =\frac{2\pi}{\omega_p}
+   \sqrt{\frac{C_0(\gamma)}{C_2(\gamma)}}.
+\label{eq:jonswap-Tz-scaling}
+\end{equation}
+Therefore
+\begin{equation}
+ \tau_\star
+ =\frac{c_\tau\pi}{\omega_p}
+   \sqrt{\frac{C_0(\gamma)}{C_2(\gamma)}}.
+\label{eq:jonswap-tau-scaling}
+\end{equation}
+Combining \eqref{eq:jonswap-acc-scale}--\eqref{eq:jonswap-tau-scaling} with
+$\sigma_{aw,\star}=c_\sigma\sigma_{a,B}$ gives
+\begin{equation}
+ \sigma_{aw,\star}\tau_\star^3
+ =\frac{H_s}{\omega_p}\,
+ c_\sigma c_\tau^3\pi^3
+ \sqrt{C_4(\gamma;\lambda_-,\lambda_+)}
+ \left(\frac{C_0(\gamma)}{C_2(\gamma)}\right)^{3/2}.
+\label{eq:jonswap-sigma-tau3-scale}
+\end{equation}
+Comparison with \eqref{eq:jonswap-S-scale} proves
+\eqref{eq:jonswap-sigmaS-cubic}, with
+\begin{equation}
+ K_J
+ =\frac{\sqrt{C_{-2}(\gamma)}}
+ {c_\sigma c_\tau^3\pi^3
+  \sqrt{C_4(\gamma;\lambda_-,\lambda_+)}
+  \left(C_0(\gamma)/C_2(\gamma)\right)^{3/2}}.
+\label{eq:jonswap-KJ}
+\end{equation}
+Multiplying by the dimensionless regularization factor $k_i$ gives
+\eqref{eq:Rs-sigmaa-tau3}.
 \end{proof}
 
-The spectral argument above and Theorems~\ref{thm:rs-scale-equivariance}--
-\ref{thm:rs-performance-cubic} have complementary roles.  Equation
-\eqref{eq:sigmaS-scaling} relates the natural $S$ fluctuation level to a
-specified acceleration spectrum and low-frequency cutoff; the theorems show
-that, independent of that particular spectral calculation, preserving the same
-normalized OU--III regularization forces the outer $\sigma_{aw}\tau^3$ scale.
-The remaining coefficient is dimensionless and may depend on dimensionless
-sampling, bandwidth, and noise ratios.
-
-A physically scaled Gaussian design can therefore be written
+\begin{remark}[Why the powers one and three are not arbitrary]
+\label{rem:jonswap-power-uniqueness}
+The theorem gives a direct uniqueness argument for the monomial exponents.
+Suppose a scale law were instead
+$r_S=C\sigma_{aw}^{\alpha}\tau^{\beta}$ with a dimensionless constant $C$.
+For the fixed-shape JONSWAP family,
 \begin{equation}
-  r_S(\sigma_{aw},\tau)
-  =k_i\sigma_S
-  =k_i c_{\mathrm{spec}}(u_{\min})\sigma_{aw}\tau^3,
-\label{eq:Rs-from-sigmaS}
+ \sigma_{aw}\propto H_s\omega_p^2,
+ \qquad
+ \tau\propto\omega_p^{-1},
+ \qquad
+ \sigma_S\propto H_s\omega_p^{-1}.
 \end{equation}
-or, after absorbing spectral-shape and performance calibration into one
-coefficient,
+Hence
+$r_S\propto H_s^{\alpha}\omega_p^{2\alpha-\beta}$.
+Matching the amplitude and period dependence of the physical $S$ scale for all
+$H_s$ and $\omega_p$ requires
 \begin{equation}
-  r_{S,\star}=c_R\sigma_{aw,\star}\tau_\star^3.
-\label{eq:rs-practical-cubic-law}
+ \alpha=1,
+ \qquad
+ 2\alpha-\beta=-1,
 \end{equation}
-The deployed $c_R$ is therefore a dimensionless calibration; the cubic outer
-scaling is the structural part of the law.  Exact scale equivariance is broken
-when physical-rate sampling, clipping, gating, or other dimensionless ratios
-change with the sea state.  In that more general case the optimum has the form
-$c_R=c_R(\vct\eta)$, while the mandatory outer scale remains
-$\sigma_{aw}\tau^3$.
+so uniquely
+\begin{equation}
+ \boxed{\alpha=1,\qquad\beta=3.}
+\label{eq:jonswap-unique-powers}
+\end{equation}
+Thus the linear dependence on acceleration RMS and the cubic dependence on the
+wave time scale are the unique monomial powers that preserve JONSWAP
+similarity for the third-integral regularizer.
+\end{remark}
 
-A fixed dimensional $r_S$ illustrates why the law matters.  If $\tau$ doubles
-while $\sigma_{aw}$ is unchanged, then
-$\kappa_S=r_S/(\sigma_{aw}\tau^3)$ falls by a factor of eight and the normalized
-measurement variance $\kappa_S^2$ falls by a factor of $64$.  Thus a fixed
-$r_S$ makes the same pseudo-measurement dramatically stronger in normalized
-terms as the characteristic period grows; scaling $r_S\propto\sigma_{aw}\tau^3$
-removes that artificial change.
+\subsubsection{Physical meaning of the three tuner channels}
+\label{sec:jonswap-tuner-meaning}
+
+The theorem gives a distinct role to each adaptive quantity rather than
+interpreting the three coefficients as unrelated empirical knobs.
+
+\begin{description}
+ \item[Wave time scale $\tau$.]
+ For fixed JONSWAP shape, $T_z\propto\omega_p^{-1}$, hence
+ $\tau_\star=c_\tau T_z/2$ tracks the inverse characteristic wave frequency.
+ The coefficient $c_\tau$ maps the observable JONSWAP wave time scale to the OU
+ surrogate correlation time; it does not assert that a JONSWAP sea is itself
+ an OU process.
+
+ \item[Acceleration scale $\sigma_{aw}$.]
+ In a fixed dimensionless wave band,
+ $\sigma_{a,B}\propto H_s\omega_p^2$.  Thus
+ $\sigma_{aw,\star}=c_\sigma\sigma_{a,B}$ supplies the amplitude scale of the
+ latent acceleration prior, while $c_\sigma$ maps the physical band-limited
+ wave acceleration RMS to the OU stationary standard deviation.
+
+ \item[Integral regularization $r_S$.]
+ The natural third-integral scale is
+ $\sigma_S\propto H_s/\omega_p$.  Combining the first two channels gives
+ $\sigma_{aw}\tau^3\propto H_s/\omega_p$ exactly, so
+ $r_S=c_R\sigma_{aw}\tau^3$ keeps the $S=0$ pseudo-measurement on the same
+ physical scale as the JONSWAP third-integral fluctuations.  The coefficient
+ $c_R$ absorbs the dimensionless JONSWAP moment ratio, $c_\tau$, $c_\sigma$,
+ and the chosen regularization multiple $k_i$.
+\end{description}
+
+If $\mat R_S$ denotes pseudo-measurement covariance rather than standard
+deviation, the corresponding scalar covariance scaling is
+\begin{equation}
+ R_S\propto\sigma_{aw}^2\tau^6.
+\label{eq:jonswap-RS-variance-law}
+\end{equation}
+The implementation in this work uses $r_S$ as a standard-deviation scale and
+squares it componentwise when constructing $\mat R_S$.
+
+\subsubsection{Implication for the current tuner and recommended change}
+\label{sec:jonswap-tuner-recommendation}
+
+The exact theorem requires $\sigma_{a,B}$ to be measured over a band whose
+edges remain fixed relative to the characteristic JONSWAP frequency.  The
+current tuner does \emph{not} yet enforce that condition: it changes the EWMA
+variance horizon with the estimated period, but it forms the variance from the
+vertical acceleration stream without an explicit period-scaled band-pass.
+Consequently the deployed law should presently be interpreted as a
+JONSWAP-motivated approximation, because its effective upper acceleration
+bandwidth is set by the IMU and preprocessing rather than by a fixed
+$\omega/\omega_p$ interval.
+
+A theoretically matched revision is to form the variance from a
+measurement-only adaptive wave-band signal
+\begin{equation}
+ f_L=\beta_L f_{\mathrm{tune}},
+ \qquad
+ f_H=\beta_H f_{\mathrm{tune}},
+ \qquad 0\le\beta_L<\beta_H<\infty,
+\label{eq:recommended-scaled-band}
+\end{equation}
+with practical absolute clamps below Nyquist and below the sensor anti-alias
+limit.  Since $f_{\mathrm{tune}}=1/T_z\propto\omega_p$ for fixed JONSWAP
+shape, fixed $(\beta_L,\beta_H)$ implement the fixed dimensionless band
+required by the theorem.  The band edges should be changed smoothly using the
+same measurement-only period estimate so that no estimator-state feedback is
+introduced and filter-coefficient transients are controlled.
+
+The variance and noise-floor subtraction should then be performed in the same
+band,
+\begin{equation}
+ \widehat\sigma_{\mathrm{wave},B}^2
+ =\max\!\left\{0,
+ \widehat\Var[a_B]-\sigma_{\mathrm{nf},B}^2\right\},
+ \qquad
+ \sigma_{aw,\star}
+ =c_\sigma\sqrt{\widehat\sigma_{\mathrm{wave},B}^2},
+\label{eq:recommended-band-variance}
+\end{equation}
+where $\sigma_{\mathrm{nf},B}$ is the bench noise floor after the same adaptive
+band-pass (or its analytically propagated equivalent).  Merely shortening or
+lengthening the EWMA horizon in proportion to the period does not impose the
+spectral similarity required by Theorem~\ref{thm:jonswap-rs-similarity}.
+
+If $\gamma$ is allowed to vary substantially, the moment ratio in
+\eqref{eq:jonswap-KJ} also varies.  The simplest rigorous scope is therefore a
+fixed-$\gamma$ JONSWAP family.  A broader tuner could later replace the
+constant $c_R$ by a dimensionless shape correction based on an estimated
+spectral peakedness or bandwidth.  Likewise, hard clamps on $\tau$,
+$\sigma_{aw}$, or $r_S$ deliberately break the similarity law at the operating
+boundaries and should be treated as saturation safeguards rather than part of
+the theorem.


### PR DESCRIPTION
## What changed

This PR has been revised around a JONSWAP spectral-similarity result. The earlier integrated-OU scale-equivariance theorem was removed because it overstated what follows from OU nondimensionalization and did not carry the missing spectral/time-scale dependence.

### JONSWAP theorem

For a fixed-shape JONSWAP family written as

`S_eta(omega) = Hs^2 / omega_p * Phi_gamma(omega / omega_p)`,

the manuscript now proves the spectral-moment similarity

`m_n = Hs^2 * omega_p^n * C_n`.

From that identity it derives all three tuner scalings:

- the natural OU-III third-integral scale is `sigma_S ~ Hs / omega_p`;
- wave-band acceleration RMS is `sigma_a,B ~ Hs * omega_p^2` when its band edges are fixed in units of the characteristic wave frequency;
- the zero-crossing period gives `tau = c_tau T_z/2 ~ omega_p^-1`.

Therefore

`sigma_a,B * tau^3 ~ Hs / omega_p`,

which has exactly the same amplitude/period scaling as the physical third-integral state. The theorem gives the explicit dimensionless JONSWAP moment coefficient relating the two.

### Why sigma * tau^3 is structurally important

The paper now includes a uniqueness argument. If the regularization law were a general monomial

`r_S = C * sigma_aw^alpha * tau^beta`,

then fixed-shape JONSWAP similarity gives

`r_S ~ Hs^alpha * omega_p^(2 alpha - beta)`.

Matching the physical `S` scale `Hs * omega_p^-1` for all wave heights and periods forces

`alpha = 1`, `beta = 3`.

Thus the linear sigma factor and cubic tau factor are the unique monomial exponents compatible with the JONSWAP similarity family.

### Theoretical meaning of all three tuner channels

The manuscript now distinguishes the roles of the three adaptive quantities:

1. `tau = c_tau T_z/2` maps the observable JONSWAP wave time scale to the OU surrogate correlation time; it does not claim that JONSWAP itself is an OU process.
2. `sigma_aw = c_sigma sigma_a,B` maps band-limited physical wave-acceleration RMS to the stationary OU acceleration scale.
3. `r_S = c_R sigma_aw tau^3` follows the natural third-integral scale `Hs/omega_p`; `c_R` is dimensionless and absorbs the JONSWAP shape moments, the two mapping coefficients, and the chosen pseudo-measurement regularization multiple.

The standard-deviation/covariance distinction remains explicit: if `R_S` denotes variance rather than standard deviation, the corresponding outer scaling is `sigma_aw^2 tau^6`.

## Important high-frequency condition

The theorem explicitly notes that ideal JONSWAP has an `omega^-5` elevation tail, so its unbounded fourth elevation moment diverges logarithmically. Therefore the acceleration scale in the theorem must be a finite wave-band RMS. The low-frequency negative moment used for the third-integral state is finite because JONSWAP is exponentially suppressed as omega -> 0.

This is the key condition missing from the previous theorem.

## Tuner-code recommendation

No production estimator code is changed in this PR, but the manuscript now records a concrete design change needed to make the implementation match the theorem exactly:

- form the acceleration variance from a measurement-only adaptive band-pass with edges proportional to `f_tune`, e.g. `f_L = beta_L f_tune`, `f_H = beta_H f_tune`, with fixed dimensionless beta values and practical sensor/Nyquist clamps;
- update those filter corners smoothly from the existing measurement-only period estimate so no estimator-state feedback is introduced;
- perform the noise-floor subtraction after the same adaptive band-pass, using a band-referred bench noise floor;
- keep the period-scaled EWMA horizon for statistical smoothing, but do not treat that horizon alone as spectral band selection;
- if JONSWAP peakedness gamma is allowed to vary substantially, either scope the constant `c_R` claim to fixed gamma or later schedule a dimensionless shape correction from an estimated bandwidth/peakedness parameter.

The current tuner changes the variance averaging horizon with period but does not explicitly enforce a period-scaled acceleration band, so the paper now calls the current constant-coefficient law a JONSWAP-motivated approximation until that code change is made.

## Scope

- Documentation/theory only; no production estimator behavior is changed.
- The theorem applies away from hard parameter clamps; clamps are saturation safeguards and intentionally break exact similarity at the boundaries.
- The branch remains a draft PR for review before merge.

## Validation

The theorem uses the existing Hasselmann JONSWAP reference already present in the OU-III bibliography. GitHub Actions provides the authoritative LaTeX/build validation for the updated branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a theorem documenting how the OU third-integral scale and pseudo-measurement deviation vary with acceleration RMS and wave period.
  * Documented covariance scaling, tuner-channel roles, uniqueness of the scaling exponents, and applicable limitations.
  * Added guidance on adaptive band-pass filtering, noise-floor subtraction, shape corrections, and saturation safeguards.
  * Replaced the inline practical scale discussion with the new dedicated documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->