### PR TITLE
Tighten the OU gates onto a relative quantum, and gate roll and pitch

### DIFF
--- a/docs/quality-gate-regauge.md
+++ b/docs/quality-gate-regauge.md
@@ -26,6 +26,14 @@ this was written; OU-III's re-derivation for `S_factor = 1`, below, put its
 PM-Stokes vertical gate at 0.69% because a hundredth is the finest quantum that
 channel is quoted in.)
 
+That 0.69% is the residue of quoting the quantum in absolute terms at all. The
+two OU families have since gone to a **relative** quantum — four significant
+figures, so the last digit is always a thousandth of the value — which removes
+the choice of decimal from the margin and lands all of their gates between
+0.50% and 0.57%; see "The OU families" below, which also adds the first bars
+this repository has ever put on roll and pitch. The other three families still
+carry the absolute quantum and the 0.50–0.69% band above.
+
 ## What was measured
 
 The deterministic protocol each simulator gates on: default seeds, the final
@@ -44,8 +52,8 @@ instead of exiting at the first one.
 
 | family | gates | verdict |
 | --- | --- | --- |
-| OU-II | 7 | four re-derived for the continuous hard-iron correction, three cut finer |
-| OU-III | 7 | six cut finer; then all seven re-derived for `S_factor = 1` |
+| OU-II | 7 → **9** | four re-derived for the continuous hard-iron correction, three cut finer; then four cut finer again on the relative quantum, and roll and pitch gated for the first time |
+| OU-III | 7 → **9** | six cut finer; then all seven re-derived for `S_factor = 1`; then three cut finer again on the relative quantum, and roll and pitch gated for the first time |
 | NLO | 2 gated (Z only) | both cut finer |
 | PII observer | 3 gated (Z, yaw) | all three cut finer |
 | TFG | 7 | all seven re-derived, then five cut finer; then re-derived again after the OU parity work |
@@ -68,6 +76,9 @@ of the maximum true bias in the window. Bracketed record is where the worst
 value occurs.
 
 ### OU-II — four re-derived for the continuous hard-iron correction, three cut finer
+
+Four of these were cut again, and two bars added, in "The OU families" below;
+this section is the state before that pass.
 
 Limits below are for the shipped filter, which now runs the correction. The
 "was" column is the same filter without it, which is the `SF_MAG_CONT_HI=0`
@@ -100,6 +111,9 @@ motion. Displacement does not move (vertical mean 6.454 → 6.461 %Hs, 3D mean
 18.90 → 19.03 %) and pitch improves, 0.289 → 0.255 deg.
 
 ### OU-III — six cut finer, then all seven re-derived for `S_factor = 1`
+
+Three of these were cut again, and two bars added, in "The OU families" below;
+this section is the state before that pass.
 
 The first pass, at the then-shipped `S_factor = 1.87`:
 
@@ -143,6 +157,83 @@ of five seeds on the binding record itself; the deployed draw is one of the few
 that moves the other way. The rule is applied to the protocol as written, and
 the quality claim rests on the seeds — `reports/results/ou_anisotropy` carries
 both.
