### PR TITLE
Score horizontal displacement in the record's own frame

### DIFF
--- a/src/ahrs/FrameConversions.h
+++ b/src/ahrs/FrameConversions.h
@@ -204,6 +204,26 @@ struct MagSim_WMM {
         return zu_to_ned(mag_world_nautical(declination_deg, inclination_deg, total_field_uT));
     }
 
+    // Rotate a nautical ENU (x=East, y=North, z=Up) world vector out of the
+    // magnetic frame a magnetometer-aided filter locks onto and into the
+    // geographic frame.  A filter with no declination input takes north to be
+    // wherever the horizontal field points, so its world horizontal axes sit
+    // declination_deg away from true north.  The vertical axis is shared by
+    // both frames and passes through untouched, which is why only x and y
+    // need this and z never does.
+    static Eigen::Vector3f mag_frame_to_geographic_nautical(
+        const Eigen::Vector3f& v_mag_zu,
+        float declination_deg = default_declination_deg)
+    {
+        const float dec_rad = declination_deg * std::numbers::pi_v<float> / 180.0f;
+        const float c = std::cos(dec_rad);
+        const float s = std::sin(dec_rad);
+        return Eigen::Vector3f(
+            c * v_mag_zu.x() + s * v_mag_zu.y(),
+           -s * v_mag_zu.x() + c * v_mag_zu.y(),
+            v_mag_zu.z());
+    }
+
     // Simulate body-frame magnetometer [uT] from nautical Euler (deg)
     static Eigen::Vector3f simulate_mag_from_euler_nautical(
         float roll_deg, float pitch_deg, float yaw_deg,

--- a/src/util/W3dSimCommon.cpp
+++ b/src/util/W3dSimCommon.cpp
@@ -579,7 +579,20 @@ std::optional<W3dSimulationRunResult> W3dSimulationRunner::run(const std::string
             }
         }
 
-        const FilterSnapshot snap = fusion_adapter_.snapshot();
+        FilterSnapshot snap = fusion_adapter_.snapshot();
+
+        // The filter has no declination input, so with the magnetometer live
+        // its world horizontal axes are magnetic, while the record's disp/vel/
+        // acc columns are geographic.  Scoring x and y across that offset
+        // charges every horizontal metric a fixed rotation the vertical axis
+        // cannot have.  The yaw reference above is already moved into the
+        // filter's frame; do the mirror move here and bring the translational
+        // estimate back into the record's frame, before anything reads it.
+        if (options_.with_mag) {
+            snap.disp_est_zu = MagSim_WMM::mag_frame_to_geographic_nautical(snap.disp_est_zu);
+            snap.vel_est_zu  = MagSim_WMM::mag_frame_to_geographic_nautical(snap.vel_est_zu);
+            snap.acc_est_zu  = MagSim_WMM::mag_frame_to_geographic_nautical(snap.acc_est_zu);
+        }
 
         Vector3f disp_ref(rec.wave.disp_x, rec.wave.disp_y, rec.wave.disp_z);
         Vector3f vel_ref(rec.wave.vel_x, rec.wave.vel_y, rec.wave.vel_z);
@@ -847,7 +860,15 @@ std::optional<TvgNloSimulationRunResult> TvgNloSimulationRunner::run(const std::
             }
         }
 
-        const TvgNloFilterSnapshot snap = fusion_adapter_.snapshot();
+        TvgNloFilterSnapshot snap = fusion_adapter_.snapshot();
+
+        // Same magnetic-versus-geographic horizontal offset as the W3D runner
+        // above; see the comment there.
+        if (options_.with_mag) {
+            snap.disp_est_zu = MagSim_WMM::mag_frame_to_geographic_nautical(snap.disp_est_zu);
+            snap.vel_est_zu  = MagSim_WMM::mag_frame_to_geographic_nautical(snap.vel_est_zu);
+            snap.acc_est_zu  = MagSim_WMM::mag_frame_to_geographic_nautical(snap.acc_est_zu);
+        }
 
         result.snapshots.push_back(snap);
         result.final_snapshot = snap;


### PR DESCRIPTION
The filters take no declination input, so with the magnetometer live their
world horizontal axes are magnetic north, while the wave records' disp/vel/acc
columns are geographic.  The runners already move the yaw reference into the
filter's frame before scoring it, but the translational estimate was
differenced straight against the record, charging x and y a fixed
-12.6 degree rotation that the shared vertical axis structurally cannot have.

Fitting the best horizontal map from reference to estimate recovers exactly
that offset: the fitted rotation matches declination plus the run's mean yaw
error to within 0.06 degrees on every record and both families, and with
--no-noise (where the yaw error nearly vanishes) it lands on the declination
itself.

Add MagSim_WMM::mag_frame_to_geographic_nautical() and apply it to
disp/vel/acc_est_zu right after the snapshot in both runners, gated on
with_mag, so scoring and the emitted timeseries share one frame.  This is a
scoring-path change only -- nothing feeds back into the filters, and the
vertical metrics come out bit-identical.

On the JONSWAP H1.5 and H8.5 records the residual fitted rotation drops to
each run's real yaw error (+1.00, +1.22, -0.06, +0.58 deg), horizontal
acceleration error falls from 0.13-0.34 to 0.030-0.043 m/s^2, and 3D
displacement RMS improves for both families.

The committed evidence bundle under reports/results/ and the x/y figures
quoted in docs/ou-3d-error-attribution.md predate this and need regenerating.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017JkHCh1Y2tDpGDdYWwvgzK