### PR TITLE
Prove OU-III observability under bounded pseudo-update gaps

### DIFF
--- a/doc/kalman_ou_ii/ou2-iss-stability.tex-part
+++ b/doc/kalman_ou_ii/ou2-iss-stability.tex-part
@@ -389,9 +389,12 @@ stability.  The current default code supplies several of its bounds directly:
 \end{equation}
 At the nominal \SI{200}{Hz} validation rate,
 $T_{pv}=\SI{15}{ms}=3h$, so successive joint $p/v$ pseudo-updates have a
-strictly positive, finite gap.  Unlike the OU--III four-sample determinant, the
-OU--II translational proof remains valid under bounded timing jitter as long as
-Eq.~\eqref{eq:ou2-iss-pv-gap} remains true.
+strictly positive, finite gap.  OU--II retains the fixed pseudo-update period;
+it does not use the self-similar cadence deployed by the OU--III wrapper.  In
+either case the translational proof remains valid under bounded timing jitter
+as long as Eq.~\eqref{eq:ou2-iss-pv-gap} remains true: the OU--II argument needs
+only one nonzero propagation gap, and the OU--III four-point determinant is
+likewise proved in the unequal-spacing case.
 
 \begin{table}[H]
 \centering

--- a/doc/kalman_ou_iii/w3d-fus-methods.tex-part
+++ b/doc/kalman_ou_iii/w3d-fus-methods.tex-part
@@ -63,7 +63,10 @@ componentwise to form the covariance $\mat{R}_S$, as defined in
 \eqref{eq:RS-from-rS}.  The channel is a regularizer, not a physical sensor.
 The purpose of the scaling argument below is to choose $r_S$ on the same
 physical scale as the natural fluctuations of $S$ within a stated family of
-wave spectra and a fixed pseudo-update cadence.
+wave spectra, at a reference pseudo-update cadence.  Section
+\ref{sec:riccati-similarity-design-guidance} revisits the cadence itself and
+Sec.~\ref{sec:riccati-deployed-cadence} records what the wrapper actually
+schedules.
 
 \subsection{Variance of \texorpdfstring{$S$}{S} from the acceleration spectrum}
 

--- a/doc/kalman_ou_iii/w3d-iss-stability.tex-part
+++ b/doc/kalman_ou_iii/w3d-iss-stability.tex-part
@@ -100,7 +100,16 @@ m_0\le\|\widehat{\vct m}_b\|\le m_1,
 \end{equation}
 where $\vct u_f$ and $\vct u_m$ are the corresponding unit vectors. Every
 finite proof horizon contains four consecutive $S$ pseudo-updates at relative
-times $0,T_S,2T_S,3T_S$ and two accepted accelerometer--magnetometer
+times
+\begin{equation}
+0=t_0<t_1<t_2<t_3,
+\qquad
+T_j:=t_j-t_{j-1}\in[T_-,T_+],
+\qquad
+0<T_-\le T_+<\infty,
+\label{eq:iss-S-gap-bounds}
+\end{equation}
+and two accepted accelerometer--magnetometer
 vector-update instants separated by
 $\Delta\in[\Delta_{\min},\Delta_{\max}]$, with
 \begin{equation}
@@ -109,14 +118,24 @@ $\Delta\in[\Delta_{\min},\Delta_{\max}]$, with
 \end{equation}
 No hard reset occurs inside the horizon.
 
-The exact $S$-update spacing is an explicit theorem assumption.  The production
-scheduler in Sec.~\ref{sec:measurement_model} is time based and, for general
-variable $h_k$, may apply an intended deadline on the first IMU sample after
-that deadline.  The fixed-rate validation uses $h=\SI{5}{ms}$ and the default
-$T_S=\SI{15}{ms}$, so its pseudo-updates occur every three IMU samples and
-satisfy the exact-spacing assumption.  Extending the determinant argument to
-bounded sample-time jitter would require an explicit perturbation margin for
-the finite-horizon Gramian; that extension is not claimed here.
+Only the \emph{bounded-gap} condition \eqref{eq:iss-S-gap-bounds} is required;
+the four pseudo-updates need not be equally spaced.  This matters because the
+production scheduler in Sec.~\ref{sec:measurement_model} is time based and
+applies an intended deadline on the first IMU sample at or after that deadline,
+so realized gaps are quantized to the IMU grid and, under the self-similar
+cadence $T_S=c_T\tau_{\mathrm{applied}}$, are generally not integer multiples
+of $h_k$.  Both bounds in \eqref{eq:iss-S-gap-bounds} are nevertheless
+unconditional properties of that scheduler: a gap is never shorter than one IMU
+step and never longer than one configured period plus one step,
+\begin{equation}
+T_-\ge h_{\min},
+\qquad
+T_+\le T_{S,\max}+h_{\max},
+\label{eq:iss-scheduler-gap-witness}
+\end{equation}
+where $T_{S,\max}$ is the largest configured period on the interval.  Lemma
+\ref{lem:iss-axis-uco} below is proved directly in the unequal-spacing case, so
+no separate jitter-perturbation argument is needed.
 
 \subsection{Exact Live-state linearized structure}
 
@@ -210,46 +229,78 @@ Then
 \begin{equation}
 S(t)=S_0+t p_0+\frac{t^2}{2}v_0+A_3(t)a_0.
 \end{equation}
-At $t_j=jT_S$, $j=0,1,2,3$, the observation matrix is
+At the four pseudo-update instants $t_0,\dots,t_3$ of
+Eq.~\eqref{eq:iss-S-gap-bounds}, the observation matrix is
 \begin{equation}
 \mat O_S=
 \begin{bmatrix}
-0&0&1&0\\
-T_S^2/2&T_S&1&A_3(T_S)\\
-(2T_S)^2/2&2T_S&1&A_3(2T_S)\\
-(3T_S)^2/2&3T_S&1&A_3(3T_S)
-\end{bmatrix}.
+t_0^2/2&t_0&1&A_3(t_0)\\
+t_1^2/2&t_1&1&A_3(t_1)\\
+t_2^2/2&t_2&1&A_3(t_2)\\
+t_3^2/2&t_3&1&A_3(t_3)
+\end{bmatrix},
+\qquad t_0=0 .
 \end{equation}
 
 \begin{lemma}[Uniform observability of one OU--III axis]
