### PR TITLE
Document the Mahony proxy's tilt, magnetic, and vertical-channel roles

### DIFF
--- a/doc/kalman_ou_iii/w3d-direction-methods.tex-part
+++ b/doc/kalman_ou_iii/w3d-direction-methods.tex-part
@@ -30,6 +30,13 @@ $\vct{s}_k=[-h_{E,k},h_{N,k}]^\top$, the estimator inputs are
 \qquad a_{\uparrow,k}=-a^N_{D,k}.
 \label{eq:dir-heading-signals}
 \end{equation}
+The quaternion $\vct q_k$ is the MEKF attitude once the filter is live. Before
+the handoff of Sec.~\ref{sec:proxy-handoff} the MEKF has no attitude to offer
+and the private observer's is used instead, which is admissible because
+\eqref{eq:dir-heading-signals} resolves into the projected bow axis and is
+therefore invariant under $\vct q\mapsto R_z(\psi)\vct q$: only tilt reaches
+the result, so the observer's drifting yaw cannot, and the later switch to the
+MEKF quaternion is continuous in everything this stage observes.
 \subsection{Quadrature estimator for the propagation axis}
 
 The tracked phase is advanced from the dominant frequency, but its absolute

--- a/doc/kalman_ou_iii/w3d-fus-methods.tex-part
+++ b/doc/kalman_ou_iii/w3d-fus-methods.tex-part
@@ -172,6 +172,66 @@ Let $a_{z,\mathrm{inert}}=a_z+g$ denote vertical inertial acceleration in the bo
 a_{\uparrow}:=-a_{z,\mathrm{inert}}.
 \]
 
+\subsubsection{Exogenous levelled vertical acceleration}
+\label{sec:vertical-proxy}
+The tuner needs that signal levelled, for the reason quantified below, and it
+must not be levelled with the filter's own attitude, which would close a loop
+the stability argument then has to carry.  The deployed solution is a private Mahony
+complementary observer \cite{Mahony2008NonlinearComplementary} running on the
+raw gyro and accelerometer, ahead of the MEKF and independently of it,
+\begin{equation}
+\begin{aligned}
+\vct\varepsilon&=\hat{\vct d}_{\mathrm{meas}}\times\hat{\vct d}(\hat q),
+\qquad
+\hat{\vct d}_{\mathrm{meas}}=-\vct f^{B}/\lVert\vct f^{B}\rVert,\\
+\dot{\hat q}&=\tfrac12\,\hat q\otimes
+\bigl(\vct\omega^{B}+\vct\beta+k_P\vct\varepsilon\bigr),
+\qquad
+\dot{\vct\beta}=k_I\vct\varepsilon,
+\end{aligned}
+\label{eq:proxy-mahony}
+\end{equation}
+where $\hat{\vct d}_{\mathrm{meas}}$ is the measured world-down direction in
+body coordinates, $\hat{\vct d}(\hat q)$ the observer's own, $\vct\omega^{B}$
+the raw gyro, and $\vct\beta$ its estimated bias; the implementation is the
+first-order discretization of \eqref{eq:proxy-mahony} with renormalization.
+Its levelled output is
+\begin{equation}
+a^{P}_{\uparrow,k}
+=-\!\left(\left[\mat{R}_{NB}(\hat q_k)\vct f^{B}_k\right]_{D}+g\right),
+\label{eq:proxy-vertical}
+\end{equation}
+which is a function of the measurements alone.  The observer is seeded from
+the first accelerometer sample so that it starts levelled, and yaw, which is
+unobservable to it, is left to drift; only the tilt of $\hat q$ enters
+\eqref{eq:proxy-vertical}.
+
+The gains are $k_P=\SI{0.1}{\per\second}$ and $k_I=\SI{0.01}{\per\second\squared}$
+(the implementation parameterizes them as $2k_P$ and $2k_I$).  The correction
+corner near \SI{0.016}{\hertz} must sit \emph{below} the wave band, not above
+it: a fast observer chases the horizontal orbital acceleration into tilt,
+which is the same gravity-leakage failure by another route.  At an order of
+magnitude under the \SIrange{0.11}{0.42}{\hertz} the reference records occupy,
+the gyro carries attitude through the wave band and the accelerometer only
+trims slow drift.  The integral term estimates the gyro bias; it is required
+because the same observer supplies the startup attitude seed
+(Sec.~\ref{sec:proxy-handoff}), and with $k_I=0$ a constant bias $b$ leaves a
+static tilt of about $b/k_P$ --- roughly \SI{0.5}{\degree} at the
+\SI{0.05}{\degree\per\second} residual bias of the reference records --- that
+nothing downstream of an attitude seed high-passes.
+
+Equation~\eqref{eq:proxy-vertical} is the default vertical measurement for all
+three measurement-only consumers --- the frequency tracker and its stillness
+detector, the wave-period estimator, and the sigma channel --- so a single
+levelled acceleration serves the whole adaptation path.  Until the observer's
+\SI{20}{s} settling window has elapsed --- long enough that the levelling
+transient never reaches the period statistics --- they fall back to the
+unlevelled body-$Z$ proxy $-(a_z+g)$.  The startup bootstrap does not wait for
+that window, because it needs the attitude as soon as it exists and applies
+its own quality gate instead (Sec.~\ref{sec:proxy-handoff}).  Both the older
+attitude-levelled input and the raw body-$Z$ proxy remain selectable for
+ablation; what each costs is quantified in Sec.~\ref{sec:wave-band-period}.
+
 \subsubsection{Wave-band period}
 \label{sec:wave-band-period}
 Both $\tau$ and $r_S$ are properties of the wave band, so the frequency that