+
+### The OU families — a relative quantum, and two new attitude bars
+
+Neither family's filter moved for this pass. Both sets of gates got stricter
+anyway, in two independent ways.
+
+#### The quantum goes relative
+
+"Rounded up in the last digit the channel is quoted in" only delivers one
+margin if that digit is a fixed *fraction* of the value. It was a fixed
+absolute step — a hundredth for both families — which is 0.2% of OU-III's 4.7
+vertical gate and 0.01% of OU-II's 94 bias gate, so the decimal point was
+setting the margin instead of the rule. Quoting every channel to four
+significant figures makes the quantum a thousandth of the value everywhere.
+Seven gates move; the other seven were already on a four-figure value and are
+unchanged:
+
+| family | gate | was | now | worst observed | margin |
+| --- | --- | --- | --- | --- | --- |
+| OU-II | Z %Hs JONSWAP | 6.9 | **6.899** | 6.8644 (H0.27) | 0.52% → 0.50% |
+| OU-II | Z %Hs PM-Stokes | 6.85 | **6.841** | 6.8062 (H0.27) | 0.64% → 0.51% |
+| OU-II | acc Z bias % | 5.44 | **5.435** | 5.4073 (jonswap H8.5) | 0.61% → 0.51% |
+| OU-II | bias 3D % | 94.4 | **94.37** | 93.8979 (jonswap H4.0, accel) | 0.53% → 0.50% |
+| OU-III | Z %Hs JONSWAP | 4.74 | **4.735** | 4.7106 (H0.27) | 0.63% → 0.52% |
+| OU-III | Z %Hs PM-Stokes | 4.69 | **4.682** | 4.6580 (H0.27) | 0.69% → 0.52% |
+| OU-III | acc Z bias % | 4.63 | **4.624** | 4.6004 (jonswap H8.5) | 0.64% → 0.51% |
+
+The 0.69% that this document had to explain away when it was written is gone,
+and the widest margin left in either family is OU-III's yaw at 0.57%.
+
+#### Roll and pitch are gated
+
+Both simulators have printed roll and pitch RMS on every record since they were
+written, and neither had a bar on either. That is the wrong shape for what
+these filters have actually been doing: the Mahony-proxy startup policy, the
+two-stage magnetic reference, the continuous hard-iron correction and OU-III's
+`S_factor = 1` are attitude work, and yaw was the only attitude channel
+carrying a sentinel. Mean pitch improved under both of the changes whose
+ablations are still wired up — OU-II 0.2987 → 0.2545 deg for the startup
+policy and 0.2890 → 0.2545 for the hard-iron correction, OU-III 0.2230 and
+0.2200 → 0.1891 — with nothing watching it.
+
+| family | gate | new bar | worst observed | margin |
+| --- | --- | --- | --- | --- |
+| OU-II | roll deg | **0.4778** | 0.4753 (jonswap H4.0) | 0.52% |
+| OU-II | pitch deg | **0.3639** | 0.3620 (jonswap H8.5) | 0.52% |
+| OU-III | roll deg | **0.42** | 0.4179 (jonswap H4.0) | 0.50% |
+| OU-III | pitch deg | **0.2211** | 0.2200 (pmstokes H4.0) | 0.50% |
+
+Fitted by the same rule on the same protocol, and they discriminate. Both
+matched ablations — `SF_MAG_CONT_HI=0` and `W3D_STARTUP_INIT=staged_mekf`,
+which are the filters these defaults replaced — breach the new pitch bar:
+OU-III on four of the eight records under either ablation, OU-II on two. The
+roll bars are the weaker of the pair, and only OU-III's discriminates at all:
+`staged_mekf` breaches it on two records, `SF_MAG_CONT_HI=0` on one, and
+neither ablation moves OU-II's roll enough to reach its bar.
+
+| family | arm | worst roll | worst pitch | mean pitch |
+| --- | --- | --- | --- | --- |
+| OU-II | deployed | 0.4753 | 0.3620 | 0.2545 |
+| OU-II | `SF_MAG_CONT_HI=0` | 0.4711 | 0.4176 | 0.2890 |
+| OU-II | `staged_mekf` | 0.3998 | 0.4756 | 0.2987 |
+| OU-III | deployed | 0.4179 | 0.2200 | 0.1891 |
+| OU-III | `SF_MAG_CONT_HI=0` | 0.4215 | 0.2656 | 0.2200 |
+| OU-III | `staged_mekf` | 0.5398 | 0.2626 | 0.2230 |
+
+Those breaches are the point, in the same way the yaw breach under
+`SF_MAG_CONT_HI=0` is: a bar fitted to the filter that ships should fail the
+filter it replaced. Score the ablations with `W3D_COLLECT_ALL_GATES=1`.
+
+Both bars are gated on the magnetometer-on protocol only, like yaw, because
+`--nomag` is a different filter and these bars were not fitted to it. OU-II
+loses the most: worst-case roll 0.4753 → 0.5382 and worst-case pitch
+0.3620 → 0.7113 deg, both past its bars. OU-III's worst-case pitch goes
+0.2200 → 0.2595, also past its bar, while its worst-case roll *improves* by
+19% — the magnetic reference is not uniformly good for tilt, which is worth
+knowing and is not something a gate should be deciding.
 
 ### NLO — both cut finer
 
@@ -243,20 +334,22 @@ cd tests/<dir> && W3D_COLLECT_ALL_GATES=1 W3D_WRITE_TIMESERIES=0 ./<sim>
 with the eight `wave_data_{jonswap,pmstokes}_*.csv` records in the working
 directory.
 
-For OU-III the rule itself is mechanised, which removes the arithmetic from the
-hand-application above:
+For both OU families the rule itself is mechanised, which removes the
+arithmetic from the hand-application above:
 
 ```
-python3 tools/ou_iii_regauge_gates.py
+python3 tools/ou_regauge_gates.py --family ou_iii
+python3 tools/ou_regauge_gates.py --family ou_ii
 ```
 
 It runs the eight records under this protocol, reports the worst value and its
 record per gate, applies the half-percent rule at the quantum the channel is
 quoted in, flags any shipped gate the filter no longer clears, and prints a
-`FAIL_LIMITS` body to paste. It reproduces all seven shipped limits from the
-filter that produced them, which is the check that it implements the rule
-rather than a rule. `--env OU_III_S_FACTOR=1.87` and friends re-gauge an
-ablation without rebuilding.
+`FAIL_LIMITS` body to paste. It reproduces all nine shipped limits of each
+family from the filter that produced them, which is the check that it
+implements the rule rather than a rule. `--env OU_III_S_FACTOR=1.87` and
+friends re-gauge an ablation without rebuilding, and `--json` dumps every
+channel of every record for the build-drift comparison below.
 
 ## How tight is safe: the determinism budget, measured
 
@@ -303,6 +396,40 @@ cutting any of these further, or below half a percent on any channel, needs this
 measurement redone first rather than the old 6e-6 quoted at it. The three
 ratios named above are where that bites first.
 
