### PR TITLE
Resolve the Riccati/ablation contradiction over the r_S amplitude exponent

### DIFF
--- a/doc/kalman_ou_iii/w3d-rs-riccati-analysis.tex-part
+++ b/doc/kalman_ou_iii/w3d-rs-riccati-analysis.tex-part
@@ -455,7 +455,12 @@ Theorem~\ref{thm:ou-regularized-rs}, is not the operative one.  Taken at face
 value, \eqref{eq:riccati-strong-fixed-cadence} and
 \eqref{eq:riccati-scaled-cadence-strong} then predict a pole-preserving
 schedule $r_S\propto\tau^{5/2}$ with \emph{no} leading-order $\sigma_{aw}$
-dependence, one factor of $\sigma_{aw}$ away from what is deployed.
+dependence, one factor of $\sigma_{aw}$ away from what is deployed.  That
+prediction is contradicted by direct measurement
+(Sec.~\ref{sec:riccati-law-ablation}); the two assumptions it rests on, an
+amplitude-free $q_{\mathrm{eff}}$ \emph{and} an amplitude-free target
+$\kappa$, are examined in Sec.~\ref{sec:riccati-mis-specified-pseudo}, where
+the second is shown to be the one that fails.
 
 This branch also supplies the natural explanation for a measured property of
 the filter.  In the strong limit
@@ -497,7 +502,12 @@ The filter is then simultaneously in the strong branch \emph{and} governed by
 a $\sigma_{aw}$-proportional noise intensity, for which the pole-preserving
 schedule is $r_S\propto\sigma_{aw}\tau^{5/2}$ --- the deployed law.  Which of
 the two readings is correct is an empirical question, settled in
-Sec.~\ref{sec:riccati-law-ablation}.
+Sec.~\ref{sec:riccati-law-ablation}.  It is worth recording that neither
+reading is \emph{required} to recover an amplitude-dependent schedule: once
+the cost this covariance analysis omits is restored, the sensor-floor reading
+$\beta_m=0$ already yields $r_S\propto\sigma_{aw}^{6/7}$
+(Sec.~\ref{sec:riccati-mis-specified-pseudo}).  This remark postulates a
+mechanism; that section removes the need to postulate one.
 \end{remark}
 
 \subsubsection{Similarity-scaled pseudo-update cadence}
@@ -567,6 +577,11 @@ The analysis separates three statements that should not be conflated:
  \item The monomial $r_S=c_R\sigma_a\tau^3$ is an approximation to a
        pole-placement schedule, not a universal covariance identity.
 \end{enumerate}
+The first two are not as independent as they look.  Because the $S=0$
+observation is false, the scale in item 1 is also the amplitude of the signal
+the correction of item 2 works against, and that coupling --- invisible to a
+covariance recursion --- is what fixes the amplitude exponent of item 3
+(Sec.~\ref{sec:riccati-mis-specified-pseudo}).
 The exact four-state sampled problem depends on the dimensionless groups in
 \eqref{eq:riccati-four-groups}; the closed-form
 Eqs.~\eqref{eq:riccati-omegaR}--\eqref{eq:riccati-pole-target-rs} expose the
@@ -574,10 +589,15 @@ leading drift-band mechanism.  The full MEKF additionally contains attitude,
 gyro-bias, accelerometer-bias, three-axis correlation, and nonlinear
 measurement couplings, so the reduced result is a design theorem/asymptotic
 model rather than an exact closed-form solution of the complete estimator.
-Nevertheless it identifies the quantity that should govern regularization:
-the low-frequency posterior acceleration-error intensity
+Nevertheless it identifies one of the two quantities that should govern
+regularization: the low-frequency posterior acceleration-error intensity
 $q_{\mathrm{eff}}=S_{e_a}(0)$, together with the desired normalized
-regularization bandwidth $\omega_R\tau$.
+regularization bandwidth $\omega_R\tau$.  The second, which no covariance
+recursion built on \eqref{eq:riccati-false-measurement} can produce, is the
+amplitude of the true $S$ process the constraint contradicts;
+Sec.~\ref{sec:riccati-mis-specified-pseudo} shows that it carries six-sevenths
+of the weight in the optimal schedule and that $\omega_R\tau$ need not be
+prescribed once it is included.
 
 Accordingly, the current implementation should be described as an empirically
 calibrated approximation to this Riccati/pole law.  The self-similar cadence

--- a/doc/kalman_ou_iii/w3d-rs-similarity-design-guidance.tex-part
+++ b/doc/kalman_ou_iii/w3d-rs-similarity-design-guidance.tex-part
@@ -647,3 +647,62 @@ it.  Second, the search was scored on a five-seed training split and confirmed
 on the five held-out seeds, where the same floor change gives $-2.6\%$ against
 $-2.5\%$ on the training split, so the effect is not an artifact of the seeds
 used to find it.