@@ -187,8 +247,8 @@ independent of the sea, and because $r_S\propto\tau^3$ that error is cubed.
 
 The tuner therefore estimates the zero-crossing period
 $T_z=2\pi\sqrt{m_0/m_2}$ of the elevation, where $m_n$ are elevation spectral
-moments.  Leveled vertical acceleration $a^{W}_{\uparrow}$, from
-(\ref{eq:dir-heading-signals}), is passed through two first-order high-pass
+moments.  The levelled vertical acceleration $a^{P}_{\uparrow}$ of
+\eqref{eq:proxy-vertical} is passed through two first-order high-pass
 stages and two leaky integrators, all sharing the corner $\lambda$, giving
 band-limited velocity and elevation proxies $v_p$ and $\eta_p$.  The proxies
 differ by exactly one integrator $1/(s+\lambda)$, so for a narrow band at
@@ -211,24 +271,35 @@ corner make the shared response $s^{2}/(s+\lambda)^{2}$, removing that growth at
 a cost below \SI{6}{\percent} of gain at the lowest wave frequency of interest,
 and leaving (\ref{eq:wave-band-period}) unchanged.
 
-The estimator reads the accelerometer and the attitude solution only.  It does
+The estimator reads the accelerometer and an attitude solution only.  It does
 not read the filter's own displacement, which would close a positive feedback
 loop: the integral pseudo-measurement high-passes displacement, which raises the
 apparent frequency, which shortens $\tau$, which strengthens the
 pseudo-measurement.
 
-Reading the attitude solution is itself a weaker coupling, and it is worth
-stating plainly because the stability appendix has to account for it.  Levelling
-uses the attitude estimate, so $\delta\vct\theta$ reaches $f$, hence $\tau$
-and $r_S$, hence the gains.  That is why the deployed input is not levelled
-with the filter's attitude at all: it is levelled with a private Mahony
-observer reading only the raw gyro and accelerometer, so $\vct\vartheta$ is a
-function of the measurements alone.  Selecting the older attitude-levelled
-input instead reinstates the loop --- a \SI{0.25}{rad} attitude displacement
-then moves the estimated period from \SI{8.05}{s} to \SI{10.1}{s} and $\tau$
-by a factor $1.25$, and reaches the linear block indirectly besides, since
-displacing $\vct v$, $\vct p$, $\vct S$ or $\vct a_w$ perturbs attitude
-through the filter's cross-covariances; see Sec.~\ref{app:iss-tuner}.
+Whose attitude solution it reads is the remaining coupling, and it is worth
+stating plainly because the stability appendix has to account for it.
+Levelling with the MEKF estimate would let $\delta\vct\theta$ reach $f$, hence
+$\tau$ and $r_S$, hence the gains.  That is why the deployed input is
+$a^{P}_{\uparrow}$, levelled by the private observer of
+Sec.~\ref{sec:vertical-proxy}, which makes $\vct\vartheta$ a function of the
+measurements alone.  The two ablations bound what that choice buys and what it
+avoids.  Selecting the older attitude-levelled input reinstates the loop --- a
+\SI{0.25}{rad} attitude displacement then moves the estimated period from
+\SI{8.05}{s} to \SI{10.1}{s} and $\tau$ by a factor $1.25$, and reaches the
+linear block indirectly besides, since displacing $\vct v$, $\vct p$, $\vct S$
+or $\vct a_w$ perturbs attitude through the filter's cross-covariances; see
+Sec.~\ref{app:iss-tuner}.  Selecting the unlevelled body-$Z$ proxy opens the
+loop but destroys the estimate, because double integration weights a spectrum
+by $\omega^{-4}$ and the gravity a tilting platform leaks into body $Z$ then
+dominates $\eta_p$: the estimator reports \SIrange{6.8}{10.0}{s} whatever the
+sea does, against a truth of \SIrange{2.4}{8.7}{s}, and vertical RMS error
+degrades by $2.5\times$.  Opening the loop is therefore free only because the
+observer levels as well as the MEKF does: over the eight reference records
+$a^{P}_{\uparrow}$ reproduces the attitude-levelled input to within \pct{0.2}
+of vertical RMS.  The frequency tracker is the one consumer indifferent to the
+choice --- it is not integrated, so it never sees the $\omega^{-4}$ weighting,
+and the two measurement-only inputs are RMS-equivalent on these records.
 
 Online coefficients are additionally staged by one IMU sample. At step $k$ the
 MEKF uses only $\vartheta_k$ committed before the current innovation; after

