### PR TITLE
Correct OU-III hard iron continuously, and re-gauge with it

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,13 @@ transition, and adaptation outcomes rather than uniform superiority. See
 [`docs/ou-validation.md`](docs/ou-validation.md) for the protocol, seed controls,
 and interpretation.
 
+OU-III also keeps a magnetometer hard-iron estimator running for the life of
+the filter, in a gravity-referenced frame that reads no filter state, and moves
+the magnetic reference with it. That halves the standing heading error the
+one-shot startup calibration leaves behind; see
+[`docs/ou-iii-continuous-hard-iron.md`](docs/ou-iii-continuous-hard-iron.md)
+for the mechanism, the results, and the case it cannot fix.
+
 The adaptation channels themselves smooth their targets with an EMA whose time
 constant scales with the OU operating point. `tools/ou_ema_adapt_study.py`
 sweeps those horizons against synthesized sea-state transitions, which is the

--- a/docs/ou-iii-continuous-hard-iron.md
+++ b/docs/ou-iii-continuous-hard-iron.md
@@ -1,0 +1,245 @@
+# OU-III continuous magnetic hard-iron correction
+
+`SeaStateFusion_OU_III::Config::mag_continuous_hard_iron` runs a body-fixed
+magnetometer offset estimator for the whole life of the filter and feeds its
+answer back into the magnetic measurement model. It is on by default. The
+simulator exposes it as `SF_MAG_CONT_HI=0|1`, which is also the matched
+ablation.
+
+Scored on the eight reference records, the deterministic 900 s protocol, it
+takes yaw RMS from 1.835 deg mean / 2.162 deg worst to **0.822 deg mean /
+1.063 deg worst**. Every record improves. Pitch improves, roll and the
+displacement channels do not move.
+
+## What the standing yaw error actually was
+
+The OU-III yaw error is not a tracking error. On `pmstokes H1.5` the scored
+window has mean 2.146 deg and standard deviation 0.265 deg: the filter tracks
+heading well and points 2.1 deg away from magnetic north the whole time.
+
+That offset is a **gauge**. The startup acquisition averages the magnetometer
+in a yaw-stripped tilt frame and declares the horizontal direction of that
+average to be north:
+
+    ref = mean(R_tilt m) = B_hull + mean(R_tilt) b + (distortion),
+
+for a hull at fixed heading, where `B_hull` is the true field in the hull's own
+level frame and `b` is the body-fixed offset. The filter's north is the
+direction of `ref`; true north is the direction of `B_hull`; the yaw error is
+the angle between them, which for the simulator's offset of about 1.15 uT
+against a 20.7 uT horizontal field is a couple of degrees. Nothing downstream
+can recover it, because the world frame *is* that direction.
+
+Measured directly, by removing each part of the simulator's magnetometer error
+with simulator truth and rescoring (branch-only oracle, not deployable):
+
+| oracle correction | yaw mean | yaw worst |
+| --- | --- | --- |
+| none (baseline) | 1.835 | 2.162 |
+| soft iron and misalignment only | 1.811 | 2.121 |
+| hard iron only | 0.496 | 1.084 |
+| both | 0.479 | 1.059 |
+
+So on the shipped seed essentially all of the standing error is the hard-iron
+offset, and removing it perfectly would leave 0.5 deg. That is the headroom the
+estimator is chasing.
+
+## Why a startup window cannot get it
+
+`MagAutoTuner` already solves this identification problem, and its
+`estimate_hard_iron` flag has always been off by default. Its own tests say
+why: at one attitude an offset and a rotated world field are the same reading,
+and only tilt breaks the tie. The normal matrix that decides the tie is, to
+second order in roll and pitch standard deviations,
+
+    I - mean(R)^T mean(R)  ~  diag(sigma_p^2, sigma_r^2, sigma_r^2 + sigma_p^2),
+
+which is of order 1e-3 for a hull working through a few degrees. Fifteen
+seconds of that is not enough, and the fix is not a longer startup window --
+it is not closing the window at all.
+
+## The estimator
+
+`src/tuner/ContinuousMagHardIronEstimator.h` keeps exponentially weighted
+sufficient statistics of `(R_i, m_i)` and solves
+
+    (I - Abar^T Abar) b = mbar - Abar^T wbar,      Abar = mean(R_i),
+
+periodically, eliminating the world field analytically so it never becomes a
+filter state. Inputs are the raw magnetometer and the yaw-stripped tilt
+quaternion of the private Mahony observer. Both are exogenous: no MEKF state is
+read, no loop is closed through the filter, and the ISS argument, the state
+dimension, `F`, `Q`, `P` and the gain computation are untouched.
+
+Stripping yaw from the accumulation frame matters twice. It makes the frame a
+pure function of gravity, so the observer's unobservable, drifting heading
+cannot leak in. And it ties the frame to the hull's own heading, so a hull that
+turns makes the world field move inside the frame and the model residual rises
+immediately -- which is what the residual gate is for.
+
+### Why the solve is regularised, and why the ridge scales
+
+Inverting a matrix of order 1e-3 multiplies everything the model does *not*
+carry by up to a thousand. What it does not carry is soft iron and sensor
+misalignment, and those are modulated by the very tilt the offset is read from.
+The consequence is not noise and does not average away: fitted over the full
+1200 s against truth attitude, the unregularised solve returns about 1.8x the
+true offset on every well-excited record, and applying that overshoots the
+correction into a yaw error of the opposite sign.
+
+The size of that aliased error is roughly `eps*|B|` — the distortion times the
+field — *independently of the sea state*, because it enters the right-hand side
+through the same tilt that carries the signal. A hull working through thirty
+degrees is not fitting a cleaner offset than one working through five; it is
+fitting the same wrong one with more confidence. A fixed ridge therefore
+shrinks hardest exactly where the fit is most trustworthy, which is backwards,
+and the sweep shows it: at a fixed ridge the big seas over-apply and regress
+while the calm seas are barely corrected.
+
+`Config::model_ridge_relative` scales the ridge with the mean eigenvalue of the
+normal matrix, so the fraction returned is a property of the sensor rather than
+of the weather. `Config::model_ridge` remains as an absolute floor for a window
+with almost no excitation at all. `continuous_mag_hard_iron-test` pins the
+difference: replaying one offset and one distortion through a small and a large
+sea, a fixed ridge alone returns 0.27 and 0.88 of the offset, and the relative
+ridge returns 0.24 and 0.66.
+
+## Why the reference cannot simply follow the offset
+
+The obvious way to keep the correction self-consistent is to subtract `b` from
+every sample and subtract the matching `mean(R) b` from the magnetic reference.
+That is exactly wrong, and it took a measurement to see it: it is a **no-op**.
+The innovation
+
+    m - b - R^T (ref - mean(R) b)
+
+is identical to the uncorrected one at the attitude the filter already holds,
+because `R^T mean(R) ~ I`. Forcing a 10 uT offset through that path moves the
+scored yaw by 0.3 deg. The error being removed is a gauge, and a change that
+preserves the innovation preserves the gauge.
+
+What the filter does instead:
+
+- the offset is subtracted from the magnetometer stream, and
+- the reference stays in `MagAutoTuner`'s canonical form -- horizontal
+  magnitude on `+X`, vertical below it -- with only its magnitude and vertical
+  component moved, and only by the amount the offset changes them.
+
+The corrected field then implies a different heading than the reference asserts,
+and the magnetometer update walks the yaw onto it over its own time constant.
+No attitude state is written: the correction stays a change of measurement-model
+parameters, which is what keeps it out of the stability argument.
+
+The magnitude and dip are moved by a *delta* against the value the startup
+acquisition gated, not adopted wholesale from the estimator's own window. That
+window is longer and less selective, and simply adopting its magnitude and dip
+costs a fifth of the roll accuracy on the moderate seas while the offset
+correction itself costs none of it. With the delta form, an estimator that
+never validates leaves all 56 scored metrics bit-identical.
+
+Nothing starts until the two-stage startup acquisition has finished, so first
+heading, handoff and the refinement are exactly as they were. Accumulation,
+however, begins with the first magnetometer sample, so by the time the
+correction is armed there is already a window to solve.
+
+## Results
+
+Deterministic 900 s protocol, one realization per record, default seeds. RMS in
+degrees; 3D is displacement RMS in metres.
+
+| Record | Hs (m) | yaw off | yaw on | roll off | roll on | pitch off | pitch on | 3D off | 3D on |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| JONSWAP | 0.27 | 2.075 | 1.063 | 0.279 | 0.281 | 0.174 | 0.175 | 0.0586 | 0.0588 |
+| JONSWAP | 1.50 | 1.825 | 1.050 | 0.256 | 0.257 | 0.169 | 0.152 | 0.2689 | 0.2688 |
+| JONSWAP | 4.00 | 1.298 | 1.041 | 0.481 | 0.491 | 0.358 | 0.330 | 0.7902 | 0.7941 |
+| JONSWAP | 8.50 | 1.104 | 0.709 | 0.439 | 0.447 | 0.469 | 0.445 | 1.5260 | 1.5169 |
+| PM--Stokes | 0.27 | 2.155 | 0.741 | 0.265 | 0.266 | 0.200 | 0.200 | 0.0569 | 0.0573 |
+| PM--Stokes | 1.50 | 2.162 | 1.026 | 0.260 | 0.259 | 0.223 | 0.208 | 0.2549 | 0.2550 |
+| PM--Stokes | 4.00 | 2.053 | 0.473 | 0.405 | 0.401 | 0.278 | 0.235 | 0.7095 | 0.7199 |
+| PM--Stokes | 8.50 | 2.007 | 0.476 | 0.328 | 0.317 | 0.259 | 0.196 | 1.3043 | 1.2887 |
+| **mean** | | **1.835** | **0.822** | 0.339 | 0.340 | 0.266 | 0.243 | 0.6212 | 0.6199 |
+| **worst** | | **2.162** | **1.063** | 0.481 | 0.491 | 0.469 | 0.445 | 1.5260 | 1.5169 |
+
+Across all 56 scored metrics the geometric mean of the ratio is 0.877 and the
+single worst regression is +4.8%, on the Y displacement of `pmstokes H4.0`.
+
+## The limit, stated plainly
+
+The estimator corrects one of the two things that shift the gauge. It cannot
+correct the other, and there is no local signal that says which one it is
+facing.
+
+Repeating the study over five draws of the magnetometer calibration
+(`W3D_INIT_SEED`, which redraws both the offset and the distortion), 40
+record/seed pairs:
+
+| | yaw mean | yaw worst | pairs with worse yaw |
+| --- | --- | --- | --- |
+| off | 2.430 | 3.827 | -- |
+| on | 1.726 | 4.510 | 5 / 40 |
+
+All five regressions are one draw, `seed=23`, and the oracle says why: on that
+draw the standing error is misalignment-dominated, not offset-dominated —
+removing its hard iron perfectly takes yaw from 2.98 to 2.74, while removing
+its soft iron and misalignment perfectly takes it to 1.02. A hard-iron
+estimator has nothing useful to do there, and the fraction of the distortion it
+aliases into its answer moves the gauge the wrong way, by up to 28%.
+
+That case is not detectable from inside. The distortion's aliased part is, by
+construction, the part the model *explains*, so it does not raise the residual:
+the estimator reports 1.683 uT on the shipped draw and 1.685 uT on `seed=23`,
+against a white-noise floor of 1.386 uT. The residual gate catches a turning
+hull, not a misaligned sensor.
+
+Two things follow. The shrinkage is not a tuning convenience, it is the bound
+on that failure mode, and it is why the ridge is left large enough to give up
+real accuracy on the good draws. And the way to actually fix `seed=23` is to
+identify the distortion, which needs heading excitation the records do not
+contain — a hull that turns. The estimator stands itself down on a turn today
+rather than exploiting it; using the turn is the obvious next piece of work and
+is deliberately not attempted here.
+
+## Quality gates
+
+`FAIL_LIMITS` in `kalman_ou_iii-sim.cpp` is re-derived, by the documented rule
+of worst observed plus about half a percent rounded up to the next tenth:
+
+| gate | was | now | worst observed |
+| --- | --- | --- | --- |
+| yaw deg | 2.2 | **1.1** | 1.06 (jonswap H0.27) |
+| 3D % PM--Stokes | 20.6 | **20.9** | 20.72 (pmstokes H4.0) |
+| acc Z bias % | 5.6 | **5.0** | 4.91 (jonswap H8.5) |
+| acc 3D bias % | 95.8 | **98.4** | 97.89 (jonswap H4.0) |
+| Z %Hs JONSWAP | 4.8 | 4.8 | 4.70 (jonswap H0.27) |
+| Z %Hs PM--Stokes | 4.7 | 4.7 | 4.66 (pmstokes H0.27) |
+| 3D % JONSWAP | 21.1 | 21.1 | 20.94 (jonswap H1.5) |
+
+Two go up. The correction walks the heading onto the corrected field during the
+run, and the horizontal accelerometer bias absorbs some of that motion. That
+quantity is the least observable one scored here — its error exceeds the true
+bias under every configuration this filter has shipped, which is what a figure
+near 100% means — so a 2.6 point move on it is not a meaningful loss of
+accelerometer-bias accuracy, but the sentinel has to admit it rather than hide
+it.
+
+Running the `SF_MAG_CONT_HI=0` ablation now exceeds the yaw gate, as it should:
+that limit is fitted to the filter that ships. Score the ablation with
+`W3D_COLLECT_ALL_GATES=1`.
+
+## Configuration
+
+| field | default | what it does |
+| --- | --- | --- |
+| `mag_continuous_hard_iron` | `true` | master switch (`SF_MAG_CONT_HI`) |
+| `mag_hi_memory_sec` | 600 | exponential memory of the statistics |
+| `mag_hi_model_ridge` | 4e-3 | absolute ridge floor |
+| `mag_hi_model_ridge_relative` | 0.5 | ridge as a multiple of the mean excitation |
+| `mag_hi_min_information` | 2.0 | `weight * lambda_min` the window must reach |
+| `mag_hi_min_effective_weight` | 500 | effective samples before any answer |
+| `mag_hi_max_residual_rms_uT` | 3.0 | model-fit gate; this is what a turn trips |
+| `mag_hi_max_bias_fraction` | 0.35 | plausibility bound against the field norm |
+| `mag_hi_apply_fraction` | 1.0 | blunt shrinkage on top of the ridge |
+| `mag_hi_slew_tau_sec` | 45 | how fast the applied offset moves |
+
+The simulator reads each as `SF_MAG_HI_*`; `W3D_MAG_HI_TRACE=1` prints the fit,
+the applied offset, the information and the residual once a minute to stderr.

