### PR TITLE
Clarify that the r_S floor table pools eight seas, not the JONSWAP endpoint

### DIFF
--- a/doc/kalman_ou_iii/w3d-rs-similarity-design-guidance.tex-part
+++ b/doc/kalman_ou_iii/w3d-rs-similarity-design-guidance.tex-part
@@ -375,7 +375,13 @@ $(1.0,0.9,0.35)$, so the two effects are separable.
 \begin{table}[t]
 \caption{Effect of the $r_S$ lower clamp.  OU--III Adaptive, ten paired seed
 triplets, \SI{900}{s} scoring window; vertical error in percent of $H_s$.  The
-gain is confined to the low-motion seas, where the floor was binding.}
+gain is confined to the low-motion seas, where the floor was binding.  The
+eight seas are the four stationary JONSWAP and the four stationary PM--Stokes
+scenarios; the non-stationary transition is listed separately and is not
+included in that mean.  This pooled figure is therefore not the declared
+JONSWAP-only primary endpoint quoted in the abstract
+(\OUValidationOUIIINormalizedMean\ percent of $H_s$), which is larger because
+the PM--Stokes family scores better on this metric.}
 \label{tab:rs-floor-effect}
 \centering
 \footnotesize


### PR DESCRIPTION
The abstract of the OU--III article reports 4.82% of $H_s$ for the OU--III vertical RMS error, while Table `tab:rs-floor-effect` in the $r_S$ similarity design-guidance section reports 4.625%. That reads as a contradiction, but the two are different populations:

- **4.82%** (`kalman_ou-w3d.tex:210`, via `\OUValidationOUIIINormalizedMean`) is the declared primary endpoint — the seed-wise mean normalized vertical RMS error over the **four stationary JONSWAP seas**, 10 seeds. Matches `stationary_normalized_aggregate.OU_III.mean = 4.8158` in the result bundle; `tools/ou_validation.py:1589` filters to `spectrum == "jonswap"`.
- **4.625%** (`w3d-rs-similarity-design-guidance.tex-part:397`) is the mean over the **eight stationary seas** — four JONSWAP plus four PM--Stokes — at the new $r_{S,\min}=0.15$ m·s floor.

The PM--Stokes family scores better on this metric (mean 4.40 vs 4.82 for JONSWAP), so pooling all eight pulls the mean down. Recomputed from the current 10-seed bundle: JONSWAP-only 4.816, all eight stationary 4.605, which is where the table's 4.625 sits (the table came from its own sweep run, hence the small offset). Both figures are at the same deployed floor — `MIN_R_S = 0.15f` in `src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h:128` — and the table's new-floor entries agree with the per-scenario validation values (5.115 vs 5.121, 4.771 vs 4.762).

So no number is wrong. The problem is that the row label said only "Mean over the eight seas", with nothing stating which eight or how the figure relates to the headline number.

## Change

Extended the caption of `tab:rs-floor-effect` to state that the eight seas are the four stationary JONSWAP plus the four stationary PM--Stokes scenarios, that the non-stationary transition row is not included in that mean, and that the pooled figure is therefore not the JONSWAP-only primary endpoint quoted in the abstract. The abstract's value is referenced through the existing generated macro so the two stay in sync when the study is regenerated.

Caption text only — no results, tables, or numbers changed.

## Verification

Verified the numbers against `reports/results/ou_validation/ou_validation.json` as regenerated on current `main` (3795296): the endpoint is still 4.816 → 4.82 and the eight-sea mean still 4.605, so the caption's claim holds after that regeneration.

No LaTeX toolchain is available in this environment, so the change is unbuilt — a compile check is worth doing, mainly for the added caption length.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YH58i31ec6WZj4uwj8JHUf)_