--- a/doc/kalman_ou_iii/w3d-init.tex-part
+++ b/doc/kalman_ou_iii/w3d-init.tex-part
@@ -18,13 +18,73 @@ stale attitude cross-covariances.  In live operation, a large sustained tilt
 error may instead trigger a tilt-only re-lock that preserves the current yaw
 gauge.
 
+\subsection{Which estimator solves the startup attitude}
+\label{sec:startup-policy}
+
+Startup has to deliver two things before the filter can be trusted: an
+operating point $(\tau,\sigma_{aw},r_S)$, and a tilt --- because the tilt is
+what gates the magnetometer and what the magnetic world reference is averaged
+in.  Two policies are implemented and they differ only in which estimator
+supplies the tilt.
+
+\emph{StagedMekf} is the earlier behaviour, retained as the matched ablation.
+The MEKF is driven from the first sample in a deliberately degraded
+configuration --- linear block disabled, accelerometer-bias learning frozen,
+$\mat R_{\mathrm{acc}}$ inflated by $2.5\times$ --- and its own attitude is
+read back out for both jobs.  Those reads happen at the moment the MEKF is
+least able to level, since the linear block that would otherwise absorb the
+orbital specific force is precisely the part that is switched off.  That would
+be a bounded transient if the results were revisable, but they are not: the
+world reference and the yaw gauge are locked exactly once, so whatever tilt
+error survives the averaging window becomes a standing attitude and heading
+bias for the whole run, scored long after any transient has decayed.
+
+\emph{MahonyProxy} is the deployed default.  It gives both jobs to the private
+Mahony observer the filter already runs for the vertical channel
+(Sec.~\ref{sec:vertical-proxy}).  That observer is a pure function of the raw
+gyro and accelerometer, and its correction corner sits an order of magnitude
+below the wave band, so it rejects the orbital specific force by construction
+instead of chasing it.  Under this policy:
+
+\begin{enumerate}[leftmargin=1.4em]
+  \item The measurement-only front end --- proxy, frequency tracker and its
+        stillness detector, wave-period estimator, sigma band, tuner, and the
+        wave-direction stage --- runs from the first sample with the MEKF left
+        untouched.  Every one of those consumers is already exogenous by
+        design, so withholding the MEKF changes none of their outputs; the
+        regression suite pins that bit-for-bit.  The one stage that needs an
+        attitude, the direction estimator, is given the proxy quaternion, and
+        it resolves acceleration into the projected bow axis of a levelled
+        heading frame, which is invariant under $q\mapsto R_z(\psi)q$, so the
+        proxy's drifting yaw cannot reach it and the later handoff to the MEKF
+        quaternion is continuous in everything the stage can see.
+  \item The gravity-agreement gate and the magnetic accumulation frame read the
+        proxy tilt, at both acquisition stages
+        (Sec.~\ref{sec:mag-two-stage}).
+  \item When the tilt has held agreement with gravity, north has been gauged,
+        and the tuner is ready, the MEKF is seeded with the finished attitude
+        and goes Live in one step --- linear block on, nominal
+        $\mat R_{\mathrm{acc}}$, operating point already converged.  It never
+        occupies the degraded warmup configuration at all.
+\end{enumerate}
+
+Model parameters staged by the tuner are still written to the MEKF while the
+front end runs alone.  They are parameters, not state, so the filter reaches
+its first live sample already on the right operating point rather than
+adapting toward it from the initial frequency guess.
+
 \subsection{Staged enabling and covariance policy}