--- a/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
+++ b/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
@@ -60,6 +60,7 @@
 #include "tuner/WavePeriodEstimator.h"
 #include "tuner/VerticalAccelComplementary.h"
 #include "tuner/MagAutoTuner.h"
+#include "tuner/ContinuousMagHardIronEstimator.h"
 #include "kalman_ou_iii/Kalman3D_Wave_OU_III.h"
 #include "wave_dir/KalmanWaveDirection.h"
 #include "wave_dir/WaveDirectionDetector.h"
@@ -1927,6 +1928,43 @@ public:
         // heading, and a wrong one subtracted everywhere is worse than none.
         // Turn it on where the platform changes heading during startup.
         bool  mag_estimate_hard_iron = false;
+
+        // Continuous hard-iron estimation, and the reference that goes with it.
+        //
+        // The startup estimate above is a single window, and a single window is
+        // where the offset is least identifiable: the excitation is whatever
+        // tilt the hull happened to take in fifteen seconds.  This one never
+        // closes its accumulation, so the question stops being "can the offset
+        // be read out of these fifteen seconds" and becomes "keep watching, and
+        // correct when the data finally say something".
+        //
+        // Two things make that safe to leave running.  The estimator is
+        // exogenous -- gravity-referenced tilt from the private Mahony observer
+        // and the raw magnetometer, never a filter state, so no loop is closed
+        // through the MEKF and the ISS argument is untouched.  And the applied
+        // offset and the magnetic reference move together, out of the same
+        // statistics, so the filter is never subtracting one offset while
+        // steering to a reference that belongs to another.
+        //
+        // Nothing here starts until the two-stage startup acquisition has
+        // finished, so first heading, handoff and refinement are exactly as
+        // they were.
+        bool  mag_continuous_hard_iron        = true;
+        float mag_hi_memory_sec               = 600.0f;
+        float mag_hi_model_ridge              = 4.0e-3f;
+        float mag_hi_model_ridge_relative     = 0.5f;
+        float mag_hi_min_information          = 2.0f;
+        float mag_hi_min_effective_weight     = 500.0f;
+        float mag_hi_max_residual_rms_uT      = 3.0f;
+        float mag_hi_max_bias_fraction        = 0.35f;
+
+        // Fraction of the fitted offset the filter is willing to apply, and the
+        // time constant it moves over.  The ridge already shrinks the fit for
+        // what the model cannot see; this is the separate, blunter statement
+        // that a calibration nobody has checked should not arrive as a step.
+        float mag_hi_apply_fraction           = 1.0f;
+        float mag_hi_slew_tau_sec             = 45.0f;
+
         bool  mag_enable_quality_weighting = false;
         float mag_min_effective_weight     = 0.0f;
         float mag_acc_norm_rel_soft        = 0.22f;
