### PR TITLE
Fix OU paper LaTeX build

### DIFF
--- a/doc/kalman_ou_iii/w3d-fus-methods.tex-part
+++ b/doc/kalman_ou_iii/w3d-fus-methods.tex-part
@@ -49,7 +49,7 @@ The derivative follows the standard state-sensitivity recursion, and
 \section{Variance-Informed Online Adaptation}
 \label{sec:adaptation}
 
-\subsection{Spectral scaling and pseudo-measurement on $S$}
+\subsection{Spectral scaling and pseudo-measurement on \texorpdfstring{$S$}{S}}
 \label{sec:spectral-Rs}
 \label{app:rs-scaling}
 
@@ -65,7 +65,7 @@ The purpose of the scaling argument below is to choose $r_S$ on the same
 physical scale as the natural fluctuations of $S$ within a stated family of
 wave spectra and a fixed pseudo-update cadence.
 
-\subsection{Variance of $S$ from the acceleration spectrum}
+\subsection{Variance of \texorpdfstring{$S$}{S} from the acceleration spectrum}
 
 Let $a(t)$ denote vertical acceleration and let
 \[

--- a/doc/kalman_ou_iii/w3d-jonswap-integrated-elevation-clarification.tex-part
+++ b/doc/kalman_ou_iii/w3d-jonswap-integrated-elevation-clarification.tex-part
@@ -7,7 +7,7 @@ The JONSWAP spectrum in Sec.~\ref{sec:jonswap-tuner-map} is an \emph{elevation}
 and it is not the stochastic process propagated by the Kalman filter.  Under
 linear wave kinematics,
 \begin{equation}
- A(\omega)=-\omega^2\Eta(\omega).
+ A(\omega)=-\omega^2\widehat{\eta}(\omega).
 \label{eq:jonswap-acc-from-elevation-clarification}
 \end{equation}
 The OU--III state $S$ is the third time integral of acceleration.  Therefore,
@@ -15,7 +15,7 @@ for a physical wave acceleration generated from elevation,
 \begin{equation}
  S(\omega)
  =\frac{A(\omega)}{(j\omega)^3}
- =\frac{-\omega^2}{(j\omega)^3}\Eta(\omega),
+ =\frac{-\omega^2}{(j\omega)^3}\widehat{\eta}(\omega),
 \label{eq:jonswap-S-from-eta-clarification}
 \end{equation}
 which, apart from the sign/phase convention, is one time integration of

--- a/doc/kalman_ou_iii/w3d-rs-scale-theorem.tex-part
+++ b/doc/kalman_ou_iii/w3d-rs-scale-theorem.tex-part
@@ -38,11 +38,12 @@ Define
 \end{equation}
 Then the dimensionless dynamics contain neither $\sigma_{aw}$ nor $\tau$:
 \begin{equation}
- d\bar a=-\bar a\,d\bar t+\sqrt{2}\,d\bar W_{\bar t},
-\qquad
- \frac{d\bar v}{d\bar t}=\bar a,\quad
- \frac{d\bar p}{d\bar t}=\bar v,\quad
- \frac{d\bar S}{d\bar t}=\bar p .
+\begin{aligned}
+ d\bar a&=-\bar a\,d\bar t+\sqrt{2}\,d\bar W_{\bar t},\\
+ \frac{d\bar v}{d\bar t}&=\bar a,\qquad
+ \frac{d\bar p}{d\bar t}&=\bar v,\qquad
+ \frac{d\bar S}{d\bar t}&=\bar p .
+\end{aligned}
 \label{eq:ou-chain-nondim-dynamics}
 \end{equation}
 Hence the natural similarity scales of $(a_w,v,p,S)$ are respectively
@@ -513,9 +514,12 @@ candidate statistics but cannot retroactively choose the band applied to its
 own sample.
 
 The variance horizon remains period scaled,
-$\tau_{\mathrm{var}}\approx K_{\mathrm{periods}}/f_{\mathrm{tune}}$, but it has
-only its intended statistical role: it controls averaging time after the
-spectral band has been selected.  It is not used to derive the
+\begin{equation}
+ \tau_{\mathrm{var}}\approx
+ \frac{K_{\mathrm{periods}}}{f_{\mathrm{tune}}},
+\end{equation}
+but it has only its intended statistical role: it controls averaging time
+after the spectral band has been selected.  It is not used to derive the
 $r_S\propto\sigma_{aw}\tau^3$ law.
 
 Noise-floor subtraction is performed in the same band.  The configured bench


### PR DESCRIPTION
## Summary
- replace the undefined Fourier-domain `\Eta` symbol with `\widehat{\eta}`
- make the two math-bearing subsection titles bookmark-safe for `hyperref`
- reflow the OU nondimensional dynamics and variance-horizon expression to remove the reported box warnings

## Why
The undefined `\Eta` command stops LuaLaTeX in `w3d-jonswap-integrated-elevation-clarification.tex-part`. Because that first pass aborts, `latexmk` never gets to complete the later bibliography/reference passes, which explains the large cascade of unresolved citations and references even though the bibliography keys are present.

## Validation
- branch is a single commit based directly on current `main`
- net diff contains only the three intended OU manuscript fragments
- exact-match source edits and `git diff --check` completed successfully
- GitHub `build` workflow on this PR provides the full LuaLaTeX/latexmk validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved PDF bookmarks by providing plain-text labels for mathematical subsection headings.
  * Standardized Fourier-domain elevation notation in the JONSWAP derivation.
  * Reformatted dimensionless dynamics and variance-horizon equations for improved readability without changing their meaning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->