-Startup proceeds through Cold, TunerWarm, and Live stages.  During Cold and
-TunerWarm, the attitude MEKF and frequency tracker run, while the
+Startup proceeds through Cold, TunerWarm, TunerReady, and Live stages.  During
+Cold and TunerWarm the tuner collects a dominant-frequency estimate and an
+acceleration-variance estimate, producing targets for
+$(\tau,\matg{\Sigma}_{aw}^{\mathrm{stat}},\mat{R}_S)$, while the
 $[\vct{v},\vct{p},\vct{S},\vct{a}_w]$ block is disabled and accelerometer-bias
-learning may be frozen.  The tuner collects a dominant-frequency estimate and
-an acceleration-variance estimate, producing targets for
-$(\tau,\matg{\Sigma}_{aw}^{\mathrm{stat}},\mat{R}_S)$.
+learning may be frozen.  Under StagedMekf the attitude MEKF and frequency
+tracker both run through these stages and the filter enters Live by itself
+once the tuner is ready.  Under MahonyProxy the same tuner logic runs inside
+the measurement-only front end and parks at TunerReady: the operating point is
+trusted, but the attitude is not the filter's to decide, so it waits for the
+handoff described below.
 
 The transition into Live follows this order:
 \begin{enumerate}
@@ -41,10 +101,175 @@ posterior covariance.  At initial construction, where no useful
 cross-covariances exist, a hard reset may additionally zero the $a_w$
 cross-covariances.
 
+\subsection{Handoff to the MEKF}
+\label{sec:proxy-handoff}
+
+The normal exit from the bootstrap is by quality and requires three conditions
+at once: the proxy tilt has held gravity agreement for \SI{2}{s}, meaning the
+sine of the angle between the observer's own gravity direction and the
+low-passed specific force stayed below \num{0.075} (about \SI{4.3}{\degree}),
+with a veto on gyro rates above \SI{30}{\degree\per\second}; magnetic north
+has been gauged when a magnetometer is fitted; and the tuner is ready.  A floor of \SI{8}{s} keeps a record whose first seconds happen to look
+calm from handing over on a tilt the observer has barely integrated.  A
+timeout of \SI{150}{s} guarantees the filter always starts on the best
+attitude available rather than sitting in bootstrap forever; it is raised
+internally to at least the magnetic settle time plus twice the averaging
+window plus the tilt fallback, because a timeout that fires mid-acquisition
+would hand over with no yaw gauge at all, which is a worse start than waiting.
+
+At handoff the seed is the proxy tilt carrying the magnetometer's yaw gauge if
+one has been acquired, and the attitude covariance is seeded anisotropically,
+$\sigma_{\mathrm{tilt}}=\SI{0.035}{\radian}$ and
+$\sigma_{\mathrm{yaw}}=\SI{0.087}{\radian}$ once north is gauged, against
+$\sigma_{\mathrm{yaw}}=\pi/2$ when it is not.  The split is the point: tilt has
+been integrated through the wave band by an observer whose correction corner
+lies below it, while yaw is either gauged or arbitrary, and those two cases
+are an order of magnitude apart.  Only yaw is written when the gauge lands
+after the MEKF is already live; the MEKF tilt is the gyro-propagated,
+accel-corrected estimate and is strictly better than any instantaneous
+accel-derived level frame, so overwriting the whole quaternion would reinject
+the wave tilt error the filter has already rejected.
+
+\paragraph{The observer needs an integral term}
+The vertical channel ran at $k_I=0$ for years and accepted the $\approx b/k_P$
+static tilt a gyro bias $b$ leaves, because everything downstream of it is
+high-passed.  Nothing high-passes an attitude \emph{seed}: the same error is a
+standing roll and pitch bias.  Measured, a \SI{0.05}{\degree\per\second} bias
+settles at \SI{0.71}{\degree} of tilt with no integral term, and seeding from a
+zero-integral observer cost \SI{0.17}{\degree} of roll RMS on the
+$H_s=\SI{1.5}{m}$ JONSWAP record.  Enabling the integral term is also the
+better answer for the vertical channel on its own terms, since the static tilt
+it tolerated was leaking gravity into the levelled acceleration and being
+high-passed away afterwards, and it leaves the wave-period, sigma and $r_S$
+channels unmoved over the eight reference records.  One observer therefore
+serves both roles, at the gains of Sec.~\ref{sec:vertical-proxy}.
+
 \subsection{Magnetic reference and yaw lock}
