### PR TITLE
Read the R_S bias-variance optimum per axis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,17 @@ tests/wave_sim/wave-convention-check
 # moved into doc/ for the manuscript.
 plots/*/*.pgf
 plots/*/*.svg
+
+# LaTeX build products from compiling the manuscripts under doc/.  The papers
+# are built in CI and the PDFs published as release assets; nothing generated
+# by a local latexmk run belongs in the tree.
+doc/**/*.aux
+doc/**/*.bbl
+doc/**/*.blg
+doc/**/*.fdb_latexmk
+doc/**/*.fls
+doc/**/*.log
+doc/**/*.out
+doc/**/*.pdf
+doc/**/*.synctex.gz
+doc/**/*.toc

--- a/doc/kalman_ou_iii/w3d-fus-methods.tex-part
+++ b/doc/kalman_ou_iii/w3d-fus-methods.tex-part
@@ -400,14 +400,15 @@ agreeing, PM-Stokes flat to $0.15\,\%$, vertical unchanged at $+0.16\,\%$, and
 yaw $-3.2\,\%$.  Both $0.9$ and $1.1$ score $-1.19\,\%$, so the minimum is
 interior rather than a fitted edge.
 and the integral pseudo-measurement standard-deviation vector is
-\[
+\begin{equation}
 \vct{r}_S=\begin{bmatrix}
 \rho_{xy}r_{S,\mathrm{appl}}&
 \rho_{xy}r_{S,\mathrm{appl}}&
 r_{S,\mathrm{appl}}
 \end{bmatrix}^{\top},
 \qquad \rho_{xy}=1 .
-\]
+\label{eq:fus-rs-anisotropy}
+\end{equation}
 The horizontal weight was previously $\rho_{xy}=0.36$, which made the
 horizontal high-pass $2.8\times$ stronger than the vertical one.  That was a
 small-sea optimum applied to every sea state, and with the operating point tied
@@ -437,6 +438,17 @@ low-frequency content does not scale with the sea's horizontal acceleration
 amplitude.  Closing it downward, by taking $S_\sigma$ to the value the records
 measure, both satisfies the theorem and improves every pooled metric, and is
 what the deployed constant now does.
+
+Both readings above argue from similarity of the prior.  A sharper statement is
+available from the bias--variance optimum: Sec.~\ref{sec:riccati-per-axis}
+reads \eqref{eq:riccati-optimal-RS} per axis and obtains $\rho_{xy}$ as a
+prediction rather than a calibration,
+$r_{S,i}^\star/r_{S,z}^\star=(q_{\mathrm{eff},i}/q_{\mathrm{eff},z})^{1/14}
+(m_{-4,i}/m_{-4,z})^{3/7}$, measuring $1.14$ on $x$ and $0.86$ on $y$ across
+the eight calibration seas.  The deployed $\rho_{xy}=1$ therefore sits within
+$14\,\%$ of the analytic optimum, and the discarded $0.36$ was wrong by a
+factor of three --- in the wrong direction on $x$, where the optimum asks for a
+looser horizontal anchor than the vertical one.
 
 Its componentwise square defines the covariance,
 \begin{equation}

--- a/doc/kalman_ou_iii/w3d-rs-similarity-design-guidance.tex-part
+++ b/doc/kalman_ou_iii/w3d-rs-similarity-design-guidance.tex-part
@@ -550,6 +550,223 @@ floor must eventually dominate --- \eqref{eq:riccati-exponent-law} predicts the
 exponent should fall toward $6/7$.  That is a sharper and more testable
 statement than the $\beta_m$ postulate it replaces.
 