@@ -1978,6 +2016,29 @@ public:
         mag_cfg.gyro_soft_dps            = cfg_.mag_gyro_soft_dps;
 
         mag_auto_tuner_.setConfig(mag_cfg);
+
+        ContinuousMagHardIronEstimator::Config hi_cfg;
+        hi_cfg.memory_sec           = cfg_.mag_hi_memory_sec;
+        hi_cfg.model_ridge          = cfg_.mag_hi_model_ridge;
+        hi_cfg.model_ridge_relative = cfg_.mag_hi_model_ridge_relative;
+        hi_cfg.min_information      = cfg_.mag_hi_min_information;
+        hi_cfg.min_effective_weight = cfg_.mag_hi_min_effective_weight;
+        hi_cfg.max_residual_rms_uT  = cfg_.mag_hi_max_residual_rms_uT;
+        hi_cfg.max_bias_fraction    = cfg_.mag_hi_max_bias_fraction;
+        hi_cfg.min_mag_norm_uT      = cfg_.mag_init_min_mag_norm;
+        mag_hi_estimator_.setConfig(hi_cfg);
+
+        mag_hi_startup_body_uT_.setZero();
+        mag_hi_applied_body_uT_.setZero();
+        mag_hi_anchor_bias_body_uT_.setZero();
+        mag_hi_anchor_world_ref_uT_.setZero();
+        mag_hi_anchored_ = false;
+        last_hi_sample_t_ = NAN;
+        last_hi_apply_t_  = NAN;
+        mag_hard_iron_body_uT_.setZero();
+
+        mag_world_ref_uT_.setZero();
+        mag_world_ref_valid_ = false;
 
         resetTiltInit_();
 
@@ -2210,6 +2271,12 @@ public:
         if (!usingProxyInit_() && stage_ == Stage::Uninitialized) return;
         if (t_ < cfg_.mag_delay_sec) return;
 
+        // Ahead of every gate below, and deliberately.  The continuous
+        // estimator wants the whole magnetometer record, not the part the
+        // startup machinery was willing to average, and it is reading a frame
+        // the startup machinery does not own.
+        accumulateContinuousHardIron_(mag_body_ned);
+
         // Hold the whole magnetometer path off until the startup observer has
         // settled.  This sits ahead of the eligibility clock deliberately, so
         // the tilt-fallback timer cannot start running and then wave the
@@ -2295,7 +2362,7 @@ public:
                         // model parameter, so writing it before the MEKF has
                         // been handed the attitude is safe and leaves it ready
                         // to use the magnetometer from its first live sample.
-                        impl_.mekf().set_mag_world_ref(mag_world_ref_uT);
+                        setMagWorldRef_(mag_world_ref_uT);
 
                         const float mag_tilt_yaw_rad =
                             mag_auto_tuner_.getYawGaugeCorrectionRad();
@@ -2351,10 +2418,11 @@ public:
                         }
 
                         Eigen::Vector3f hard_iron_uT;
-                        mag_hard_iron_body_uT_ =
+                        mag_hi_startup_body_uT_ =
                             mag_auto_tuner_.getHardIronBodyUT(hard_iron_uT)
                                 ? hard_iron_uT
                                 : Eigen::Vector3f::Zero();
+                        mag_hard_iron_body_uT_ = mag_hi_startup_body_uT_;
 
                         mag_ref_set_ = true;
                         mag_north_lock_time_sec_ = t_;
@@ -2365,6 +2433,7 @@ public:
         }
 
         maybeRefineMagReference_(mag_body_ned);
+        maybeApplyContinuousHardIron_();
 
         // Magnetometer corrections go to the MEKF only once it owns the
         // attitude.  Before handoff its state is not the one being solved.
@@ -2392,6 +2461,19 @@ public:
     // constrained it well enough to use.
     const Eigen::Vector3f& magHardIronBodyUT() const noexcept {
         return mag_hard_iron_body_uT_;
+    }
+
+    // Continuous estimator, for diagnostics and for tests that need to see why
+    // it did or did not act.  estimate().valid is the gate; information() is
+    // how much attitude excitation the memory window has actually collected.
+    const ContinuousMagHardIronEstimator& magContinuousHardIron() const noexcept {
+        return mag_hi_estimator_;
+    }
+
+    // The part of magHardIronBodyUT() the continuous estimator is responsible
+    // for, as opposed to the startup solve.
+    const Eigen::Vector3f& magContinuousHardIronAppliedUT() const noexcept {
+        return mag_hi_applied_body_uT_;
     }
 
 
@@ -2532,6 +2614,127 @@ private:
     // (when a magnetometer is fitted), and an operating point the tuner
     // stands behind.  Waiting for all three is what lets the MEKF skip the
     // staged warmup entirely -- there is nothing left for it to converge.
+    // Every write of the magnetometer's world reference goes through here, so
+    // the wrapper always knows the vector the MEKF is steering to.  The MEKF
+    // does not offer it back, and the continuous correction below moves the
+    // reference by a delta rather than replacing it.
+    void setMagWorldRef_(const Eigen::Vector3f& mag_world_ref_uT) {
+        impl_.mekf().set_mag_world_ref(mag_world_ref_uT);
+        mag_world_ref_uT_ = mag_world_ref_uT;
+        mag_world_ref_valid_ = true;
+    }
+
+    // Feed the exogenous accumulation.  Raw magnetometer -- not the corrected
+    // stream -- because the estimator is fitting the offset itself and must
+    // not be shown data with its own answer already subtracted.
+    void accumulateContinuousHardIron_(const Eigen::Vector3f& mag_body_ned) {
+        if (!cfg_.mag_continuous_hard_iron) return;
+        if (!usingProxyInit_()) return;
+        if (!impl_.startupProxyInitialized()) return;
+
+        const float dt_mag =
+            (std::isfinite(last_hi_sample_t_) && t_ > last_hi_sample_t_)
+                ? (t_ - last_hi_sample_t_)
+                : cfg_.mag_sample_dt_sec;
+
+        last_hi_sample_t_ = t_;
+
+        mag_hi_estimator_.update(dt_mag,
+                                 impl_.startupProxyTiltQuat(),
+                                 mag_body_ned);
+    }
+
+    // Move the applied offset toward the fit, and re-gauge the reference.
+    //
+    // The reference has to be rebuilt in MagAutoTuner's canonical form --
+    // horizontal magnitude on +X, vertical below it -- and not merely shifted
+    // by the same amount as the measurement.  A shift that tracks the offset
+    // exactly is a no-op: subtracting b from every sample and subtracting the
+    // matching mean(R) b from the reference leaves the innovation identical at
+    // the attitude the filter already holds, so nothing moves and the standing
+    // yaw error survives the correction that was meant to remove it.
+    //
+    // The standing error is a *gauge*: the startup acquisition put the world
+    // frame's north along the average of the uncorrected field, which is
+    // magnetic north rotated by whatever the offset contributes.  Leaving the
+    // canonical reference in place while the offset comes out of the stream
+    // asks the filter for the heading the corrected field implies, and the
+    // magnetometer update walks the yaw there over its own time constant.  No
+    // attitude state is written, so the correction remains a change of
+    // measurement-model parameters.
+    //
+    // Only the horizontal magnitude and the vertical component move with the
+    // offset, and only by the amount the offset changes them.  They are not
+    // recomputed from the estimator's own window: that window is longer and
+    // less selective than the one the startup acquisition gated, and simply
+    // adopting its magnitude and dip costs a fifth of the roll accuracy on the
+    // moderate seas while the offset correction itself costs none of it.
+    void maybeApplyContinuousHardIron_() {
+        if (!cfg_.mag_continuous_hard_iron) return;
+        if (!usingProxyInit_()) return;
+        if (!mag_ref_set_ || stage_ != Stage::Live) return;
+        if (cfg_.mag_refine_enabled && !mag_refine_done_) return;
+        if (!mag_world_ref_valid_) return;
+
+        const auto& est = mag_hi_estimator_.estimate();
+        if (!est.valid) return;
+
+        if (!mag_hi_anchored_) {
+            mag_hi_anchor_bias_body_uT_ = mag_hi_applied_body_uT_;
+            mag_hi_anchor_world_ref_uT_ = mag_world_ref_uT_;
+            mag_hi_anchored_ = true;
+        }
+
+        const Eigen::Vector3f target =
+            cfg_.mag_hi_apply_fraction * est.bias_body_uT;
+        if (!target.allFinite()) return;
+
+        const float dt_apply =
+            (std::isfinite(last_hi_apply_t_) && t_ > last_hi_apply_t_)
+                ? (t_ - last_hi_apply_t_)
+                : cfg_.mag_sample_dt_sec;
+
+        last_hi_apply_t_ = t_;
+
+        const float tau = cfg_.mag_hi_slew_tau_sec;
+        const float alpha = (std::isfinite(tau) && tau > 1.0e-3f)
+                                ? (1.0f - std::exp(-dt_apply / tau))
+                                : 1.0f;
+
+        const Eigen::Vector3f applied =
+            mag_hi_applied_body_uT_ + alpha * (target - mag_hi_applied_body_uT_);
+        if (!applied.allFinite()) return;
+
+        // Both evaluated against the statistics as they stand now, so the
+        // difference is the offset's doing and nothing else.
+        Eigen::Vector3f level_new;
+        Eigen::Vector3f level_anchor;
+        if (!mag_hi_estimator_.levelReferenceForBias(applied, level_new) ||
+            !mag_hi_estimator_.levelReferenceForBias(mag_hi_anchor_bias_body_uT_,
+                                                     level_anchor)) {
+            return;
+        }
+
+        const float h_new = level_new.head<2>().norm();
+        const float h_anchor = level_anchor.head<2>().norm();
+        if (!std::isfinite(h_new) || !std::isfinite(h_anchor)) return;
+
+        const float h = mag_hi_anchor_world_ref_uT_.x() + (h_new - h_anchor);
+        const float z = mag_hi_anchor_world_ref_uT_.z() +
+                        (level_new.z() - level_anchor.z());
+        if (!(h > cfg_.mag_init_min_mag_norm) || !std::isfinite(h) ||
+            !std::isfinite(z)) {
+            return;
+        }
+
+        const Eigen::Vector3f ref(h, 0.0f, z);
+        if (!ref.allFinite()) return;
+
+        mag_hi_applied_body_uT_ = applied;
+        mag_hard_iron_body_uT_ = mag_hi_startup_body_uT_ + applied;
+        setMagWorldRef_(ref);
+    }
+
     // Second-stage magnetic acquisition.
     //
     // The provisional reference was averaged in a tilt frame the startup