+\label{sec:mag-two-stage}
+
 Magnetometer updates are delayed until tilt is sufficiently trustworthy.
-Samples are accumulated in a gravity-only tilt frame to estimate a consistent
-world magnetic reference without using the MEKF's initially arbitrary yaw.
-After the reference is accepted, a one-time yaw-gauge correction is applied and
-normal magnetometer updates begin.  Configuration may optionally require this
-magnetic lock before enabling the linear block.
+Samples are accumulated in a yaw-stripped tilt frame, which is invariant under
+$q_{bw}\mapsto R_z(\psi)q_{bw}$, so no arbitrary estimator heading can leak
+into the learned world reference.  A gravity-only frame rebuilt from
+low-passed accelerometer data would be yaw-free as well, but in waves that
+signal is gravity plus a phase-lagged remnant of the orbital specific force,
+so its tilt is wrong by a wave-correlated angle the averaging window is too
+short to cancel.  Which estimator supplies the tilt is the substance of the
+startup policy of Sec.~\ref{sec:startup-policy}.  The reference is an average
+of the field in that frame, so whatever tilt error survives the window
+survives in the reference; in waves that error is periodic, so the window has
+to buy whole wave periods rather than samples, and it is specified in seconds
+(\SI{15}{s} with a \num{128}-sample floor) so that it cannot silently shorten
+at a higher magnetometer ODR.  After the reference is accepted, a one-time
+yaw-gauge correction puts learned north on the boat's $+X$ axis and normal
+magnetometer updates begin.  Configuration may optionally require this magnetic
+lock before enabling the linear block.
+
+Under the proxy policy acquisition runs in two stages, because the two things
+it has to deliver want opposite schedules.  A usable heading is wanted within
+seconds of power-on, whereas a \emph{good} reference wants the observer to have
+settled first: the same low correction corner that makes it reject waves makes
+it slow to converge from its accelerometer seed, worst in the large seas where
+levelling matters most.  Measured against truth over a \SI{23}{s} averaging
+window, mean tilt error runs \SIrange{0.33}{2.76}{\degree} for a window opening
+at \SI{7}{s} and \SIrange{0.13}{0.85}{\degree} for one opening at \SI{40}{s}.
+Waiting for the good frame before locking anything puts first heading near
+\SI{105}{s}, which is not a usable device.  So a provisional reference is
+locked as soon as the gravity gate allows, giving heading and a live filter in
+\SIrange{22}{52}{s}, and a refinement at \SI{90}{s} re-learns the reference and
+re-gauges heading over a \SI{30}{s} window once the observer has converged.
+Before the handoff there is no MEKF attitude to rewrite, so the provisional
+gauge is carried forward and composed with the proxy tilt at the handoff
+itself, and the filter's very first attitude already has north in it.
+
+Two properties of the refinement are not optional.
+
+\begin{itemize}[leftmargin=1.2em]
+  \item \emph{It is framed on the observer, not on the MEKF.}  By
+        \SI{90}{s} the MEKF looks like the better frame --- it has the linear
+        block, the magnetometer and the bias states --- but it has been
+        steering to the provisional reference that the refinement exists to
+        replace, so its tilt carries that reference's error and averaging the
+        field in it re-derives the error.  Framed that way the refinement is
+        self-confirming: reference and yaw come back within
+        \SI{1e-3}{\degree} of the provisional ones and the standing roll bias
+        is untouched.  The observer never saw the reference, so its tilt is
+        independent of it.
+  \item \emph{Accelerometer-bias learning is held until the refinement
+        lands.}  Bias and tilt error are barely separable in waves and the
+        bias state has a \SI{5000}{s} correlation time, so a value fitted to
+        the provisional reference outlives the record.  Without the hold the
+        early-lock path fails the bias gate outright (\pct{187} against a
+        \pct{109} limit).
+\end{itemize}
+
+Refining later is worse rather than better --- \SI{90}{s} beats \SI{120}{s} and
+\SI{150}{s} --- because damage accumulates for as long as the filter steers to
+the provisional reference.  The refinement is a one-time reconfiguration
+event: it rewrites the world reference and steps yaw once, and it lands well
+before the \SI{900}{s} scoring window opens.  Like any hard reset it is outside
+the Live-interval stability result of Sec.~\ref{app:iss-stability}.
+
+\subsection{Measured effect of the startup policy}
+\label{sec:startup-policy-results}
+
+Table~\ref{tab:startup_policy} compares the two policies over the eight
+reference records (JONSWAP and PM--Stokes, $H_s$ from \SI{0.27}{m} to
+\SI{8.5}{m}), scored on the same trailing \SI{900}{s} window used everywhere
+else in this paper.  The deployed two-stage default improves roll by about
+\pct{10}, accelerometer bias by about \pct{10}, and pitch by about \pct{3}, at
+the same time to first heading as before, with vertical and 3D displacement
+marginally better.  The single-stage variant --- refinement disabled and the
+provisional lock deferred to \SI{90}{s} --- is the accuracy ceiling of the
+approach, roughly doubling the roll and bias gain at the cost of about
+\SI{80}{s} more before the device reports a heading.  Which of those matters is
+an application decision, so both are supported and the fast one is the default.
+
+\begin{table}[t]
+\caption{Startup-policy comparison over the eight reference records, trailing
+\SI{900}{s}, mean across records.  The one-stage column is the same policy
+with the refinement disabled and the provisional lock deferred to \SI{90}{s};
+its displacement figures are omitted because they were measured on an earlier
+tree and are not restated here.}
+\label{tab:startup_policy}
+\centering
+\footnotesize
+\setlength{\tabcolsep}{4pt}
+\begin{tabular}{@{}l c c c@{}}
+\toprule
+ & \makecell{Staged\\MEKF} & \makecell{Mahony proxy\\two-stage (default)} &
+   \makecell{Mahony proxy\\one-stage} \\
+\midrule
+Time to first heading (s)      & $\approx22$ & 22--52 & $\approx105$ \\
+Vertical RMS (\% $H_s$)        & 4.301  & 4.287  & --     \\
+3D displacement RMS (\%)       & 19.872 & 19.851 & --     \\
+Roll RMS (\si{\degree})        & 0.372  & 0.339  & 0.310  \\
+Pitch RMS (\si{\degree})       & 0.275  & 0.266  & 0.259  \\
+Yaw RMS (\si{\degree})         & 1.796  & 1.835  & 1.839  \\
+Accel.\ bias error (\si{\meter\per\second\squared})
+                               & 0.0631 & 0.0574 & 0.0517 \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+The gain is not uniform record by record: roll on PM--Stokes $H_s=\SI{4}{m}$
+moves \SIrange{0.242}{0.405}{\degree} the wrong way and JONSWAP
+$H_s=\SI{0.27}{m}$ \SIrange{0.234}{0.279}{\degree}, paid for by
+\SIrange{0.564}{0.256}{\degree} on JONSWAP $H_s=\SI{1.5}{m}$ and
+\SIrange{0.396}{0.265}{\degree} on PM--Stokes $H_s=\SI{0.27}{m}$.  Both
+configurations improve the mean; neither dominates everywhere.
+
+Yaw is about \pct{2} worse under every proxy configuration, and the residual is
+a property of the learned reference \emph{vector} rather than of the one-time
+gauge: seeding the handoff yaw variance anywhere from \SI{5}{\degree} to
+\SI{90}{\degree} moves the scored yaw by less than \SI{1e-4}{\degree}, so the
+filter is converging to the reference, not to the gauge.  Retuning the observer
+does not recover it either.  A full grid over $k_P$ and $k_I$ moves the
+eight-record mean yaw only between \SI{1.825}{\degree} and
+\SI{1.856}{\degree}, and with the noise generators disabled yaw RMS on the
+calmest record falls from \SI{2.071}{\degree} to \SI{0.153}{\degree}: about
+\pct{93} of it is magnetometer error, not attitude error.  Heading is constant
+in these records, so the hard-iron offset is absorbed into the reference and
+what remains is wave-modulated soft-iron distortion, which no attitude
+estimator can undo and no averaging window can cancel.  Closing that gap is a
+magnetometer-calibration question, not a startup-initialization one.