+\subsubsection{Reading the optimum per axis}
+\label{sec:riccati-per-axis}
+
+Everything above is written for the vertical channel, but nothing in the
+derivation of either term of \eqref{eq:riccati-optimal-pole} uses the axis.
+The drift term comes from the triple-integrator error transfer
+\eqref{eq:riccati-error-transfers}, which is the same three chains on $x$, $y$
+and $z$; the distortion term comes from the $S=0$ constraint, which is imposed
+componentwise.  Read per axis $i\in\{x,y,z\}$, the optimum is
+\begin{equation}
+ \mathrm{MSE}_{p_i}\simeq\frac{3q_{\mathrm{eff},i}}{2\omega_{R,i}^3}
+ +4m_{-4,i}\omega_{R,i}^4,
+ \qquad
+ \omega_{R,i}^{\star7}=\frac{9}{32}\,\frac{q_{\mathrm{eff},i}}{m_{-4,i}},
+\label{eq:riccati-axis-optimal-pole}
+\end{equation}
+and, inverting $\omega_{R,i}=(q_{\mathrm{eff},i}/R_{S,i}T_S)^{1/6}$ with
+$R_{S,i}=r_{S,i}^2$,
+\begin{equation}
+ \boxed{
+ r_{S,i}^{\star}
+ =\left(\tfrac{32}{9}\right)^{3/7}
+ q_{\mathrm{eff},i}^{1/14}\,m_{-4,i}^{3/7}\,T_S^{-1/2} .}
+\label{eq:riccati-axis-optimal-rs}
+\end{equation}
+The horizontal weight $\rho_{xy}$ of \eqref{eq:fus-rs-anisotropy} is therefore
+not a free constant.  Taking the ratio, $T_S$ and the numerical prefactor
+cancel and
+\begin{equation}
+ \boxed{
+ \frac{r_{S,i}^{\star}}{r_{S,j}^{\star}}
+ =\left(\frac{q_{\mathrm{eff},i}}{q_{\mathrm{eff},j}}\right)^{1/14}
+  \left(\frac{m_{-4,i}}{m_{-4,j}}\right)^{3/7} ,}
+\label{eq:riccati-axis-ratio}
+\end{equation}
+so the deployed anisotropy is fixed by two measurable quantities and needs no
+new calibration.  The exponents are six to one apart, which is the whole point
+of what follows: the axis anisotropy is set by the wave signal the regularizer
+fights, not by the drift noise it exists to suppress.
+
+\paragraph{Why $q_{\mathrm{eff}}$ is anisotropic, and by how much.}
+Per axis the reduction of Sec.~\ref{sec:riccati-drift-band} reads
+$\mu_i=\sqrt{\tau^{-2}+2\sigma_{a,i}^2/(\tau r_{a,i})}$ with
+$\sigma_{a,i}^2=[\matg\Sigma_{aw}^{\mathrm{stat}}]_{ii}$, and
+$q_{\mathrm{eff},i}=2r_{a,i}(1-1/\mu_i\tau)$.  What differs across axes is
+$r_{a,i}$, and \eqref{eq:acc-meas} already says why.  With
+$\vct\varepsilon_a=\hat{\vct a}_w-\vct a_w$ and the Jacobians of
+Sec.~\ref{sec:measurement_model},
+\begin{equation}
+ \vct\varepsilon_a\simeq
+ -\Rot_{bw}\Skew{\vct f_{\mathrm{cog},b}}\delta\vct\theta
+ +\Rot_{bw}\delta\vct b_a+\Rot_{bw}\vct n_a+\vct\varepsilon_{\mathrm{model}},
+\label{eq:riccati-axis-acc-error}
+\end{equation}
+and near level, with $\vct f_{\mathrm{cog}}\simeq(a_x,a_y,a_z-g)^{T}$,
+\begin{equation}
+\begin{aligned}
+ \varepsilon_{a,x}&\simeq-g\,\delta\theta_y-a_y\delta\theta_z+\delta b_x+n_x,\\
+ \varepsilon_{a,y}&\simeq+g\,\delta\theta_x+a_x\delta\theta_z+\delta b_y+n_y,\\
+ \varepsilon_{a,z}&\simeq\;\;\,a_y\delta\theta_x-a_x\delta\theta_y+\delta b_z+n_z.
+\end{aligned}
+\label{eq:riccati-axis-tilt-leak}
+\end{equation}
+The horizontal rows carry tilt uncertainty multiplied by
+$g\simeq\SI{9.81}{m/s^2}$; the vertical row carries it multiplied only by the
+horizontal wave acceleration, which is smaller by an order of magnitude in
+every calibration sea.  This is a first- versus second-order distinction, not a
+tuning accident: to first order the vertical channel does not see tilt error at
+all, because $\vct a_w-\vct g$ is almost exactly $-g\vct e_z$ and
+$\Skew{\vct e_z}$ annihilates its own axis.  The natural definition is
+therefore the spectral one,
+\begin{equation}
+ \mat Q_{\mathrm{eff}}=\mat S_{\varepsilon_a}(0),
+ \qquad
+ q_{\mathrm{eff},i}=\vct e_i^{T}\mat S_{\varepsilon_a}(0)\vct e_i ,
+\label{eq:riccati-axis-qeff}
+\end{equation}
+which is preferable to forcing attitude, bias and model error into a fictitious
+white $r_{a,i}$.
+
+\paragraph{Per-axis $m_{-4}$.}
+Equally, \eqref{eq:riccati-m4} generalizes by replacing the elevation spectrum
+with the spectrum of the displacement component the constraint acts on,
+\begin{equation}
+ m_{-4,i}=\int_0^\infty\frac{S_{p_i}(\omega)}{\omega^4}\,d\omega
+ =\Var\!\left[\textstyle\int S_i\,dt\right]
+ =\int_0^\infty\frac{S_{a_i}(\omega)}{\omega^8}\,d\omega .
+\label{eq:riccati-axis-m4}
+\end{equation}
+The last form shows why this quantity must be band-limited in practice: the
+$\omega^{-8}$ weight puts essentially all of it on the lowest resolved
+frequencies, so it is taken from the reference channel over the band the sea
+actually occupies, never from the estimate.  The complete object is the matrix
+\begin{equation}
+ \mat M_{-4}=\int_0^\infty\frac{\mat S_p(\omega)}{\omega^4}\,d\omega ,
+\label{eq:riccati-axis-m4-matrix}
+\end{equation}
+whose diagonal is \eqref{eq:riccati-axis-m4} and whose off-diagonal entries
+carry the directional correlation between $x$ and $y$.  For a directional sea
+$\mat M_{-4}$ is not diagonal in NED, so the componentwise reading below is a
+choice, not an identity; the rotated reading it invites is noted in
+Sec.~\ref{sec:riccati-per-axis-limits} and deliberately not deployed here.
+
+\paragraph{Measurement.}
+Both quantities are measured directly from the simulator rather than inferred
+(\texttt{tools/ou\_axis\_rs\_optimum.py}), over the same trailing
+\SI{900}{s} window the validation study scores, by Welch periodogram with
+\SI{300}{s} Hann segments at \SI{75}{\percent} overlap.  For $q_{\mathrm{eff},i}$
+the residual $\varepsilon_{a,i}=\hat a_{w,i}-a_{w,i}^{\mathrm{ref}}$ is formed
+and its drift-band spectrum --- everything below the bottom edge of the sea's
+own energy --- fitted to $2P_i\mu_i/(\mu_i^2+\omega^2)$, whose zero-frequency
+value is $q_{\mathrm{eff},i}$.  For $m_{-4,i}$ the reference displacement
+spectrum is integrated against $\omega^{-4}$ over that same wave band.
+Table~\ref{tab:riccati-axis-ratios} gives the result for the eight stationary
+calibration seas.
+
+\begin{table}[t]
+\caption{Per-axis drift-band intensity and true-displacement moment, measured
+over the trailing \SI{900}{s} of the eight stationary calibration records, with
+the regularizer ratio \eqref{eq:riccati-axis-ratio} they imply.  The deployed
+filter runs $\rho_{xy}=1$, i.e.\ unity in both of the last two columns.}
+\label{tab:riccati-axis-ratios}
+\centering
+\footnotesize
+\begin{tabular}{@{}lrrrrrr@{}}
+\toprule
+& \multicolumn{2}{c}{$q_{\mathrm{eff},i}/q_{\mathrm{eff},z}$}
+& \multicolumn{2}{c}{$m_{-4,i}/m_{-4,z}$}
+& \multicolumn{2}{c}{$r_{S,i}^\star/r_{S,z}^\star$} \\
+\cmidrule(lr){2-3}\cmidrule(lr){4-5}\cmidrule(lr){6-7}
+Sea & $x$ & $y$ & $x$ & $y$ & $x$ & $y$ \\
+\midrule
+JONSWAP $H_s=0.27$  & 106.9 & 229.9 & 0.694 & 0.306 & 1.193 & 0.888 \\
+JONSWAP $H_s=1.50$  &  77.2 & 150.1 & 0.729 & 0.272 & 1.191 & 0.819 \\
+JONSWAP $H_s=4.00$  &  32.7 &  51.9 & 0.677 & 0.320 & 1.085 & 0.813 \\
+JONSWAP $H_s=8.50$  &  73.5 &  60.9 & 0.644 & 0.370 & 1.126 & 0.875 \\
+PM/Stokes $H_s=0.27$& 112.3 & 232.0 & 0.658 & 0.338 & 1.171 & 0.926 \\
+PM/Stokes $H_s=1.50$&  77.5 & 143.9 & 0.703 & 0.293 & 1.173 & 0.843 \\
+PM/Stokes $H_s=4.00$&  49.3 &  84.4 & 0.643 & 0.361 & 1.093 & 0.887 \\
+PM/Stokes $H_s=8.50$&  39.5 &  39.0 & 0.646 & 0.362 & 1.079 & 0.840 \\
+\midrule
+Geometric mean      &  65.4 & 102.3 & 0.674 & 0.326 & \textbf{1.138} & \textbf{0.861} \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+\paragraph{What the measurement says.}
+Four things, and the first three are checks on the measurement itself.
+
+The measured $q_{\mathrm{eff},z}$ runs from \SI{9.3e-7}{m^2/s^3} at
+$H_s=\SI{0.27}{m}$ to \SI{2.0e-5}{m^2/s^3} at $H_s=\SI{8.5}{m}$, bracketing the
+bench floor $2r_a=\SI{2.19e-6}{m^2/s^3}$ of \eqref{eq:riccati-ra-sensor} from
+below in the smallest seas --- as \eqref{eq:riccati-qeff} requires, since
+$q_{\mathrm{eff}}=2r_a(1-1/\mu\tau)<2r_a$ --- and rising above it with sea
+state, which is the model-mismatch term
+\eqref{eq:riccati-Ra-floor-plus-model} showing up on the axis where it is
+weakest.
+
+The measured moments satisfy $m_{-4,x}+m_{-4,y}=m_{-4,z}$ to between
+\SI{0.03}{\percent} and \SI{1.4}{\percent} on all eight records.  That is the
+deep-water orbital identity --- horizontal displacement equal in magnitude to
+vertical, split between the two horizontal axes by the record azimuth --- and
+it is an independent confirmation that \eqref{eq:riccati-axis-m4} is being
+estimated correctly rather than a result in its own right.  It also says the
+$m_{-4}$ anisotropy is pure geometry: at azimuth $\alpha$ the split is
+$\cos^2\alpha:\sin^2\alpha$, broadened toward $1:1$ by the directional spread,
+which is why the measured $0.674:0.326$ sits between $\cos^2 30^\circ:\sin^2
+30^\circ=0.75:0.25$ and even.
+
+The prediction is insensitive to the harder of the two measurements.  Because
+$q_{\mathrm{eff}}$ enters \eqref{eq:riccati-axis-ratio} through the $1/14$
+power, an error of a factor of two in it moves $r_{S,i}^\star$ by
+\SI{5}{\percent} and an error of a factor of ten moves it by
+\SI{18}{\percent}.  Substituting the drift-band plateau mean for the
+Lorentzian fit --- a materially different estimator --- moves the geometric
+means from $1.138$ and $0.861$ to $1.110$ and $0.822$.
+
+Finally, the substantive result.  The horizontal channels carry $65$ to $102$
+times the vertical drift-band intensity, two orders of magnitude, and it buys
+almost nothing: the $1/14$ exponent turns $65\times$ into $1.35\times$, the
+geometric factor $m_{-4,x}/m_{-4,z}=0.674$ pulls back by $0.84\times$, and the
+product is $1.14$.  The deployed isotropic $\rho_{xy}=1$ is within
+\SI{14}{\percent} of the analytic optimum on both horizontal axes, well inside
+the spread of the estimate, whereas the historical $\rho_{xy}=0.36$ was wrong
+by a factor of $3.2$ on $x$ and $2.4$ on $y$ --- and wrong in sign of
+correction on $x$, where the optimum asks for a \emph{looser} anchor than the
+vertical, not a tighter one.  The intuition that drove $\rho_{xy}=0.36$, that
+noisier horizontal channels need harder regularization, is exactly the
+inference \eqref{eq:riccati-axis-ratio} forbids.
+
+\paragraph{Consequences, and what this does not fix.}
+\label{sec:riccati-per-axis-limits}
+The horizontal displacement RMS is overwhelmingly a $q_{\mathrm{eff}}$ problem
+--- the two orders of magnitude in Table~\ref{tab:riccati-axis-ratios} are not
+subtle --- and \eqref{eq:riccati-axis-ratio} says that $R_S$ is the wrong
+instrument against it.  At the optimum the regularizer is already doing what it
+can; the residual is set by $\mathrm{MSE}_{p_i}^\star\propto
+q_{\mathrm{eff},i}^{4/7}m_{-4,i}^{3/7}$, in which $q_{\mathrm{eff}}$ now enters
+with weight $4/7$, eight times its weight in the tuning ratio.  Reducing the
+horizontal error therefore requires reducing $q_{\mathrm{eff},x}$ and
+$q_{\mathrm{eff},y}$ themselves --- that is, better tilt and horizontal-bias
+observability, per \eqref{eq:riccati-axis-tilt-leak} --- and no choice of
+$\rho_{xy}$ substitutes for it.  This is consistent with the direct ablation:
+loosening the anchor toward the horizontal optimum improves the in-band gain
+and worsens total error, because the drift it was holding back is real.
+
+Two limits are worth stating.  The componentwise reading uses only the diagonal
+of $\mat M_{-4}$ and $\mat Q_{\mathrm{eff}}$, and for a directional sea both
+have off-diagonal entries; a reading in the frame that diagonalizes
+$\mat M_{-4}$ would separate the along-crest and cross-crest channels, which
+carry very different low-frequency moments, and is the natural next step but is
+not taken here.  And the whole construction is per-sea and offline: across a factor of thirty in
+$H_s$ the measured ratios span $1.08$--$1.19$ on $x$ and $0.81$--$0.93$ on $y$,
+a spread of \SI{11}{\percent} and \SI{14}{\percent} of their own value, which is
+why a single constant is defensible, but a filter that estimated
+$\mat M_{-4}$ online would not need one.
+
 \subsubsection{The multipliers are calibrated; the floor was not}
 \label{sec:riccati-multiplier-retune}
 