@@ -2607,7 +2810,7 @@ private:
             return;
         }
 
-        impl_.mekf().set_mag_world_ref(mag_world_ref_uT);
+        setMagWorldRef_(mag_world_ref_uT);
 
         const float mag_tilt_yaw_rad = mag_auto_tuner_.getYawGaugeCorrectionRad();
 
@@ -2870,6 +3073,18 @@ private:
     bool mag_ref_set_ = false;
     Eigen::Vector3f mag_hard_iron_body_uT_ = Eigen::Vector3f::Zero();
     MagAutoTuner mag_auto_tuner_{};
+
+    ContinuousMagHardIronEstimator mag_hi_estimator_{};
+    Eigen::Vector3f mag_hi_startup_body_uT_     = Eigen::Vector3f::Zero();
+    Eigen::Vector3f mag_hi_anchor_bias_body_uT_ = Eigen::Vector3f::Zero();
+    Eigen::Vector3f mag_hi_anchor_world_ref_uT_ = Eigen::Vector3f::Zero();
+    bool  mag_hi_anchored_ = false;
+    Eigen::Vector3f mag_hi_applied_body_uT_     = Eigen::Vector3f::Zero();
+    float last_hi_sample_t_ = NAN;
+    float last_hi_apply_t_  = NAN;
+
+    Eigen::Vector3f mag_world_ref_uT_ = Eigen::Vector3f::Zero();
+    bool mag_world_ref_valid_ = false;
 
     float last_mag_sample_t_ = NAN;
 