--- a/doc/kalman_ou_iii/w3d-intro.tex-part
+++ b/doc/kalman_ou_iii/w3d-intro.tex-part
@@ -48,7 +48,11 @@ framework.
 Section~\ref{app:iss-stability} gives a local 21-state stability result for the
 normal Live recursion under explicit operating conditions. Because the tuner is
 driven by raw IMU data and a private Mahony attitude solution, its schedule is
-exogenous with respect to the MEKF state. The section proves uniform
+exogenous with respect to the MEKF state. That same observer also owns startup:
+it supplies the tilt that gates the magnetometer and frames the learned
+magnetic reference, and the MEKF is seeded from the finished solution and
+starts live rather than warming up in a degraded configuration
+(Sec.~\ref{sec:startup-policy}). The section proves uniform
 finite-horizon observability of the OU--III translational block and of the
 attitude--gyro-bias block under bounded noncollinear accel/mag geometry. The
 formerly problematic accelerometer-bias coordinates are now residuals about the

--- a/doc/kalman_ou_iii/w3d-iss-stability.tex-part
+++ b/doc/kalman_ou_iii/w3d-iss-stability.tex-part
@@ -31,9 +31,24 @@ The adaptive wave variables are treated as exogenous signals,
 \label{eq:iss-schedule}
 \end{equation}
 The wave-period and variance estimators are driven by raw IMU measurements and