+\label{lem:iss-axis-uco}
 For every measurable $\tau(t)$ satisfying
-$\underline\tau\le\tau(t)\le\overline\tau$ and four consecutive $S$
-pseudo-measurements separated exactly by $T_S$,
+$\underline\tau\le\tau(t)\le\overline\tau$ and any four consecutive $S$
+pseudo-measurements obeying the bounded-gap condition
+\eqref{eq:iss-S-gap-bounds},
 \begin{equation}
 |\det\mat O_S|
-\ge T_S^6\exp\!\left(-\frac{3T_S}{\underline\tau}\right)>0.
+\ge T_-^6\exp\!\left(-\frac{3T_+}{\underline\tau}\right)>0.
 \label{eq:iss-det-lower}
 \end{equation}
 Hence the scalar $[v,p,S,a]$ chain is uniformly observable over that
-exact-cadence four-update horizon.
+four-update horizon.
 \end{lemma}
 
 \begin{proof}
-Since $A_3'''(t)=E(t)$, direct expansion gives
+Write $f=A_3$ and let $f[t_0,\dots,t_3]$ denote the third divided difference.
+For any $f$, the determinant of the matrix with rows
+$[1,t_j,t_j^2,f(t_j)]$ equals
+$V(t)\,f[t_0,\dots,t_3]$ with the Vandermonde factor
+$V(t)=\prod_{i<j}(t_j-t_i)$: both sides are linear in $f$, both annihilate
+every polynomial of degree $\le2$, and both equal $V(t)$ at $f(t)=t^3$.
+Passing to the column order $[t^2/2,\,t,\,1,\,f]$ transposes the first and
+third columns and scales the first by $\tfrac12$, so
 \begin{equation}
-\det\mat O_S=-T_S^3\Delta_{T_S}^3A_3(0),
+\det\mat O_S=-\tfrac12\,V(t)\,A_3[t_0,t_1,t_2,t_3].
+\label{eq:iss-det-divided-difference}
 \end{equation}
-where
+Since $A_3'''=E$ is continuous, the Hermite--Genocchi formula gives
 \begin{equation}
-\Delta_T^3A_3(0)=
-\int_0^T\!\int_0^T\!\int_0^T E(u+v+w)\,du\,dv\,dw.
+A_3[t_0,t_1,t_2,t_3]
+=\int_{\mathcal T_3}E\!\left(\textstyle\sum_{j}s_jt_j\right)d\mu,
+\qquad
+\mathcal T_3=\Bigl\{s_j\ge0,\ \textstyle\sum_js_j=1\Bigr\},
 \end{equation}
-The lower bound $E(t)\ge e^{-t/\underline\tau}$ gives
+where $\mathcal T_3$ carries total mass $1/3!$. Every argument
+$\sum_js_jt_j$ lies in $[0,t_3]$, and $\tau(t)\ge\underline\tau$ gives
+$E(u)\ge e^{-u/\underline\tau}$, so
+\begin{equation}
+A_3[t_0,t_1,t_2,t_3]\ge\tfrac16\,e^{-t_3/\underline\tau}>0 .
+\end{equation}
+The six pairwise gaps in $V(t)$ are $T_1,T_2,T_3,T_1+T_2,T_2+T_3$ and
+$T_1+T_2+T_3$, hence $V(t)\ge12\,T_-^6$, while $t_3\le3T_+$. Substituting both
+into \eqref{eq:iss-det-divided-difference} yields
 Eq.~\eqref{eq:iss-det-lower}. The entries of $\mat O_S$ are uniformly bounded
 on the compact parameter set, so nonsingularity with the determinant lower
 bound also yields a uniform positive lower bound on
 $\sigma_{\min}(\mat O_S)$.
 \end{proof}
+
+\begin{remark}[Reduction to the equal-spacing case]
+For $T_1=T_2=T_3=T_S$ one has $V=12T_S^6$ and
+$A_3[t_0,\dots,t_3]=\Delta_{T_S}^3A_3(0)/(6T_S^3)$, so
+Eq.~\eqref{eq:iss-det-divided-difference} collapses to the finite-difference
+form $\det\mat O_S=-T_S^3\Delta_{T_S}^3A_3(0)$ and
+Eq.~\eqref{eq:iss-det-lower} to
+$T_S^6\exp(-3T_S/\underline\tau)$. The bounded-gap lemma therefore contains the
+exact-cadence statement as a special case rather than replacing it.
+\end{remark}
 
 The three-axis 12-state result follows componentwise. Bounded positive
 $\mat R_S$ converts this singular-value bound into a uniform finite-horizon
@@ -458,7 +509,8 @@ is not covered by the theorem.
 \begin{theorem}[21-state Live UES]
 \label{thm:iss-21-ues}
 Under Eqs.~\eqref{eq:iss-step-tau-bounds}--\eqref{eq:iss-vector-gap}, including
-the exact $T_S$ spacing of the four $S$ pseudo-updates on each translational
+the bounded-gap spacing \eqref{eq:iss-S-gap-bounds} of the four $S$
+pseudo-updates on each translational
 proof horizon, the positive process-density assumptions above, the default PSD
 $a_w$ covariance inflation (or no periodic covariance maintenance), active
 slow-OU residual accelerometer-bias estimation with finite
@@ -569,6 +621,9 @@ The proof covers the default prediction-time PSD $a_w$ covariance inflation and
 the case in which periodic covariance maintenance is disabled. It does not
 cover the optional legacy raw covariance replacement, startup/re-lock/hard-reset
 maps, arbitrarily long measurement outages, collinear gravity/magnetic reference
-geometry, sample-time jitter of the nominal $S$ pseudo-update deadlines, or the
+geometry, or the
 random-walk limit $\tau_b=\infty$. In particular, the finite upper bound on
-$\tau_b$ is essential for a uniform 21-state stability margin.
+$\tau_b$ is essential for a uniform 21-state stability margin. Sample-time
+quantization and adaptive variation of the $S$ pseudo-update deadlines are
+inside the theorem, because Lemma~\ref{lem:iss-axis-uco} assumes only bounded
+positive gaps.