--- a/src/tuner/ContinuousMagHardIronEstimator.h
+++ b/src/tuner/ContinuousMagHardIronEstimator.h
@@ -1,0 +1,343 @@
+#pragma once
+
+/*
+  Copyright (c) 2025-2026  Mikhail Grushinskiy
+  Released under the MIT License
+
+  ContinuousMagHardIronEstimator
+
+  Exogenous, continuously running estimator of a body-fixed magnetometer
+  offset, for a hull that only ever rolls and pitches.
+
+  MagAutoTuner solves the same identification problem once, over a startup
+  window, and its documentation says why that is hard: at a single attitude an
+  offset and the world field are the same reading, and the tilt a hull takes
+  through a wave breaks the tie only weakly.  This class keeps the accumulation
+  running instead of closing it, so the window is no longer the startup window,
+  and it prices the part of the problem that no amount of accumulation fixes.
+
+  Model
+
+      m_i = R_i^T B + b + n_i,
+
+  with R_i the tilt-only rotation body->level.  Left-multiplying by R_i and
+  eliminating the world field B from the weighted normal equations leaves
+
+      (I - Abar^T Abar) b = mbar - Abar^T wbar,          Abar = mean(R_i),
+
+  so B never becomes a filter state and the estimator never reads one.
+
+  Why the solve is regularised
+
+  The left matrix is the attitude excitation.  For roll and pitch of standard
+  deviation sigma_r and sigma_p about a fixed heading it is, to second order,
+
+      diag(sigma_p^2, sigma_r^2, sigma_r^2 + sigma_p^2),
+
+  which for a few degrees of hull motion is of order 1e-3.  Inverting it
+  multiplies everything the model does not carry by up to a thousand, and what
+  it does not carry is soft iron and sensor misalignment -- both of which are
+  modulated by the very tilt the offset is being read from, and neither of
+  which averages away with time.  An unregularised fit therefore does not
+  converge on the offset as the record lengthens; it converges on the offset
+  plus an aliased image of the distortion, and in a wave record that image is
+  as large as the offset itself.
+
+  The ridge is that model error, not sample noise.  Config::model_ridge is a
+  prior variance ratio in the same dimensionless units as the excitation above:
+  a direction excited far above it is returned nearly whole, and one excited far
+  below it is returned nearly zero.  It does not shrink as samples accumulate,
+  because the error it prices does not either.
+
+  The class estimates only.  A caller decides whether, how much, and how
+  quickly to apply the result, and levelReferenceForBias() gives it the
+  magnetic reference belonging to whatever fraction it chose, computed from the
+  same statistics, so a partly applied offset is never paired with a reference
+  learned under a different one.
+*/
+
+#include <algorithm>
+#include <cmath>
+
+#ifdef EIGEN_NON_ARDUINO
+  #include <Eigen/Dense>
+#else
+  #include <ArduinoEigenDense.h>
+#endif
+
+class ContinuousMagHardIronEstimator {
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  struct Config {
+    // Exponential-memory time constant.  <= 0 makes the statistics cumulative.
+    float memory_sec = 600.0f;
+
+    // The eigensolve does not belong on every magnetometer sample.
+    float solve_period_sec = 1.0f;
+
+    // Effective sample count the window must reach before a result is offered.
+    float min_effective_weight = 500.0f;
+
+    // Excitation the window must reach, as effective_weight * lambda_min of
+    // the un-ridged normal matrix.  Low, and deliberately: this gate only has
+    // to answer "has the hull moved at all", because how much of a poorly
+    // excited window survives is already decided by the ridge below.  Set high
+    // enough to be a second shrinkage and it stands the estimator down in
+    // exactly the calm seas where the standing yaw error is largest.
+    float min_information = 2.0f;
+
+    // Prior variance ratio that regularises the solve; see the header note.
+    // The floor is what protects a window with almost no excitation at all.
+    float model_ridge = 4.0e-3f;
+
+    // The part of the ridge that scales with the excitation, as a multiple of
+    // the mean eigenvalue of the normal matrix.
+    //
+    // This is the term that matters, and the reason is that the error it
+    // prices does not behave like noise.  The distortion aliased into the fit
+    // enters the right-hand side through the same tilt that carries the
+    // offset, so the resulting offset error is of order eps*|B| whatever the
+    // sea state -- a hull working through thirty degrees is not fitting a
+    // cleaner offset than one working through five, it is fitting the same
+    // wrong one with more confidence.  A fixed ridge therefore shrinks hardest
+    // exactly where the fit is most trustworthy and hardly at all where it is
+    // least, which is backwards.  Scaling with the excitation makes the
+    // fraction returned a property of the sensor rather than of the weather.
+    //
+    // The value is eps*|B| over the offset a caller expects: distortion of a
+    // percent or two on a 50 uT field against an offset of a couple of uT.
+    float model_ridge_relative = 0.5f;
+
+    // Reject an implausible offset as a fraction of the measured field norm.
+    float max_bias_fraction = 0.35f;
+
+    // Reject a window the hard-iron model does not explain.  This is what
+    // stands between the estimator and a hull that changes heading: the
+    // accumulation frame is tied to the hull's own heading, so a turn makes
+    // the world field move within it and the residual rises immediately.
+    // <= 0 disables the gate.
+    float max_residual_rms_uT = 3.0f;
+
+    float min_mag_norm_uT = 1.0e-3f;
+  };
+
+  struct Estimate {
+    Eigen::Vector3f bias_body_uT = Eigen::Vector3f::Zero();
+    Eigen::Vector3f field_level_uT = Eigen::Vector3f::Zero();
+    float information = 0.0f;
+    float effective_weight = 0.0f;
+    float residual_rms_uT = NAN;
+    bool valid = false;
+  };
+
+  ContinuousMagHardIronEstimator() { reset(); }
+
+  explicit ContinuousMagHardIronEstimator(const Config& cfg) : cfg_(cfg) {
+    reset();
+  }
+
+  void setConfig(const Config& cfg) {
+    cfg_ = cfg;
+    reset();
+  }
+
+  const Config& config() const noexcept { return cfg_; }
+
+  void reset() {
+    weight_sum_ = 0.0;
+    rot_sum_.setZero();
+    level_mag_sum_.setZero();
+    body_mag_sum_.setZero();
+    mag_sq_sum_ = 0.0;
+    solve_elapsed_sec_ = 0.0f;
+    estimate_ = Estimate{};
+  }
+
+  // q_tilt_bw is the yaw-stripped body->level rotation.  Stripping yaw is what
+  // makes the input exogenous in the strong sense: the frame is built from
+  // gravity alone, so no heading estimate -- and no heading drift -- enters the
+  // accumulation.  The level frame's own gauge is the hull's heading, which is
+  // why a turn shows up as model residual rather than as a silent error.
+  void update(float dt,
+              const Eigen::Quaternionf& q_tilt_bw_in,
+              const Eigen::Vector3f& mag_body_uT)
+  {
+    if (!(std::isfinite(dt) && dt > 0.0f)) return;
+    if (!q_tilt_bw_in.coeffs().allFinite() || !mag_body_uT.allFinite()) return;
+
+    const float mag_norm = mag_body_uT.norm();
+    if (!(std::isfinite(mag_norm) && mag_norm > cfg_.min_mag_norm_uT)) return;
+
+    Eigen::Quaternionf q = q_tilt_bw_in;
+    const float qn = q.norm();
+    if (!(std::isfinite(qn) && qn > 1.0e-6f)) return;
+    q.normalize();
+
+    const Eigen::Matrix3d R = q.toRotationMatrix().cast<double>();
+    if (!R.allFinite()) return;
+
+    // The normal matrix is I minus a product of near-identity rotations, so it
+    // is a small difference of large terms.  The accumulators carry double for
+    // that subtraction alone; everything the caller sees is float.
+    const Eigen::Vector3d m = mag_body_uT.cast<double>();
+
+    const double lambda =
+        (std::isfinite(cfg_.memory_sec) && cfg_.memory_sec > 0.0f)
+            ? std::exp(-double(dt) / double(cfg_.memory_sec))
+            : 1.0;
+
+    weight_sum_ *= lambda;
+    rot_sum_ *= lambda;
+    level_mag_sum_ *= lambda;
+    body_mag_sum_ *= lambda;
+    mag_sq_sum_ *= lambda;
+
+    weight_sum_ += 1.0;
+    rot_sum_ += R;
+    level_mag_sum_ += R * m;
+    body_mag_sum_ += m;
+    mag_sq_sum_ += m.squaredNorm();
+
+    solve_elapsed_sec_ += dt;
+    if (solve_elapsed_sec_ >= std::max(0.02f, cfg_.solve_period_sec)) {
+      solve_elapsed_sec_ = 0.0f;
+      solve_();
+    }
+  }
+
+  const Estimate& estimate() const noexcept { return estimate_; }
+  bool valid() const noexcept { return estimate_.valid; }
+  float information() const noexcept { return estimate_.information; }
+  float effectiveWeight() const noexcept { return float(weight_sum_); }
+  float residualRmsUT() const noexcept { return estimate_.residual_rms_uT; }
+
+  // Magnetic reference in the level accumulation frame that belongs to an
+  // applied offset, from the same statistics as the fit:
+  //
+  //     ref(b) = mean(R_i m_i) - mean(R_i) b.
+  //
+  // A caller applying a fraction of the estimate asks for the reference at
+  // that fraction, so the two never disagree.
+  bool levelReferenceForBias(const Eigen::Vector3f& applied_bias_body_uT,
+                             Eigen::Vector3f& level_ref_uT) const
+  {
+    if (!(weight_sum_ > 1.0e-6) || !std::isfinite(weight_sum_)) return false;
+    if (!applied_bias_body_uT.allFinite()) return false;
+
+    const Eigen::Vector3d ref =
+        (level_mag_sum_ - rot_sum_ * applied_bias_body_uT.cast<double>())
+        / weight_sum_;
+
+    level_ref_uT = ref.cast<float>();
+    return level_ref_uT.allFinite() &&
+           (level_ref_uT.norm() > cfg_.min_mag_norm_uT);
+  }
+
+private:
+  void solve_() {
+    Estimate out;
+    out.effective_weight = float(weight_sum_);
+
+    if (!(weight_sum_ >= double(cfg_.min_effective_weight)) ||
+        !std::isfinite(weight_sum_)) {
+      estimate_ = out;
+      return;
+    }
+
+    const Eigen::Matrix3d A = rot_sum_ / weight_sum_;
+    const Eigen::Vector3d wbar = level_mag_sum_ / weight_sum_;
+    const Eigen::Vector3d mbar = body_mag_sum_ / weight_sum_;
+    if (!A.allFinite() || !wbar.allFinite() || !mbar.allFinite()) {
+      estimate_ = out;
+      return;
+    }
+
+    Eigen::Matrix3d M = Eigen::Matrix3d::Identity() - A.transpose() * A;
+    M = 0.5 * (M + M.transpose());
+    if (!M.allFinite()) {
+      estimate_ = out;
+      return;
+    }
+
+    Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> es(M);
+    if (es.info() != Eigen::Success || !es.eigenvalues().allFinite()) {
+      estimate_ = out;
+      return;
+    }
+
+    // Reported on the un-ridged matrix, so it measures the hull and not the
+    // prior.  The gate below is about whether the window says anything at all;
+    // how much of what it says survives is the ridge's business.
+    const double lambda_min = es.eigenvalues().minCoeff();
+    out.information = float(weight_sum_ * lambda_min);
+    if (!(std::isfinite(out.information) &&
+          out.information >= cfg_.min_information)) {
+      estimate_ = out;
+      return;
+    }
+
+    const double ridge =
+        std::max(0.0, double(cfg_.model_ridge)) +
+        std::max(0.0, double(cfg_.model_ridge_relative)) * (M.trace() / 3.0);
+    const Eigen::Vector3d rhs = mbar - A.transpose() * wbar;
+    const Eigen::Vector3d b =
+        (M + ridge * Eigen::Matrix3d::Identity()).ldlt().solve(rhs);
+    if (!b.allFinite()) {
+      estimate_ = out;
+      return;
+    }
+
+    const Eigen::Vector3d B = wbar - A * b;
+    if (!B.allFinite()) {
+      estimate_ = out;
+      return;
+    }
+
+    const double field_scale = std::sqrt(std::max(0.0, mag_sq_sum_ / weight_sum_));
+    if (!(std::isfinite(field_scale) && field_scale > double(cfg_.min_mag_norm_uT))) {
+      estimate_ = out;
+      return;
+    }
+    if (b.norm() > double(cfg_.max_bias_fraction) * field_scale) {
+      estimate_ = out;
+      return;
+    }
+
+    // Weighted residual of w_i = B + R_i b.  R is orthonormal, so
+    // sum ||R_i m_i||^2 == sum ||m_i||^2 and the whole sum is available from
+    // the accumulators.
+    const double sse =
+        mag_sq_sum_
+        - 2.0 * B.dot(level_mag_sum_)
+        - 2.0 * b.dot(body_mag_sum_)
+        + 2.0 * B.dot(rot_sum_ * b)
+        + weight_sum_ * (B.squaredNorm() + b.squaredNorm());
+
+    out.residual_rms_uT = float(std::sqrt(std::max(0.0, sse / weight_sum_)));
+
+    if (std::isfinite(cfg_.max_residual_rms_uT) &&
+        cfg_.max_residual_rms_uT > 0.0f &&
+        (!std::isfinite(out.residual_rms_uT) ||
+         out.residual_rms_uT > cfg_.max_residual_rms_uT)) {
+      estimate_ = out;
+      return;
+    }
+
+    out.bias_body_uT = b.cast<float>();
+    out.field_level_uT = B.cast<float>();
+    out.valid = true;
+    estimate_ = out;
+  }
+
+  Config cfg_{};
+
+  double weight_sum_ = 0.0;
+  Eigen::Matrix3d rot_sum_ = Eigen::Matrix3d::Zero();
+  Eigen::Vector3d level_mag_sum_ = Eigen::Vector3d::Zero();
+  Eigen::Vector3d body_mag_sum_ = Eigen::Vector3d::Zero();
+  double mag_sq_sum_ = 0.0;
+
+  float solve_elapsed_sec_ = 0.0f;
+  Estimate estimate_{};
+};