-a private Mahony attitude solution that does not read the OU--III state or
+a private Mahony attitude solution, Eqs.~\eqref{eq:proxy-mahony}--%
+\eqref{eq:proxy-vertical}, that does not read the OU--III state or
 covariance. Thus no MEKF-state-to-tuner feedback is present in the deployed
 configuration analyzed here.
+
+The same observer also supplies the startup attitude, the magnetometer gate,
+and the frame the magnetic reference is averaged in
+(Sec.~\ref{sec:startup-policy}), and the coupling stays one-way there too: the
+observer never reads a filter state, so the information flow is
+proxy~$\to$~MEKF only. What that policy does change is where the analyzed
+interval begins. Under it the MEKF is not propagated at all before the
+handoff; the handoff seeds attitude and its covariance in one step, which is a
+hard reset and therefore the left endpoint of a Live interval rather than
+something inside one. The second-stage magnetic acquisition is a second such
+event: at $t=\SI{90}{s}$ it replaces the world magnetic reference and steps
+yaw once, so the analyzed interval is the record after that correction. Both
+events are excluded on the same grounds as the startup and re-lock operations
+listed above, and both land well before the \SI{900}{s} scoring window opens.
 
 The implementation also makes the online schedule predictable with respect to
 the current Kalman innovation. Let $\mathcal F_k$ denote the sigma-algebra

--- a/doc/kalman_ou_iii/w3d-iss-theorem-audit.tex-part
+++ b/doc/kalman_ou_iii/w3d-iss-theorem-audit.tex-part
@@ -156,7 +156,7 @@ Bounded adaptive schedule & Enforced by the default fusion-wrapper clamps; concr
 Predictable schedule & Enforced by staging the tuner result for the following IMU sample, Eq.~\eqref{eq:iss-predictable-schedule}. \\
 Bounded $S$ pseudo-update gaps & Proved for the deployed self-similar cadence, Eq.~\eqref{eq:iss-deployed-cadence-gap-check}; the scheduler bound Eq.~\eqref{eq:iss-scheduler-gap-witness} holds for any configured period. Equal spacing is not required. \\
 Vector excitation & Live-interval assumption: accepted accelerometer/magnetometer pairs must satisfy Eqs.~\eqref{eq:iss-vector-magnitude-bounds}--\eqref{eq:iss-vector-gap}. \\
-No reset/outage & Live-interval assumption; startup, hard reset, re-lock, and arbitrarily long rejection/outage patterns remain outside the theorem. \\
+No reset/outage & Live-interval assumption; startup, hard reset, re-lock, and arbitrarily long rejection/outage patterns remain outside the theorem.  Under the deployed startup policy this excludes the proxy handoff and the second-stage magnetic re-acquisition, both of which precede the analyzed interval (Sec.~\ref{app:iss-tuner}). \\
 \bottomrule
 \end{tabular}
 \end{table}