--- a/tools/ou_axis_rs_optimum.py
+++ b/tools/ou_axis_rs_optimum.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Per-axis measurement of the two quantities that set the MSE-optimal R_S.
+
+Section "Riccati interpretation of the S=0 regularizer" of the OU-III paper
+carries the bias--variance optimum for the vertical channel only.  Its result,
+
+    MSE_p(w_R) = 3 q_eff / (2 w_R^3)  +  4 m_{-4} w_R^4,
+    w_R*^7 = (9/32) q_eff / m_{-4},
+    r_S* = (32/9)^{3/7} q_eff^{1/14} m_{-4}^{3/7} T_S^{-1/2},
+
+is not intrinsically vertical: nothing in the derivation of either term uses
+the axis.  Reading it per axis i in {x, y, z} gives
+
+    r_S*_i / r_S*_j = (q_i/q_j)^{1/14} (m_i/m_j)^{3/7},
+
+so the anisotropy the filter should deploy is fixed by two measurable
+quantities and no new calibration constant.  The exponents are wildly
+unequal: the drift-noise intensity enters with weight 1/14 and the true
+displacement moment with weight 3/7, six times larger.  Observing that x and y
+carry more acceleration error is therefore *not* on its own an argument for a
+tighter horizontal anchor.
+
+This driver measures both, per axis, from simulator output rather than
+inferring them from the IMU white-noise floor.
+
+    q_eff,i = S_eps_i(0),   eps_i(t) = acc_est_i(t) - acc_ref_i(t)
+
+is the zero-frequency intensity of the *posterior acceleration error*, which
+the paper notes is dominated by attitude error through gravity and by residual
+accelerometer bias, not by the sensor floor.  It is read off a Lorentzian
+    S_eps(w) ~ 2 P mu / (mu^2 + w^2)
+fitted over the drift band, i.e. below the sea's own energy.
+
+    m_{-4,i} = int S_p_i^truth(w) / w^4 dw
+
+is the negative fourth moment of the *true* displacement spectrum -- the real
+motion the S_i = 0 constraint destroys.  It is taken from the reference
+columns, never the estimate, and band-limited at the bottom edge of the wave
+band because the 1/w^4 weight would otherwise amplify the estimator floor.
+
+Typical use:
+
+    python3 tools/ou_axis_rs_optimum.py
+    python3 tools/ou_axis_rs_optimum.py --glob 'tests/kalman_ou_ii/w3d_*_ou2.csv'
+    python3 tools/ou_axis_rs_optimum.py --csv-out axis_rs.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import glob as globmod
+import math
+import os
+import re
+import sys
+
+import numpy as np
+
+# Fraction of reference displacement power left below the wave band.  The
+# bottom edge found this way is where the sea's own energy starts; below it the
+# synthetic records carry nothing, so it is also the honest floor for the
+# 1/w^4 integrand.
+BAND_FLOOR_FRACTION = 0.005
+BAND_CEIL_FRACTION = 0.995
+
+# Welch settings.  300 s segments at 75 percent overlap keep ~9 averages inside
+# a 900 s window while still resolving the drift band below the sea.
+SEGMENT_SECONDS = 300.0
+OVERLAP = 0.75
+
+AXES = ("x", "y", "z")
+
+
+def welch_psd(x: np.ndarray, fs: float, nseg: int,
+              overlap: float = OVERLAP) -> tuple[np.ndarray, np.ndarray]:
+    """One-sided PSD in units per rad/s, so int S dw recovers the variance."""
+    win = np.hanning(nseg)
+    step = max(1, int(round(nseg * (1.0 - overlap))))
+    starts = range(0, len(x) - nseg + 1, step)
+    acc = np.zeros(nseg // 2 + 1)
+    count = 0
+    for s in starts:
+        seg = x[s:s + nseg]
+        spec = np.fft.rfft((seg - seg.mean()) * win)
+        acc += np.abs(spec) ** 2
+        count += 1
+    if count == 0:
+        raise ValueError("window shorter than one Welch segment")
+    # Per-Hz one-sided, then per rad/s.
+    psd_hz = 2.0 * acc / (count * fs * np.sum(win ** 2))
+    freqs = np.fft.rfftfreq(nseg, 1.0 / fs)
+    return 2.0 * math.pi * freqs, psd_hz / (2.0 * math.pi)
+
+
+def wave_band(w: np.ndarray, psd: np.ndarray) -> tuple[float, float]:
+    """Bottom and top edge of the band carrying the reference energy."""
+    total = float(np.trapezoid(psd, w))
+    if total <= 0.0:
+        return float(w[1]), float(w[-1])
+    cum = np.concatenate(([0.0], np.cumsum(0.5 * (psd[1:] + psd[:-1]) * np.diff(w)))) / total
+    lo = float(np.interp(BAND_FLOOR_FRACTION, cum, w))
+    hi = float(np.interp(BAND_CEIL_FRACTION, cum, w))
+    return lo, hi
+
+
+def fit_lorentzian(w: np.ndarray, psd: np.ndarray) -> tuple[float, float]:
+    """Fit S(w) = 2 P mu / (mu^2 + w^2) over a drift band; return (S(0), mu).
+
+    1/S is linear in w^2 with slope 1/(2 P mu) and intercept mu/(2 P), so the
+    fit is a straight line in w^2 and needs no iteration.  A non-positive or
+    non-finite slope means the band shows no roll-off; fall back to the plateau
+    mean, which is what S(0) degenerates to for mu well above the band.
+    """
+    good = np.isfinite(psd) & (psd > 0.0)
+    if good.sum() < 4:
+        return float("nan"), float("nan")
+    x = w[good] ** 2
+    y = 1.0 / psd[good]
+    slope, intercept = np.polyfit(x, y, 1)
+    if not (np.isfinite(slope) and np.isfinite(intercept)) \
+            or slope <= 0.0 or intercept <= 0.0:
+        return float(np.mean(psd[good])), float("inf")
+    mu = math.sqrt(intercept / slope)
+    return float(1.0 / intercept), float(mu)
+
+
+def negative_fourth_moment(w: np.ndarray, psd: np.ndarray, w_lo: float,
+                           w_hi: float) -> float:
+    """int S_p(w)/w^4 dw over the band the sea actually occupies."""
+    sel = (w >= w_lo) & (w <= w_hi)
+    if sel.sum() < 2:
+        return float("nan")
+    return float(np.trapezoid(psd[sel] / w[sel] ** 4, w[sel]))
+
+
+def scenario_label(path: str) -> str:
+    base = os.path.basename(path)
+    base = re.sub(r"^w3d_", "", base)
+    base = re.sub(r"_fusion.*$", "", base)
+    m = re.match(r"([a-z]+)_H([0-9.]+)_", base)
+    return f"{m.group(1)} Hs={float(m.group(2)):.2f}" if m else base
+
+
+def analyse(path: str, window_s: float) -> dict | None:
+    data = np.genfromtxt(path, delimiter=",", names=True)
+    if data.size == 0 or "time" not in (data.dtype.names or ()):
+        return None
+    t = data["time"]
+    mask = t >= t[-1] - window_s
+    t = t[mask]
+    if len(t) < 16:
+        return None
+    dt = float(np.median(np.diff(t)))
+    fs = 1.0 / dt
+    nseg = int(round(SEGMENT_SECONDS * fs))
+    if nseg > len(t):
+        nseg = 1 << int(math.floor(math.log2(len(t))))
+
+    out: dict = {"scenario": scenario_label(path), "path": path}
+    for ax in AXES:
+        acc_err = data["acc_est_" + ax][mask] - data["acc_ref_" + ax][mask]
+        disp_ref = data["disp_ref_" + ax][mask]
+
+        w, psd_ref = welch_psd(disp_ref, fs, nseg)
+        w_lo, w_hi = wave_band(w, psd_ref)
+
+        _, psd_err = welch_psd(acc_err, fs, nseg)
+        drift = (w > 0.0) & (w < w_lo)
+        q_eff, mu = fit_lorentzian(w[drift], psd_err[drift])
+        plateau = float(np.mean(psd_err[drift])) if drift.sum() else float("nan")
+
+        out[ax] = {
+            "q_eff": q_eff,
+            "q_plateau": plateau,
+            "mu": mu,
+            "m4": negative_fourth_moment(w, psd_ref, w_lo, w_hi),
+            "band_lo_hz": w_lo / (2.0 * math.pi),
+            "band_hi_hz": w_hi / (2.0 * math.pi),
+            "acc_err_rms": float(np.sqrt(np.mean(acc_err ** 2))),
+            "disp_ref_rms": float(np.sqrt(np.mean(disp_ref ** 2))),
+            "n_drift_bins": int(drift.sum()),
+        }
+    return out
+
+
+def rs_ratio(q_i: float, q_z: float, m_i: float, m_z: float) -> float:
+    """r_S*_i / r_S*_z from the per-axis optimum: q^{1/14} m^{3/7}."""
+    if not all(map(np.isfinite, (q_i, q_z, m_i, m_z))) or q_z <= 0 or m_z <= 0:
+        return float("nan")
+    return (q_i / q_z) ** (1.0 / 14.0) * (m_i / m_z) ** (3.0 / 7.0)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--glob", default="tests/kalman_ou_iii/w3d_*_fusion_ou3.csv",
+                    help="fusion timeseries to analyse")
+    ap.add_argument("--window-sec", type=float, default=900.0,
+                    help="trailing window scored, matching the validation study")
+    ap.add_argument("--csv-out", default=None, help="write the table as CSV")
+    args = ap.parse_args(argv)
+
+    paths = sorted(globmod.glob(args.glob))
+    if not paths:
+        print(f"no files matched {args.glob!r}", file=sys.stderr)
+        return 1
+
+    rows = []
+    for path in paths:
+        res = analyse(path, args.window_sec)
+        if res is not None:
+            rows.append(res)
+    if not rows:
+        print("no usable records", file=sys.stderr)
+        return 1
+
+    print("Per-axis drift-noise intensity and true-displacement moment")
+    print(f"  window {args.window_sec:.0f} s, Welch {SEGMENT_SECONDS:.0f} s "
+          f"segments at {OVERLAP:.0%} overlap")
+    print()
+    head = (f"{'scenario':22}{'band lo':>9}"
+            + "".join(f"{'q_' + a:>11}" for a in AXES)
+            + "".join(f"{'m4_' + a:>11}" for a in AXES))
+    print(head)
+    print("-" * len(head))
+    for r in rows:
+        print(f"{r['scenario']:22}{r['z']['band_lo_hz']:9.4f}"
+              + "".join(f"{r[a]['q_eff']:11.3e}" for a in AXES)
+              + "".join(f"{r[a]['m4']:11.3e}" for a in AXES))
+
+    print()
+    head2 = (f"{'scenario':22}"
+             + f"{'qx/qz':>9}{'qy/qz':>9}{'m4x/m4z':>10}{'m4y/m4z':>10}"
+             + f"{'rSx/rSz':>10}{'rSy/rSz':>10}")
+    print(head2)
+    print("-" * len(head2))
+    for r in rows:
+        qx = r["x"]["q_eff"] / r["z"]["q_eff"]
+        qy = r["y"]["q_eff"] / r["z"]["q_eff"]
+        mx = r["x"]["m4"] / r["z"]["m4"]
+        my = r["y"]["m4"] / r["z"]["m4"]
+        print(f"{r['scenario']:22}{qx:9.2f}{qy:9.2f}{mx:10.3f}{my:10.3f}"
+              f"{rs_ratio(r['x']['q_eff'], r['z']['q_eff'], r['x']['m4'], r['z']['m4']):10.3f}"
+              f"{rs_ratio(r['y']['q_eff'], r['z']['q_eff'], r['y']['m4'], r['z']['m4']):10.3f}")
+
+    def geo(vals):
+        vals = [v for v in vals if np.isfinite(v) and v > 0]
+        return math.exp(sum(map(math.log, vals)) / len(vals)) if vals else float("nan")
+
+    print()
+    print("geometric mean over scenarios:")
+    for ax in ("x", "y"):
+        print(f"  {ax}: q/qz={geo([r[ax]['q_eff'] / r['z']['q_eff'] for r in rows]):6.2f}"
+              f"  m4/m4z={geo([r[ax]['m4'] / r['z']['m4'] for r in rows]):6.3f}"
+              f"  rS*/rS*z={geo([rs_ratio(r[ax]['q_eff'], r['z']['q_eff'], r[ax]['m4'], r['z']['m4']) for r in rows]):6.3f}")
+    print("  deployed: rSx/rSz = rSy/rSz = 1.000 (isotropic R_S_xy_factor)")
+
+    if args.csv_out:
+        with open(args.csv_out, "w", newline="") as fh:
+            wtr = csv.writer(fh)
+            wtr.writerow(["scenario", "axis", "q_eff", "q_plateau", "mu",
+                          "m4", "band_lo_hz", "band_hi_hz", "acc_err_rms",
+                          "disp_ref_rms", "rs_ratio_vs_z"])
+            for r in rows:
+                for ax in AXES:
+                    wtr.writerow([r["scenario"], ax, r[ax]["q_eff"],
+                                  r[ax]["q_plateau"], r[ax]["mu"], r[ax]["m4"],
+                                  r[ax]["band_lo_hz"], r[ax]["band_hi_hz"],
+                                  r[ax]["acc_err_rms"], r[ax]["disp_ref_rms"],
+                                  rs_ratio(r[ax]["q_eff"], r["z"]["q_eff"],
+                                           r[ax]["m4"], r["z"]["m4"])])
+        print(f"\nwrote {args.csv_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Extends the scalar MSE derivation in Sec. XII-F14 to be axis-specific, and measures the two quantities it depends on. Nothing in the derivation of either term uses the axis, so this is a direct extension of the manuscript's own equations rather than a new model.

## What it adds

**`tools/ou_axis_rs_optimum.py`** — measures, per axis and per sea:

- `q_eff,i = S_eps_i(0)`, the zero-frequency intensity of the posterior acceleration error `acc_est_i - acc_ref_i`, read off a Lorentzian `2 P mu / (mu^2 + w^2)` fitted over the drift band (below the sea's own energy);
- `m_{-4,i} = int S_p_i(w)/w^4 dw`, the negative fourth moment of the **true** displacement spectrum, taken from the reference channel and band-limited at the bottom edge of the wave band because the `w^-4` weight would otherwise amplify the estimator floor.

**`doc/kalman_ou_iii/w3d-rs-similarity-design-guidance.tex-part`** — new Sec. XII-F15, "Reading the optimum per axis", carrying the per-axis optimum, the accelerometer-Jacobian argument for why `q_eff` is anisotropic, the per-axis and matrix-valued moments, the ratio law, the measured table, and the limits.

**`doc/kalman_ou_iii/w3d-fus-methods.tex-part`** — cross-reference from the anisotropic-parameterization section, plus a label on the `rho_xy` display so it can be referenced.

## The result

The regularizer ratio needs no new calibration constant:

```
r_S*_i / r_S*_j = (q_i/q_j)^(1/14) (m_i/m_j)^(3/7)
```

Measured over the eight stationary calibration seas (geometric means): the horizontal channels carry **65x** (x) and **102x** (y) the vertical drift-band intensity — the `g * delta_theta` leak, which is first-order on x/y and only second-order on z — but `m_{-4,x}/m_{-4,z} = 0.674` and `m_{-4,y}/m_{-4,z} = 0.326`. The 1/14 exponent turns 65x into 1.35x, the geometric factor pulls back by 0.84x, and the product is:

| | r_S*x / r_S*z | r_S*y / r_S*z |
|---|---|---|
| predicted | 1.138 | 0.861 |
| deployed (`rho_xy = 1`) | 1.000 | 1.000 |
| retired (`rho_xy = 0.36`) | 0.360 | 0.360 |

So the deployed isotropy is within 14% of the analytic optimum on both horizontal axes, while the retired 0.36 was wrong by a factor of 3.2 — and wrong in the sign of the correction on x, where the optimum asks for a *looser* horizontal anchor than the vertical. The intuition that noisier horizontal channels need harder regularization is the inference the ratio law forbids.

## Checks on the measurement

- `q_eff,z` runs 9.3e-7 to 2.0e-5 m^2/s^3 across the envelope, bracketing the bench floor `2 r_a = 2.19e-6` from below in the smallest seas — as `q_eff = 2 r_a (1 - 1/mu tau) < 2 r_a` requires — and rising above it with sea state.
- `m_{-4,x} + m_{-4,y} = m_{-4,z}` to between 0.03% and 1.4% on all eight records. That is the deep-water orbital identity, unforced, and it says the `m_{-4}` anisotropy is pure geometry: `cos^2 alpha : sin^2 alpha`, broadened toward 1:1 by the directional spread.
- The prediction is insensitive to the harder measurement: a factor of two error in `q_eff` moves the ratio by 5%, a factor of ten by 18%. Substituting the drift-band plateau mean for the Lorentzian fit moves the geometric means from 1.138/0.861 to 1.110/0.822.

## What this does not fix

Horizontal displacement RMS is overwhelmingly a `q_eff` problem, and the ratio law says `R_S` is the wrong instrument against it. At the optimum `MSE* ~ q_eff^(4/7) m_{-4}^(3/7)`, in which `q_eff` carries eight times its weight in the tuning ratio. Reducing horizontal error requires reducing `q_eff` itself — tilt and horizontal-bias observability — and no choice of `rho_xy` substitutes for it. This is consistent with the direct ablation, where loosening the anchor toward the horizontal optimum improves in-band gain and worsens total error.

Two limits are stated in the text: the componentwise reading uses only the diagonals of `M_{-4}` and `Q_eff`, which are not diagonal in NED for a directional sea — the rotated (wave-aligned) reading is noted as the natural next step and deliberately not taken here — and the construction is per-sea and offline.

## Validation

- Paper compiles: 42 pages, **0 undefined references**, no errors in the added content.
- `make build`: clean, exit 0, no warnings across all 14 test directories.
- Quality gates: 24/24 pass, 0 fail.
- `tests/validation`: 83/83 pass.

Docs-and-tooling only — no filter or runtime code is touched, so no numerical results change.

`.gitignore` additionally covers `doc/**/*.pgf` and latexmk build products, which are CI-generated and were previously untracked-but-not-ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JkHCh1Y2tDpGDdYWwvgzK

---
_Generated by [Claude Code](https://claude.ai/code/session_017JkHCh1Y2tDpGDdYWwvgzK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified per-axis regularizer optimization and horizontal/vertical anisotropy.
  * Documented calibration findings, limitations, and recommended tuning guidance.
  * Updated mathematical notation and labeling for integral pseudo-measurement scaling.

* **New Features**
  * Added a command-line analysis tool for estimating axis-specific regularizer ratios from simulator data.
  * Supports spectral analysis, scenario summaries, validation, and optional CSV output.

* **Chores**
  * Ignored generated LaTeX build artifacts under documentation directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->