--- a/tests/kalman_ou_iii/Makefile
+++ b/tests/kalman_ou_iii/Makefile
@@ -21,7 +21,7 @@ LDFLAGS  =
 # Tell make to look for source files in src/util
 VPATH = $(REPO_ROOT)/src/util
 
-TARGETS = kalman_ou_iii-sim kalman_ou_common-test aw_covariance_policy-test acc_bias_ou-test channel_freeze-test wave_period-test mag_hard_iron-test tuner_coupling-test tuner_schedule-test wave_band_sigma-test iss_contract-test rs_law-test startup_init-test
+TARGETS = kalman_ou_iii-sim kalman_ou_common-test aw_covariance_policy-test acc_bias_ou-test channel_freeze-test wave_period-test mag_hard_iron-test continuous_mag_hard_iron-test tuner_coupling-test tuner_schedule-test wave_band_sigma-test iss_contract-test rs_law-test startup_init-test
 
 all: build test
 
@@ -56,6 +56,9 @@ tuner_coupling-test: tuner_coupling-test.o W3dSimCommon.o
 	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
 
 mag_hard_iron-test: mag_hard_iron-test.o
+	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
+
+continuous_mag_hard_iron-test: continuous_mag_hard_iron-test.o
 	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
 
 # Needs W3dSimCommon for g_std, like the simulator target.

--- a/tests/kalman_ou_iii/continuous_mag_hard_iron-test.cpp
+++ b/tests/kalman_ou_iii/continuous_mag_hard_iron-test.cpp
@@ -1,0 +1,282 @@
+/*
+    Copyright (c) 2025-2026  Mikhail Grushinskiy
+
+    ContinuousMagHardIronEstimator.
+
+    MagAutoTuner's own tests establish what a single startup window can and
+    cannot do with a body-fixed magnetic offset.  These are about what changes
+    when the accumulation is never closed, and about the one thing that does
+    not change no matter how long it runs.
+
+    A hull that only rolls and pitches never separates the offset from the
+    world field cleanly, because the sensor's other errors -- soft iron and
+    misalignment -- are modulated by the same tilt the offset is read from and
+    are aliased into the fit.  That aliasing is not noise: it does not average
+    away, and its size does not fall as the record lengthens.  So the tests
+    below check the two properties that make a continuously running fit safe to
+    leave switched on rather than merely accurate on a good day:
+
+      - the regularisation returns a bounded fraction of the fit, and the
+        fraction is set by the sensor rather than by the sea state, so a big
+        sea does not license a confident wrong answer;
+      - the reference belonging to a partly applied offset is available from
+        the same statistics, so the caller can never pair one with the other.
+*/
+
+#define EIGEN_NON_ARDUINO
+
+#include <cmath>
+#include <cstdio>
+#include <numbers>
+#include <random>
+#include <string>
+
+#include <Eigen/Dense>
+
+#include "tuner/ContinuousMagHardIronEstimator.h"
+
+namespace {
+
+using Eigen::Matrix3f;
+using Eigen::Quaternionf;
+using Eigen::Vector3f;
+
+int g_failures = 0;
+
+void check(bool ok, const std::string& what)
+{
+    std::printf("%-62s %s\n", what.c_str(), ok ? "ok" : "FAILED");
+    if (!ok) ++g_failures;
+}
+
+constexpr float kDt = 1.0f / 25.0f;
+
+// NED: north, east, down.  Dip and magnitude of the reference field the OU
+// simulator uses, so the numbers here are the ones the filter actually sees.
+const Vector3f kFieldNed(52.0f * std::cos(66.5f * float(std::numbers::pi_v<float>) / 180.0f),
+                         0.0f,
+                         52.0f * std::sin(66.5f * float(std::numbers::pi_v<float>) / 180.0f));
+
+Quaternionf tiltQuat(float roll_rad, float pitch_rad)
+{
+    return Quaternionf(Eigen::AngleAxisf(pitch_rad, Vector3f::UnitY()) *
+                       Eigen::AngleAxisf(roll_rad, Vector3f::UnitX()));
+}
+
+struct Sea {
+    float roll_amp_rad;
+    float pitch_amp_rad;
+    float roll_hz = 0.11f;
+    float pitch_hz = 0.083f;
+};
+
+// One replay of a hull rolling and pitching at a fixed heading, with the
+// sensor errors the simulator injects: a body-fixed offset, a soft-iron and
+// misalignment matrix, and white noise.
+struct Replay {
+    Sea sea;
+    Vector3f offset_body = Vector3f::Zero();
+    Matrix3f distortion = Matrix3f::Identity();
+    float noise_uT = 0.0f;
+    float duration_sec = 900.0f;
+    float heading_rate_dps = 0.0f;
+    unsigned seed = 7u;
+};
+
+void run(ContinuousMagHardIronEstimator& est, const Replay& r)
+{
+    std::mt19937 rng(r.seed);
+    std::normal_distribution<float> white(0.0f, r.noise_uT);
+
+    const int n = int(r.duration_sec / kDt);
+    for (int i = 0; i < n; ++i) {
+        const float t = float(i) * kDt;
+        const float roll = r.sea.roll_amp_rad *
+                           std::sin(2.0f * float(std::numbers::pi_v<float>) * r.sea.roll_hz * t);
+        const float pitch = r.sea.pitch_amp_rad *
+                            std::sin(2.0f * float(std::numbers::pi_v<float>) * r.sea.pitch_hz * t + 0.7f);
+
+        const Quaternionf q_tilt = tiltQuat(roll, pitch);
+
+        // The hull's own heading rotates the world field within the level
+        // frame; the estimator is not told about it, which is the point.
+        const float heading =
+            r.heading_rate_dps * t * float(std::numbers::pi_v<float>) / 180.0f;
+        const Vector3f field_level =
+            Eigen::AngleAxisf(-heading, Vector3f::UnitZ()) * kFieldNed;
+
+        Vector3f mag = q_tilt.conjugate() * field_level;
+        mag = r.distortion * mag + r.offset_body;
+        if (r.noise_uT > 0.0f) {
+            mag += Vector3f(white(rng), white(rng), white(rng));
+        }
+
+        est.update(kDt, q_tilt, mag);
+    }
+}
+
+Matrix3f misalignment(float rx, float ry, float rz)
+{
+    return (Eigen::AngleAxisf(rz, Vector3f::UnitZ()) *
+            Eigen::AngleAxisf(ry, Vector3f::UnitY()) *
+            Eigen::AngleAxisf(rx, Vector3f::UnitX())).toRotationMatrix();
+}
+
+// Heading a level-frame field vector implies, in degrees.
+float headingDeg(const Vector3f& v)
+{
+    return std::atan2(v.y(), v.x()) * 180.0f / float(std::numbers::pi_v<float>);
+}
+
+void testCleanOffsetIsRecovered()
+{
+    ContinuousMagHardIronEstimator::Config cfg;
+    cfg.model_ridge = 0.0f;
+    cfg.model_ridge_relative = 0.0f;
+    ContinuousMagHardIronEstimator est(cfg);
+
+    Replay r;
+    r.sea = Sea{0.20f, 0.26f};          // a big sea, and no sensor error but the offset
+    r.offset_body = Vector3f(1.4f, -0.9f, 2.1f);
+    run(est, r);
+
+    check(est.valid(), "clean model: the solve is offered");
+    check((est.estimate().bias_body_uT - r.offset_body).norm() < 0.05f,
+          "clean model: offset recovered to better than 0.05 uT");
+}
+
+void testFixedAttitudeDeclines()
+{
+    ContinuousMagHardIronEstimator est;
+
+    Replay r;
+    r.sea = Sea{0.0f, 0.0f};
+    r.offset_body = Vector3f(1.4f, -0.9f, 2.1f);
+    run(est, r);
+
+    check(!est.valid(), "fixed attitude: the solve declines");
+    check(est.information() < 1.0e-3f, "fixed attitude: reported information is ~0");
+}
+
+// The property the ridge exists for.  A hull working through a large sea does
+// not fit a cleaner offset than one working through a small sea when the error
+// is aliased distortion rather than noise -- it fits the same wrong one with
+// more confidence -- so the fraction the solve returns must not grow with the
+// sea.  A fixed prior cannot hold that: the excitation outruns it, and the big
+// sea hands back an offset the sensor never had.
+void testShrinkageDoesNotChaseTheSeaState()
+{
+    const Vector3f offset(1.4f, -0.9f, 2.1f);
+    const Matrix3f distortion =
+        misalignment(0.012f, -0.009f, 0.006f) *
+        (Matrix3f::Identity() + 0.012f * Matrix3f::Identity());
+    const Sea seas[2] = {Sea{0.035f, 0.045f}, Sea{0.16f, 0.21f}};
+
+    float ratio[2][2] = {{0.0f, 0.0f}, {0.0f, 0.0f}};   // [relative ridge?][sea]
+
+    for (int rel = 0; rel < 2; ++rel) {
+        for (int k = 0; k < 2; ++k) {
+            ContinuousMagHardIronEstimator::Config cfg;
+            if (rel == 0) cfg.model_ridge_relative = 0.0f;
+            ContinuousMagHardIronEstimator est(cfg);
+
+            Replay r;
+            r.sea = seas[k];
+            r.offset_body = offset;
+            r.distortion = distortion;
+            r.noise_uT = 0.8f;
+            run(est, r);
+
+            if (rel == 1) {
+                check(est.valid(),
+                      std::string("aliased distortion: solve is offered, sea ") +
+                          (k ? "large" : "small"));
+            }
+            ratio[rel][k] = est.estimate().bias_body_uT.norm() / offset.norm();
+        }
+    }
+
+    std::printf("    returned fraction, fixed ridge only:  small %.3f  large %.3f\n",
+                double(ratio[0][0]), double(ratio[0][1]));
+    std::printf("    returned fraction, with relative:     small %.3f  large %.3f\n",
+                double(ratio[1][0]), double(ratio[1][1]));
+
+    const float spread_fixed = ratio[0][1] - ratio[0][0];
+    const float spread_rel   = ratio[1][1] - ratio[1][0];
+
+    check(spread_fixed > 0.4f,
+          "a fixed ridge alone lets the fraction chase the sea state");
+    check(spread_rel < 0.75f * spread_fixed,
+          "the relative ridge materially narrows that spread");
+    check(ratio[1][0] < 1.0f && ratio[1][1] < 1.0f,
+          "neither sea returns more offset than the sensor carries");
+}
+
+void testHeadingChangeIsRejected()
+{
+    ContinuousMagHardIronEstimator est;
+
+    Replay r;
+    r.sea = Sea{0.10f, 0.13f};
+    r.offset_body = Vector3f(1.4f, -0.9f, 2.1f);
+    r.heading_rate_dps = 0.05f;   // 45 deg over the replay
+    run(est, r);
+
+    check(!est.valid(), "hull turning: the residual gate declines the window");
+    check(est.residualRmsUT() > est.config().max_residual_rms_uT,
+          "hull turning: the residual is what declines it");
+}
+
+void testReferenceTracksTheAppliedOffset()
+{
+    ContinuousMagHardIronEstimator::Config cfg;
+    cfg.model_ridge = 0.0f;
+    cfg.model_ridge_relative = 0.0f;
+    ContinuousMagHardIronEstimator est(cfg);
+
+    const Vector3f offset(1.4f, -0.9f, 2.1f);
+    Replay r;
+    r.sea = Sea{0.20f, 0.26f};
+    r.offset_body = offset;
+    run(est, r);
+
+    Vector3f ref_none, ref_full, ref_half;
+    check(est.levelReferenceForBias(Vector3f::Zero(), ref_none) &&
+              est.levelReferenceForBias(offset, ref_full) &&
+              est.levelReferenceForBias(0.5f * offset, ref_half),
+          "reference: available at zero, half and full correction");
+
+    check((ref_full - kFieldNed).norm() < 0.1f,
+          "reference: correcting fully recovers the true field");
+
+    // Half the offset applied puts the reference half way there, which is what
+    // keeps a slewing correction consistent with what it is subtracting.
+    check(((ref_half - 0.5f * (ref_none + ref_full)).norm() < 0.02f),
+          "reference: a partial correction lands half way");
+
+    const float err_none = std::fabs(headingDeg(ref_none) - headingDeg(kFieldNed));
+    const float err_full = std::fabs(headingDeg(ref_full) - headingDeg(kFieldNed));
+    std::printf("    heading implied by the reference: %.3f deg uncorrected, "
+                "%.3f deg corrected\n", double(err_none), double(err_full));
+
+    check(err_none > 1.0f && err_full < 0.05f,
+          "reference: the standing heading error is what the correction removes");
+}
+
+} // namespace
+
+int main()
+{
+    testCleanOffsetIsRecovered();
+    testFixedAttitudeDeclines();
+    testShrinkageDoesNotChaseTheSeaState();
+    testHeadingChangeIsRejected();
+    testReferenceTracksTheAppliedOffset();
+
+    if (g_failures) {
+        std::printf("\n%d continuous hard-iron check(s) failed\n", g_failures);
+        return 1;
+    }
+    std::printf("\nall continuous hard-iron checks passed\n");
+    return 0;
+}