+
+\paragraph{The floor read against the bias--variance criterion.}
+The clamp was found empirically, but
+Sec.~\ref{sec:riccati-mis-specified-pseudo} supplies a criterion it can be
+scored against independently, and the low-motion ladder is the ideal test bed:
+it scales one record, so $T_p$ and $\tau$ are held and only $\sigma_{aw}$
+moves, and it is the regime in which any $\beta_m\sigma_{aw}^2$ mismatch term
+must die out and leave the sensor floor dominating $q_{\mathrm{eff}}$ ---
+$m=0$, the $p=6/7$ branch of \eqref{eq:riccati-exponent-law}.
+Table~\ref{tab:riccati-floor-criterion} evaluates
+\eqref{eq:riccati-bias-variance} along that ladder.
+
+\begin{table}[t]
+\caption{The $r_S$ lower clamp against the MSE optimum of
+\eqref{eq:riccati-bias-variance}, on the low-motion stress ladder
+($T_p=\SI{3.00}{s}$ and $\tau=\SI{1.247}{s}$ held, $\sigma_{aw}$ scaled with
+$H_s$, $q_{\mathrm{eff}}=2r_a$).  The clamp acts on the base $r_S$; all values
+are shown as the filter sees them, after the cadence renormalization
+\eqref{eq:riccati-deployed-information-scale}.}
+\label{tab:riccati-floor-criterion}
+\centering
+\footnotesize
+\begin{tabular}{@{}rrrrrrr@{}}
+\toprule
+$H_s$ [m] & $\sigma_{aw}$ & $r_S^\star$ & law &
+\multicolumn{3}{c}{predicted $Z$ [\%$H_s$]} \\
+\cmidrule(lr){5-7}
+ & [\si{\meter\per\second\squared}] & [\si{\meter\second}] &
+ [\si{\meter\second}] & at $r_S^\star$ & floor \num{0.40} & floor \num{0.15} \\
+\midrule
+0.27 & 0.354 & 0.138 & 0.226 &  3.09 &  4.00 &  3.09 \\
+0.15 & 0.197 & 0.084 & 0.125 &  4.33 &  7.03 &  4.70 \\
+0.10 & 0.131 & 0.059 & 0.084 &  5.46 & 10.48 &  6.69 \\
+0.05 & 0.066 & 0.033 & 0.042 &  8.13 & 20.88 & 12.93 \\
+0.03 & 0.039 & 0.021 & 0.025 & 10.90 & 34.77 & 21.38 \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+Three readings follow, and the first two corroborate the change.  The
+\SI{0.15}{m.s} floor lands almost exactly on the criterion's optimum at
+$H_s=\SI{0.27}{m}$ --- \num{0.141} against $r_S^\star=\num{0.138}$ in
+filter-input units --- which is why the empirical sweep saw the gain saturate
+there: below that value the floor stops binding on any calibrated sea.  And
+the criterion reproduces the stress-case improvement it was not fitted to,
+predicting \SIrange{20.9}{12.9}{\percent} of $H_s$ across the floor change, a
+relative $-38\%$ against the measured $-35\%$ of
+Table~\ref{tab:rs-floor-effect}.
+
+The third reading is a caveat on the new floor rather than the old one.  At
+$H_s=\SI{0.05}{m}$ the clamp still binds, and binds hard: it sits a factor
+$4.3$ above $r_S^\star$, and the criterion says a further $-37\%$ remains
+available there.  An eight-sea mean cannot see this, because \SI{0.15}{m.s} is
+clear of every calibrated sea, so the saturation observed in the sweep is a
+property of the scoring set and not evidence that the clamp has stopped
+costing anything.  Whether to pursue that residue is a design question rather
+than a tuning one --- some guard against $r_S\rightarrow0$ in flat water is
+wanted regardless of what the MSE criterion asks for --- but it should be
+recorded that the guard is not free, and that its price is now quantified.

--- a/doc/kalman_ou_iii/w3d-rs-similarity-design-guidance.tex-part
+++ b/doc/kalman_ou_iii/w3d-rs-similarity-design-guidance.tex-part
@@ -303,28 +303,252 @@ would degrade one end and improve the other.  The full posterior law
 $p=0$ column, as $\zeta\gg1$ requires; the two differ by less than
 $0.002$ percent of $H_s$ in every scenario.
 
-The conclusion is therefore that the deployed filter occupies the strong
-acceleration-observation branch, but with an effective low-frequency
-acceleration-noise density dominated by the sea-state-proportional
-model-mismatch term of \eqref{eq:riccati-Ra-floor-plus-model} rather than by
-the sensor floor \eqref{eq:riccati-ra-sensor}.  Equation
-\eqref{eq:riccati-mismatch-branch} is then the operative asymptotics, and the
-schedule it prescribes, $r_S\propto\sigma_{aw}\tau^{5/2}$, is what the
-implementation already applies.  The earlier statement that the cubic law is
-``an approximation to a pole-placement schedule'' survives, but its
-justification changes: the coefficient $c_R$ should be read as absorbing
-$\sqrt{\beta_m}$ and the target pole $\kappa$, not as the weak-branch
-coordinate-similarity constant of Theorem~\ref{thm:ou-regularized-rs}.
+Read within the covariance analysis alone, the conclusion would be that the
+deployed filter occupies the strong acceleration-observation branch but with an
+effective low-frequency acceleration-noise density dominated by the
+sea-state-proportional model-mismatch term of
+\eqref{eq:riccati-Ra-floor-plus-model} rather than by the sensor floor
+\eqref{eq:riccati-ra-sensor}, so that \eqref{eq:riccati-mismatch-branch} is the
+operative asymptotics and prescribes exactly the deployed
+$r_S\propto\sigma_{aw}\tau^{5/2}$.  That reading is available, but it rests
+entirely on a postulated $\beta_m$ large enough to bury a sensor floor many
+orders of magnitude below it, and it is not the only explanation.
+Section~\ref{sec:riccati-mis-specified-pseudo} shows that the amplitude
+dependence survives even when $\beta_m=0$, because the covariance analysis is
+missing a term rather than a coefficient.
 