--- a/doc/kalman_ou_iii/w3d-iss-theorem-audit.tex-part
+++ b/doc/kalman_ou_iii/w3d-iss-theorem-audit.tex-part
@@ -80,7 +80,7 @@ than merely assuming their existence.  The defaults give
 \SI{0.12}{m/s^2}\le\sigma_{z,k}\le\SI{6}{m/s^2},
 \qquad
 \sigma_{x,k}=\sigma_{y,k}=1.87\,\sigma_{z,k},\\
-0.4\le r_{S,k}\le400\ \mathrm{m\,s},
+0.4\le r_{S,k}^{\mathrm{base}}\le400\ \mathrm{m\,s},
 \qquad
 \tau_b=\SI{5000}{s}.
 \end{gathered}
@@ -92,15 +92,53 @@ also clamps a directly supplied OU time constant away from zero, and the default
 legacy raw $P_{a_wa_w}$ replacement is disabled, leaving the proof-compatible
 positive-semidefinite covariance-inflation path active.
 
-At the fixed-rate validation point quoted in the proof,
+\paragraph{Deployed pseudo-update cadence.}
+The default wrapper schedules the $S=0$ regularizer on the self-similar cadence
+of Sec.~\ref{sec:riccati-similarity-design-guidance},
 \begin{equation}
-h=\SI{5}{ms},\qquad T_S=\SI{15}{ms}=3h,
-\label{eq:iss-fixed-rate-cadence-check}
+T_{S,k}=\operatorname{clip}\!\left(
+c_T\tau_{\mathrm{applied},k},\,
+T_{S,\min},\,T_{S,\max}\right),
+\qquad
+c_T=\frac{\SI{15}{ms}}{\SI{1.1}{s}}\approx0.0136,
+\label{eq:iss-deployed-cadence}
 \end{equation}
-so the four required $S$ observations occur on exact sample boundaries.  This
-checks the cadence assumption for that validation configuration; it is not a
-claim that arbitrary variable-step deployment automatically has exact
-$T_S$ spacing.
+with $T_{S,\min}=\SI{5}{ms}$ and $T_{S,\max}=\SI{250}{ms}$.  Over the clamped
+$\tau$ envelope this gives $T_{S,k}\in[\SI{5}{ms},\SI{164}{ms}]$, so at the
+nominal \SI{200}{Hz} rate the realized pseudo-update gaps satisfy
+\begin{equation}
+h=\SI{5}{ms}\le T_j\le T_{S,\max}+h=\SI{169}{ms},
+\label{eq:iss-deployed-cadence-gap-check}
+\end{equation}
+which is exactly the bounded-gap hypothesis
+Eq.~\eqref{eq:iss-S-gap-bounds} discharged through
+Eq.~\eqref{eq:iss-scheduler-gap-witness}.  The gaps are \emph{not} in general
+equally spaced: at a representative $\tau_{\mathrm{applied}}=\SI{3.49}{s}$ the
+configured period is $T_S=\SI{47.6}{ms}=9.53\,h$, and the scheduler alternates
+between nine- and ten-sample gaps.  Lemma~\ref{lem:iss-axis-uco} is stated for
+that case, so no equal-spacing claim is made or needed.
+
+The wrapper additionally renormalizes the pseudo-measurement standard deviation
+so that the per-update information rate $r_S^2T_S$ is cadence invariant,
+\begin{equation}
+r_{S,k}=r_{S,k}^{\mathrm{base}}\sqrt{\frac{T_{S,0}}{T_{S,k}}},
+\qquad
+T_{S,0}=\SI{15}{ms},
+\label{eq:iss-cadence-information-scale}
+\end{equation}
+and does not re-apply the base clamp afterwards.  The value actually reaching
+the MEKF is therefore bounded, but not by the base interval in
+Eq.~\eqref{eq:iss-default-implementation-bounds}.  Since
+$\sqrt{T_{S,0}/T_{S,k}}\in[0.303,1.733]$ over the envelope above, a
+conservative enclosure is
+\begin{equation}
+0.121\le r_{S,k}\le693\ \mathrm{m\,s},
+\label{eq:iss-effective-rs-bounds}
+\end{equation}
+which is all Eq.~\eqref{eq:iss-R-bounds} requires: uniformly positive and
+uniformly finite.  Equation~\eqref{eq:iss-effective-rs-bounds} encloses the
+attainable set rather than describing it tightly, because the base clamp and
+the cadence factor cannot reach their extremes at the same $\tau$.
 
 \begin{table}[t]
 \caption{Audit of the conditions entering the local ISS claim.}
@@ -114,9 +152,9 @@ Condition & Status in the OU--III argument \\
 21-state uniform detectability & Proved by Lemma~\ref{lem:iss-21-detectable}: the 18-state block is UCO and the residual accelerometer-bias OU block contracts with $\rho_b<1$. \\
 Uniform stabilizability & Proved from the full-rank positive process covariance, Eq.~\eqref{eq:iss-Qeff-bounds}. \\
 Positive bounded $R_k$ & Explicit theorem/configuration assumption, Eq.~\eqref{eq:iss-R-bounds}; callers must retain nonzero finite sensor and pseudo-measurement covariances. \\
-Bounded adaptive schedule & Enforced by the default fusion-wrapper clamps; concrete values are displayed in Eq.~\eqref{eq:iss-default-implementation-bounds}. \\
+Bounded adaptive schedule & Enforced by the default fusion-wrapper clamps; concrete values are displayed in Eqs.~\eqref{eq:iss-default-implementation-bounds} and \eqref{eq:iss-effective-rs-bounds}. \\
 Predictable schedule & Enforced by staging the tuner result for the following IMU sample, Eq.~\eqref{eq:iss-predictable-schedule}. \\
-Exact $S$ cadence & Satisfied by the fixed \SI{200}{Hz} validation, Eq.~\eqref{eq:iss-fixed-rate-cadence-check}; otherwise a Live-interval assumption. \\
+Bounded $S$ pseudo-update gaps & Proved for the deployed self-similar cadence, Eq.~\eqref{eq:iss-deployed-cadence-gap-check}; the scheduler bound Eq.~\eqref{eq:iss-scheduler-gap-witness} holds for any configured period. Equal spacing is not required. \\
 Vector excitation & Live-interval assumption: accepted accelerometer/magnetometer pairs must satisfy Eqs.~\eqref{eq:iss-vector-magnitude-bounds}--\eqref{eq:iss-vector-gap}. \\
 No reset/outage & Live-interval assumption; startup, hard reset, re-lock, and arbitrarily long rejection/outage patterns remain outside the theorem. \\
 \bottomrule