--- a/tests/kalman_ou_iii/kalman_ou_iii-sim.cpp
+++ b/tests/kalman_ou_iii/kalman_ou_iii-sim.cpp
@@ -335,6 +335,17 @@ public:
         if (env_float("SF_MAG_REFINE_START_SEC", vf)) cfg_.mag_refine_start_sec = vf;
         if (env_float("SF_MAG_REFINE_WINDOW_SEC", vf)) cfg_.mag_refine_window_sec = vf;
         if (const char* r = std::getenv("SF_MAG_REFINE")) cfg_.mag_refine_enabled = (std::string(r) != "0");
+        // Continuous exogenous hard-iron estimation.
+        if (const char* h = std::getenv("SF_MAG_CONT_HI")) cfg_.mag_continuous_hard_iron = (std::string(h) != "0");
+        if (env_float("SF_MAG_HI_MEMORY_SEC", vf)) cfg_.mag_hi_memory_sec = vf;
+        if (env_float("SF_MAG_HI_RIDGE", vf)) cfg_.mag_hi_model_ridge = vf;
+        if (env_float("SF_MAG_HI_RIDGE_REL", vf)) cfg_.mag_hi_model_ridge_relative = vf;
+        if (env_float("SF_MAG_HI_MIN_INFO", vf)) cfg_.mag_hi_min_information = vf;
+        if (env_float("SF_MAG_HI_MIN_WEIGHT", vf)) cfg_.mag_hi_min_effective_weight = vf;
+        if (env_float("SF_MAG_HI_MAX_RESID", vf)) cfg_.mag_hi_max_residual_rms_uT = vf;
+        if (env_float("SF_MAG_HI_FRACTION", vf)) cfg_.mag_hi_apply_fraction = vf;
+        if (env_float("SF_MAG_HI_SLEW_TAU", vf)) cfg_.mag_hi_slew_tau_sec = vf;
+
         if (env_float("SF_PROXY_TILT_SIGMA", vf)) cfg_.proxy_handoff_tilt_sigma_rad = vf;
         if (env_float("SF_PROXY_YAW_SIGMA", vf)) cfg_.proxy_handoff_yaw_sigma_rad = vf;
     }
@@ -362,6 +373,23 @@ public:
         if (!reported_refine_ && fusion_.hasRefinedMagReference()) {
             reported_refine_ = true;
             std::cerr << "STARTUP mag_refined_s=" << fusion_.magRefineTimeSec() << "\n";
+        }
+
+        if (trace_hard_iron_) {
+            trace_elapsed_ += dt;
+            if (trace_elapsed_ >= 60.0f) {
+                trace_elapsed_ = 0.0f;
+                const auto& e = fusion_.magContinuousHardIron().estimate();
+                const Vector3f& a = fusion_.magContinuousHardIronAppliedUT();
+                std::cerr << "MAGHI t=" << int(t_trace_)
+                          << " valid=" << e.valid
+                          << " info=" << e.information
+                          << " w=" << e.effective_weight
+                          << " resid=" << e.residual_rms_uT
+                          << " fit=[" << e.bias_body_uT.transpose() << "]"
+                          << " applied=[" << a.transpose() << "]\n";
+            }
+            t_trace_ += dt;
         }
 
         auto& filter = fusion_.raw();