-This also bounds what the reduced scalar model can be asked to do.  It
-correctly predicts the $\tau^{5/2}$ exponent that the self-similar cadence
-produces, and it correctly predicts insensitivity to $\sigma_{aw}$ at fixed
-$r_S$; it does not predict the amplitude dependence of $r_S$ itself, because
-that is controlled by a term the reduction omits.  A physically calibrated
-$\beta_m$, measured from the actual low-frequency acceleration residual of the
-full MEKF rather than from the accelerometer datasheet, is the natural next
-refinement and would make \eqref{eq:riccati-pole-target-rs} usable directly
-instead of through the empirical coefficient $c_R$.
+Either way, the earlier statement that the cubic law is ``an approximation to a
+pole-placement schedule'' survives, but its justification changes: the
+coefficient $c_R$ absorbs the target pole $\kappa$ and the amplitude scale of
+the true third integral, not the weak-branch coordinate-similarity constant of
+Theorem~\ref{thm:ou-regularized-rs}.
+
+\subsubsection{Why the covariance analysis cannot see the amplitude exponent}
+\label{sec:riccati-mis-specified-pseudo}
+
+The ablation contradicts a \emph{prediction}, not the Riccati algebra.  Two
+steps separate \eqref{eq:riccati-omegaR} from the claim that $R_S$ carries no
+$\sigma_{aw}$, and both are assumptions rather than consequences.
+
+The first is the design objective itself.  Equation
+\eqref{eq:riccati-pole-target-RS} gives $R_S=q_{\mathrm{eff}}\tau^6/(T_S\kappa^6)$,
+so $\sigma_{aw}$ disappears only if $q_{\mathrm{eff}}$ is amplitude free
+\emph{and} the target $\kappa$ is.  Constancy of $\omega_R\tau$ was posited in
+\eqref{eq:riccati-pole-objective} as ``physically meaningful''; nothing in the
+Riccati equation selects it.  A covariance recursion computes the error of a
+given filter, it does not choose the filter's bandwidth, so the section never
+optimized anything and could not have predicted how the best $\kappa$ moves
+with sea state.
+
+The second is more serious, and it is visible in the paper's own equations.
+The pseudo-measurement is false.  A Kalman covariance recursion is the error
+covariance of the estimator only if its measurement model is true, and
+\begin{equation}
+ y_S=0=S+n_S,\qquad n_S\sim\mathcal N(0,R_S)
+\label{eq:riccati-false-measurement}
+\end{equation}
+is not: the third integral of a real wave record is a band-limited random
+process whose variance is fixed by the sea, and
+Theorem~\ref{thm:ou-regularized-rs} already computes it as
+$\Var[S]=C_{\mathrm{OU}}\sigma_{aw}^2\tau^6$.  The quantity propagated by
+\eqref{eq:riccati-drift-care} is therefore the covariance the filter
+\emph{believes} it has, not its mean square error.  How much of the belief is
+fictitious is quantified exactly: the closed-form solution of
+\eqref{eq:riccati-drift-care} is
+\begin{equation}
+ P_{pp}=\frac{3q_{\mathrm{eff}}}{\omega_R^3},
+\label{eq:riccati-Ppp}
+\end{equation}
+and splitting it by driving source gives $3q_{\mathrm{eff}}/2\omega_R^3$ from
+the acceleration residual and the other half from the assumed white
+pseudo-measurement noise of density $R_ST_S$.  Half of the nominal
+steady-state position variance is attributed to a noise process that does not
+exist, and the real process standing in its place is the wave signal.
+
+\paragraph{Restoring the missing term.}
+Write the drift-band error $e=\hat x_d-x_d$ with the pseudo-update applied as
+in \eqref{eq:riccati-triple-integrator}.  The innovation is
+$0-H_d\hat x_d=-(S+e_S)$, so the true third integral enters as an exogenous
+input:
+\begin{equation}
+ \dot e=(A_d-K_dH_d)e+G_d\varepsilon_a-K_dH_dx_d,
+\label{eq:riccati-mis-specified-error}
+\end{equation}
+with $\varepsilon_a$ the residual acceleration error of intensity
+$q_{\mathrm{eff}}$.  With
+$D(s)=(s+\omega_R)(s^2+\omega_Rs+\omega_R^2)$, the position row of
+$(sI-A_d+K_dH_d)^{-1}$ gives the two error transfers
+\begin{equation}
+ T_{p\varepsilon}(s)=\frac{s+2\omega_R}{D(s)},
+ \qquad
+ T_{pS}(s)=-\frac{s\left(2\omega_R^2s+\omega_R^3\right)}{D(s)} ,
+\label{eq:riccati-error-transfers}
+\end{equation}
+and hence the mean square vertical error
+\begin{equation}
+ \boxed{
+ \mathrm{MSE}_p(\omega_R)
+ =\underbrace{\frac{q_{\mathrm{eff}}}{\pi}
+   \int_0^\infty\!\left|T_{p\varepsilon}\right|^2\!d\omega}_{\text{drift}}
+ +\underbrace{\int_0^\infty\!\left|T_{pS}\right|^2
+   \frac{S_\eta(\omega)}{\omega^2}\,d\omega}_{\text{signal distortion}} .}
+\label{eq:riccati-bias-variance}
+\end{equation}
+The first term is $\tfrac32q_{\mathrm{eff}}/\omega_R^3$ and is the one the
+Riccati keeps.  The second is what the regularizer costs by insisting on
+something false, it is absent from every equation of
+Sec.~\ref{sec:riccati-drift-band}, and it is the only term that carries the
+sea-state amplitude.  Note $T_{pS}(0)=0$: a constant offset in $S$ is absorbed
+by the $\hat S$ state and never biases position, which is why the constraint is
+usable at all; only the wave-band content of $S$ leaks through.
+
+\paragraph{The optimal schedule, and its amplitude exponent.}
+For $\omega_R\ll\omega_p$ one has $|T_{pS}|\simeq2\omega_R^2/\omega$, so the
+distortion term is $4\omega_R^4m_{-4}$ with
+\begin{equation}
+ m_{-4}:=\int_0^\infty\frac{S_\eta(\omega)}{\omega^4}\,d\omega
+ =\Var\!\left[\textstyle\int S\,dt\right],
+\label{eq:riccati-m4}
+\end{equation}
+the negative fourth moment of the elevation spectrum --- the variance of the
+running integral of $S$, one integration further down the chain than $S$
+itself, because the leakage $2\omega_R^2/\omega$ is itself an integrator.  Both
+are set by the same sea-state scales: under the OU similarity of
+Theorem~\ref{thm:ou-chain-similarity}, $\Var[S]\propto\sigma_{aw}^2\tau^6$ and
+$m_{-4}\propto\sigma_{aw}^2\tau^8$, so the two differ in their $\tau$ exponent
+but carry the sea-state amplitude identically.  With this,
+\eqref{eq:riccati-bias-variance} becomes an explicit bias--variance
+trade-off,
+\begin{equation}
+ \mathrm{MSE}_p\simeq\frac{3q_{\mathrm{eff}}}{2\omega_R^3}
+ +4m_{-4}\omega_R^4,
+ \qquad
+ \omega_R^{\star7}=\frac{9}{32}\,\frac{q_{\mathrm{eff}}}{m_{-4}} .
+\label{eq:riccati-optimal-pole}
+\end{equation}
+Inverting $\omega_R=(q_{\mathrm{eff}}/R_ST_S)^{1/6}$ at the optimum,
+\begin{equation}
+ \boxed{
+ R_S^\star T_S
+ =\left(\tfrac{32}{9}\right)^{6/7}
+ q_{\mathrm{eff}}^{1/7}\,m_{-4}^{6/7} .}
+\label{eq:riccati-optimal-RS}
+\end{equation}
+This is the central result.  The MSE-optimal regularizer is governed
+predominantly by the amplitude of the wave signal it fights --- weight $6/7$
+on $m_{-4}$ against weight $1/7$ on the drift-noise intensity that
+Sec.~\ref{sec:riccati-drift-band} treats as the whole story.  The similarity
+scale of the $S$ chain, which the opening of
+Sec.~\ref{sec:rs-riccati-analysis} set aside as a fact that ``does \emph{not}
+determine the pseudo-measurement covariance $R_S$'', turns out to determine
+almost all of it; what the opening argument correctly identified is only that
+the mechanism is not covariance matching.  Writing
+$q_{\mathrm{eff}}\propto\sigma_{aw}^m$ and
+$m_{-4}\propto\sigma_{aw}^2\tau^8$,
+\begin{equation}
+ \boxed{r_S^\star\propto\sigma_{aw}^{p},\qquad p=\frac{m+12}{14}.}
+\label{eq:riccati-exponent-law}
+\end{equation}
+For $m=0$ --- the sensor-floor reading of the strong branch, taken entirely at
+face value, with $\beta_m=0$ --- this gives $p=6/7\approx0.86$, not $0$.
+Recovering the predicted $p=0$ would require $q_{\mathrm{eff}}\propto
+\sigma_{aw}^{-12}$.  The amplitude dependence the ablation measures is
+therefore not evidence about $\beta_m$ at all in the first instance; it is a
+term the reduction dropped.
+
+\paragraph{Numerical confirmation.}
+Table~\ref{tab:riccati-bias-variance} evaluates
+\eqref{eq:riccati-bias-variance} exactly, with the deployed cadence and the
+JONSWAP spectra of the four calibration seas, using the bench floor
+$q_{\mathrm{eff}}=2r_a$ of \eqref{eq:riccati-ra-sensor} throughout
+(\texttt{tools/rs\_law\_bias\_variance.py}).  Three things follow.
+
+\begin{table}[t]
+\caption{MSE-optimal integral regularizer from \eqref{eq:riccati-bias-variance}
+with the amplitude-free $q_{\mathrm{eff}}=2r_a=\SI{2.19e-6}{m^2/s^3}$, against
+the deployed schedule, for the four JONSWAP calibration seas.  The last column
+is the predicted vertical RMS error at the \emph{deployed} operating point.}
+\label{tab:riccati-bias-variance}
+\centering
+\footnotesize
+\begin{tabular}{@{}lrrrrrr@{}}
+\toprule
+Sea & $\omega_R^\star$ [rad/s] & $\omega_R^\star\tau$ &
+$r_S^\star$ [\si{\meter\second}] & $r_S$ deployed &
+$\omega_R^\star/\omega_R$ & pred.\ $Z$ [\%$H_s$] \\
+\midrule
+$H_s=0.27$ m & 0.435 & 0.543 & 0.138 & 0.226 & 1.18 & 3.33 \\
+$H_s=1.50$ m & 0.185 & 0.403 & 1.359 & 1.863 & 1.11 & 2.07 \\
+$H_s=4.00$ m & 0.111 & 0.399 & 4.865 & 10.068 & 1.27 & 1.87 \\
+$H_s=8.50$ m & 0.076 & 0.320 & 14.150 & 19.092 & 1.11 & 1.39 \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+First, the objective assumed in \eqref{eq:riccati-pole-objective} is
+approximately \emph{derived}: the optimal $\omega_R^\star\tau$ is
+$0.32$--$0.54$ across a $31\times$ range of $H_s$, rather than free to drift.
+Constant normalized pole is a good design rule for the reason the covariance
+analysis could not supply, namely that both terms of
+\eqref{eq:riccati-bias-variance} are pinned to the sea scale.
+
+Second, the deployed schedule is close to this optimum without having been
+derived from it: $\omega_R^\star$ exceeds the deployed pole by only
+\SIrange{11}{27}{\percent}, and $r_S^\star$ sits within a factor
+$1.4$--$2.1$ of the deployed value, with the distortion term contributing
+\SIrange{12}{27}{\percent} of the predicted mean square at the deployed point.
+The empirically tuned $c_R$ landed near a genuine minimum of a criterion the
+Riccati section never wrote down.  The predicted vertical error,
+\SIrange{1.4}{3.3}{\percent} of $H_s$ against the \num{4.747} percent
+measured for the full estimator (Table~\ref{tab:riccati-exponent-ablation}),
+is the right order for a reduction that carries neither attitude coupling nor
+bias estimation.
+
+Third, a controlled amplitude sweep --- $H_s$ scaled over two decades at fixed
+$T_p$ and fixed $\tau$, so that only $\sigma_{aw}$ moves, exactly as the
+ablation family \eqref{eq:riccati-exponent-family} does --- reproduces
+\eqref{eq:riccati-exponent-law} to three decimals:
+$p=0.854$ for $m=0$ against $6/7=0.857$, $p=0.927$ for $m=1$ against
+$13/14=0.929$, and $p=1.000$ for $m=2$.
+
+\paragraph{What this changes.}
+The discrepancy is resolved without a postulate.  Any low-frequency
+acceleration-error intensity that does not \emph{decrease} with sea state puts
+the optimal amplitude exponent in $[6/7,\,\infty)$, and the interval
+$[6/7,\,1]$ --- covering everything from a strictly sea-state-independent noise
+floor to a fully $\sigma_{aw}^2$-proportional one --- brackets the deployed
+$p=1$ and excludes $p=0$ by a margin far larger than the ablation's confidence
+interval.  Read in reverse, \eqref{eq:riccati-exponent-law} turns
+Table~\ref{tab:riccati-exponent-ablation} into a measurement rather than a
+calibration: the minimum at $p\simeq1$ implies $m\simeq2$, that is, a drift-band
+acceleration-error intensity proportional to $\sigma_{aw}^2$, which is
+independent corroboration of the model-mismatch form
+\eqref{eq:riccati-Ra-floor-plus-model} obtained without assuming it.
+
+Two limits of the deployed law also become visible.  Equation
+\eqref{eq:riccati-optimal-RS} depends on the sea only through $m_{-4}$, a
+low-frequency moment of the actual wave spectrum, for which the monomial
+$\sigma_{aw}\tau^3$ is an OU surrogate.  The surrogate is exact in amplitude
+and only approximate in time scale.  With $T_S=c_T\tau$ and exact OU
+similarity, $m_{-4}\propto\sigma_{aw}^2\tau^8$ and
+\eqref{eq:riccati-optimal-RS} gives
+$r_S^\star\propto\sigma_{aw}^{6/7}\tau^{41/14}$; a controlled time-scale sweep
+of the JONSWAP family at fixed $\sigma_{aw}$ measures
+$d\log m_{-4}/d\log\tau=7.61$ and hence
+$d\log r_S^\star/d\log\tau=2.76$, against the deployed $5/2$.  The gap is
+$m_{-4}$ weighting the low-frequency tail of the real spectrum more heavily
+than the OU prior does.  Across the four calibration seas the schedules
+nevertheless agree to a factor of two
+(Table~\ref{tab:riccati-bias-variance}) with no systematic trend in $\tau$, so
+the practical consequence is small; a tuner that estimated $m_{-4}$ directly
+would remove the residual spectral-shape dependence.  And with $m=2$ the two
+terms of
+\eqref{eq:riccati-optimal-pole} scale identically, which is precisely why a
+single dimensionless $\kappa$ works across the envelope; if the drift-band
+intensity ever leaves that scaling --- at very low sea states, where the sensor
+floor must eventually dominate --- \eqref{eq:riccati-exponent-law} predicts the
+exponent should fall toward $6/7$.  That is a sharper and more testable
+statement than the $\beta_m$ postulate it replaces.
 
 \subsubsection{The multipliers are calibrated; the floor was not}
 \label{sec:riccati-multiplier-retune}