+### Re-measured for the OU families' nine gates
+
+The relative quantum and the two new attitude bars, above, are a cut, so the
+measurement was redone first rather than the paragraph above quoted at them.
+Both simulators were rebuilt at `-march=x86-64` and all eight records rescored,
+and the drift is taken **per binding record** — the record that actually sets
+each bar — rather than as a worst-channel figure, since that is the number the
+bar has to survive:
+
+| family | gate | margin | drift on its binding record | ratio |
+| --- | --- | --- | --- | --- |
+| OU-II | Z %Hs JONSWAP | 0.50% | 2.2e-5 | 227x |
+| OU-II | Z %Hs PM-Stokes | 0.51% | 1.0e-4 | 51x |
+| OU-II | yaw deg | 0.51% | 1.7e-4 | 31x |
+| OU-II | roll deg | 0.52% | 1.2e-4 | 44x |
+| OU-II | pitch deg | 0.52% | 5.6e-4 | **9.3x** |
+| OU-II | 3D % JONSWAP | 0.54% | 8.0e-6 | 675x |
+| OU-II | 3D % PM-Stokes | 0.50% | 1.4e-4 | 37x |
+| OU-II | acc Z bias % | 0.51% | 4.6e-5 | 111x |
+| OU-II | bias 3D % | 0.50% | 2.8e-4 | 18x |
+| OU-III | every gate | 0.51–0.57% | 2.2e-6 – 3.0e-5 | 169x – 2400x |
+
+All eighteen pass on both builds. OU-III is comfortable everywhere: its worst
+binding-record drift is 3.0e-5, on pitch, which is 169x inside that bar.
+
+OU-II's pitch, at 9.3x, is now the thinnest margin-to-drift ratio in the whole
+document — thinner than the two 15x cases named above — and it is thin because
+the channel is drifty rather than because the bar is tight: 5.6e-4 relative
+between builds against 2.2e-5 for the same family's vertical channel. It still
+clears on both builds (0.48% of headroom on the `x86-64` one), and it is the
+first bar to re-measure rather than re-cut if a rebuild ever breaches it. No OU
+gate should be cut below half a percent, and this one should not be cut at all
+without a fresh measurement.
+
 Reproduce with:
 
 ```
@@ -312,4 +439,10 @@ make -C tests/<dir> build CXXFLAGS="-O3 -std=c++20 -Wall -Wextra -Wshadow \
   -isystem /usr/include/eigen3 -march=x86-64"
 ```
 
-and compare the `Angles RMS` and `XYZ RMS` lines against a native build.
+and compare the `Angles RMS` and `XYZ RMS` lines against a native build. Note
+that `make clean` in a test directory deletes `*.csv`, which includes the
+unpacked wave records — re-fetch them with `make ensure-sim-data` afterwards, or
+delete only `*.o *.d` and the binary. For the two OU families,
+`tools/ou_regauge_gates.py --family ou_ii --json before.json` dumps every
+channel of every record, so the two builds can be differenced directly instead
+of by eye.