--- a/doc/kalman_ou_iii/w3d-meas.tex-part
+++ b/doc/kalman_ou_iii/w3d-meas.tex-part
@@ -95,12 +95,21 @@ e_{k+1}=\tilde e_{k+1}\bmod T_S.
 A floating-point tolerance is used at the boundary.  Defining cadence in
 seconds rather than as every $N$ samples makes the regularization rate invariant
 to the IMU sample rate; the same $T_S$ produces the same number of updates per
-unit time at 100, 200, or 400~Hz.  The effective regularization strength still
-depends on both $\vct{r}_S$ and $T_S$, so comparisons of tuning laws assume a
-fixed pseudo-update cadence unless stated otherwise.  Appendix~\ref{app:iss-stability}
-uses the narrower exact-$T_S$ spacing assumption for its translational
-observability lemma; general sample-time quantization of these deadlines under
-variable $h_k$ is not part of that theorem.
+unit time at 100, 200, or 400~Hz.  Because the deadline is served on the first
+IMU sample at or after it, realized gaps are quantized to the IMU grid and need
+not be integer multiples of $T_S$; they always lie between one IMU step and one
+configured period plus one step.
+
+The period $T_S$ is itself a scheduled quantity.  The default OU--III wrapper
+sets it self-similarly from the applied OU time constant,
+$T_S=\operatorname{clip}(c_T\tau_{\mathrm{applied}},T_{S,\min},T_{S,\max})$;
+Sec.~\ref{sec:riccati-deployed-cadence} gives the deployed coefficients and the
+accompanying renormalization of $\vct r_S$.  The effective regularization
+strength depends on both $\vct{r}_S$ and $T_S$, so comparisons of tuning laws
+hold the cadence policy fixed unless stated otherwise.
+Appendix~\ref{app:iss-stability} assumes only that successive pseudo-update
+gaps are bounded above and below, which the scheduler above guarantees; equal
+spacing is not required by its translational observability lemma.
 
 \subsection{IMU lever-arm model}
 If the IMU is displaced from the center of gravity by known body-frame vector

--- a/doc/kalman_ou_iii/w3d-rs-riccati-analysis.tex-part
+++ b/doc/kalman_ou_iii/w3d-rs-riccati-analysis.tex-part
@@ -444,7 +444,8 @@ In the weak-measurement limit this reduces to $T_S\propto\tau$; in the
 strong-measurement limit it approaches $T_S\propto1/\sigma_a^2$.  The latter is
 less attractive operationally because it makes update timing strongly
 amplitude dependent.  A bounded $T_S=c_T\tau$ schedule is therefore the
-simpler self-similar candidate for future evaluation.
+simpler self-similar choice, and is the cadence the wrapper now deploys
+(Sec.~\ref{sec:riccati-deployed-cadence}).
 
 \subsubsection{Interpretation and limits of the adaptation law}
 
@@ -471,9 +472,12 @@ $q_{\mathrm{eff}}=S_{e_a}(0)$, together with the desired normalized
 regularization bandwidth $\omega_R\tau$.
 
 Accordingly, the current implementation should be described as an empirically
-calibrated approximation to this Riccati/pole law.  A particularly clean future
-variant is to set $T_S=c_T\tau$ and compare (i) the existing cubic target,
-(ii) a $\tau$-only or saturating-amplitude target motivated by the
-strong-accelerometer limit, and (iii) the full posterior-noise expression
+calibrated approximation to this Riccati/pole law.  The self-similar cadence
+$T_S=c_T\tau$ is now deployed; what it is paired with at the filter input, and
+which of the four groups that pairing actually holds fixed, is recorded in
+Sec.~\ref{sec:riccati-deployed-cadence}.  The remaining open comparison is
+between (i) the existing cubic target, (ii) a $\tau$-only or
+saturating-amplitude target motivated by the strong-accelerometer limit, and
+(iii) the full posterior-noise expression
 \eqref{eq:riccati-pole-target-rs}.  Such tests distinguish coordinate
 similarity from actual closed-loop regularization invariance.

--- a/doc/kalman_ou_iii/w3d-rs-scale-theorem.tex-part
+++ b/doc/kalman_ou_iii/w3d-rs-scale-theorem.tex-part
@@ -279,14 +279,16 @@ exactly $\sigma_{aw}^2\tau^6$ and the remaining integral is
 \eqref{eq:ou-F3}.
 \end{proof}
 
-\begin{remark}[What a fixed pseudo-update cadence does and does not prove]
+\begin{remark}[What the pseudo-update cadence does and does not prove]
 \label{rem:ou-cadence-boundary}
 The finite-horizon theorem gives a second exact OU scaling, but it also shows
 why a fixed pseudo-update period alone cannot justify a universal
 $r_S=c_R\sigma_{aw}\tau^3$ coefficient.  If the relevant horizon $T_S$ obeys
 $T_S/\tau=\mathrm{const}$, then $\sqrt{F_3(T_S/\tau)}$ is constant and the cubic
 law follows immediately.  If $T_S$ is fixed in seconds while $\tau$ varies,
-the coefficient changes with $T_S/\tau$.  In particular,
+the coefficient changes with $T_S/\tau$.  The deployed wrapper takes the first
+branch away from its safety clamps
+(Sec.~\ref{sec:riccati-deployed-cadence}).  In particular,
 \begin{equation}
  F_3(\rho)=\frac{\rho^6}{36}+O(\rho^7),
  \qquad \rho\rightarrow0,
@@ -560,9 +562,11 @@ Disabling wave-band tuning bypasses this period-scaled variance band and keeps
 the older broadband path available for ablation.  Hard frequency clamps,
 parameter clamps, and the fixed physical dynamics of the upstream
 complementary levelling observer introduce additional time scales and therefore