--- a/tools/rs_law_bias_variance.py
+++ b/tools/rs_law_bias_variance.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Bias--variance analysis of the OU-III integral (S=0) regularizer.
+
+Section "Riccati interpretation of the S=0 regularizer" of the OU-III paper
+derives a pole-placement law for R_S and, in the strong acceleration-observation
+branch that the deployed filter demonstrably occupies, predicts a schedule with
+*no* leading-order dependence on sigma_aw.  The amplitude-exponent ablation
+(tools/ou_rs_law_ablation.py) measures the opposite: removing the sigma_aw
+factor costs +0.300 percent of Hs, and the optimum sits at the deployed p = 1.
+
+This driver resolves that contradiction inside the paper's own reduced model.
+
+The covariance recursion behind the pole law treats
+
+    y_S = 0 = S + n_S,   n_S ~ N(0, R_S)
+
+as a real observation.  It is not: the true third integral of a wave record is
+a band-limited random process whose variance is set by the sea, not by R_S
+(Theorem "Low-frequency-regularized triple integral of OU acceleration" gives
+Var[S] = C_OU sigma_aw^2 tau^6).  The Kalman covariance is therefore the
+*believed* covariance of a mis-specified filter, not its mean square error.
+Restoring the missing term gives, for the drift-band triple integrator with
+gain K_d = [2 w_R, 2 w_R^2, w_R^3]^T,
+
+    MSE_p(w_R) = int |T_pe(jw)|^2 q_eff dw/pi          (drift; the Riccati term)
+               + int |T_pn(jw)|^2 S_S(w) dw            (distortion; not in the
+                                                        Riccati at all)
+
+    T_pe(s) = (s + k1)/D(s),  T_pn(s) = -s(k2 s + k3)/D(s),
+    D(s) = s^3 + k1 s^2 + k2 s + k3 = (s + w_R)(s^2 + w_R s + w_R^2),
+
+with S_S = S_eta/w^2 the one-sided spectrum of the true third integral.  Only
+the second term carries the sea-state amplitude, and it is the term the
+covariance analysis cannot see.
+
+Minimising the sum gives w_R* ~ (q_eff/m_{-4})^{1/7}, where
+
+    m_{-4} = int S_eta/w^4 dw = Var[int S dt] ~ sigma_aw^2 tau^8
+
+is the negative fourth moment of the elevation spectrum -- one integration
+below Var[S], because the leakage 2 w_R^2/w is itself an integrator, but
+carrying the same sea-state amplitude.  Hence
+
+    r_S* ~ q_eff^{1/14} m_{-4}^{3/7}   and   r_S* ~ sigma_aw^p,
+    p = (m + 12)/14   when   q_eff ~ sigma_aw^m.
+
+So p = 6/7 = 0.857 even for a completely amplitude-independent q_eff -- the
+paper's own strong-branch reading -- and p = 1 exactly when q_eff ~ sigma_aw^2.
+Reproducing the measured p = 0 would need q_eff ~ sigma_aw^-12.  The
+experimental result is not in conflict with the Riccati algebra; it is in
+conflict with the assumption that a covariance recursion built on a false
+measurement bounds the estimator's actual error.
+
+Typical use:
+
+    python3 tools/rs_law_bias_variance.py
+    python3 tools/rs_law_bias_variance.py --exponents 0,1,2,3
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import sys
+
+import numpy as np
+
+GRAV = 9.80665
+
+# Calibrated OU-III operating points, from
+# doc/kalman_ou_iii/w3d-ou-validation-tuning-points-generated.tex-part, paired
+# with the peak wavelength encoded in each JONSWAP scenario name.
+# (label, Hs [m], peak wavelength [m], tau [s], sigma_aw [m/s^2])
+SEAS = (
+    ("Hs=0.27", 0.270, 14.047, 1.247, 0.354),
+    ("Hs=1.50", 1.500, 50.710, 2.179, 0.724),
+    ("Hs=4.00", 4.000, 112.766, 3.589, 1.124),
+    ("Hs=8.50", 8.500, 202.839, 4.222, 1.420),
+)
+
+# Deployed regularizer schedule (Sec. "What the wrapper currently deploys").
+C_R = 0.35
+C_T = 0.015 / 1.1
+TS0 = 0.015
+TS_MIN, TS_MAX = 0.005, 0.250
+
+# Validated accelerometer noise floor: R_a dt at dt = 5 ms.
+DT_IMU = 0.005
+SIGMA_NA = 0.0148
+R_A = SIGMA_NA**2 * DT_IMU
+
+NOMINAL = 1  # index of the Hs = 1.5 m anchor sea in SEAS
+
+
+def peak_period(wavelength_m: float) -> float:
+    """Deep-water peak period of a scenario's peak wavelength."""
+    return math.sqrt(2.0 * math.pi * wavelength_m / GRAV)
+
+
+def jonswap(w: np.ndarray, hs: float, tp: float, gamma: float = 3.3) -> np.ndarray:
+    """One-sided JONSWAP elevation spectrum scaled so int S dw = (Hs/4)^2."""
+    wp = 2.0 * math.pi / tp
+    sigma = np.where(w <= wp, 0.07, 0.09)
+    peak = np.exp(-((w - wp) ** 2) / (2.0 * sigma**2 * wp**2))
+    with np.errstate(divide="ignore", over="ignore", invalid="ignore"):
+        s = w**-5.0 * np.exp(-1.25 * (wp / w) ** 4) * gamma**peak
+    s = np.nan_to_num(np.where(w > 0.0, s, 0.0))
+    return s * ((hs / 4.0) ** 2 / np.trapezoid(s, w))
+
+
+def transfer_gains(w: np.ndarray, w_r: float) -> tuple[np.ndarray, np.ndarray]:
+    """Squared magnitudes of the two error transfers of the drift-band observer.
+
+    Returns (|T_pe|^2, |T_pn|^2): residual acceleration error -> position error,
+    and true third integral -> position error.
+    """
+    s = 1j * w
+    k1, k2, k3 = 2.0 * w_r, 2.0 * w_r**2, w_r**3
+    den = s**3 + k1 * s**2 + k2 * s + k3
+    return (np.abs((s + k1) / den) ** 2,
+            np.abs(-s * (k2 * s + k3) / den) ** 2)
+
+
+def mse_terms(w_r: float, w: np.ndarray, s_eta: np.ndarray,
+              q_eff: np.ndarray) -> tuple[float, float]:
+    """Drift and distortion contributions to the mean square position error."""
+    t_pe2, t_pn2 = transfer_gains(w, w_r)
+    drift = float(np.trapezoid(t_pe2 * q_eff / math.pi, w))
+    distortion = float(np.trapezoid(t_pn2 * s_eta / w**2, w))
+    return drift, distortion
+
+
+def optimal_pole(w: np.ndarray, s_eta: np.ndarray,
+                 q_eff: np.ndarray) -> tuple[float, float]:
+    """Minimise the total mean square position error over w_R."""
+    lo, hi = -3.0, 1.0
+    grid = np.logspace(lo, hi, 161)
+    best_w, best_v = grid[0], math.inf
+    for _ in range(4):
+        vals = np.array([sum(mse_terms(x, w, s_eta, q_eff)) for x in grid])
+        i = int(np.argmin(vals))
+        best_w, best_v = float(grid[i]), float(vals[i])
+        lo = math.log10(grid[max(i - 1, 0)])
+        hi = math.log10(grid[min(i + 1, len(grid) - 1)])
+        grid = np.logspace(lo, hi, 41)
+    return best_w, best_v
+
+
+def pseudo_period(tau: float) -> float:
+    """Deployed self-similar pseudo-update cadence with its clamps."""
+    return min(max(C_T * tau, TS_MIN), TS_MAX)
+
+
+def deployed_rs(sigma_a: float, tau: float) -> float:
+    """r_S actually reaching the filter, after the information renormalization."""
+    return C_R * sigma_a * tau**3 * math.sqrt(TS0 / pseudo_period(tau))
+
+
+def rs_from_pole(w_r: float, q_eff_at_pole: float, tau: float) -> float:
+    """Invert w_R = (q_eff/(R_S T_S))^{1/6} for r_S = sqrt(R_S)."""
+    ts = pseudo_period(tau)
+    return math.sqrt(q_eff_at_pole / w_r**6 / ts)
+
+
+def frequency_grid() -> np.ndarray:
+    return np.logspace(-4.0, 1.2, 6001)
+
+
+def self_check(w: np.ndarray) -> None:
+    """Reproduce the nominal Riccati covariance from the same transfers.
+
+    Feeding the *assumed* white pseudo-measurement noise (two-sided density
+    r_S,c) back through T_pn must return the CARE solution P_pp = 3 q/w_R^3,
+    which the closed form of the paper implies.  The split is exactly half and
+    half: the Riccati attributes 1.5 q/w_R^3 of the steady-state position
+    variance to a pseudo-measurement noise that does not exist.
+    """
+    print("self-check: nominal Riccati P_pp against the closed form")
+    print(f"  {'w_R':>8}{'process':>12}{'pseudo':>12}{'sum':>12}"
+          f"{'3q/w_R^3':>12}{'ratio':>9}")
+    for w_r in (0.05, 0.2, 1.0):
+        q = 1.0
+        r_sc = q / w_r**6
+        t_pe2, t_pn2 = transfer_gains(w, w_r)
+        proc = float(np.trapezoid(t_pe2 * q / math.pi, w))
+        pseudo = float(np.trapezoid(t_pn2 * r_sc / math.pi, w))
+        exact = 3.0 * q / w_r**3
+        print(f"  {w_r:8.2f}{proc:12.4e}{pseudo:12.4e}{proc + pseudo:12.4e}"
+              f"{exact:12.4e}{(proc + pseudo) / exact:9.5f}")
+    print()
+
+
+def sea_table(w: np.ndarray) -> None:
+    """MSE-optimal regularizer per calibrated sea, against the deployed one."""
+    print("MSE-optimal regularizer, q_eff = 2 r_a (the paper's strong branch)")
+    print(f"  r_a = {R_A:.3e} m^2/s^3, q_eff = {2 * R_A:.3e} m^2/s^3\n")
+    print(f"  {'sea':>8}{'Tp':>7}{'tau':>7}{'sigma_aw':>10}{'w_R*':>9}"
+          f"{'w_R* tau':>10}{'r_S*':>10}{'r_S dep':>10}{'r_S*/dep':>10}"
+          f"{'rms %Hs':>9}")
+    for label, hs, lam, tau, sigma_a in SEAS:
+        tp = peak_period(lam)
+        s_eta = jonswap(w, hs, tp)
+        q_eff = np.full_like(w, 2.0 * R_A)
+        w_r, mse = optimal_pole(w, s_eta, q_eff)
+        rs = rs_from_pole(w_r, 2.0 * R_A, tau)
+        dep = deployed_rs(sigma_a, tau)
+        print(f"  {label:>8}{tp:7.2f}{tau:7.2f}{sigma_a:10.3f}{w_r:9.4f}"
+              f"{w_r * tau:10.3f}{rs:10.3f}{dep:10.3f}{rs / dep:10.3f}"
+              f"{100.0 * math.sqrt(mse) / hs:9.2f}")
+    print()
+
+
+def deployed_balance(w: np.ndarray) -> None:
+    """Where the deployed schedule sits on the bias--variance curve."""
+    print("Deployed schedule: term balance at its own operating point")
+    print(f"  {'sea':>8}{'w_R dep':>10}{'drift':>12}{'distortion':>12}"
+          f"{'distort/tot':>13}{'rms %Hs':>9}{'w_R*/w_R dep':>14}")
+    for label, hs, lam, tau, sigma_a in SEAS:
+        s_eta = jonswap(w, hs, peak_period(lam))
+        q_eff = np.full_like(w, 2.0 * R_A)
+        r_sc = deployed_rs(sigma_a, tau) ** 2 * pseudo_period(tau)
+        w_r = (2.0 * R_A / r_sc) ** (1.0 / 6.0)
+        drift, distortion = mse_terms(w_r, w, s_eta, q_eff)
+        w_star, _ = optimal_pole(w, s_eta, q_eff)
+        total = drift + distortion
+        print(f"  {label:>8}{w_r:10.4f}{drift:12.3e}{distortion:12.3e}"
+              f"{distortion / total:13.3f}{100.0 * math.sqrt(total) / hs:9.2f}"
+              f"{w_star / w_r:14.3f}")
+    print()
+
+
+def amplitude_sweep(w: np.ndarray, exponents: list[float], span: float,
+                    points: int) -> None:
+    """Controlled amplitude sweep at fixed Tp and tau: measure p directly."""
+    _, hs0, lam0, tau0, sigma0 = SEAS[NOMINAL]
+    tp = peak_period(lam0)
+    scales = np.logspace(-span, span, points)
+    print(f"Controlled amplitude sweep about {SEAS[NOMINAL][0]} "
+          f"(Tp = {tp:.2f} s and tau = {tau0:.2f} s held fixed)")
+    print(f"  {'q_eff ~ sigma_aw^m':>20}{'p measured':>13}"
+          f"{'(m+12)/14':>12}{'w_R*/w_p span':>16}")
+    for m in exponents:
+        logs, logr, poles = [], [], []
+        for scale in scales:
+            sigma_a = sigma0 * scale
+            s_eta = jonswap(w, hs0 * scale, tp)
+            q_at = 2.0 * R_A * (sigma_a / sigma0) ** m
+            w_r, _ = optimal_pole(w, s_eta, np.full_like(w, q_at))
+            logs.append(math.log(sigma_a))
+            logr.append(math.log(rs_from_pole(w_r, q_at, tau0)))
+            poles.append(w_r / (2.0 * math.pi / tp))
+        p = float(np.polyfit(logs, logr, 1)[0])
+        print(f"  {m:20.2f}{p:13.4f}{(m + 12.0) / 14.0:12.4f}"
+              f"{min(poles):8.3f}-{max(poles):<7.3f}")
+    print("\n  p = 0, the schedule the covariance analysis predicts, would need"
+          "\n  q_eff ~ sigma_aw^-12.  The ablation minimum at p = 1 implies"
+          "\n  q_eff ~ sigma_aw^2 in the drift band.\n")
+
+
+def time_scale_sweep(w: np.ndarray, span: float, points: int) -> None:
+    """Controlled time-scale sweep at fixed sigma_aw: measure the tau exponent.
+
+    Tp (and with it tau) is scaled while Hs is renormalised to hold
+    sigma_aw^2 = m_4 fixed, so only the time scale moves.  Exact OU similarity
+    would give m_{-4} ~ tau^8 and r_S* ~ tau^(41/14); the JONSWAP shape is not
+    exactly self-similar, so the measured moment exponent is used to check the
+    identity d log r_S*/d log tau = (6/7 * d log m_{-4}/d log tau - 1)/2.
+    """
+    _, hs0, lam0, tau0, sigma0 = SEAS[NOMINAL]
+    tp0 = peak_period(lam0)
+    logt, logr, logm = [], [], []
+    for scale in np.logspace(-span, span, points):
+        tp, tau = tp0 * scale, tau0 * scale
+        s_eta = jonswap(w, hs0, tp)
+        s_eta = s_eta * (sigma0**2 / float(np.trapezoid(w**4 * s_eta, w)))
+        q_eff = np.full_like(w, 2.0 * R_A)
+        w_r, _ = optimal_pole(w, s_eta, q_eff)
+        logt.append(math.log(tau))
+        logr.append(math.log(rs_from_pole(w_r, 2.0 * R_A, tau)))
+        logm.append(math.log(float(np.trapezoid(s_eta / w**4, w))))
+    slope_r = float(np.polyfit(logt, logr, 1)[0])
+    slope_m = float(np.polyfit(logt, logm, 1)[0])
+    print("Controlled time-scale sweep (sigma_aw held fixed, amplitude-free q_eff)")
+    print(f"  d log m_-4 / d log tau = {slope_m:8.4f}   (exact OU similarity: 8)")
+    print(f"  d log r_S* / d log tau = {slope_r:8.4f}   "
+          f"(identity: {(6.0 / 7.0 * slope_m - 1.0) / 2.0:.4f}, "
+          f"exact similarity 41/14 = {41.0 / 14.0:.4f})")
+    print(f"  deployed exponent      = {2.5:8.4f}\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--exponents", default="0,1,2,3",
+                    help="amplitude exponents m of q_eff to sweep (default 0,1,2,3)")
+    ap.add_argument("--sweep-span", type=float, default=1.0,
+                    help="half-width in decades of the amplitude sweep (default 1)")
+    ap.add_argument("--sweep-points", type=int, default=21)
+    ap.add_argument("--skip-self-check", action="store_true")
+    args = ap.parse_args(argv)
+
+    exponents = [float(e) for e in args.exponents.split(",") if e.strip()]
+    w = frequency_grid()
+
+    if not args.skip_self_check:
+        self_check(w)
+    sea_table(w)
+    deployed_balance(w)
+    amplitude_sweep(w, exponents, args.sweep_span, args.sweep_points)
+    time_scale_sweep(w, 0.3, 13)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/rs_law_bias_variance.py
+++ b/tools/rs_law_bias_variance.py
@@ -257,6 +257,44 @@ def amplitude_sweep(w: np.ndarray, exponents: list[float], span: float,
           "\n  q_eff ~ sigma_aw^2 in the drift band.\n")
 
 