@@ -527,6 +555,10 @@ private:
     };
 
     bool with_mag_ = true;
+    const bool trace_hard_iron_ = std::getenv("W3D_MAG_HI_TRACE") != nullptr;
+    mutable float trace_elapsed_ = 0.0f;
+    mutable float t_trace_ = 0.0f;
+
     mutable bool reported_lock_ = false;
     mutable bool reported_live_ = false;
     mutable bool reported_refine_ = false;
@@ -561,12 +593,12 @@ private:
 // filter that now ships, which is slack a regression can hide in.
 //
 // These are fitted to the deployed configuration -- the default
-// StartupInitPolicy::MahonyProxy.  The W3D_STARTUP_INIT=staged_mekf ablation
-// deliberately exceeds two of them, 3D on jonswap H1.5 (21.15 against 21.1)
-// and the 3D accelerometer-bias aggregate (106.2 against 95.8), because that
-// is precisely the behaviour the default replaced.  Scoring the ablation means
-// scoring the old filter, so run it with W3D_COLLECT_ALL_GATES if you want the
-// numbers rather than an early exit.
+// StartupInitPolicy::MahonyProxy with the continuous hard-iron correction on.
+// Both matched ablations, W3D_STARTUP_INIT=staged_mekf and SF_MAG_CONT_HI=0,
+// deliberately exceed some of them, because that is precisely the behaviour
+// the defaults replaced.  Scoring an ablation means scoring the old filter, so
+// run it with W3D_COLLECT_ALL_GATES if you want the numbers rather than an
+// early exit.
 //
 // bias_3d_percent remains dominated by the horizontal accelerometer bias,
 // which is close to unobservable on the smaller seas -- the error exceeds the
@@ -574,14 +606,22 @@ private:
 // 95.3 because holding accelerometer-bias learning until the magnetic
 // reference is refined stops the bias absorbing the provisional reference's
 // tilt error; see docs/ou-iii-startup-init.md.
+// Re-derived once more for the continuous hard-iron correction, which moved
+// three of the seven.  Yaw is the point of that change and drops by half, so
+// its limit comes down with it or it stops being a sentinel.  The two that go
+// up are the price: the correction walks the heading onto the corrected field
+// during the run, and the horizontal accelerometer bias -- already the least
+// observable quantity here, with an error that exceeds the true bias under
+// every configuration this filter has ever shipped -- absorbs some of that
+// motion.  See docs/ou-iii-continuous-hard-iron.md.
 static constexpr W3dFailureLimits FAIL_LIMITS{
-    .err_limit_percent_z_jonswap   = 4.8f,    // worst 4.69 (jonswap H0.27)
+    .err_limit_percent_z_jonswap   = 4.8f,    // worst 4.70 (jonswap H0.27)
     .err_limit_percent_z_pmstokes  = 4.7f,    // worst 4.66 (pmstokes H0.27)
-    .err_limit_yaw_deg             = 2.2f,    // worst 2.16 (pmstokes H1.5)
-    .err_limit_percent_3d_jonswap  = 21.1f,   // worst 20.95 (jonswap H1.5)
-    .err_limit_percent_3d_pmstokes = 20.6f,   // worst 20.42 (pmstokes H4.0)
-    .acc_z_bias_percent            = 5.6f,    // worst 5.48 (pmstokes H8.5)
-    .bias_3d_percent               = 95.8f,   // worst 95.30 (jonswap H4.0, accel)
+    .err_limit_yaw_deg             = 1.1f,    // worst 1.06 (jonswap H0.27)
+    .err_limit_percent_3d_jonswap  = 21.1f,   // worst 20.94 (jonswap H1.5)
+    .err_limit_percent_3d_pmstokes = 20.9f,   // worst 20.72 (pmstokes H4.0)
+    .acc_z_bias_percent            = 5.0f,    // worst 4.91 (jonswap H8.5)
+    .bias_3d_percent               = 98.4f,   // worst 97.89 (jonswap H4.0, accel)
 };
 
 static constexpr W3dSummaryLabels SUMMARY_LABELS{

--- a/tests/kalman_ou_iii/run_tests.sh
+++ b/tests/kalman_ou_iii/run_tests.sh
@@ -7,6 +7,7 @@
 ./channel_freeze-test
 ./wave_period-test
 ./mag_hard_iron-test
+./continuous_mag_hard_iron-test
 ./tuner_coupling-test
 ./tuner_schedule-test
 ./wave_band_sigma-test


### PR DESCRIPTION
The OU-III yaw error was not a tracking error.  On pmstokes H1.5 the scored
window has mean 2.146 deg and standard deviation 0.265 deg: the filter tracks
heading well and points two degrees off magnetic north for the whole run.  That
offset is a gauge.  Startup averages the magnetometer in a yaw-stripped tilt
frame and declares the horizontal direction of that average to be north, so a
body-fixed magnetic offset rotates north by the angle it contributes and
nothing downstream can recover it.

Removing the simulator's hard iron with truth and rescoring puts the headroom
at 1.835 -> 0.496 deg mean.  MagAutoTuner already solves that identification
problem and has always defaulted to off, for a reason its own tests state: the
excitation that separates an offset from the world field is a matrix of order
1e-3 for a hull working through a few degrees, and fifteen startup seconds is
not enough of it.  The answer is not a longer startup window but not closing
the window.

ContinuousMagHardIronEstimator keeps exponentially weighted statistics for the
life of the filter and solves the same joint problem periodically, eliminating
the world field analytically so it never becomes a state.  It reads the raw
magnetometer and the yaw-stripped tilt of the private Mahony observer, so it is
exogenous: no MEKF state, no loop through the filter, and the state dimension,
F, Q, P, the gain computation and the ISS argument are untouched.

Two things were needed to make it work rather than merely run.

The ridge has to scale with the excitation.  What an unregularised fit converges
on is not the offset but the offset plus an aliased image of soft iron and
misalignment, and that image is of order eps*|B| whatever the sea state, because
it enters through the same tilt that carries the signal.  A fixed prior
therefore shrinks hardest where the fit is most trustworthy; with one, the big
seas over-apply and regress.  Scaled, the fraction returned is a property of the
sensor rather than of the weather.

And the reference must not simply follow the offset.  Subtracting b from every
sample and the matching mean(R) b from the reference leaves the innovation
identical at the attitude already held -- measured, not argued: forcing 10 uT
through that path moves scored yaw by 0.3 deg.  The gauge is what has to move.
The offset comes out of the stream, the reference keeps its canonical form with
only its magnitude and dip shifted by the amount the offset changes them, and
the magnetometer update walks the heading onto the corrected field.  No attitude
state is written.

Yaw RMS over the eight records goes 1.835 -> 0.822 deg mean, 2.162 -> 1.063 deg
worst, improving on every record.  Pitch improves, roll and displacement do not
move; worst regression across all 56 metrics is +4.8%.  FAIL_LIMITS is
re-derived: yaw 2.2 -> 1.1, and two limits go up because the heading walk is
absorbed in part by the horizontal accelerometer bias, which is the least
observable quantity scored here.

Over five draws of the magnetometer calibration it is 2.430 -> 1.726 deg mean,
with five of forty record/seed pairs worse.  All five are one draw whose error
is misalignment-dominated rather than offset-dominated, where a hard-iron
estimator has nothing useful to do.  That case is not detectable from inside --
the aliased part of the distortion is by construction the part the model
explains, so it does not raise the residual -- which is why the shrinkage is
left large enough to give up real accuracy on the good draws.  Fixing it needs
heading excitation the records do not contain.  See
docs/ou-iii-continuous-hard-iron.md.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01659JQaMHkGnNZ2Nw9VZUpE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added continuous magnetometer hard-iron correction during proxy startup.
  * Added configurable estimator behavior, diagnostics, and optional simulator tracing.
  * Improved magnetic-reference updates as corrections are refined.

* **Documentation**
  * Added detailed documentation covering operation, configuration, results, and limitations.

* **Tests**
  * Added coverage for offset recovery, invalid-data rejection, sea-state behavior, and partial corrections.
  * Updated simulation regression checks for improved heading and bias accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->