-break exact JONSWAP similarity at the boundaries.  Likewise, the fixed
-pseudo-update cadence means the finite-horizon coefficient of
-Theorem~\ref{thm:ou-finite-horizon-rs} is not invariant over all $\tau$.
+break exact JONSWAP similarity at the boundaries.  Likewise, the finite-horizon
+coefficient of Theorem~\ref{thm:ou-finite-horizon-rs} is invariant only while
+$T_S/\tau$ is held fixed; the deployed self-similar cadence does hold it fixed
+between the period clamps, but not on them
+(Sec.~\ref{sec:riccati-deployed-cadence}).
 Neither fact changes the dimensional OU state scale
 $\sigma_{aw}\tau^3$; both limit how literally a single calibrated $c_R$ should
 be interpreted over a very wide operating envelope.

--- a/doc/kalman_ou_iii/w3d-rs-similarity-design-guidance.tex-part
+++ b/doc/kalman_ou_iii/w3d-rs-similarity-design-guidance.tex-part
@@ -149,3 +149,88 @@ holds the cadence ratio and normalized pseudo-measurement covariance fixed,
 but it does not erase the physical dependence of the posterior Riccati solution
 on accelerometer SNR.  The pole-based analysis above remains the stronger guide
 when that SNR dependence is significant.
+
+\subsubsection{What the wrapper currently deploys}
+\label{sec:riccati-deployed-cadence}
+
+The deployed adaptive wrapper implements the self-similar cadence
+\eqref{eq:riccati-scaled-pseudo-period-clipped} with
+\begin{equation}
+ c_T=\frac{\SI{15}{ms}}{\SI{1.1}{s}}\approx0.0136,
+ \qquad
+ T_{S,\min}=\SI{5}{ms},
+ \qquad
+ T_{S,\max}=\SI{250}{ms},
+ \label{eq:riccati-deployed-cadence-constants}
+\end{equation}
+the ratio being chosen so that the historical fixed \SI{15}{ms} period is
+reproduced exactly at the wrapper's initial $\tau_{\mathrm{applied}}=\SI{1.1}{s}$.
+It does \emph{not}, however, pair that cadence with the invariant normalized
+covariance of
+\eqref{eq:riccati-two-parameter-similar-regularizer}.  The tuner's base value
+$r_S^{\mathrm{base}}=c_R\sigma_{aw}\tau^3$ is renormalized before it reaches the
+filter,
+\begin{equation}
+ \boxed{
+ r_S=r_S^{\mathrm{base}}\sqrt{\frac{T_{S,0}}{T_S}}},
+ \qquad
+ T_{S,0}=\SI{15}{ms},
+ \label{eq:riccati-deployed-information-scale}
+\end{equation}
+so that the per-update information rate $r_S^2T_S$ is invariant to the cadence.
+
+The consequence is worth stating plainly, because it is the opposite of the
+grouping recommended in
+\eqref{eq:riccati-recommended-four-group-interpretation}.  Substituting
+$T_S=c_T\tau$ into \eqref{eq:riccati-deployed-information-scale} gives an
+effective filter-input law
+\begin{equation}
+ r_S=c_R\sqrt{\frac{T_{S,0}}{c_T}}\;\sigma_{aw}\tau^{5/2},
+ \qquad
+ \frac{R_S}{\sigma_{aw}^2\tau^6}
+ =\frac{c_R^2T_{S,0}}{c_T\,\tau}\;\propto\;\frac1\tau .
+ \label{eq:riccati-deployed-effective-law}
+\end{equation}
+The deployed schedule therefore holds $\rho=T_S/\tau$ exactly while letting
+$r=R_S/(\sigma_{aw}^2\tau^6)$ drift as $\tau^{-1}$, whereas the previous
+fixed-cadence schedule held $r$ and let $\rho$ drift.  In the drift-band
+reduction of Sec.~\ref{sec:riccati-drift-band} the quantity that matters is the
+continuous-equivalent density
+\begin{equation}
+ r_{S,c}=R_ST_S=c_R^2T_{S,0}\,\sigma_{aw}^2\tau^6,
+ \label{eq:riccati-deployed-rsc}
+\end{equation}
+which is exactly the value the fixed-cadence design produced.  The closed-loop
+regularization pole is thus unchanged by the cadence schedule, and in the
+weak-acceleration-observation limit
+\begin{equation}
+ \omega_R\tau
+ =\left(\frac{2}{c_R^2T_{S,0}}\right)^{1/6}\tau^{1/6},
+ \label{eq:riccati-deployed-pole}
+\end{equation}
+rather than the constant $\kappa$ targeted by
+\eqref{eq:riccati-pole-objective}.  Dropping the factor in
+\eqref{eq:riccati-deployed-information-scale} — that is, pairing the
+self-similar cadence with the unmodified cubic law as
+\eqref{eq:riccati-two-parameter-similar-regularizer} prescribes — is what
+yields the invariant value $\omega_R\tau=(2/c_R^2c_T)^{1/6}$.
+
+Consistently with \eqref{eq:riccati-deployed-rsc}, regenerating the full
+validation and robustness evidence across the cadence change moved the
+vertical-displacement error metric by at most $1.1\times10^{-4}$ in relative
+terms over all scenarios and modes, i.e. by less than run-to-run reproduction
+noise.  The present cadence schedule should therefore be read as a structural
+change that is deliberately neutral in the drift band, not as an implementation
+of the pole-invariance design; whether to adopt the invariant pairing instead
+is left as the open calibration question identified above.
+
+Two further caveats apply at the clamps.  Below
+$\tau=T_{S,\min}/c_T\approx\SI{0.37}{s}$ the period floor binds, so neither
+$\rho$ nor $r$ is invariant there and the factor in
+\eqref{eq:riccati-deployed-information-scale} saturates at
+$\sqrt{T_{S,0}/T_{S,\min}}=\sqrt3$.  The upper clamp $T_{S,\max}$ is inactive
+over the deployed $\tau\le\SI{12}{s}$ envelope.  The renormalization is also
+applied after the base clamp on $r_S^{\mathrm{base}}$ and is not itself
+re-clamped, so the value reaching the filter can leave the nominal base
+interval; Appendix~\ref{app:iss-stability} records the resulting effective
+bounds.

--- a/tests/kalman_ou_iii/Makefile
+++ b/tests/kalman_ou_iii/Makefile
@@ -21,7 +21,7 @@ LDFLAGS  =
 # Tell make to look for source files in src/util
 VPATH = $(REPO_ROOT)/src/util
 