--- a/src/util/W3dSimCommon.cpp
+++ b/src/util/W3dSimCommon.cpp
@@ -1476,6 +1476,25 @@ void print_summary_and_fail_if_needed(const W3dSimulationRunResult& result,
     fail_if("Z", z_pct, limit_z);
     fail_if("3D", pct_3d, limit_3d);
 
+    // The attitude bars are fitted to the deployed protocol, which runs the
+    // magnetometer, so an IMU-only run is not scored against them -- the same
+    // rule yaw has always followed here, and for the same reason.  Roll and
+    // pitch are observable without a magnetometer, but not equally well:
+    // worst-case pitch over the eight records rises 18 percent for OU-III and
+    // 97 percent for OU-II under --nomag, while worst-case roll rises 13
+    // percent for OU-II and *falls* 19 percent for OU-III.  A bar fitted with
+    // the magnetometer is measuring a different filter without it.
+    auto fail_attitude_if = [&](const char* label, float deg, float limit) {
+        if (!result.with_mag || !(limit > 0.0f)) return;
+        if (deg > limit) {
+            failed = true;
+            fail_reason = std::string(label) + "_limit_exceeded";
+            std::cerr << "ERROR: " << label << " RMS above limit (" << deg
+                      << " deg > " << limit << " deg). Failing.\n";
+            if (!collect_all_gates) std::exit(EXIT_FAILURE);
+        }
+    };
+
     if (result.with_mag && rms_yaw.rms() > limits.err_limit_yaw_deg) {
         failed = true;
         fail_reason = "yaw_limit_exceeded";
@@ -1483,6 +1502,8 @@ void print_summary_and_fail_if_needed(const W3dSimulationRunResult& result,
                   << limits.err_limit_yaw_deg << " deg). Failing.\n";
         if (!collect_all_gates) std::exit(EXIT_FAILURE);
     }
+    fail_attitude_if("Roll", rms_roll.rms(), limits.err_limit_roll_deg);
+    fail_attitude_if("Pitch", rms_pitch.rms(), limits.err_limit_pitch_deg);
 
     const float accb_z_pct = pct_of_max(accb_rz, acc_true_max_z);
     if (std::isfinite(accb_z_pct) && accb_z_pct > limits.acc_z_bias_percent) {

--- a/src/util/W3dSimCommon.h
+++ b/src/util/W3dSimCommon.h
@@ -438,6 +438,13 @@ struct W3dFailureLimits {
     float err_limit_percent_z_jonswap = 0.0f;
     float err_limit_percent_z_pmstokes = 0.0f;
     float err_limit_yaw_deg = 0.0f;
+    // Roll and pitch, like yaw, in degrees RMS over the scored window.  Zero
+    // means the channel is not gated for this family, which is what the
+    // families that have never fitted a bar for it get: a sentinel of zero
+    // would fail every run, and silence is the correct behaviour for a bar
+    // nobody has measured.
+    float err_limit_roll_deg = 0.0f;
+    float err_limit_pitch_deg = 0.0f;
     float err_limit_percent_3d_jonswap = 0.0f;
     float err_limit_percent_3d_pmstokes = 0.0f;
     float acc_z_bias_percent = 0.0f;

--- a/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
+++ b/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
@@ -712,14 +712,57 @@ private:
 // has to survive.  docs/quality-gate-regauge.md carries that measurement and
 // the command that redoes it, which is the check to repeat before cutting any
 // of these finer.
+//
+// Then tightened twice more, with the filter standing still for both -- the
+// same two passes OU-III took, since the two families are gated by one rule
+// and one script.
+//
+// First the quantum.  Cutting a tenth to a hundredth, above, fixed the two
+// channels where a tenth was worth over a percent, but a fixed absolute step
+// still cannot deliver one margin across values from 1 to 94: a hundredth is
+// 0.15 percent of a 6.8 and 0.01 percent of a 94.  Quoting every channel to
+// four significant figures instead -- so the quantum is a thousandth of the
+// value everywhere -- puts all seven between 0.50 and 0.54 percent:
+//
+//   Z %Hs JONSWAP    6.9  -> 6.899    worst 6.8644   0.52% -> 0.50%
+//   Z %Hs PM-Stokes  6.85 -> 6.841    worst 6.8062   0.64% -> 0.51%
+//   acc Z bias %     5.44 -> 5.435    worst 5.4073   0.61% -> 0.51%
+//   bias 3D %        94.4 -> 94.37    worst 93.8979  0.53% -> 0.50%
+//
+// Then roll and pitch, which this simulator has measured every run and gated
+// never.  What this family has taken on over its last several changes -- the
+// OU-III parity work, the Mahony-proxy startup policy, and the continuous
+// hard-iron correction, which improved pitch from 0.289 to 0.255 deg mean --
+// is largely attitude work, and yaw was the only attitude channel carrying a
+// sentinel.  Roll and pitch run 0.2511 to 0.4753 and 0.1801 to 0.3620 deg
+// across the eight records, well clear of the bars fitted to them.
+//
+// They are gated like yaw, on the magnetometer-on protocol only, and for the
+// same reason: without it worst-case roll goes to 0.5382 and worst-case pitch
+// to 0.7113 deg, both past the bars below.  That is the largest IMU-only
+// attitude penalty of the two OU families -- OU-III loses 18 percent of
+// worst-case pitch and gains on roll -- and it is a fact about the filter, not
+// about the gates, which is why the gates decline to score it.
+//
+// All nine limits are what tools/ou_regauge_gates.py --family ou_ii prints for
+// the filter that ships.  They are checked against this family's own build
+// drift rather than against the rule alone, and this family is the noisier of
+// the two: the binding records move by 8.0e-6 to 5.6e-4 relative between a
+// native and an -march=x86-64 build, and both builds pass all nine.  The
+// thinnest margin-to-drift ratio in the set is pitch at 9.3x -- the tightest
+// anywhere in the five families, and the first bar to re-measure rather than
+// re-cut if a rebuild ever breaches it.  docs/quality-gate-regauge.md carries
+// that measurement and the command that redoes it.
 static constexpr W3dFailureLimits FAIL_LIMITS{
-    .err_limit_percent_z_jonswap   = 6.9f,    // unchanged, worst 6.8638 (jonswap H0.27)
-    .err_limit_percent_z_pmstokes  = 6.85f,   // was 6.9,   worst 6.8061 (pmstokes H0.27)
-    .err_limit_yaw_deg             = 1.095f,  // was 2.18,  worst 1.0895 (jonswap H1.5)
-    .err_limit_percent_3d_jonswap  = 21.1f,   // unchanged, worst 20.99 (jonswap H1.5)
-    .err_limit_percent_3d_pmstokes = 21.3f,   // was 21.2,  worst 21.19 (pmstokes H8.5)
-    .acc_z_bias_percent            = 5.44f,   // was 5.4,   worst 5.4059 (jonswap H8.5)
-    .bias_3d_percent               = 94.4f,   // was 92.2,  worst 93.90 (jonswap H4.0, accel)
+    .err_limit_percent_z_jonswap   = 6.899f,  // was 6.9,   worst 6.8644 (jonswap H0.27)
+    .err_limit_percent_z_pmstokes  = 6.841f,  // was 6.85,  worst 6.8062 (pmstokes H0.27)
+    .err_limit_yaw_deg             = 1.095f,  // unchanged, worst 1.0895 (jonswap H1.5)
+    .err_limit_roll_deg            = 0.4778f, // new,       worst 0.4753 (jonswap H4.0)
+    .err_limit_pitch_deg           = 0.3639f, // new,       worst 0.3620 (jonswap H8.5)
+    .err_limit_percent_3d_jonswap  = 21.1f,   // unchanged, worst 20.9867 (jonswap H1.5)
+    .err_limit_percent_3d_pmstokes = 21.3f,   // unchanged, worst 21.1935 (pmstokes H8.5)
+    .acc_z_bias_percent            = 5.435f,  // was 5.44,  worst 5.4073 (jonswap H8.5)
+    .bias_3d_percent               = 94.37f,  // was 94.4,  worst 93.8979 (jonswap H4.0, accel)
 };
 
 static constexpr W3dSummaryLabels SUMMARY_LABELS{

--- a/tests/kalman_ou_iii/kalman_ou_iii-sim.cpp
+++ b/tests/kalman_ou_iii/kalman_ou_iii-sim.cpp
@@ -675,14 +675,50 @@ private:
 // the few that moves the other way.  reports/results/ou_anisotropy carries
 // both.  The three bias and displacement gates that come down are real gains
 // and are cut to the rule like the rest.
+//
+// Then tightened twice more, with the filter standing still for both.
+//
+// First the quantum.  "Rounded up in the last digit the channel is quoted in"
+// only delivers one margin if that digit is a fixed *fraction* of the value,
+// and it was a fixed absolute step -- a hundredth, which is 0.2 percent of a
+// 4.7 and 0.01 percent of an 81.  The three gates quoted near 4.7 were
+// carrying 0.63 to 0.69 percent against a rule that asks for half of one,
+// purely from where the decimal fell.  Quoting every channel to four
+// significant figures lands all of them between 0.51 and 0.57:
+//
+//   Z %Hs JONSWAP    4.74 -> 4.735    worst 4.7106   0.63% -> 0.52%
+//   Z %Hs PM-Stokes  4.69 -> 4.682    worst 4.6580   0.69% -> 0.52%
+//   acc Z bias %     4.63 -> 4.624    worst 4.6004   0.64% -> 0.51%
+//
+// Then roll and pitch, which this simulator has measured every run and gated
+// never.  What the filter has taken on over the last several changes -- the
+// Mahony-proxy startup policy, the two-stage magnetic reference, the
+// continuous hard-iron correction, and S_factor = 1 -- is mostly attitude
+// work, and yaw was the only attitude channel carrying a sentinel.  Both are
+// quiet and well clear of their bars across the eight records (roll 0.2374 to
+// 0.4179, pitch 0.1716 to 0.2200 deg).  They are gated like yaw, on the
+// magnetometer-on protocol only, and for the same reason: dropping the
+// magnetometer takes worst-case pitch to 0.2595 deg, past the bar below,
+// while worst-case roll goes the other way and improves by 19 percent.  Bars
+// fitted with the magnetometer are not measuring the IMU-only filter, and
+// scoring it against them would fail it on a channel nobody fitted for it.
+//
+// All nine limits are what tools/ou_regauge_gates.py prints for the filter
+// that ships, and all nine hold on an -march=x86-64 rebuild as well as on a
+// native one -- the thinnest margin-to-drift ratio in this family is 169x, on
+// pitch.  docs/quality-gate-regauge.md carries that measurement and the
+// command that redoes it, which is the check to repeat before cutting any of
+// these finer.
 static constexpr W3dFailureLimits FAIL_LIMITS{
-    .err_limit_percent_z_jonswap   = 4.74f,   // was 4.72,  worst 4.7106 (jonswap H0.27)
-    .err_limit_percent_z_pmstokes  = 4.69f,   // unchanged, worst 4.6580 (pmstokes H0.27)
-    .err_limit_yaw_deg             = 1.297f,  // was 1.068, worst 1.2896 (jonswap H1.5)
-    .err_limit_percent_3d_jonswap  = 20.95f,  // was 21.05, worst 20.8367 (jonswap H1.5)
-    .err_limit_percent_3d_pmstokes = 20.86f,  // was 20.83, worst 20.7483 (pmstokes H4.0)
-    .acc_z_bias_percent            = 4.63f,   // was 4.93,  worst 4.6004 (jonswap H8.5)
-    .bias_3d_percent               = 81.84f,  // was 98.4,  worst 81.4268 (pmstokes H4.0, accel)
+    .err_limit_percent_z_jonswap   = 4.735f,  // was 4.74,  worst 4.7106 (jonswap H0.27)
+    .err_limit_percent_z_pmstokes  = 4.682f,  // was 4.69,  worst 4.6580 (pmstokes H0.27)
+    .err_limit_yaw_deg             = 1.297f,  // unchanged, worst 1.2896 (jonswap H1.5)
+    .err_limit_roll_deg            = 0.42f,   // new,       worst 0.4179 (jonswap H4.0)
+    .err_limit_pitch_deg           = 0.2211f, // new,       worst 0.2200 (pmstokes H4.0)
+    .err_limit_percent_3d_jonswap  = 20.95f,  // unchanged, worst 20.8367 (jonswap H1.5)
+    .err_limit_percent_3d_pmstokes = 20.86f,  // unchanged, worst 20.7483 (pmstokes H4.0)
+    .acc_z_bias_percent            = 4.624f,  // was 4.63,  worst 4.6004 (jonswap H8.5)
+    .bias_3d_percent               = 81.84f,  // unchanged, worst 81.4268 (pmstokes H4.0, accel)
 };
 
 static constexpr W3dSummaryLabels SUMMARY_LABELS{

--- a/tools/ou_regauge_gates.py
+++ b/tools/ou_regauge_gates.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Re-derive OU-III's seven deterministic quality gates from the shipped filter.
+"""Re-derive the OU families' deterministic quality gates from the shipped filter.
 
 The rule, from docs/quality-gate-regauge.md:
 
@@ -14,13 +14,18 @@ remaining records instead of exiting at the first one.
 
 Run it after any change to the filter that could move a gated quantity, and
 paste the printed table into the FAIL_LIMITS comment block in
+tests/kalman_ou_ii/kalman_ou_ii-sim.cpp or
 tests/kalman_ou_iii/kalman_ou_iii-sim.cpp.
+
+`--json` writes every channel of every record, which is what the -march drift
+measurement in docs/quality-gate-regauge.md compares between two builds.
 """
 
 from __future__ import annotations
 
 import argparse
 import concurrent.futures as cf
+import json
 import math
 import os
 import re
@@ -29,7 +34,6 @@ import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-SIM = REPO_ROOT / "tests" / "kalman_ou_iii" / "kalman_ou_iii-sim"
 
 RECORDS = (
     "wave_data_jonswap_H0.270_L14.047_A30.00_P60.00.csv",
@@ -42,19 +46,54 @@ RECORDS = (
     "wave_data_pmstokes_H8.500_L202.839_A-30.00_P72.00.csv",
 )
 
-# gate field -> (heading, which records it is taken over, current shipped value)
-GATES = {
-    "err_limit_percent_z_jonswap":   ("Z %Hs JONSWAP",     "jonswap",  4.72),
-    "err_limit_percent_z_pmstokes":  ("Z %Hs PM-Stokes",   "pmstokes", 4.69),
-    "err_limit_yaw_deg":             ("yaw deg",           "all",      1.068),
-    "err_limit_percent_3d_jonswap":  ("3D % JONSWAP",      "jonswap",  21.05),
-    "err_limit_percent_3d_pmstokes": ("3D % PM-Stokes",    "pmstokes", 20.83),
-    "acc_z_bias_percent":            ("acc Z bias %",      "all",      4.93),
-    "bias_3d_percent":               ("bias 3D %",         "all",      98.4),
+# gate field -> (heading, which records it is taken over, scraped channel)
+GATE_CHANNELS = {
+    "err_limit_percent_z_jonswap":   ("Z %Hs JONSWAP",   "jonswap",  "z_pct_hs"),
+    "err_limit_percent_z_pmstokes":  ("Z %Hs PM-Stokes", "pmstokes", "z_pct_hs"),
+    "err_limit_yaw_deg":             ("yaw deg",         "all",      "yaw_deg"),
+    "err_limit_roll_deg":            ("roll deg",        "all",      "roll_deg"),
+    "err_limit_pitch_deg":           ("pitch deg",       "all",      "pitch_deg"),
+    "err_limit_percent_3d_jonswap":  ("3D % JONSWAP",    "jonswap",  "d3_pct"),
+    "err_limit_percent_3d_pmstokes": ("3D % PM-Stokes",  "pmstokes", "d3_pct"),
+    "acc_z_bias_percent":            ("acc Z bias %",    "all",      "acc_z_bias_pct"),
+    # One limit covers both the accelerometer and the gyro 3D bias; handled below.
+    "bias_3d_percent":               ("bias 3D %",       "all",      None),
+}
+
+# The gates each family currently ships, in the order above.
+FAMILIES = {
+    "ou_ii": {
+        "sim": REPO_ROOT / "tests" / "kalman_ou_ii" / "kalman_ou_ii-sim",
+        "shipped": {
+            "err_limit_percent_z_jonswap":   6.899,
+            "err_limit_percent_z_pmstokes":  6.841,
+            "err_limit_yaw_deg":             1.095,
+            "err_limit_roll_deg":            0.4778,
+            "err_limit_pitch_deg":           0.3639,
+            "err_limit_percent_3d_jonswap":  21.1,
+            "err_limit_percent_3d_pmstokes": 21.3,
+            "acc_z_bias_percent":            5.435,
+            "bias_3d_percent":               94.37,
+        },
+    },
+    "ou_iii": {
+        "sim": REPO_ROOT / "tests" / "kalman_ou_iii" / "kalman_ou_iii-sim",
+        "shipped": {
+            "err_limit_percent_z_jonswap":   4.735,
+            "err_limit_percent_z_pmstokes":  4.682,
+            "err_limit_yaw_deg":             1.297,
+            "err_limit_roll_deg":            0.42,
+            "err_limit_pitch_deg":           0.2211,
+            "err_limit_percent_3d_jonswap":  20.95,
+            "err_limit_percent_3d_pmstokes": 20.86,
+            "acc_z_bias_percent":            4.624,
+            "bias_3d_percent":               81.84,
+        },
+    },
 }
 
 
-def scrape(record: str, env_extra: dict[str, str]) -> dict[str, float]:
+def scrape(sim: Path, record: str, env_extra: dict[str, str]) -> dict[str, float]:
     """One deterministic replay; returns the gated quantities it produced."""
     env = os.environ.copy()
     env.update(env_extra)
@@ -63,7 +102,7 @@ def scrape(record: str, env_extra: dict[str, str]) -> dict[str, float]:
         "W3D_WRITE_TIMESERIES": "0",
         "W3D_VALIDATION_WINDOW_SEC": "900",
     })
-    proc = subprocess.run([str(SIM), "--input", record], cwd=SIM.parent, env=env,
+    proc = subprocess.run([str(sim), "--input", record], cwd=sim.parent, env=env,
                           capture_output=True, text=True, check=False)
     out = proc.stdout
     metrics = next((l for l in out.splitlines()
@@ -86,6 +125,8 @@ def scrape(record: str, env_extra: dict[str, str]) -> dict[str, float]:
         "z_pct_hs": metric("disp_z_pct_hs"),
         "d3_pct": metric("disp_3d_pct_refmax"),
         "yaw_deg": metric("yaw_rms_deg"),
+        "roll_deg": metric("roll_rms_deg"),
+        "pitch_deg": metric("pitch_rms_deg"),
         "acc_z_bias_pct": bias_pct("acc", "Z"),
         "acc_3d_bias_pct": bias_pct("acc", r"\|3D\|"),
         "gyro_3d_bias_pct": bias_pct("gyro", r"\|3D\|"),
@@ -95,44 +136,59 @@ def scrape(record: str, env_extra: dict[str, str]) -> dict[str, float]:
 def round_to_rule(worst: float) -> tuple[float, float]:
     """Half a percent above `worst`, rounded up to this channel's quantum.
 
-    The quantum is chosen by magnitude rather than fixed at a tenth, which is
-    the change docs/quality-gate-regauge.md records: a tenth is 0.03% of a
-    400-valued gate and 3.5% of a 1-valued one.  A thousandth where the value
-    is near 1, a hundredth for everything larger.  Reproduces all seven shipped
-    gates from the shipped filter's worst values.
+    The quantum is a fixed *relative* precision -- four significant digits, so
+    one part in a thousand of the value -- rather than a fixed absolute one.
+    That is what lets a single half-percent rule land the same margin on a
+    channel quoted near 0.2 and one quoted near 100: an absolute quantum is
+    0.05% of a 94-valued gate and 45% of a 0.22-valued one, so it decides the
+    margin instead of the rule doing it.  With this quantum the rounding costs
+    at most a tenth of a percent on top of the half, which is the whole point
+    of quoting the rounding rather than the rule.
     """
-    quantum = 0.001 if worst < 2.0 else 0.01
+    quantum = 10.0 ** (math.floor(math.log10(worst)) - 3)
     limit = math.ceil(worst * 1.005 / quantum) * quantum
-    return round(limit, 3), 100.0 * (limit - worst) / worst
+    # Renormalize: the ceil is exact in decimal but the product is not.
+    limit = round(limit, max(0, 3 - math.floor(math.log10(worst))))
+    return limit, 100.0 * (limit - worst) / worst
 
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--family", choices=sorted(FAMILIES), default="ou_iii",
+                    help="which simulator to re-gauge (default: ou_iii)")
     ap.add_argument("--env", action="append", default=[],
                     help="extra VAR=VALUE for the replays, e.g. OU_III_S_FACTOR=1.0")
+    ap.add_argument("--json", type=Path, default=None,
+                    help="also write every channel of every record here")
     ap.add_argument("--jobs", type=int, default=4)
     args = ap.parse_args()
 
-    if not SIM.is_file():
-        raise SystemExit(f"{SIM} not built; run make -C tests/kalman_ou_iii build")
+    family = FAMILIES[args.family]
+    sim = family["sim"]
+    if not sim.is_file():
+        raise SystemExit(f"{sim} not built; run make -C {sim.parent} build")
     env_extra = dict(kv.split("=", 1) for kv in args.env)
+    print(f"family: {args.family}")
     if env_extra:
         print("overrides: " + " ".join(f"{k}={v}" for k, v in env_extra.items()))
 
     with cf.ThreadPoolExecutor(max_workers=args.jobs) as pool:
-        rows = list(pool.map(lambda r: scrape(r, env_extra), RECORDS))
+        rows = list(pool.map(lambda r: scrape(sim, r, env_extra), RECORDS))
     for row in rows:
         print(f"  {row['record'].split('_')[2]:9} "
               f"{row['record'].split('_')[3]:8} "
               f"z={row['z_pct_hs']:7.4f}%  3D={row['d3_pct']:8.4f}%  "
+              f"roll={row['roll_deg']:6.4f}  pitch={row['pitch_deg']:6.4f}  "
               f"yaw={row['yaw_deg']:7.4f}  accZbias={row['acc_z_bias_pct']:8.4f}%  "
               f"acc3Dbias={row['acc_3d_bias_pct']:8.4f}%  "
               f"gyr3Dbias={row['gyro_3d_bias_pct']:8.4f}%")
+    if args.json:
+        args.json.write_text(json.dumps(rows, indent=1) + "\n")
 
-    def worst_of(key: str, family: str) -> tuple[float, str]:
+    def worst_of(key: str, group: str) -> tuple[float, str]:
         picked = [r for r in rows
-                  if family == "all" or f"_{family}_" in r["record"]]
+                  if group == "all" or f"_{group}_" in r["record"]]
         best = max(picked, key=lambda r: r[key])
         return best[key], f"{best['record'].split('_')[2]} {best['record'].split('_')[3]}"
 
@@ -140,26 +196,21 @@ def main() -> int:
           f"{'rule':>9} {'margin':>8}")
     print("-" * 96)
     verdict_lines = []
-    for field, (heading, family, shipped) in GATES.items():
-        if field == "bias_3d_percent":
+    for field, (heading, group, channel) in GATE_CHANNELS.items():
+        shipped = family["shipped"][field]
+        if channel is None:
             # One limit covers both the accelerometer and the gyro 3D bias.
             worst_a, rec_a = worst_of("acc_3d_bias_pct", "all")
             worst_g, rec_g = worst_of("gyro_3d_bias_pct", "all")
             worst, rec = ((worst_a, rec_a + ", accel") if worst_a >= worst_g
                           else (worst_g, rec_g + ", gyro"))
         else:
-            key = {"err_limit_percent_z_jonswap": "z_pct_hs",
-                   "err_limit_percent_z_pmstokes": "z_pct_hs",
-                   "err_limit_yaw_deg": "yaw_deg",
-                   "err_limit_percent_3d_jonswap": "d3_pct",
-                   "err_limit_percent_3d_pmstokes": "d3_pct",
-                   "acc_z_bias_percent": "acc_z_bias_pct"}[field]
-            worst, rec = worst_of(key, family)
+            worst, rec = worst_of(channel, group)
         limit, margin = round_to_rule(worst)
         shipped_margin = 100.0 * (shipped - worst) / worst
         if shipped <= worst:
             flag = "  <-- SHIPPED GATE NOW FAILS"
-        elif 0.45 <= shipped_margin <= 0.70:
+        elif abs(shipped - limit) < 0.5 * 10.0 ** (math.floor(math.log10(worst)) - 3):
             # Already at the rule; moving it would be churn, not a re-gauge.
             limit, margin, flag = shipped, shipped_margin, "  (shipped already at the rule)"
         else:


### PR DESCRIPTION
Neither OU filter moved for this.  Both gate sets get stricter anyway, in two
ways, and the re-gauge script that fits them now covers both families.

The quantum goes relative.  "Rounded up in the last digit the channel is quoted
in" only delivers one margin if that digit is a fixed fraction of the value,
and it was a fixed absolute step -- a hundredth for both families, which is
0.2 percent of OU-III's 4.7 vertical bar and 0.01 percent of OU-II's 94 bias
bar.  The decimal point was setting the margin instead of the rule, and the
0.69 percent this repository's gate document had to explain away was the
result.  Quoting to four significant figures makes the quantum a thousandth of
the value everywhere.  Seven of the fourteen existing bars come down; the rest
were already on a four-figure value:

    OU-II    Z %Hs JONSWAP     6.9  -> 6.899    0.52% -> 0.50%
    OU-II    Z %Hs PM-Stokes   6.85 -> 6.841    0.64% -> 0.51%
    OU-II    acc Z bias %      5.44 -> 5.435    0.61% -> 0.51%
    OU-II    bias 3D %         94.4 -> 94.37    0.53% -> 0.50%
    OU-III   Z %Hs JONSWAP     4.74 -> 4.735    0.63% -> 0.52%
    OU-III   Z %Hs PM-Stokes   4.69 -> 4.682    0.69% -> 0.52%
    OU-III   acc Z bias %      4.63 -> 4.624    0.64% -> 0.51%

Roll and pitch are gated, for the first time in any family.  Both simulators
have printed them on every record since they were written and neither had a bar
on either, which is the wrong shape for what these filters have been doing: the
Mahony-proxy startup policy, the two-stage magnetic reference, the continuous
hard-iron correction and OU-III's S_factor = 1 are attitude work, and yaw was
the only attitude channel carrying a sentinel.  Mean pitch improved under both
changes whose ablations are still wired up, with nothing watching it.

    OU-II    roll 0.4778   pitch 0.3639     worst 0.4753, 0.3620
    OU-III   roll 0.42     pitch 0.2211     worst 0.4179, 0.2200

They discriminate rather than decorate.  Both matched ablations -- the filters
these defaults replaced -- breach the pitch bar: OU-III on four of eight
records under either, OU-II on two, and staged_mekf breaches OU-III's roll bar
on two more.  Like yaw, they score the magnetometer-on protocol only, since
--nomag takes OU-II's worst pitch to 0.7113 deg and OU-III's to 0.2595, both
past bars that were not fitted to that filter.  W3dFailureLimits takes the two
limits as optional: zero means ungated, which is what NLO, the PII observer and
TFG keep until someone measures bars for them.

Because this is a cut, the determinism budget was re-measured first rather than
the old figure quoted at it.  Both simulators were rebuilt at -march=x86-64 and
all eight records rescored, and the drift is taken per binding record -- the
record that actually sets each bar.  All eighteen gates pass on both builds.
OU-III is comfortable everywhere, 169x at its worst.  OU-II's new pitch bar is
9.3x, now the thinnest margin-to-drift ratio in the whole document, and thin
because the channel is drifty rather than because the bar is tight: 5.6e-4
between builds against 2.2e-5 for the same family's vertical channel.  It is
recorded as the first bar to re-measure rather than re-cut.

tools/ou_iii_regauge_gates.py becomes ou_regauge_gates.py with --family, since
the rule is now applied to two families by one script; it reproduces all
eighteen shipped limits from the filter that produced them, and --json dumps
every channel of every record so two builds can be differenced directly.

make all passes: 24 quality gates green, and tests/validation's 81 tests pass
once numpy and matplotlib are installed (they are absent from this container,
which is the only thing that fails without them).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PzEZdcNWZzV8qZmA1qyMzW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added roll and pitch attitude quality gates for magnetometer-enabled simulations.
  * Added configurable roll and pitch error limits, disabled by default when unset.
  * Expanded gate re-gauging to support both OU-II and OU-III simulation families.
  * Added optional JSON output for measured gate data.

* **Bug Fixes**
  * Tightened and refined regression thresholds for OU-II and OU-III simulations.
  * Improved rebuild guidance and documented build-drift measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->