+def low_motion_floor(w: np.ndarray) -> None:
+    """Independent check of the r_S lower clamp against the same criterion.
+
+    The low-motion stress ladder of tools/ou_robustness.py scales the whole
+    Hs = 0.27 m record, so Tp and tau are held and only sigma_aw moves -- the
+    controlled amplitude experiment again, and the regime where the
+    model-mismatch term must die out and the sensor floor dominate q_eff.  The
+    clamp is applied to the base r_S before the cadence renormalization, so
+    both are reported in filter-input units for comparison with r_S*.
+    """
+    _, hs_ref, lam_ref, tau, sigma_ref = SEAS[0]
+    tp = peak_period(lam_ref)
+    q_eff = np.full_like(w, 2.0 * R_A)
+    ts = pseudo_period(tau)
+    renorm = math.sqrt(TS0 / ts)
+    print("Low-motion stress ladder: r_S floor against the MSE optimum")
+    print(f"  Tp = {tp:.2f} s, tau = {tau:.3f} s held; floors shown as the filter"
+          f" sees them\n")
+    print(f"  {'Hs':>6}{'sigma_aw':>10}{'r_S*':>9}{'law':>9}"
+          f"{'floor .40':>11}{'floor .15':>11}"
+          f"{'Z* %Hs':>9}{'Z@.40':>9}{'Z@.15':>9}")
+    for hs in (0.27, 0.15, 0.10, 0.05, 0.03):
+        sigma_a = sigma_ref * hs / hs_ref
+        s_eta = jonswap(w, hs, tp)
+        w_r, mse = optimal_pole(w, s_eta, q_eff)
+        cells = []
+        for floor in (0.40, 0.15):
+            rs = floor * renorm
+            pole = (2.0 * R_A / (rs**2 * ts)) ** (1.0 / 6.0)
+            drift, distortion = mse_terms(pole, w, s_eta, q_eff)
+            cells.append(100.0 * math.sqrt(drift + distortion) / hs)
+        print(f"  {hs:6.2f}{sigma_a:10.4f}{rs_from_pole(w_r, 2 * R_A, tau):9.4f}"
+              f"{C_R * sigma_a * tau**3 * renorm:9.4f}"
+              f"{0.40 * renorm:11.3f}{0.15 * renorm:11.3f}"
+              f"{100.0 * math.sqrt(mse) / hs:9.2f}{cells[0]:9.2f}{cells[1]:9.2f}")
+    print()
+
+
 def time_scale_sweep(w: np.ndarray, span: float, points: int) -> None:
     """Controlled time-scale sweep at fixed sigma_aw: measure the tau exponent.
 
@@ -309,6 +347,7 @@ def main(argv: list[str] | None = None) -> int:
     deployed_balance(w)
     amplitude_sweep(w, exponents, args.sweep_span, args.sweep_points)
     time_scale_sweep(w, 0.3, 13)
+    low_motion_floor(w)
     return 0
 
 


### PR DESCRIPTION
The Riccati section predicts a regularizer schedule with no leading-order
sigma_aw dependence in the strong acceleration-observation branch the filter
demonstrably occupies; the amplitude-exponent ablation measures a clean
minimum at the deployed p = 1 and a +0.300 %Hs cost for removing the factor.
The prediction is what fails, and for two identifiable reasons.

First, the covariance analysis never optimized anything: constancy of
omega_R tau was posited as the design objective, not derived, so sigma_aw
drops out only because the target pole was assumed to be amplitude free.

Second, and decisively, the S = 0 pseudo-measurement is false, so the Riccati
solution is the covariance the filter believes it has, not its mean square
error.  Exactly half of the nominal steady-state position variance
P_pp = 3 q_eff/omega_R^3 is attributed to a pseudo-measurement noise that does
not exist; the process standing in its place is the wave signal, whose
amplitude is set by the sea and not by R_S.  Restoring that term gives a
bias-variance trade-off between drift (~ q_eff/omega_R^3) and signal
distortion (~ m_{-4} omega_R^4), whose optimum obeys

    R_S* T_S ~ q_eff^(1/7) m_{-4}^(6/7),   r_S* ~ sigma_aw^p,  p = (m+12)/14

for q_eff ~ sigma_aw^m.  So p = 6/7 even for a strictly amplitude-free
q_eff -- the paper's own sensor-floor reading with beta_m = 0 -- and p = 1 for
q_eff ~ sigma_aw^2.  Reproducing the predicted p = 0 would need
q_eff ~ sigma_aw^-12.

Adds tools/rs_law_bias_variance.py, which evaluates the restored error
exactly over the four JONSWAP calibration seas.  It confirms the exponent law
to three decimals, shows the optimal omega_R tau is 0.32-0.54 across a 31x
range of Hs (so the assumed pole objective is approximately derived rather
than postulated), and places the deployed schedule within 11-27 % of the
optimal pole with a predicted vertical error of 1.4-3.3 %Hs against the
measured 4.747.  Read in reverse, the ablation minimum now measures the
drift-band noise exponent as m = 2, corroborating the model-mismatch form
R_a = R_a,sensor + beta_m sigma_a^2 instead of assuming it.

Documentation only plus a new analysis driver; no filter code changes.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Wvp45o4Tc8ZJjcQGYNaoK6