-TARGETS = kalman_ou_iii-sim kalman_ou_common-test aw_covariance_policy-test acc_bias_ou-test channel_freeze-test wave_period-test mag_hard_iron-test tuner_coupling-test tuner_schedule-test wave_band_sigma-test
+TARGETS = kalman_ou_iii-sim kalman_ou_common-test aw_covariance_policy-test acc_bias_ou-test channel_freeze-test wave_period-test mag_hard_iron-test tuner_coupling-test tuner_schedule-test wave_band_sigma-test iss_contract-test
 
 all: build test
 
@@ -62,6 +62,9 @@ tuner_schedule-test: tuner_schedule-test.o
 	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
 
 wave_band_sigma-test: wave_band_sigma-test.o
+	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
+
+iss_contract-test: iss_contract-test.o
 	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
 
 # -MMD -MP records the headers each object depends on, so editing a filter

--- a/tests/kalman_ou_iii/iss_contract-test.cpp
+++ b/tests/kalman_ou_iii/iss_contract-test.cpp
@@ -1,0 +1,249 @@
+// Pins the implementation-side hypotheses of the OU-III local ISS theorem
+// (doc/kalman_ou_iii/w3d-iss-stability.tex-part and its hypothesis audit).
+//
+// Environmental excitation and the absence of resets cannot be made true by a
+// unit test and remain explicit Live-interval assumptions.  What *can* regress
+// mechanically is checked here: the 21-state proof configuration, the finite
+// residual accelerometer-bias OU contraction, the proof-compatible covariance
+// policy, the wrapper clamps that witness the bounded exogenous schedule, and
+// the pseudo-update cadence contract underlying the translational
+// observability lemma.
+#define EIGEN_NON_ARDUINO
+#include <cmath>
+#include <iostream>
+#include <limits>
+#include <vector>
+#include <Eigen/Dense>
+#include <Eigen/Geometry>
+
+#define private public
+#include "kalman_ou_iii/SeaStateFusionFilter_OU_III.h"
+#undef private
+
+const float g_std = 9.80665f;
+
+using Filter = SeaStateFusionFilter_OU_III<TrackerType::KALMANF>;
+
+static bool near(float a, float b, float rel = 2e-5f) {
+    return std::fabs(a - b) <= rel * std::max(1.0f, std::max(std::fabs(a), std::fabs(b)));
+}
+
+static int fail(const char* msg) {
+    std::cerr << "FAIL: " << msg << "\n";
+    return 1;
+}
+
+// A_3(t) = 1/2 \int_0^t (t-s)^2 E(s) ds with E(s) = exp(-s/tau), evaluated by
+// composite Simpson quadrature.  The closed form is a difference of terms of
+// order tau^3, so for t << tau it loses most of its significant digits; the
+// quadrature form mirrors the definition used in the lemma and stays accurate.
+static double A3_of(double t, double tau) {
+    if (t <= 0.0) return 0.0;
+    const int n = 20000;                 // even
+    const double dt = t / double(n);
+    double acc = 0.0;
+    for (int i = 0; i <= n; ++i) {
+        const double s = double(i) * dt;
+        const double f = (t - s) * (t - s) * std::exp(-s / tau);
+        const double w = (i == 0 || i == n) ? 1.0 : ((i % 2) ? 4.0 : 2.0);
+        acc += w * f;
+    }
+    return 0.5 * acc * dt / 3.0;
+}
+
+// Observation matrix of the S=0 pseudo-measurement over four update instants,
+// in state order [v, p, S, a]:  row_j = [t_j^2/2, t_j, 1, A_3(t_j)].
+static double detOS(const double t[4], double tau) {
+    Eigen::Matrix4d O;
+    for (int j = 0; j < 4; ++j) {
+        O(j, 0) = 0.5 * t[j] * t[j];
+        O(j, 1) = t[j];
+        O(j, 2) = 1.0;
+        O(j, 3) = A3_of(t[j], tau);
+    }
+    return O.determinant();
+}
+
+int main() {
+    Filter f(true);
+    f.initialize(Eigen::Vector3f::Constant(0.0148f),
+                 Eigen::Vector3f::Constant(0.00157f),
+                 Eigen::Vector3f::Constant(0.25f));
+    if (!f.mekf_) return fail("OU-III core was not created");
+
+    // ---- Proof configuration -------------------------------------------
+    // 21 states: attitude(3), gyro bias(3), v/p/S/a_w(12), residual accel
+    // bias(3).  The 21-state detectability lemma is stated for exactly this.
+    if (f.mekf_->covariance_full().rows() != 21 ||
+        f.mekf_->covariance_full().cols() != 21) {
+        return fail("default OU-III state dimension is no longer 21");
+    }
+
+    // A finite tau_b is what makes the residual-bias block UES; the random-walk
+    // limit is explicitly outside the theorem.
+    if (!near(f.mekf_->get_acc_bias_time_constant(), 5000.0f))
+        return fail("default residual accel-bias OU time constant changed");
+    if (!(f.mekf_->get_acc_bias_time_constant() < std::numeric_limits<float>::max()))
+        return fail("residual accel-bias block degenerated to a random walk");
+
+    // Only the prediction-time PSD inflation path is covered by the proof.
+    if (f.mekf_->legacy_aw_covariance_replacement())
+        return fail("legacy raw a_w covariance replacement became default");
+    if (!f.periodicAwCovarianceSync())
+        return fail("default PSD a_w covariance synchronization was disabled");
+
+    // ---- Bounded exogenous schedule -------------------------------------
+    if (!near(MIN_TAU_S, 0.02f) || !near(MAX_TAU_S, 12.0f) ||
+        !near(MAX_SIGMA_A, 6.0f) ||
+        !near(MIN_R_S, 0.4f) || !near(MAX_R_S, 400.0f) ||
+        !near(ACC_NOISE_FLOOR_SIGMA_DEFAULT, 0.12f)) {
+        return fail("proof-relevant OU-III wrapper clamps changed");
+    }
+    if (!near(f.S_factor_, 1.87f))
+        return fail("default OU-III acceleration anisotropy no longer matches proof audit");
+
+    // ---- Pseudo-update cadence contract ---------------------------------
+    // The audit quotes T_S = clip(c_T * tau_applied, T_min, T_max).  Pin the
+    // constants that turn the bounded-gap hypothesis into a checked statement.
+    if (!near(PSEUDO_UPDATE_PERIOD_MIN_S_DEFAULT, 0.005f) ||
+        !near(PSEUDO_UPDATE_PERIOD_MAX_S_DEFAULT, 0.25f) ||
+        !near(PSEUDO_UPDATE_TAU_RATIO_DEFAULT, 0.015f / 1.1f)) {
+        return fail("deployed OU-III pseudo-update cadence constants changed");
+    }
+    // Over the clamped tau envelope the configured period stays inside the
+    // interval quoted by the audit.
+    const float TS_at_tau_min =
+        std::min(std::max(PSEUDO_UPDATE_TAU_RATIO_DEFAULT * MIN_TAU_S,
+                          PSEUDO_UPDATE_PERIOD_MIN_S_DEFAULT),
+                 PSEUDO_UPDATE_PERIOD_MAX_S_DEFAULT);
+    const float TS_at_tau_max =
+        std::min(std::max(PSEUDO_UPDATE_TAU_RATIO_DEFAULT * MAX_TAU_S,
+                          PSEUDO_UPDATE_PERIOD_MIN_S_DEFAULT),
+                 PSEUDO_UPDATE_PERIOD_MAX_S_DEFAULT);
+    if (!near(TS_at_tau_min, 0.005f) || TS_at_tau_max > 0.165f ||
+        TS_at_tau_max < 0.160f) {
+        return fail("configured pseudo-update period left the audited envelope");
+    }
+
+    // ---- Realized cadence, observed from the running scheduler -----------
+    f.startup_stage_ = Filter::StartupStage::Live;
+    f.mekf_->set_linear_block_enabled(true);
+    if (!f.mekf_->linear_block_enabled())
+        return fail("Live state did not enable the OU-III linear block");
+
+    const float h = 0.005f;
+    const float Tp = 7.0f;
+    const float w = 2.0f * float(M_PI) / Tp;
+
+    std::vector<double> fire_times;
+    double t_now = 0.0;
+    float prev_elapsed = f.mekf_->pseudo_update_elapsed_s_;
+    for (int k = 0; k < 60000; ++k) {
+        const Eigen::Vector3f gyro = Eigen::Vector3f::Zero();
+        const Eigen::Vector3f acc(0.0f, 0.0f, -g_std + 1.2f * std::sin(w * float(t_now)));
+        f.updateTime(h, gyro, acc);
+        t_now += double(h);
+        const float elapsed = f.mekf_->pseudo_update_elapsed_s_;
+        // The elapsed accumulator only decreases when an update is applied.
+        if (elapsed < prev_elapsed && t_now > 200.0) fire_times.push_back(t_now);
+        prev_elapsed = elapsed;
+    }
+    if (fire_times.size() < 64)
+        return fail("pseudo-update scheduler did not run");
+
+    const float tau_applied = f.getTauApplied();
+    const float TS_cfg = f.getPseudoUpdatePeriodSec();
+    if (!(tau_applied >= MIN_TAU_S && tau_applied <= MAX_TAU_S))
+        return fail("applied tau left its clamp interval");
+    // T_S/tau is the similarity group the deployed cadence holds fixed.
+    if (!near(TS_cfg / tau_applied, PSEUDO_UPDATE_TAU_RATIO_DEFAULT, 1e-3f))
+        return fail("realized T_S/tau is not the configured self-similar ratio");
+
+    // Bounded-gap witness of Lemma "Uniform observability of one OU-III axis":
+    // a gap is never shorter than one IMU step, never longer than one
+    // configured period plus one step.
+    double gap_min = 1e30, gap_max = 0.0;
+    for (size_t i = 1; i < fire_times.size(); ++i) {
+        const double g = fire_times[i] - fire_times[i - 1];
+        gap_min = std::min(gap_min, g);
+        gap_max = std::max(gap_max, g);
+    }
+    const double h_d = double(h);
+    if (gap_min < h_d - 1e-9)
+        return fail("realized pseudo-update gap fell below one IMU step");
+    if (gap_max > double(PSEUDO_UPDATE_PERIOD_MAX_S_DEFAULT) + h_d + 1e-9)
+        return fail("realized pseudo-update gap exceeded T_S_max + h");
+
+    // The gaps are quantized to the IMU grid and are NOT equal: this is the
+    // regression guard for the paper's bounded-gap (not exact-cadence)
+    // formulation.  If a future change restores an exactly periodic cadence
+    // this fires, and the proof text should be revisited rather than silently
+    // left stronger than needed.
+    if (gap_max - gap_min < 0.5 * h_d)
+        return fail("realized cadence became (near) exactly periodic; revisit the ISS cadence text");
+
+    // ---- Determinant witness for the translational UCO lemma ------------
+    // Take four consecutive realized instants and check the lemma's bound
+    //      |det O_S| >= T_-^6 exp(-3 T_+ / tau_min)
+    // holds on the unequally spaced grid the scheduler actually produces.
+    for (size_t i = 0; i + 3 < fire_times.size(); i += 7) {
+        double t[4];
+        for (int j = 0; j < 4; ++j) t[j] = fire_times[i + j] - fire_times[i];
+        double lo = 1e30, hi = 0.0;
+        for (int j = 1; j < 4; ++j) {
+            const double g = t[j] - t[j - 1];
+            lo = std::min(lo, g);
+            hi = std::max(hi, g);
+        }
+        const double bound = std::pow(lo, 6.0) * std::exp(-3.0 * hi / double(tau_applied));
+        const double det = std::fabs(detOS(t, double(tau_applied)));
+        if (!(det > 0.0) || !(det >= bound)) {
+            std::cerr << "  det=" << det << " bound=" << bound
+                      << " gaps=[" << lo << "," << hi << "]\n";
+            return fail("OU-III four-point observability determinant violated the lemma bound");
+        }
+    }
+
+    // ---- Effective r_S bounds after cadence renormalization --------------
+    // apply_RS_tune_ scales the clamped base by sqrt(T_S0 / T_S) and does not
+    // re-clamp, so the audited enclosure is [0.121, 693] m*s rather than the
+    // base interval [0.4, 400].
+    const float scale_lo = std::sqrt(PSEUDO_UPDATE_PERIOD_NOMINAL_S / TS_at_tau_max);
+    const float scale_hi = std::sqrt(PSEUDO_UPDATE_PERIOD_NOMINAL_S / TS_at_tau_min);
+    if (!(scale_lo > 0.30f && scale_lo < 0.31f) || !near(scale_hi, std::sqrt(3.0f), 1e-3f))
+        return fail("cadence information-rate factor left its audited range");
+    const float rs_eff_lo = MIN_R_S * scale_lo;
+    const float rs_eff_hi = MAX_R_S * scale_hi;
+    if (!(rs_eff_lo > 0.12f && rs_eff_lo < 0.13f) || !(rs_eff_hi > 690.0f && rs_eff_hi < 694.0f))
+        return fail("effective r_S enclosure no longer matches the ISS audit");
+    const float rs_live = std::sqrt(f.mekf_->R_S(2, 2));
+    if (!(rs_live >= rs_eff_lo && rs_live <= rs_eff_hi) || !std::isfinite(rs_live))
+        return fail("live r_S left the audited effective enclosure");
+
+    // ---- Residual accelerometer-bias OU contraction ----------------------
+    f.mekf_->set_linear_block_enabled(false);
+    f.mekf_->set_acc_bias_updates_enabled(true);
+    f.mekf_->set_acc_bias_time_constant(2.0f);
+    const Eigen::Vector3f b0(0.20f, -0.10f, 0.05f);
+    f.mekf_->set_initial_acc_bias(b0);
+    f.mekf_->time_update(Eigen::Vector3f::Zero(), 0.10f);
+    const Eigen::Vector3f expected = b0 * std::exp(-0.10f / 2.0f);
+    if (!f.mekf_->get_acc_bias().isApprox(expected, 2e-6f))
+        return fail("active residual accel-bias OU block is not contractive");
+
+    // In the certified post-unlock Live regime the residual-bias OU state must
+    // be propagating, not held by the startup freeze.
+    f.accel_bias_locked_ = false;
+    f.startup_stage_ = Filter::StartupStage::TunerWarm;
+    f.enterLive_();
+    if (!f.mekf_->acc_bias_updates_enabled_)
+        return fail("post-unlock Live state did not enable accel-bias OU propagation");
+    if (!f.mekf_->linear_block_enabled())
+        return fail("default Live state did not re-enable the OU-III linear block");
+
+    std::cout << "OU-III ISS proof contract passed"
+              << " (tau=" << tau_applied
+              << " s, T_S=" << TS_cfg
+              << " s, realized gaps [" << gap_min << "," << gap_max << "] s)\n";
+    return 0;
+}

