### PR TITLE
Clarify JONSWAP integrated-elevation interpretation

### DIFF
--- a/doc/kalman_ou_iii/kalman_ou-w3d.tex
+++ b/doc/kalman_ou_iii/kalman_ou-w3d.tex
@@ -233,6 +233,7 @@ extended Kalman filter, inertial navigation, IMU, marine Motion Reference Unit, 
 \input{w3d-kalm-up.tex-part}
 \input{w3d-init.tex-part}
 \input{w3d-fus-methods.tex-part}
+\input{w3d-jonswap-integrated-elevation-clarification.tex-part}
 \input{w3d-iss-stability.tex-part}
 \input{w3d-iss-theorem-audit.tex-part}
 \input{w3d-sim-charts.tex-part}

--- a/doc/kalman_ou_iii/w3d-jonswap-integrated-elevation-clarification.tex-part
+++ b/doc/kalman_ou_iii/w3d-jonswap-integrated-elevation-clarification.tex-part
@@ -1,0 +1,90 @@
+\subsection{Kinematic interpretation of the JONSWAP consistency check}
+\label{sec:jonswap-integrated-elevation-clarification}
+
+A distinction between the OU model and the JONSWAP comparison is important here.
+The JONSWAP spectrum in Sec.~\ref{sec:jonswap-tuner-map} is an \emph{elevation}
+(or displacement) spectrum $S_\eta(\omega)$; it is not an acceleration spectrum
+and it is not the stochastic process propagated by the Kalman filter.  Under
+linear wave kinematics,
+\begin{equation}
+ A(\omega)=-\omega^2\Eta(\omega).
+\label{eq:jonswap-acc-from-elevation-clarification}
+\end{equation}
+The OU--III state $S$ is the third time integral of acceleration.  Therefore,
+for a physical wave acceleration generated from elevation,
+\begin{equation}
+ S(\omega)
+ =\frac{A(\omega)}{(j\omega)^3}
+ =\frac{-\omega^2}{(j\omega)^3}\Eta(\omega),
+\label{eq:jonswap-S-from-eta-clarification}
+\end{equation}
+which, apart from the sign/phase convention, is one time integration of
+elevation.  In the time domain this is the simple kinematic identity
+\begin{equation}
+ \boxed{\displaystyle
+ S=\iiint a\,dt^3=\int\eta\,dt}
+\label{eq:triple-acc-single-elevation-integral}
+\end{equation}
+for the corresponding zero-initial-condition components.  Thus the phrase
+``third integral'' refers to the acceleration input.  It must not be read as
+three integrations of the JONSWAP elevation process.
+
+The same cancellation is explicit at the PSD level.  Since
+\begin{equation}
+ S_a^{(2)}(\omega)=\omega^4S_\eta^{(2)}(\omega),
+\end{equation}
+three integrations of acceleration give
+\begin{equation}
+ S_S^{(2)}(\omega)
+ =\frac{S_a^{(2)}(\omega)}{\omega^6}
+ =\boxed{\displaystyle
+   \frac{S_\eta^{(2)}(\omega)}{\omega^2}}.
+\label{eq:jonswap-S-psd-clarification}
+\end{equation}
+Hence the physical $S$-variance implied by a JONSWAP elevation spectrum is
+\begin{equation}
+ \Var[S]
+ =\frac{1}{\pi}\int_0^\infty
+   \frac{S_\eta^{(2)}(\omega)}{\omega^2}\,d\omega,
+\label{eq:jonswap-integrated-elevation-variance}
+\end{equation}
+which is the variance of an \emph{integrated-elevation} quantity.  For the
+fixed-shape similarity form
+$S_\eta^{(2)}=(H_s^2/\omega_p)\Phi_\gamma(\omega/\omega_p)$, substitution of
+$x=\omega/\omega_p$ gives
+\begin{equation}
+ \sigma_{S,\mathrm{phys}}
+ \propto \frac{H_s}{\omega_p}.
+\label{eq:jonswap-integrated-elevation-scale}
+\end{equation}
+
+This physical calculation has a different role from
+Theorems~\ref{thm:ou-chain-similarity} and~\ref{thm:ou-regularized-rs}.  Inside
+the estimator the latent process $a_w$ is OU acceleration and the chain really
+is
+\[
+ a_w\xrightarrow{\int}v
+ \xrightarrow{\int}p
+ \xrightarrow{\int}S,
+\]
+so the OU similarity scale is $\sigma_{aw}\tau^3$.  JONSWAP is used only to
+motivate the sea-state dependence of the tuner inputs.  From
+Theorem~\ref{thm:jonswap-tuner-similarity},
+\begin{equation}
+ \sigma_{aw,\star}\propto H_s\omega_p^2,
+ \qquad
+ \tau_\star\propto\omega_p^{-1},
+\end{equation}
+and consequently
+\begin{equation}
+ \sigma_{aw,\star}\tau_\star^3
+ \propto\frac{H_s}{\omega_p}
+ \propto\sigma_{S,\mathrm{phys}}.
+\label{eq:jonswap-ou-physical-scale-consistency}
+\end{equation}
+Equation~\eqref{eq:jonswap-ou-physical-scale-consistency} is therefore a
+\emph{consistency check between two model layers}: the triple-integrated OU
+scale used by the estimator and the single-integrated-elevation scale implied
+by JONSWAP have the same sea-state similarity.  It is not a statement that the
+filter triple-integrates a JONSWAP process, and it is not the derivation of the
+$r_S\propto\sigma_{aw}\tau^3$ adaptation law.


### PR DESCRIPTION
## What changed

- adds an explicit kinematic clarification that JONSWAP is an elevation/displacement spectrum, not the acceleration process propagated by OU-III
- shows that for physical wave kinematics, `a = d^2 eta/dt^2`, so the OU-III-like state relation `S = triple integral(a)` is equivalently `S = integral(eta)` up to initial-condition/sign conventions
- shows the corresponding PSD cancellation: `S_a = omega^4 S_eta` and triple integration gives `S_S = S_eta / omega^2`
- derives the physical integrated-elevation scale `sigma_S,phys ∝ H_s / omega_p`
- states explicitly that `sigma_aw tau^3 ∝ H_s / omega_p` is a consistency check between the triple-integrated OU scale and the single-integrated JONSWAP-elevation scale, not a claim that the filter triple-integrates JONSWAP and not the derivation of the adaptation law

## Sync / scope

The branch was created directly from current `main` at `3fe79fa58a116d2f00d8507625d5f527928191e1` (the merged OU-theorem PR #279), and the compare is 2 commits ahead / 0 behind. The change is documentation-only: one new TeX part plus one `\input` in the main article.

## Validation

Publication CI should provide the authoritative LaTeX/build check.