--- a/doc/kalman_ou_iii/w3d-rs-scale-theorem.tex-part
+++ b/doc/kalman_ou_iii/w3d-rs-scale-theorem.tex-part
@@ -507,8 +507,9 @@ $f_{\mathrm{tune}}=1/T_z\propto\omega_p$ for fixed JONSWAP shape, the measured
 acceleration scale obeys the $H_s\omega_p^2$ similarity of
 Theorem~\ref{thm:jonswap-tuner-similarity}.
 
-The band is driven by the vertical acceleration from the private complementary
-observer.  That observer reads only gyro and accelerometer measurements and no
+The band is driven by the vertical acceleration $a^{P}_{\uparrow}$ of the
+private complementary observer, Eq.~\eqref{eq:proxy-vertical}.  That observer
+reads only gyro and accelerometer measurements and no
 OU--III estimator state, so the sigma channel preserves the exogenous tuner
 schedule used by the stability analysis.  The band corners use the previous
 smoothed tuning-frequency value; the current measurement can update the

--- a/doc/kalman_ou_iii/w3d-sim-charts-study.tex-part
+++ b/doc/kalman_ou_iii/w3d-sim-charts-study.tex-part
@@ -177,6 +177,18 @@ hard-iron bias and slow drift, and $\vct{w}_m$ is per-sample white noise.
 \end{figure}
 \fi
 
+\paragraph{Startup configuration}
+Every OU--III run reported here uses the deployed startup policy: the
+measurement-only front end and its private Mahony observer run from the first
+sample, the magnetometer is gated and its world reference framed on that
+observer's tilt, and the MEKF is seeded with the finished attitude at the
+handoff and goes live directly instead of warming up in a degraded
+configuration.  Two-stage magnetic acquisition is enabled, so the reference is
+re-learned and heading re-gauged at \SI{90}{s}, and accelerometer-bias
+learning is held until that correction lands.  Both events precede the scoring
+window defined next.  The earlier staged-MEKF policy is exercised only as a
+matched ablation.
+
 \paragraph{Scoring window}
 The deterministic regression gates, Table~\ref{tab:sim_results_rms_dir_basic},
 the four-method comparison of Sec.~\ref{sec:observer-comparison}, and the

--- a/doc/kalman_ou_iii/w3d.bib
+++ b/doc/kalman_ou_iii/w3d.bib
@@ -353,3 +353,14 @@
     month   = jul,
     doi     = {10.1109/TAES.1970.310128}
 }
+
+@article{Mahony2008NonlinearComplementary,
+    author  = {Mahony, Robert and Hamel, Tarek and Pflimlin, Jean-Michel},
+    title   = {Nonlinear Complementary Filters on the Special Orthogonal Group},
+    journal = {IEEE Transactions on Automatic Control},
+    volume  = {53},
+    number  = {5},
+    pages   = {1203--1218},
+    year    = {2008},
+    doi     = {10.1109/TAC.2008.923738}
+}


### PR DESCRIPTION
The article described the private Mahony observer only as the thing that
levels the tuner's vertical acceleration, and its initialization section
still described the staged-MEKF startup the filter no longer uses by
default. Bring both up to the deployed code.

- Add a dedicated subsection defining the observer: its complementary
  form, the levelled output that all three measurement-only consumers
  read, the gains and why the correction corner sits below the wave band,
  the integral term the attitude seed requires, and the body-Z fallback
  during the settling window. Both ablation inputs are now priced in one
  place: the attitude-levelled input reinstates the tuner loop, the raw
  body-Z proxy opens it but wrecks the period estimate.

- Rewrite the initialization section around the proxy startup policy:
  what the staged policy did and why its one-time reads were not
  revisable, the measurement-only front end, the four startup stages
  including TunerReady, the handoff conditions and anisotropic attitude
  seed, two-stage magnetic acquisition with the refinement framed on the
  observer, the accelerometer-bias hold, and the measured comparison
  against the staged ablation.

- Note in the stability appendix that the coupling stays one-way, and
  that the handoff and the magnetic refinement are hard-reset events
  bounding the analyzed Live interval; record the same in the condition
  audit.

- Note in the direction section that the stage runs on the proxy
  quaternion before handoff, admissible by Rz(psi) invariance, and state
  the startup configuration used for every reported run.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013dm5sKoLPjh4tbfGTMcNqU