--- a/tests/kalman_ou_iii/run_tests.sh
+++ b/tests/kalman_ou_iii/run_tests.sh
@@ -10,3 +10,4 @@
 ./tuner_coupling-test
 ./tuner_schedule-test
 ./wave_band_sigma-test
+./iss_contract-test


### PR DESCRIPTION
The wrapper now schedules the S=0 regularizer on the self-similar cadence
T_S = clip(c_T*tau_applied, 5 ms, 250 ms), so its pseudo-updates are no
longer an integer number of IMU samples apart and are not equally spaced.
The ISS appendix still assumed exact T_S spacing and claimed that
assumption was discharged by a fixed 15 ms = 3h validation cadence, which
is no longer what the default configuration does.

Generalize the translational observability lemma instead of narrowing the
claim. Writing the four-point observation determinant in divided-difference
form,

    det O_S = -(1/2) V(t) A_3[t_0,...,t_3],   V(t) = prod_{i<j}(t_j - t_i),

and bounding the divided difference below by Hermite-Genocchi (A_3''' = E > 0)
gives |det O_S| >= T_-^6 exp(-3 T_+ / tau_min) for any gaps in [T_-, T_+].
This contains the previous equal-spacing bound as a special case, and its
hypothesis is an unconditional property of the time-based scheduler: a gap is
never shorter than one IMU step nor longer than one configured period plus one
step. Sample-time quantization and adaptive cadence variation therefore move
inside the theorem rather than being excluded from it.

Also sync the surrounding text with what is deployed:

- Record the deployed cadence constants, the r_S renormalization
  r_S = r_S_base * sqrt(T_S0/T_S), and its consequences: the schedule holds
  T_S/tau fixed but lets R_S/(sigma^2 tau^6) drift as 1/tau, keeps R_S*T_S at
  the fixed-cadence value, and so leaves the drift-band pole at
  omega_R*tau ~ tau^(1/6) rather than the targeted constant. Behavior is
  unchanged; this documents it and flags the pairing as an open design choice.
- Correct the audited r_S bounds. The [0.4, 400] interval is the base clamp;
  the renormalization is applied afterwards and is not re-clamped, so the
  value reaching the MEKF lies in a conservative [0.121, 693] enclosure. The
  ISS hypothesis only needs uniform positivity and finiteness, which still
  holds.
- Drop the stale fixed-cadence framing in the measurement, fusion, scale and
  Riccati sections, and note in the OU-II appendix that OU-II keeps the fixed
  period while both translational proofs now tolerate bounded jitter.

Add tests/kalman_ou_iii/iss_contract-test.cpp, mirroring the OU-II proof
contract test: 21-state configuration, finite residual accel-bias OU
contraction, proof-compatible covariance policy, wrapper clamps, the deployed
cadence constants, and the effective r_S enclosure. It also drives the real
scheduler, checks the realized gaps against the bounded-gap hypothesis, and
evaluates the four-point determinant on that unequally spaced grid against the
lemma bound. A tripwire fires if the cadence ever becomes exactly periodic
again, so the proof text is revisited rather than left silently stronger than
needed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D5HjfVqp2zaeuxrB5FZ4TP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified adaptive pseudo-update scheduling, bounded timing gaps, cadence scaling, and covariance adjustments.
  - Expanded stability and observability coverage to support variable update spacing, sample quantization, and deadline variation.
  - Documented deployment limits, safety clamps, and conditions where self-similar behavior no longer applies.
  - Clarified OU–II fixed-period behavior and OU–III spectral scaling details.

- **Tests**
  - Added an OU–III contract test covering configuration, scheduling, observability, covariance bounds, stability, and state propagation.
  - Integrated the new test into the build and test workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->