### PR TITLE
Take the OU operating point off the acceleration-band frequency tracker

### DIFF
--- a/TLDR.md
+++ b/TLDR.md
@@ -8,7 +8,8 @@ In simple terms:
 - So Joseph form and small-series approximations are used for numerical stability.
 - Includes double-integration drift-correction pseudo-measurements.
 - Kalman parameters must be and are adapted to match actual sea states.
-- Adaptation uses acceleration-frequency tracking for time-scale tuning, and direct acceleration-variance estimation for amplitude-scale tuning.
+- Adaptation uses the wave-band zero-crossing period for time-scale tuning, and direct acceleration-variance estimation for amplitude-scale tuning.
+- Acceleration-frequency tracking is kept for wave direction, which needs a carrier rather than a sea state.
 - IMU sample timestamps are tracked accurately. Correct sample timestamps are very important due to samples being double integrated over time steps.
 - Performs initial learning of gravity relation to magnetic field needed because sensor might be turned on when already in waves motion
 - Optional wave shape de-trending to correct post-estimated displacememt drifts due to unmodelled biases

--- a/docs/ou-sigma-horizon.md
+++ b/docs/ou-sigma-horizon.md
@@ -1,0 +1,287 @@
+# Taking the OU operating point off the acceleration-band frequency tracker, and re-gauging the `sigma_a` horizon
+
+Two changes, one cause. The OU adaptation path had one remaining read of the
+acceleration-band frequency tracker, and that read also fixed the units of the
+`sigma_a` averaging horizon. Removing the read makes the horizon mean something
+different, so it has to be re-measured.
+
+Everything below is measured on the versioned simulation records
+(`bareboat-necessities/oceanography-waves-lib`, `v1.1.3`) with
+`tests/kalman_ou_ii/kalman_ou_ii-sim` and
+`tests/kalman_ou_iii/kalman_ou_iii-sim`, scoring the trailing 900 s of a 1200 s
+replay. `tools/ou_sigma_horizon_study.py` reproduces every table.
+
+**Result.** The tracker is gone from the adaptation path and costs nothing:
+pooled vertical RMS moves by 0.00%, worst record 0.11%. `K_periods` stays at
+`2.0`. It is not the value anyone would pick from first principles now that it
+means something different, but the sweep says the alternatives trade one
+interval of a sea-state transition for another and net to nothing, so there is
+no free improvement to take. What the sweep does establish is that `2.0` is on
+the correct side of the optimum -- halving it costs 1% -- and the constant is
+now a settable, measured knob rather than an inherited one.
+
+## 1. What was still coupled
+
+`SeaStateFusionFilter_OU_II` and `_OU_III` run two frequency estimators side by
+side, and they measure different things:
+
+| estimator | band | what it is for |
+| --- | --- | --- |
+| `TrackerPolicy` (KalmANF / Aranovskiy / PLL / Schmitt) | acceleration | carrier of the wave-direction demodulator |
+| `WavePeriodEstimator` | wave (elevation) | `T_z`, from which the OU operating point is built |
+
+They are not interchangeable. An ocean acceleration spectrum is the elevation
+spectrum weighted by `(2*pi*f)^4`, so its apparent frequency sits well above the
+spectral peak and barely moves as the sea grows: across the reference family the
+elevation zero-crossing period spans 2.3-8.4 s while the acceleration band stays
+near 0.42-0.55 Hz.
+
+The operating point already came from `WavePeriodEstimator` — but only once that
+estimator reported `isReady()`, and that gate does not clear early:
+
+| record | wave period ready | Live |
+| --- | --- | --- |
+| JONSWAP H_s = 0.27 m | 62.2 s | 22.0 s |
+| JONSWAP H_s = 1.50 m | 70.8 s | 52.1 s |
+| JONSWAP H_s = 4.00 m | 82.7 s | 109.1 s |
+| JONSWAP H_s = 8.50 m | 84.4 s | 107.1 s |
+| PM-Stokes H_s = 0.27 m | 61.9 s | 22.0 s |
+| PM-Stokes H_s = 8.50 m | 77.9 s | 150.0 s |
+
+Until then `tuner_frequency_hz_()` returned the tracker's output, and three
+things downstream consumed it: the corners of `AdaptiveWaveBandPass`, the
+`sigma_a` averaging horizon inside `SeaStateAutoTuner`, and `tau` itself. On the
+two smallest seas the filter is already Live 40 s before the period estimator
+is, so it spent that time adapting on an acceleration-band frequency.
+
+Two smaller couplings went with it. The tuning frequency was clamped to
+`[MIN_TUNE_FREQ_HZ, MAX_FREQ_HZ]`, the upper bound being the *tracker's*, so
+`setFreqBounds()` — a wave-direction knob — reached the OU operating point.
+It is now clamped to `[MIN_TUNE_FREQ_HZ, MAX_TUNE_FREQ_HZ]`, neither of which
+binds on any reference record.
+
+The stillness detector still shares the tracker's low-pass input, and that is
+not a tracker dependence: it reads the filtered acceleration, never the
+tracker's output frequency.
+
+## 2. The replacement
+
+`TunerFrequencySource::WaveBand`, now the default in both families, changes two
+things at once, so a third value exists to separate them:
+
+| source | before the estimator has a value | when it has one |
+| --- | --- | --- |
+| `TrackerFallback` (legacy) | tracker output | at `isReady()` |
+| `WaveBandGated` (ablation) | 0.2 Hz prior | at `isReady()` |
+| `WaveBand` (deployed) | 0.2 Hz prior | as soon as it is finite |
+
+The prior is a constant because that is what makes the schedule exogenous at
+every instant of the run rather than only after the gate clears — a constant is
+trivially a pure function of no measurement at all. 0.2 Hz is a 5 s
+zero-crossing period, against the 2.3-8.4 s the estimator reports across the
+reference family, and it is the same constant `SeaStateFusionFilter_TFG` has always used
+in this position. This change brings the two OU families into line with TFG
+rather than inventing a policy for them.
+
+`WaveBand` also stops waiting for `isReady()`. That gate wants a settled
+*statistic*; a value that has merely survived the integrators' settling
+transient is already a far better wave-band estimate than a constant, and it
+appears about 50 s into a run instead of 60-85 s.
+
+### What it costs
+
+Ratios to `tracker_fallback` on the identical realization, eight stationary
+records plus one crossfade, default seeds:
+
+| family | metric | `wave_band_gated` | `wave_band` | largest single-record change |
+| --- | --- | --- | --- | --- |
+| OU-II | vertical RMS | 1.0000 | 1.0000 | +0.02% |
+| OU-II | 3D RMS | 1.0000 | 1.0000 | +0.03% |
+| OU-III | vertical RMS | 1.0000 | 1.0000 | +0.01% |
+| OU-III | 3D RMS | 1.0000 | 0.9999 | -0.11% |
+
+Nothing, to three decimal places, and nothing on the crossfade intervals either
+(largest segment ratio 0.9993, on OU-II's blend). That is the expected answer and the reason the
+change is safe: the scoring window opens at 300 s, by which time both sources
+have long since converged on the same wave-band frequency, and the filter's
+memory of the first minute has washed out.
+
+The value of the change is therefore not in the scored window. It is that the
+adaptation path is now a function of one physically correct band at every
+instant, that `setFreqBounds()` and the choice of tracker no longer reach it,
+and that the exogeneity argument in the stability appendix holds from the first
+sample rather than from `isReady()`.
+
+`tests/kalman_ou_iii/tuner_coupling-test.cpp` pins this: two filters differing
+in nothing but their `TrackerType` are driven with identical samples, and at
+30 s — where the two trackers report 0.297 and 0.112 Hz — `tau`, `sigma_a`,
+`r_S` and the sigma band's corners must be bit-identical. Under
+`TrackerFallback` that check fails, on the settled comparison as well as the
+early one: the divergence the tracker injects in the first minute survives in
+the tuner's own EMAs long after the period estimator has taken over.
+
+## 3. Why the `sigma_a` horizon had to be re-gauged
+
+`SeaStateAutoTuner` averages the band-limited acceleration variance over
+`tau_var = K_periods * T_eff`, where `T_eff` is the period of whatever tuning
+frequency it is fed. It is a two-stage EWMA — mean and square, then the variance
+— so the memory is about `2 * tau_var`.
+
+`K_periods` has been 2.0 since the tuner was written, when `T_eff` was the
+acceleration band's period. That band does not move with sea state, so `K = 2`
+meant a horizon of about 4 s on every record. Once the operating point moved to
+the wave band the same constant became `2 * T_z`:
+
+| record | `T_z` | horizon at `K = 2` | memory | horizon at `K = 4` | memory |
+| --- | --- | --- | --- | --- | --- |
+| JONSWAP H_s = 0.27 m | 2.60 s | 5.2 s | 10.4 s | 10.4 s | 20.8 s |
+| JONSWAP H_s = 1.50 m | 4.37 s | 8.7 s | 17.5 s | 17.5 s | 35.0 s |
+| JONSWAP H_s = 4.00 m | 7.09 s | 14.2 s | 28.3 s | 28.3 s | 56.7 s |
+| JONSWAP H_s = 8.50 m | 8.42 s | 16.8 s | 33.7 s | 33.7 s | 67.4 s |
+
+Nobody chose those numbers; they are what the old constant became when the
+frequency underneath it changed by a factor of two to four. That is what this
+section measures.
+
+## 4. The stationary records: shorter is clearly wrong, longer is nearly free
+
+`tools/ou_sigma_horizon_study.py --axis k_periods --seeds 6`. Eight records at
+six IMU seeds, paired on the realization, geometric mean of the per-run ratio to
+`K = 2` with a normal-approximation 95% interval (n = 48):
+
+| `K_periods` | OU-III vertical | OU-III 3D | OU-II vertical | OU-II 3D |
+| --- | --- | --- | --- | --- |
+| 0.5 | 1.0038 [1.0009, 1.0066] | 1.0056 [1.0041, 1.0071] | 1.0096 [1.0065, 1.0127] | 1.0078 [1.0059, 1.0096] |
+| 1 | 1.0025 [1.0009, 1.0040] | 1.0023 [1.0016, 1.0030] | 1.0033 [1.0017, 1.0049] | 1.0031 [1.0021, 1.0042] |
+| 2 (shipped) | 1.0000 | 1.0000 | 1.0000 | 1.0000 |
+| 3 | 0.9991 [0.9983, 0.9999] | 0.9996 [0.9992, 1.0000] | 0.9993 [0.9985, 1.0001] | 0.9991 [0.9986, 0.9996] |
+| 4 | 0.9989 [0.9977, 1.0001] | 0.9996 [0.9990, 1.0003] | 0.9992 [0.9980, 1.0004] | 0.9988 [0.9981, 0.9995] |
+| 6 | 0.9987 [0.9971, 1.0003] | 0.9995 [0.9987, 1.0004] | 0.9992 [0.9976, 1.0007] | 0.9985 [0.9975, 0.9994] |
+| 8 | 0.9986 [0.9968, 1.0003] | 0.9994 [0.9984, 1.0004] | 0.9990 [0.9974, 1.0007] | 0.9982 [0.9972, 0.9992] |
+
+The curve is asymmetric. Halving `K` costs 0.4-1.0%, and the interval excludes
+1 comfortably in every column: at `K = 0.5` the horizon is 1.3-4.2 s and the
+`sigma_a` estimate is passing wave-to-wave variance through into `r_S` rather
+than estimating the sea state. Doubling it, by contrast, buys about 0.1% and
+then saturates: `K = 3` and `K = 8` are indistinguishable. Whatever the
+stationary records are measuring, it is already finished by three wave periods.
+
+## 5. Sea-state transitions: the two intervals disagree
+
+A stationary record cannot price a lag. The instrument for that is the
+crossfade: `tools/ou_ema_adapt_study.py transition` builds records that blend
+two independently phase-randomized realizations over 420-780 s, in both
+directions and on two endpoint pairs an octave apart in wave period, and scores
+the three intervals of the 900 s window separately (n = 12 records: 2 pairs x
+2 directions x 3 wave-phase seeds, OU-III).
+
+Vertical RMS, geometric mean of the ratio to `K = 2`, and the worst single
+record in the ensemble:
+
+| `K_periods` | blend | blend worst | end sea | end worst | whole window |
+| --- | --- | --- | --- | --- | --- |
+| 1 | 1.0042 | 1.0116 | 0.9940 | 1.0002 | 0.9987 |
+| 2 (shipped) | 1.0000 | 1.0000 | 1.0000 | 1.0000 | 1.0000 |
+| 3 | 0.9973 | 1.0005 | 1.0043 | 1.0112 | 1.0009 |
+| 4 | 0.9947 | 1.0007 | 1.0070 | 1.0190 | 1.0010 |
+| 6 | 0.9894 | 1.0022 | 1.0096 | 1.0251 | 0.9999 |
+| 8 | 0.9849 | 1.0023 | 1.0103 | 1.0250 | 0.9984 |
+
+The two intervals move in opposite directions, monotonically, and they very
+nearly cancel. That is the signature of a bias-variance trade rather than of a
+mis-set constant:
+
+- **While the sea state is moving**, the crossfade is where `sigma_a` is
+  hardest to estimate — the record is genuinely bimodal, so the instantaneous
+  variance swings widely — and a longer memory rejects those swings. Hence the
+  blend improves monotonically out to `K = 8`.
+- **Once it has stopped moving**, the same memory is still carrying the
+  transition. At `K = 8` and `T_z = 8.4 s` the two-stage EWMA remembers about
+  120 s, so a quarter of the 420 s endpoint interval is scored on a `sigma_a`
+  the previous sea contributed to. Hence the endpoint sea degrades
+  monotonically, by up to 2.5% on the worst record.
+
+Whole-window ratios of 0.9984 to 1.0010 across a sixteen-fold change in `K` say
+those two effects are the same size. There is no fixed `K` that takes the blend
+gain without the endpoint cost, so `K` stays at 2.0: it does not regress
+anything, and moving it would buy one interval of a transition by selling
+another.
+
+The one unambiguous finding is the direction. `K = 1` is worse on the blend
+(1.0042) *and* on the stationary ensemble (1.0025-1.0033), so the shipped value
+is on the correct side of the trade and the pre-existing constant survives the
+change of units it was subjected to. Getting the blend gain *and* the endpoint
+recovery needs a horizon that shortens when the sea state actually moves — the
+same two-regime problem `adaptiveSmoothingHorizonSec()` already solves for the
+`r_S` channel with its `slew_log` term. That is not attempted here: the
+detector would have to compare two variance timescales rather than a target
+against an applied value, and it introduces a constant of its own that this
+evidence cannot fit.
+
+## 6. Two constants that turned out not to matter
+
+**The wave-band prior.** `tools/ou_sigma_horizon_study.py --axis prior --seeds 3`
+sweeps it over 0.1-0.4 Hz, a factor of four, i.e. a 2.5-10 s assumed
+zero-crossing period. Every pooled ratio is `1.0000` with a 95% interval of
+`[1.0000, 1.0000]`, in both families, on the stationary records and on all three
+transition intervals. The prior is replaced by a measurement about 50 s into
+the run and the window opens at 300 s, so this is the expected answer; it is
+recorded because a constant that reaches the shipped filter should be shown not
+to matter rather than assumed not to.
+
+**The absolute horizon ceiling.** `--axis horizon_max` at `K = 8`, where the
+ceiling is closest to binding:
+
+| ceiling | OU-III vertical | OU-III blend |
+| --- | --- | --- |
+| 20 s | 1.0005 | 1.0185 |
+| 30 s | 1.0002 | 1.0109 |
+| 60 s (shipped) | 1.0000 | 1.0000 |
+| 120 s | 1.0000 | 0.9999 |
+| 240 s | 1.0000 | 0.9999 |
+
+Raising it changes nothing, which is what confirms section 5 is measuring `K`
+and not the clamp: at `K = 8` the requested horizon reaches 67 s on the largest
+sea, so the ceiling trims it by 10% there and by nothing anywhere else. Lowering
+it to 20 or 30 s does bind, and reproduces the short-horizon penalty from the
+other direction.
+
+## 7. What shipped
+
+| | before | after |
+| --- | --- | --- |
+| tuning frequency source | tracker until `wavePeriodReady()` | `WavePeriodEstimator`, else a 0.2 Hz constant |
+| tuning frequency ceiling | `MAX_FREQ_HZ` (tracker's) | `MAX_TUNE_FREQ_HZ` |
+| `K_periods` | 2.0, inherited | 2.0, measured |
+
+New API on both filters, and the environment overrides the simulators read:
+
+| setter | environment variable |
+| --- | --- |
+| `setTunerFrequencySource()` | `W3D_TUNER_FREQ_SOURCE` |
+| `setTuneFreqPriorHz()` | `OU_TUNE_FREQ_PRIOR_HZ` |
+| `setTuneFreqBounds()` | — |
+| `setSigmaVarianceKPeriods()` | `OU_SIGMA_VAR_K_PERIODS` |
+| `setSigmaVarianceHorizonBounds()` | `OU_SIGMA_VAR_HORIZON_MIN_S`, `OU_SIGMA_VAR_HORIZON_MAX_S` |
+
+`getSigmaVarianceHorizonSec()` reports the horizon currently in force, so the
+number in the table of section 3 can be read out of a running filter instead of
+recomputed.
+
+## 8. One quality-gate sentinel moved
+
+The OU-III simulator's pitch sentinel was cut at 0.2211 deg, half a percent
+above the 0.2200 deg the filter produced on PM-Stokes H_s = 4.0 m at the
+default seed. After the change that record reports 0.2218 deg, 0.83% up, so
+the gate is re-cut to 0.223 by `tools/ou_regauge_gates.py` and the rule in
+`docs/quality-gate-regauge.md`.
+
+That is a re-draw rather than a pitch regression, and it is worth saying why
+the distinction is not special pleading. Paired over five IMU seeds and all
+eight records, the pitch ratio is 0.9999 with a 95% interval of
+[0.9989, 1.0010] — no systematic effect, resolved ten times finer than the move
+on this one record. Roll is 0.9999 [0.9997, 1.0001] and yaw 0.9998
+[0.9992, 1.0004]. The one record that moves is the one the gate happens to be
+written against, and it moves inside its own scatter.
+
+None of the other eight limits moved, and none were re-cut.

--- a/docs/ou-validation.md
+++ b/docs/ou-validation.md
@@ -67,7 +67,8 @@ filter once on a noise-free, unrandomized 1200 s record, reading its final
 `r_p0 = clip(0.6 * sigma_aw * tau**2, 0.05, 150)` together with
 `r_v0 = clip(1.1 * sigma_aw * tau, 0.01, 40)`. Both families derive `tau` from
 the same wave-band zero-crossing period, `tau = T_z / 2`; neither reads the
-acceleration-band frequency tracker for tuning.
+acceleration-band frequency tracker for tuning, at any point in the run
+(see `docs/ou-sigma-horizon.md`).
 No fixed point is optimized against displacement error. The exact
 frozen values for the committed study are in `fixed_tuning_points` in the
 manifest and are typeset by `ou_validation_tuning_points.tex`.

--- a/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
+++ b/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
@@ -27,9 +27,12 @@
       SeaStateAutoTuner, which estimates acceleration variance and applies the
       σₐ·τ² and σₐ·τ regularization laws to stabilize displacement drift
       correction.  The time scale those laws are built on comes from
-      WavePeriodEstimator, not from the acceleration-band frequency tracker;
-      see "Where" below.  The variance channel first applies a period-scaled
-      measurement-only wave band.
+      WavePeriodEstimator, not from the acceleration-band frequency tracker,
+      at every instant of the run: before that estimator has a value a fixed
+      wave-band prior stands in rather than the tracker (see
+      TunerFrequencySource).  See "Where" below.  The variance channel first
+      applies a period-scaled measurement-only wave band, and averages its
+      variance over a horizon of K wave periods.
 
   Where
   – τ (tau):  OU process time constant = ½ · T_z, half the zero-crossing period
@@ -151,6 +154,30 @@ constexpr float MAX_FREQ_HZ = 6.0f;
 // acceleration-band tracker and is far too high for a zero-crossing period:
 // 0.03 Hz admits a 33 s swell.
 constexpr float MIN_TUNE_FREQ_HZ = 0.03f;
+
+// Ceiling for the wave-band tuning frequency.  MAX_FREQ_HZ is the tracker's
+// bound and does not belong in the adaptation path: with the tuning frequency
+// read from the wave band, setFreqBounds() is a wave-direction knob and must
+// not move the OU operating point.  Neither bound binds on any reference
+// record -- the wave band spans 0.12 to 0.40 Hz -- so this is a safety limit,
+// not a tuning surface.  1.5 Hz is a 0.67 s zero-crossing period, shorter than
+// any sea a hull responds to.
+constexpr float MAX_TUNE_FREQ_HZ = 1.5f;
+
+// Wave-band tuning frequency used before WavePeriodEstimator has a value.
+//
+// It has to be a constant: the whole point of the wave-band source is that no
+// part of the adaptation path reads the acceleration-band tracker, and a
+// constant is trivially exogenous.  0.2 Hz is a 5 s zero-crossing period, and
+// the estimator reports 2.3-8.4 s across the reference family, so the prior is
+// never worse than a factor of two off; the estimator replaces it after about
+// 50 s in any case.  It is the same constant SeaStateFusionFilter_TFG has always
+// used for this, which is where the value comes from rather than a fit.
+// Sensitivity to it is measured in docs/ou-sigma-horizon.md: sweeping it over
+// 0.1-0.4 Hz leaves every scored 900 s metric unchanged to four decimal places
+// in both families, because the estimator has replaced it 250 s before the
+// window opens.
+constexpr float TUNE_FREQ_PRIOR_HZ = 0.2f;
 
 // JONSWAP-similar acceleration-variance band, matching OU-III's.  Away from
 // the absolute safety clamps, its transfer shape is fixed in f/f_tune, which
@@ -1049,6 +1076,10 @@ public:
     inline float getR_p0_std_target()  const noexcept { return R_p0_std_target_; }
     inline float getR_v0_std_target()  const noexcept { return R_v0_std_target_; }
 
+    // Apparent period of the *acceleration* band, from the slow tracker
+    // branch.  This is a reporting channel: the OU operating point uses
+    // getWavePeriodSec(), the zero-crossing period of the elevation, which is
+    // a different and much longer quantity.
     inline float getPeriodSec() const noexcept {
         return (freq_hz_slow_ > 1e-6f) ? 1.0f / freq_hz_slow_ : NAN;
     }
@@ -1130,6 +1161,46 @@ public:
     // below the wave band; see VerticalAccelComplementary.h.
     void setWavePeriodComplementaryGains(float two_kp, float two_ki) {
         vertical_accel_comp_.setGains(two_kp, two_ki);
+    }
+
+    // Where the tuning frequency comes from.  WaveBand (default) keeps the
+    // whole adaptation path -- sigma band corners, sigma_a horizon, tau -- off
+    // the acceleration-band frequency tracker at every instant of the run; the
+    // other two are ablations.  See TunerFrequencySource.
+    void setTunerFrequencySource(TunerFrequencySource source) {
+        tuner_freq_source_ = source;
+    }
+    TunerFrequencySource tunerFrequencySource() const noexcept {
+        return tuner_freq_source_;
+    }
+
+    // Wave-band frequency used before WavePeriodEstimator has a value.
+    void setTuneFreqPriorHz(float hz) {
+        if (std::isfinite(hz) && hz > 0.0f) tune_freq_prior_hz_ = hz;
+    }
+    float tuneFreqPriorHz() const noexcept { return tune_freq_prior_hz_; }
+
+    // Bounds on the wave-band tuning frequency.  Distinct from setFreqBounds(),
+    // which bounds the acceleration-band tracker that drives wave direction.
+    void setTuneFreqBounds(float min_hz, float max_hz) {
+        if (!(std::isfinite(min_hz) && std::isfinite(max_hz))) return;
+        if (!(min_hz > 0.0f && max_hz > min_hz)) return;
+        min_tune_freq_hz_ = min_hz;
+        max_tune_freq_hz_ = max_hz;
+    }
+
+    // sigma_a averaging horizon, in periods of the tuning frequency, and its
+    // absolute clamps in seconds.  The horizon moved with the operating point
+    // when tuning moved to the wave band -- the same K is now 5-17 s instead of
+    // about 4 -- so it is a tuning surface; docs/ou-sigma-horizon.md measures it.
+    void setSigmaVarianceKPeriods(float k) { tuner_.setKPeriods(k); }
+    float getSigmaVarianceKPeriods() const noexcept { return tuner_.getKPeriods(); }
+    void setSigmaVarianceHorizonBounds(float min_s, float max_s) {
+        tuner_.setVarianceHorizonBounds(min_s, max_s);
+    }
+    // Horizon currently in force [s]; the variance is a two-stage EWMA at it.
+    float getSigmaVarianceHorizonSec() const noexcept {
+        return tuner_.getVarianceHorizonSec();
     }
 
     inline WaveDirection getDirSignState() const noexcept { return dir_sign_state_; }
@@ -1281,10 +1352,11 @@ private:
             ? tuner_.getFrequencyHz()
             : freq_hz_for_tuner;
         const float f_tune_floor = wave_band_tuning_ ? min_tune_freq_hz_ : min_freq_hz_;
+        const float f_tune_ceil = wave_band_tuning_ ? max_tune_freq_hz_ : max_freq_hz_;
         if (!std::isfinite(f_for_sigma_band) || f_for_sigma_band < f_tune_floor) {
             f_for_sigma_band = f_tune_floor;
         }
-        f_for_sigma_band = std::min(f_for_sigma_band, max_freq_hz_);
+        f_for_sigma_band = std::min(f_for_sigma_band, f_tune_ceil);
 
         const float a_for_variance = wave_band_tuning_
             ? sigma_wave_band_.step(a_vertical_measurement, dt, f_for_sigma_band)
@@ -1320,12 +1392,14 @@ private:
                 break;
         }
 
-        // The tuning frequency is a wave-band quantity and has to be allowed
-        // below the tracker's floor: a developed sea has T_z = 8.6 s, i.e.
-        // 0.12 Hz, well under the 0.2 Hz the tracker is bounded to.
+        // The tuning frequency is a wave-band quantity and is bounded by the
+        // wave band, not by the tracker's bounds: a developed sea has
+        // T_z = 8.6 s, i.e. 0.12 Hz, well under the 0.2 Hz the tracker is
+        // bounded to, and setFreqBounds() moves the demodulator carrier rather
+        // than the OU operating point.
         float f_tune = tuner_.getFrequencyHz();
         if (!std::isfinite(f_tune) || f_tune < f_tune_floor) f_tune = f_tune_floor;
-        if (f_tune > max_freq_hz_) f_tune = max_freq_hz_;
+        if (f_tune > f_tune_ceil) f_tune = f_tune_ceil;
 
         const float band_noise_sigma = band_noise_floor_sigma_();
         const float var_noise = band_noise_sigma * band_noise_sigma;
@@ -1421,12 +1495,30 @@ private:
         }
     }
 
+    // The frequency the whole adaptation path runs on: the sigma band's
+    // corners, the sigma_a averaging horizon, and tau.
+    //
+    // Under the deployed WaveBand source it never reads tracker_hz.  The
+    // estimator's own value is taken as soon as it exists rather than at
+    // isReady(): the readiness gate wants a settled *statistic*, and it does
+    // not clear until 60-85 s into a run, whereas a value that has survived the
+    // integrator settling transient is already a far better wave-band estimate
+    // than a constant.  Before that the fixed prior stands in.  Both are
+    // exogenous, so the schedule is a pure function of the measurements at
+    // every instant of the run rather than only after the gate clears.
     float tuner_frequency_hz_(float tracker_hz) const {
-        if (wave_band_tuning_ && wave_period_.isReady()) {
-            const float wave_hz = wave_period_.getFrequencyHz();
-            if (std::isfinite(wave_hz) && wave_hz > 0.0f) return wave_hz;
-        }
-        return tracker_hz;
+        if (!wave_band_tuning_) return tracker_hz;
+
+        const float wave_hz = wave_period_.getFrequencyHz();
+        const bool usable =
+            std::isfinite(wave_hz) && wave_hz > 0.0f &&
+            (tuner_freq_source_ == TunerFrequencySource::WaveBand ||
+             wave_period_.isReady());
+        if (usable) return wave_hz;
+
+        return (tuner_freq_source_ == TunerFrequencySource::TrackerFallback)
+                   ? tracker_hz
+                   : tune_freq_prior_hz_;
     }
 
     void resetTrackingState_() {
@@ -1563,7 +1655,10 @@ private:
     bool  wave_band_tuning_       = true;
     WavePeriodInputSource wave_period_input_ = WavePeriodInputSource::Complementary;
     FreqTrackerInputSource freq_tracker_input_ = FreqTrackerInputSource::Complementary;
+    TunerFrequencySource tuner_freq_source_ = TunerFrequencySource::WaveBand;
+    float tune_freq_prior_hz_     = TUNE_FREQ_PRIOR_HZ;
     float min_tune_freq_hz_       = MIN_TUNE_FREQ_HZ;
+    float max_tune_freq_hz_       = MAX_TUNE_FREQ_HZ;
     float min_freq_hz_            = MIN_FREQ_HZ;
     float max_freq_hz_            = MAX_FREQ_HZ;
     float min_tau_s_              = MIN_TAU_S;

--- a/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
+++ b/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
@@ -12,20 +12,30 @@
 
     • Quaternion-based attitude and linear motion estimation via Kalman3D_Wave_OU_III
 
-    • Dominant frequency tracking using one of:
+    • Acceleration-band dominant frequency tracking using one of:
           – AranovskiyFreqTracker     (frequency estimator)
           – KalmANFFreqTracker        (adaptive notch / Kalman frequency tracker)
           - PLLFreqTracker            (PLL frequency tracker)
           – SchmittTrigger            (zero-cross event detector)
 
-    • Dual-stage frequency smoothing:
+      This drives the wave-direction demodulator and nothing else.  The OU
+      operating point is a property of the *wave* band, which the acceleration
+      band does not measure: an ocean acceleration spectrum is the elevation
+      spectrum weighted by (2πf)⁴, so its apparent frequency sits well above
+      the spectral peak and barely moves as the sea grows.  Tuning therefore
+      reads WavePeriodEstimator, and reads it at every instant of the run --
+      before that estimator has a value, a fixed wave-band prior stands in
+      rather than the tracker.  See TunerFrequencySource.
+
+    • Dual-stage frequency smoothing of the tracker:
           – Fast 1st-order IIR (≈ few s, ~90% step) for demodulation / direction
-          – Slow 1st-order IIR (≈ longer s, ~90% step) for auto-tuning / moments
+          – Slow 1st-order IIR (≈ longer s, ~90% step) reported as getPeriodSec()
 
     • Online auto-tuning of Kalman filter parameters (τ, σₐ, Rₛ) through
       SeaStateAutoTuner.  The default OU-III variance channel first applies a
       period-scaled measurement-only wave band, then estimates acceleration
-      variance and applies the σₐ·τ³ regularization law.
+      variance over a horizon of K wave periods, and applies the σₐ·τ³
+      regularization law.
 
   Where
   – τ (tau):  OU process time constant ≈ ½ · T  (half the wave zero-crossing period)
@@ -99,6 +109,30 @@ constexpr float MAX_FREQ_HZ = 6.0f;
 // acceleration-band tracker and is far too high for a zero-crossing period:
 // 0.03 Hz admits a 33 s swell.
 constexpr float MIN_TUNE_FREQ_HZ = 0.03f;
+
+// Ceiling for the wave-band tuning frequency.  MAX_FREQ_HZ is the tracker's
+// bound and does not belong in the adaptation path: with the tuning frequency
+// read from the wave band, setFreqBounds() is a wave-direction knob and must
+// not move the OU operating point.  Neither bound binds on any reference
+// record -- the wave band spans 0.12 to 0.40 Hz -- so this is a safety limit,
+// not a tuning surface.  1.5 Hz is a 0.67 s zero-crossing period, shorter than
+// any sea a hull responds to.
+constexpr float MAX_TUNE_FREQ_HZ = 1.5f;
+
+// Wave-band tuning frequency used before WavePeriodEstimator has a value.
+//
+// It has to be a constant: the whole point of the wave-band source is that no
+// part of the adaptation path reads the acceleration-band tracker, and a
+// constant is trivially exogenous.  0.2 Hz is a 5 s zero-crossing period, and
+// the estimator reports 2.3-8.4 s across the reference family, so the prior is
+// never worse than a factor of two off; the estimator replaces it after about
+// 50 s in any case.  It is the same constant SeaStateFusionFilter_TFG has always
+// used for this, which is where the value comes from rather than a fit.
+// Sensitivity to it is measured in docs/ou-sigma-horizon.md: sweeping it over
+// 0.1-0.4 Hz leaves every scored 900 s metric unchanged to four decimal places
+// in both families, because the estimator has replaced it 250 s before the
+// window opens.
+constexpr float TUNE_FREQ_PRIOR_HZ = 0.2f;
 
 // JONSWAP-similar acceleration-variance band.  Away from the absolute safety
 // clamps, its transfer shape is fixed in f/f_tune.
@@ -1117,7 +1151,10 @@ public:
     inline float getSigmaTarget()   const noexcept { return sigma_target_; }
     inline float getRSTarget()      const noexcept { return RS_target_;    }
 
-    // Use slow frequency as a more stable "period" proxy
+    // Apparent period of the *acceleration* band, from the slow tracker
+    // branch.  This is a reporting channel: the OU operating point uses
+    // getWavePeriodSec(), the zero-crossing period of the elevation, which is
+    // a different and much longer quantity.
     inline float getPeriodSec() const noexcept {
         return (freq_hz_slow_ > 1e-6f) ? 1.0f / freq_hz_slow_ : NAN;
     }
@@ -1193,6 +1230,46 @@ public:
     // below the wave band; see VerticalAccelComplementary.h.
     void setWavePeriodComplementaryGains(float two_kp, float two_ki) {
         vertical_accel_comp_.setGains(two_kp, two_ki);
+    }
+
+    // Where the tuning frequency comes from.  WaveBand (default) keeps the
+    // whole adaptation path -- sigma band corners, sigma_a horizon, tau -- off
+    // the acceleration-band frequency tracker at every instant of the run; the
+    // other two are ablations.  See TunerFrequencySource.
+    void setTunerFrequencySource(TunerFrequencySource source) {
+        tuner_freq_source_ = source;
+    }
+    TunerFrequencySource tunerFrequencySource() const noexcept {
+        return tuner_freq_source_;
+    }
+
+    // Wave-band frequency used before WavePeriodEstimator has a value.
+    void setTuneFreqPriorHz(float hz) {
+        if (std::isfinite(hz) && hz > 0.0f) tune_freq_prior_hz_ = hz;
+    }
+    float tuneFreqPriorHz() const noexcept { return tune_freq_prior_hz_; }
+
+    // Bounds on the wave-band tuning frequency.  Distinct from setFreqBounds(),
+    // which bounds the acceleration-band tracker that drives wave direction.
+    void setTuneFreqBounds(float min_hz, float max_hz) {
+        if (!(std::isfinite(min_hz) && std::isfinite(max_hz))) return;
+        if (!(min_hz > 0.0f && max_hz > min_hz)) return;
+        min_tune_freq_hz_ = min_hz;
+        max_tune_freq_hz_ = max_hz;
+    }
+
+    // sigma_a averaging horizon, in periods of the tuning frequency, and its
+    // absolute clamps in seconds.  The horizon moved with the operating point
+    // when tuning moved to the wave band -- the same K is now 5-17 s instead of
+    // about 4 -- so it is a tuning surface; docs/ou-sigma-horizon.md measures it.
+    void setSigmaVarianceKPeriods(float k) { tuner_.setKPeriods(k); }
+    float getSigmaVarianceKPeriods() const noexcept { return tuner_.getKPeriods(); }
+    void setSigmaVarianceHorizonBounds(float min_s, float max_s) {
+        tuner_.setVarianceHorizonBounds(min_s, max_s);
+    }
+    // Horizon currently in force [s]; the variance is a two-stage EWMA at it.
+    float getSigmaVarianceHorizonSec() const noexcept {
+        return tuner_.getVarianceHorizonSec();
     }
 
     inline WaveDirection getDirSignState() const noexcept { return dir_sign_state_; }
@@ -1405,10 +1482,11 @@ private:
             ? tuner_.getFrequencyHz()
             : freq_hz_for_tuner;
         const float f_tune_floor = wave_band_tuning_ ? min_tune_freq_hz_ : min_freq_hz_;
+        const float f_tune_ceil = wave_band_tuning_ ? max_tune_freq_hz_ : max_freq_hz_;
         if (!std::isfinite(f_for_sigma_band) || f_for_sigma_band < f_tune_floor) {
             f_for_sigma_band = f_tune_floor;
         }
-        f_for_sigma_band = std::min(f_for_sigma_band, max_freq_hz_);
+        f_for_sigma_band = std::min(f_for_sigma_band, f_tune_ceil);
 
         const float a_for_variance = wave_band_tuning_
             ? sigma_wave_band_.step(a_vertical_measurement, dt, f_for_sigma_band)
@@ -1445,15 +1523,17 @@ private:
                break;
         }
 
-        // The tuning frequency is a wave-band quantity and has to be allowed
-        // below the tracker's floor: a developed sea has T_z = 8.6 s, i.e.
-        // 0.12 Hz, well under the 0.2 Hz the tracker is bounded to.
+        // The tuning frequency is a wave-band quantity and is bounded by the
+        // wave band, not by the tracker's bounds: a developed sea has
+        // T_z = 8.6 s, i.e. 0.12 Hz, well under the 0.2 Hz the tracker is
+        // bounded to, and setFreqBounds() moves the demodulator carrier rather
+        // than the OU operating point.
         float f_tune = tuner_.getFrequencyHz();
         if (!std::isfinite(f_tune) || f_tune < f_tune_floor) {
             f_tune = f_tune_floor;
         }
-        if (f_tune > max_freq_hz_) {
-            f_tune = max_freq_hz_;
+        if (f_tune > f_tune_ceil) {
+            f_tune = f_tune_ceil;
         }
 
         const float band_noise_sigma = band_noise_floor_sigma_();
@@ -1552,12 +1632,30 @@ private:
         }
     }
 
+    // The frequency the whole adaptation path runs on: the sigma band's
+    // corners, the sigma_a averaging horizon, and tau.
+    //
+    // Under the deployed WaveBand source it never reads tracker_hz.  The
+    // estimator's own value is taken as soon as it exists rather than at
+    // isReady(): the readiness gate wants a settled *statistic*, and it does
+    // not clear until 60-85 s into a run, whereas a value that has survived the
+    // integrator settling transient is already a far better wave-band estimate
+    // than a constant.  Before that the fixed prior stands in.  Both are
+    // exogenous, so the schedule is a pure function of the measurements at
+    // every instant of the run rather than only after the gate clears.
     float tuner_frequency_hz_(float tracker_hz) const {
-        if (wave_band_tuning_ && wave_period_.isReady()) {
-            const float wave_hz = wave_period_.getFrequencyHz();
-            if (std::isfinite(wave_hz) && wave_hz > 0.0f) return wave_hz;
-        }
-        return tracker_hz;
+        if (!wave_band_tuning_) return tracker_hz;
+
+        const float wave_hz = wave_period_.getFrequencyHz();
+        const bool usable =
+            std::isfinite(wave_hz) && wave_hz > 0.0f &&
+            (tuner_freq_source_ == TunerFrequencySource::WaveBand ||
+             wave_period_.isReady());
+        if (usable) return wave_hz;
+
+        return (tuner_freq_source_ == TunerFrequencySource::TrackerFallback)
+                   ? tracker_hz
+                   : tune_freq_prior_hz_;
     }
 
     void resetTrackingState_() {
@@ -1702,7 +1800,10 @@ private:
     bool  wave_band_tuning_       = true;
     WavePeriodInputSource wave_period_input_ = WavePeriodInputSource::Complementary;
     FreqTrackerInputSource freq_tracker_input_ = FreqTrackerInputSource::Complementary;
+    TunerFrequencySource tuner_freq_source_ = TunerFrequencySource::WaveBand;
+    float tune_freq_prior_hz_     = TUNE_FREQ_PRIOR_HZ;
     float min_tune_freq_hz_       = MIN_TUNE_FREQ_HZ;
+    float max_tune_freq_hz_       = MAX_TUNE_FREQ_HZ;
     float min_freq_hz_            = MIN_FREQ_HZ;
     float max_freq_hz_            = MAX_FREQ_HZ;
     float min_tau_s_              = MIN_TAU_S;

--- a/src/tuner/SeaStateAutoTuner.h
+++ b/src/tuner/SeaStateAutoTuner.h
@@ -13,10 +13,41 @@
     • K_periods is a dimensionless factor controlling the variance horizon:
         τ_var_dyn ≈ K_periods * T_eff,
       where T_eff = 1 / f_eff and f_eff is the smoothed frequency.
+    • The horizon is expressed in *periods of the frequency it is fed*, so what
+      that frequency means decides what the horizon means.  Fed the
+      acceleration-band tracker it was a few seconds whatever the sea did,
+      because that band barely moves with sea state; fed the wave-band
+      zero-crossing period it becomes a genuine multiple of the wave period and
+      stretches from about 5 s on a short chop to 17 s on a developed swell.
+      The clamps below therefore have to admit that whole span, and the
+      defaults are documented in docs/ou-sigma-horizon.md.
 */
 
 #include <cmath>
 #include <algorithm>
+
+// Where the tuning frequency the OU adaptation runs on comes from.
+//
+// WaveBand is the deployed choice: the operating point is a property of the
+// wave band, so it is read from WavePeriodEstimator alone and, before that
+// estimator has settled, from a fixed wave-band prior.  Nothing in the
+// adaptation path then reads the acceleration-band frequency tracker, which
+// stays where it is needed -- as the carrier of the wave-direction
+// demodulator.
+//
+// TrackerFallback is the previous behaviour, kept as an ablation: the same
+// wave-band frequency once the period estimator is ready, but the tracker's
+// output for the first minute or so of every run.
+//
+// WaveBandGated separates the two things WaveBand changes at once.  It drops
+// the tracker exactly like WaveBand but keeps the legacy readiness gate, so
+// comparing the three attributes the effect to "no tracker" or to "adopt the
+// period estimator as soon as it has a value" rather than to their sum.
+enum class TunerFrequencySource {
+    WaveBand,         // wave-period estimator as soon as it has a value, then a prior
+    WaveBandGated,    // ablation: same, but only once the estimator reports ready
+    TrackerFallback,  // legacy: acceleration-band tracker until the estimator is ready
+};
 
 struct DebiasedEMA {
     float value  = 0.0f;
@@ -46,6 +77,7 @@ public:
     inline void reset() {
         last_dt_freq = -1.0f;
         alpha_freq = 0.0f;
+        tau_var_sec = 0.0f;
         A_mean.reset(); A_sq.reset(); A_var.reset();
         Freq_smoothed.reset();
     }
@@ -64,20 +96,17 @@ public:
         // Effective frequency for variance horizon (use smoothed if ready)
         float f_eff = Freq_smoothed.isReady() ? Freq_smoothed.get() : f_input_hz;
         // Clamp to avoid insane horizons at tiny/zero frequency
-        const float F_MIN = 0.05f;   // 20 s period max
-        const float F_MAX = 5.0f;    // avoid crazy high freq
-        if (!std::isfinite(f_eff)) f_eff = F_MIN;
-        f_eff = std::max(F_MIN, std::min(F_MAX, f_eff));
+        if (!std::isfinite(f_eff)) f_eff = f_min_hz;
+        f_eff = std::max(f_min_hz, std::min(f_max_hz, f_eff));
 
         const float T_eff = 1.0f / f_eff;
 
         // Dynamic variance time constant: a few periods
-        const float TAU_MIN = 0.3f;       // seconds: don't go *too* twitchy
-        const float TAU_MAX = 60.0f;      // seconds: don't be glacial
-        const float tau_var_dyn = std::max(TAU_MIN, std::min(TAU_MAX, K_periods * T_eff));
+        tau_var_sec = std::max(tau_var_min_sec,
+                               std::min(tau_var_max_sec, K_periods * T_eff));
 
         // Compute alpha for variance based on dynamic tau
-        const float alpha_var = 1.0f - std::exp(-dt_s / tau_var_dyn);
+        const float alpha_var = 1.0f - std::exp(-dt_s / tau_var_sec);
 
         // Time-domain EWMA variance
         A_mean.update(accel, alpha_var);
@@ -100,14 +129,52 @@ public:
     inline bool isFreqReady() const { return Freq_smoothed.isReady(); }
     inline bool isVarReady()  const { return A_var.isReady(); }
 
+    // Horizon of the σ_a EWMA, in seconds, as last used.  The variance is a
+    // two-stage EWMA at this horizon (mean/square, then the variance itself),
+    // so the effective memory is about twice it.
+    inline float getVarianceHorizonSec() const { return tau_var_sec; }
+
     inline void setTauFreq(float t) {
         tau_freq = std::max(1e-3f, t);
         last_dt_freq = -1.0f;  // force recompute on next update
     }
 
+    // σ_a averaging horizon, in periods of the tuning frequency.
+    inline void setKPeriods(float k) {
+        if (std::isfinite(k) && k > 0.0f) K_periods = k;
+    }
+    inline float getKPeriods() const { return K_periods; }
+
+    // Absolute clamps on that horizon [s].  They exist so a degenerate tuning
+    // frequency cannot make the estimator either a pass-through or a constant;
+    // in the wave band the product K_periods * T_z should decide, not these.
+    inline void setVarianceHorizonBounds(float min_s, float max_s) {
+        if (!(std::isfinite(min_s) && std::isfinite(max_s))) return;
+        if (!(min_s > 0.0f && max_s >= min_s)) return;
+        tau_var_min_sec = min_s;
+        tau_var_max_sec = max_s;
+    }
+    inline float getVarianceHorizonMinSec() const { return tau_var_min_sec; }
+    inline float getVarianceHorizonMaxSec() const { return tau_var_max_sec; }
+
+    // Clamps on the tuning frequency the horizon is derived from [Hz].  The
+    // 0.05 Hz floor is a 20 s period, which is past the longest swell the wave
+    // band admits.
+    inline void setFrequencyBounds(float min_hz, float max_hz) {
+        if (!(std::isfinite(min_hz) && std::isfinite(max_hz))) return;
+        if (!(min_hz > 0.0f && max_hz >= min_hz)) return;
+        f_min_hz = min_hz;
+        f_max_hz = max_hz;
+    }
+
 private:
     // K_periods: dimensionless factor such that τ_var_dyn ≈ K_periods * T_eff
     float K_periods = 2.0f;
+    float tau_var_min_sec = 0.3f;   // seconds: don't go *too* twitchy
+    float tau_var_max_sec = 60.0f;  // seconds: don't be glacial
+    float f_min_hz = 0.05f;         // 20 s period max
+    float f_max_hz = 5.0f;          // avoid crazy high freq
+    float tau_var_sec = 0.0f;       // last horizon used, for inspection
     float tau_freq  = 1.0f;   // seconds
     float last_dt_freq  = -1.0f;
     float alpha_freq = 0.0f;

--- a/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
+++ b/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
@@ -211,6 +211,47 @@ public:
                 filter.mekf().set_Q_bacc_rw(Eigen::Vector3f::Constant(v));
             }
 
+            // Where the tuning frequency comes from before the wave-period
+            // estimator has a value.  "wave_band" is the deployed source and
+            // never reads the acceleration-band tracker; "wave_band_gated"
+            // keeps the legacy readiness gate but still never reads it;
+            // "tracker_fallback" is the previous behaviour.
+            if (const char* src = std::getenv("W3D_TUNER_FREQ_SOURCE")) {
+                const std::string value = src;
+                if (value == "wave_band") {
+                    filter.setTunerFrequencySource(TunerFrequencySource::WaveBand);
+                } else if (value == "wave_band_gated") {
+                    filter.setTunerFrequencySource(
+                        TunerFrequencySource::WaveBandGated);
+                } else if (value == "tracker_fallback") {
+                    filter.setTunerFrequencySource(
+                        TunerFrequencySource::TrackerFallback);
+                } else {
+                    throw std::runtime_error(
+                        "W3D_TUNER_FREQ_SOURCE must be wave_band, "
+                        "wave_band_gated or tracker_fallback");
+                }
+            }
+
+            // Wave-band prior used until the period estimator has a value.
+            if (env_float("OU_TUNE_FREQ_PRIOR_HZ", v)) {
+                filter.setTuneFreqPriorHz(v);
+            }
+
+            // sigma_a averaging horizon, in periods of the tuning frequency,
+            // and its absolute clamps in seconds.
+            if (env_float("OU_SIGMA_VAR_K_PERIODS", v)) {
+                filter.setSigmaVarianceKPeriods(v);
+            }
+            {
+                float lo = 0.3f, hi = 60.0f;
+                const bool got_lo = env_float("OU_SIGMA_VAR_HORIZON_MIN_S", lo);
+                const bool got_hi = env_float("OU_SIGMA_VAR_HORIZON_MAX_S", hi);
+                if (got_lo || got_hi) {
+                    filter.setSigmaVarianceHorizonBounds(lo, hi);
+                }
+            }
+
             // Ablate the wave-band operating point back to the
             // acceleration-band frequency the filter used before.
             if (const char* band = std::getenv("W3D_TUNING_BAND")) {

--- a/tests/kalman_ou_iii/kalman_ou_iii-sim.cpp
+++ b/tests/kalman_ou_iii/kalman_ou_iii-sim.cpp
@@ -213,6 +213,47 @@ public:
                 filter.mekf().set_Q_bacc_rw(Eigen::Vector3f::Constant(v));
             }
 
+            // Where the tuning frequency comes from before the wave-period
+            // estimator has a value.  "wave_band" is the deployed source and
+            // never reads the acceleration-band tracker; "wave_band_gated"
+            // keeps the legacy readiness gate but still never reads it;
+            // "tracker_fallback" is the previous behaviour.
+            if (const char* src = std::getenv("W3D_TUNER_FREQ_SOURCE")) {
+                const std::string value = src;
+                if (value == "wave_band") {
+                    filter.setTunerFrequencySource(TunerFrequencySource::WaveBand);
+                } else if (value == "wave_band_gated") {
+                    filter.setTunerFrequencySource(
+                        TunerFrequencySource::WaveBandGated);
+                } else if (value == "tracker_fallback") {
+                    filter.setTunerFrequencySource(
+                        TunerFrequencySource::TrackerFallback);
+                } else {
+                    throw std::runtime_error(
+                        "W3D_TUNER_FREQ_SOURCE must be wave_band, "
+                        "wave_band_gated or tracker_fallback");
+                }
+            }
+
+            // Wave-band prior used until the period estimator has a value.
+            if (env_float("OU_TUNE_FREQ_PRIOR_HZ", v)) {
+                filter.setTuneFreqPriorHz(v);
+            }
+
+            // sigma_a averaging horizon, in periods of the tuning frequency,
+            // and its absolute clamps in seconds.
+            if (env_float("OU_SIGMA_VAR_K_PERIODS", v)) {
+                filter.setSigmaVarianceKPeriods(v);
+            }
+            {
+                float lo = 0.3f, hi = 60.0f;
+                const bool got_lo = env_float("OU_SIGMA_VAR_HORIZON_MIN_S", lo);
+                const bool got_hi = env_float("OU_SIGMA_VAR_HORIZON_MAX_S", hi);
+                if (got_lo || got_hi) {
+                    filter.setSigmaVarianceHorizonBounds(lo, hi);
+                }
+            }
+
             // Ablate the wave-band operating point back to the
             // acceleration-band frequency the filter used before.
             if (const char* band = std::getenv("W3D_TUNING_BAND")) {
@@ -709,12 +750,26 @@ private:
 // pitch.  docs/quality-gate-regauge.md carries that measurement and the
 // command that redoes it, which is the check to repeat before cutting any of
 // these finer.
+// Re-derived once more, for one gate only, when the tuning frequency stopped
+// reading the acceleration-band frequency tracker (docs/ou-sigma-horizon.md).
+// The change is invisible in displacement -- pooled vertical and 3D RMS both
+// move by 0.00% -- but pitch on pmstokes H4.0 goes 0.2200 -> 0.2218 at the
+// default seed, which is 0.83% and therefore past the half-percent this gate
+// was cut with.
+//
+// That is a re-draw, not a pitch regression, and the distinction is the same
+// one the yaw paragraph above makes.  Paired over five IMU seeds and all eight
+// records the pitch ratio is 0.9999 with a 95% interval of [0.9989, 1.0010]:
+// no systematic effect at a resolution ten times finer than the move on this
+// one record.  tools/ou_sigma_horizon_study.py --axis source --seeds 5
+// reproduces it.  Only pitch is re-cut; the other eight limits are untouched
+// because nothing this change did moved them.
 static constexpr W3dFailureLimits FAIL_LIMITS{
     .err_limit_percent_z_jonswap   = 4.735f,  // was 4.74,  worst 4.7106 (jonswap H0.27)
     .err_limit_percent_z_pmstokes  = 4.682f,  // was 4.69,  worst 4.6580 (pmstokes H0.27)
     .err_limit_yaw_deg             = 1.297f,  // unchanged, worst 1.2896 (jonswap H1.5)
     .err_limit_roll_deg            = 0.42f,   // new,       worst 0.4179 (jonswap H4.0)
-    .err_limit_pitch_deg           = 0.2211f, // new,       worst 0.2200 (pmstokes H4.0)
+    .err_limit_pitch_deg           = 0.223f,  // was 0.2211, worst 0.2218 (pmstokes H4.0)
     .err_limit_percent_3d_jonswap  = 20.95f,  // unchanged, worst 20.8367 (jonswap H1.5)
     .err_limit_percent_3d_pmstokes = 20.86f,  // unchanged, worst 20.7483 (pmstokes H4.0)
     .acc_z_bias_percent            = 4.624f,  // was 4.63,  worst 4.6004 (jonswap H8.5)

--- a/tests/kalman_ou_iii/tuner_coupling-test.cpp
+++ b/tests/kalman_ou_iii/tuner_coupling-test.cpp
@@ -80,7 +80,10 @@ void sample(int k, Eigen::Vector3f& gyro, Eigen::Vector3f& acc) {
 }
 
 // Mirrors what SeaStateFusion_OU_III::begin() does to the inner filter.
-void bring_up(Filter& f) {
+// Templated because the tracker-independence check below has to bring up two
+// filters that differ in nothing but their TrackerType.
+template <typename F>
+void bring_up(F& f) {
     f.setWithMag(false);
     f.setOnlineTuneWarmupSec(5.0f);
     f.initialize(Eigen::Vector3f::Constant(0.0148f),
@@ -92,7 +95,8 @@ void bring_up(Filter& f) {
     f.initialize_from_acc(acc);
 }
 
-void run(Filter& f, int from, int to) {
+template <typename F>
+void run(F& f, int from, int to) {
     Eigen::Vector3f gyro, acc;
     for (int k = from; k < to; ++k) {
         sample(k, gyro, acc);
@@ -254,6 +258,82 @@ bool test_default_frequency_channel_is_exogenous() {
     return ok;
 }
 
+// The operating point must not depend on the acceleration-band frequency
+// tracker at all, at any point in the run -- not only after the wave-period
+// estimator reports ready.
+//
+// Two filters differing in nothing but their TrackerType are driven with
+// identical samples.  KalmANF and Aranovskiy converge differently and report
+// different frequencies, especially early, so if any part of the adaptation
+// path still read the tracker the two schedules would diverge.  Everything the
+// two filters share -- the input low-pass, the stillness detector, the private
+// Mahony observer, the sigma band -- is a function of the measurement, so the
+// only thing this can detect is a tracker dependence.
+//
+// The comparison is made at 30 s, well before the wave-period estimator is
+// ready: under the previous TrackerFallback source that is exactly the window
+// in which the tracker set the sigma band's corners, the sigma_a averaging
+// horizon and tau, and this check fails on it.
+bool test_operating_point_is_tracker_independent() {
+    bool ok = true;
+
+    SeaStateFusionFilter_OU_III<TrackerType::KALMANF> kalmanf;
+    SeaStateFusionFilter_OU_III<TrackerType::ARANOVSKIY> aranovskiy;
+    bring_up(kalmanf);
+    bring_up(aranovskiy);
+
+    ok &= check(kalmanf.tunerFrequencySource() == TunerFrequencySource::WaveBand,
+                "the default tuning-frequency source must be the wave-band one");
+
+    constexpr int EARLY = 240 * 30;
+    run(kalmanf, 0, EARLY);
+    run(aranovskiy, 0, EARLY);
+
+    ok &= check(!kalmanf.wavePeriodReady(),
+                "the period estimator must still be unsettled here, or this "
+                "measures the settled path and proves nothing about the "
+                "window the tracker used to own");
+    // Raw, not getFreqHz(): the smoothed branch is clamped into
+    // [min_freq_hz_, max_freq_hz_], and this synthetic 8 s wave sits under the
+    // 0.2 Hz floor, so both trackers report the floor however much they
+    // disagree underneath it.
+    ok &= check(kalmanf.getFreqRawHz() != aranovskiy.getFreqRawHz(),
+                "the two trackers must actually disagree, or this test cannot "
+                "detect a dependence on them");
+
+    ok &= check(kalmanf.getTauTarget() == aranovskiy.getTauTarget(),
+                "tau target must not depend on which frequency tracker runs");
+    ok &= check(kalmanf.getSigmaTarget() == aranovskiy.getSigmaTarget(),
+                "sigma target must not depend on which frequency tracker runs");
+    ok &= check(kalmanf.getRSTarget() == aranovskiy.getRSTarget(),
+                "r_S target must not depend on which frequency tracker runs");
+    ok &= check(kalmanf.sigma_wave_band_.lowHz() == aranovskiy.sigma_wave_band_.lowHz() &&
+                kalmanf.sigma_wave_band_.highHz() == aranovskiy.sigma_wave_band_.highHz(),
+                "sigma-band corners must not depend on which tracker runs");
+
+    // And again once the estimator has settled, where both sources agree.
+    run(kalmanf, EARLY, SETTLE);
+    run(aranovskiy, EARLY, SETTLE);
+    ok &= check(kalmanf.wavePeriodReady(), "the period estimator must settle");
+    ok &= check(kalmanf.getTauTarget() == aranovskiy.getTauTarget() &&
+                kalmanf.getSigmaTarget() == aranovskiy.getSigmaTarget() &&
+                kalmanf.getRSTarget() == aranovskiy.getRSTarget(),
+                "the settled operating point must be tracker-independent too");
+
+    std::cout << "  tracker independence at " << (EARLY / 240) << " s: f_raw "
+              << kalmanf.getFreqRawHz() << " vs " << aranovskiy.getFreqRawHz()
+              << " Hz, tau " << kalmanf.getTauTarget() << " s both\n";
+
+    if (!ok) {
+        std::cerr << "  Part of the adaptation path is reading the "
+                     "acceleration-band\n"
+                     "  frequency tracker again. The tracker is the wave-direction\n"
+                     "  demodulator's carrier; the operating point is a wave-band\n"
+                     "  quantity and comes from WavePeriodEstimator.\n";
+    }
+    return ok;
+}
+
 bool test_tilt_gate_stays_outside_the_live_analysis_region() {
     bool ok = true;
 
@@ -288,6 +368,7 @@ int main() {
     bool ok = true;
     ok &= test_sigma_channel_input_is_exogenous();
     ok &= test_default_frequency_channel_is_exogenous();
+    ok &= test_operating_point_is_tracker_independent();
     ok &= test_leveled_ablation_coupling_stays_bounded();
     ok &= test_tilt_gate_stays_outside_the_live_analysis_region();
 

--- a/tools/ou_sigma_horizon_study.py
+++ b/tools/ou_sigma_horizon_study.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python3
+"""Decouple the OU adaptation path from the acceleration-band frequency tracker,
+and measure what the sigma_a averaging horizon is worth once it has.
+
+Two questions, one harness, because they are the same question asked twice.
+
+``--axis source`` varies where the tuning frequency comes from
+(``W3D_TUNER_FREQ_SOURCE``).  Both OU families already read the wave-band
+zero-crossing period from ``WavePeriodEstimator`` once that estimator reports
+ready, but that gate does not clear until 60-85 s into a run, and until it does
+the operating point -- the sigma band's corners, the sigma_a averaging horizon,
+and tau -- was taken from the acceleration-band tracker:
+
+  ``tracker_fallback``   the previous behaviour and the baseline of this axis.
+  ``wave_band_gated``    the tracker replaced by a fixed wave-band prior, with
+                         the legacy readiness gate left alone.  Isolates "stop
+                         reading the tracker" from the change below.
+  ``wave_band``          (shipped) the same, and the estimator's own value
+                         adopted as soon as it exists rather than at isReady().
+
+``--axis k_periods`` varies the sigma_a averaging horizon
+(``OU_SIGMA_VAR_K_PERIODS``), which ``SeaStateAutoTuner`` expresses in periods
+of whatever tuning frequency it is fed: tau_var = K * T_eff, and the variance is
+a two-stage EWMA at that horizon, so the memory is about 2*K*T_eff.  K has not
+moved since the operating point did, and the move rescaled it: fed the
+acceleration band, T_eff was ~2 s whatever the sea was doing, so K = 2 meant a
+~4 s horizon; fed the wave band it is 2*T_z, i.e. 5 s on the shortest reference
+sea and 17 s on the longest.
+
+``--axis prior`` varies the constant that stands in before the period estimator
+has a value (``OU_TUNE_FREQ_PRIOR_HZ``), which is what makes the wave-band
+source exogenous.  It is a sensitivity check, not a tuning surface.
+
+``--axis horizon_max`` varies the absolute ceiling on the horizon
+(``OU_SIGMA_VAR_HORIZON_MAX_S``), which is what would bind first if K grew.
+
+Scenarios
+---------
+The eight released stationary records, plus -- unless ``--skip-transition`` --
+the controlled non-stationary record of ``tools/ou_validation.py``: a C2 quintic
+crossfade from H_s = 1.5 m, T_p = 5.7 s to H_s = 4.0 m, T_p = 11.4 s between 420
+and 780 s.  That record is scored three more times, over its start, blend and
+end intervals, so a horizon that is merely slow can be told apart from one that
+is wrong: a longer sigma_a memory should cost most in ``blend``.
+
+Protocol
+--------
+``--seeds N`` replays every scenario under N IMU/initialization seeds and pools
+the *paired* per-seed log ratios, which is what resolves effects smaller than
+the record-to-record scatter.  ``--seeds 1`` keeps the deterministic
+single-realization protocol of ``tools/ou_sim_table.py`` and is bit-identical to
+it.  Every ratio is against the axis baseline on the identical realization.
+
+Usage:
+  tools/ou_sigma_horizon_study.py --axis source --seeds 6
+  tools/ou_sigma_horizon_study.py --axis k_periods --seeds 6 --csv k.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import os
+import subprocess
+import sys
+import tempfile
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "tools"))
+
+import ou_validation as ouv  # noqa: E402  (path set above)
+
+# Trailing window the simulators score their own quality gates over.
+WINDOW_SEC = 900.0
+DURATION_SEC = 1200.0
+TRANSITION_START_SEC = 420.0
+TRANSITION_END_SEC = 780.0
+TRANSITION_END_HEIGHT_M = 4.0
+
+FAMILIES = {
+    "OU_II": {"subdir": "kalman_ou_ii", "binary": "kalman_ou_ii-sim"},
+    "OU_III": {"subdir": "kalman_ou_iii", "binary": "kalman_ou_iii-sim"},
+}
+
+# The eight released records, in the order the historical table reports them.
+STATIONARY = (
+    ("JONSWAP", 0.27, "wave_data_jonswap_H0.270_L14.047_A30.00_P60.00.csv"),
+    ("JONSWAP", 1.50, "wave_data_jonswap_H1.500_L50.710_A-30.00_P120.00.csv"),
+    ("JONSWAP", 4.00, "wave_data_jonswap_H4.000_L112.766_A30.00_P30.00.csv"),
+    ("JONSWAP", 8.50, "wave_data_jonswap_H8.500_L202.839_A-30.00_P72.00.csv"),
+    ("PM-Stokes", 0.27, "wave_data_pmstokes_H0.270_L14.047_A30.00_P60.00.csv"),
+    ("PM-Stokes", 1.50, "wave_data_pmstokes_H1.500_L50.710_A-30.00_P120.00.csv"),
+    ("PM-Stokes", 4.00, "wave_data_pmstokes_H4.000_L112.766_A30.00_P30.00.csv"),
+    ("PM-Stokes", 8.50, "wave_data_pmstokes_H8.500_L202.839_A-30.00_P72.00.csv"),
+)
+
+TRANSITION_LABEL = "transition"
+TRANSITION_KEY = "nonstationary_H1_5_to_H4_0"
+
+# Segments of the transition record, keyed to the same 900 s window.
+SEGMENTS = (
+    ("start", DURATION_SEC - WINDOW_SEC, TRANSITION_START_SEC),
+    ("blend", TRANSITION_START_SEC, TRANSITION_END_SEC),
+    ("end", TRANSITION_END_SEC, DURATION_SEC),
+)
+
+# axis -> (env var, values, baseline).  The baseline is the denominator of every
+# ratio.  On the source axis it is deliberately the *old* behaviour, because
+# the question that axis answers is what dropping the tracker changed.
+AXES = {
+    "source": (
+        "W3D_TUNER_FREQ_SOURCE",
+        ("tracker_fallback", "wave_band_gated", "wave_band"),
+        "tracker_fallback",
+    ),
+    "k_periods": (
+        "OU_SIGMA_VAR_K_PERIODS",
+        ("0.5", "1", "2", "3", "4", "6", "8"),
+        "2",
+    ),
+    "prior": (
+        "OU_TUNE_FREQ_PRIOR_HZ",
+        ("0.1", "0.14", "0.2", "0.28", "0.4"),
+        "0.2",
+    ),
+    "horizon_max": (
+        "OU_SIGMA_VAR_HORIZON_MAX_S",
+        ("10", "20", "30", "60", "120"),
+        "60",
+    ),
+}
+
+SEGMENT_FIELDS = tuple(
+    f"seg_{name}_{metric}"
+    for name, _, _ in SEGMENTS
+    for metric in ("disp_z_rms_m", "disp_3d_rms_m", "disp_z_pct_refrms")
+)
+
+FIELDS = (
+    "disp_z_rms_m",
+    "disp_3d_rms_m",
+    "disp_x_rms_m",
+    "disp_y_rms_m",
+    "disp_z_pct_hs",
+    "disp_z_pct_refrms",
+    "roll_rms_deg",
+    "pitch_rms_deg",
+    "yaw_rms_deg",
+    "dir_travel_rmse_deg",
+    "dir_axis_rmse_deg",
+    "dir_travel_correct_pct",
+    "wave_period_s",
+    "period_s",
+    "tau_applied_s",
+    "sigma_applied_mps2",
+    "accel_variance_m2ps4",
+    *SEGMENT_FIELDS,
+)
+
+# Metrics where a ratio is meaningful (errors, lower is better).  The attitude
+# channels are here because two of the simulators' quality-gate sentinels are
+# roll and pitch, and they are fitted with about half a percent of margin: a
+# change can be invisible in displacement and still move a gate.
+RATIO_METRICS = (
+    ("disp_z_rms_m", "vertical RMS [m]"),
+    ("disp_3d_rms_m", "3D RMS [m]"),
+    ("roll_rms_deg", "roll RMS [deg]"),
+    ("pitch_rms_deg", "pitch RMS [deg]"),
+    ("yaw_rms_deg", "yaw RMS [deg]"),
+)
+
+TRANSITION_RATIO_METRICS = (
+    ("seg_start_disp_z_rms_m", "transition start-sea vertical RMS [m]"),
+    ("seg_blend_disp_z_rms_m", "transition blend vertical RMS [m]"),
+    ("seg_end_disp_z_rms_m", "transition end-sea vertical RMS [m]"),
+)
+
+
+def transition_record(wave_seed: int, data_dir: Path, tmpdir: Path) -> Path:
+    """Synthesize the crossfade record for one wave-phase seed."""
+    start_path = ouv.find_default_input(data_dir, "1.500", "50.710")
+    end_path = ouv.find_default_input(data_dir, "8.500", "202.839")
+    columns, start_data = ouv.read_wave_csv(start_path, DURATION_SEC)
+    _, end_data = ouv.read_wave_csv(end_path, DURATION_SEC)
+    generated = ouv.make_nonstationary_wave(
+        columns,
+        start_data,
+        end_data,
+        wave_seed,
+        TRANSITION_END_HEIGHT_M / 8.5,
+        TRANSITION_START_SEC,
+        TRANSITION_END_SEC,
+    )
+    # The simulator reads H_s, wavelength and azimuth out of the filename, so
+    # the surrogate has to carry the endpoint sea's name.  This is the same
+    # name tools/ou_validation.py gives it.
+    path = (tmpdir / f"wave{wave_seed}" /
+            "wave_data_jonswap_H4.000_L202.839_A-30.00_P120.00.csv")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ouv.write_wave_csv(path, columns, generated)
+    return path
+
+
+def run_one(family: str, record_path: Path, env_var: str, value: str,
+            seed: int | None, segments: bool) -> dict[str, float]:
+    """Replay one record under one setting and parse its metrics."""
+    spec = FAMILIES[family]
+    workdir = (ROOT / "tests" / spec["subdir"]).resolve()
+    binary = workdir / spec["binary"]
+    if not binary.exists():
+        raise SystemExit(f"missing {binary}; run `make -C {workdir} build` first")
+    if not record_path.exists():
+        raise SystemExit(f"missing record {record_path}; run `make fetch-sim-data` first")
+
+    env = dict(os.environ)
+    env["W3D_WRITE_TIMESERIES"] = "0"
+    # Every record has to be scored, including any that trips a historical gate;
+    # this reports what the filter did, not whether it passed.
+    env["W3D_COLLECT_ALL_GATES"] = "1"
+    env["W3D_VALIDATION_WINDOW_SEC"] = str(WINDOW_SEC)
+    env[env_var] = value
+    if segments:
+        env["W3D_VALIDATION_SEGMENTS"] = ",".join(
+            f"{name}:{lo:.9g}:{hi:.9g}" for name, lo, hi in SEGMENTS
+        )
+    if seed is not None:
+        env["W3D_IMU_SEED"] = str(seed)
+        env["W3D_INIT_SEED"] = str(1000 + seed)
+
+    completed = subprocess.run(
+        [str(binary), "--input", str(record_path.resolve())],
+        cwd=workdir,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    try:
+        parsed = ouv.parse_validation_metrics(completed.stdout)
+    except ValueError:
+        sys.stderr.write(completed.stdout[-2000:] + completed.stderr[-2000:])
+        raise SystemExit(
+            f"no VALIDATION_METRICS for {family} {record_path.name} "
+            f"{env_var}={value} seed={seed}")
+
+    return {field: float(parsed.get(field, float("nan"))) for field in FIELDS}
+
+
+def pct(new: float, old: float) -> str:
+    if not (old > 0.0) or not (new == new):
+        return "   n/a"
+    return f"{100.0 * (new / old - 1.0):+6.2f}%"
+
+
+def summarize_ratio(logs: list[float]) -> tuple[float, float, float]:
+    """Geometric mean of a paired ratio with a normal-approximation 95% CI."""
+    n = len(logs)
+    if n == 0:
+        return float("nan"), float("nan"), float("nan")
+    mean = sum(logs) / n
+    if n < 2:
+        return math.exp(mean), float("nan"), float("nan")
+    var = sum((x - mean) ** 2 for x in logs) / (n - 1)
+    half = 1.96 * math.sqrt(var / n)
+    return math.exp(mean), math.exp(mean - half), math.exp(mean + half)
+
+
+def paired_logs(raw, family, metric, value, baseline, keys, seeds) -> list[float]:
+    out = []
+    for key in keys:
+        for seed in seeds:
+            num = raw[(family, key, value, seed)][metric]
+            den = raw[(family, key, baseline, seed)][metric]
+            if num > 0.0 and den > 0.0 and num == num and den == den:
+                out.append(math.log(num / den))
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--axis", choices=sorted(AXES), default="source")
+    ap.add_argument("--values", help="comma-separated override of the axis values")
+    ap.add_argument("--baseline", help="override the ratio denominator")
+    ap.add_argument("--family", choices=sorted(FAMILIES), action="append")
+    ap.add_argument("--jobs", type=int, default=os.cpu_count() or 4)
+    ap.add_argument("--seeds", type=int, default=1)
+    ap.add_argument("--wave-seed", type=int, default=11,
+                    help="phase seed of the synthesized transition record")
+    ap.add_argument("--skip-transition", action="store_true")
+    ap.add_argument("--data-dir", type=Path,
+                    default=ROOT / "tests" / "kalman_ou_iii")
+    ap.add_argument("--csv", type=Path, help="write the raw rows here")
+    args = ap.parse_args()
+
+    families = args.family or ["OU_II", "OU_III"]
+    env_var, values, baseline = AXES[args.axis]
+    if args.values:
+        values = tuple(v.strip() for v in args.values.split(",") if v.strip())
+    if args.baseline:
+        baseline = args.baseline
+    if baseline not in values:
+        raise SystemExit(f"baseline {baseline!r} is not among {values}")
+    others = [v for v in values if v != baseline]
+
+    # seed=None reproduces the simulator's default seeds exactly, so --seeds 1
+    # stays bit-identical to the deterministic protocol.
+    seeds = [None] if args.seeds <= 1 else list(range(1, args.seeds + 1))
+
+    tmpdir_holder = tempfile.TemporaryDirectory(prefix="ou_sigma_horizon_")
+    tmpdir = Path(tmpdir_holder.name)
+
+    scenarios: list[tuple[str, str, float, bool]] = [
+        (record, spectrum, hs, False) for spectrum, hs, record in STATIONARY
+    ]
+    # The stationary records are replayed as released, so a seed varies only the
+    # IMU noise; the transition record is synthesized, so its wave phases are
+    # re-drawn per seed as well.  One crossfade realization is not enough to
+    # read a blend-interval effect off, and the pairing is unaffected: both
+    # settings see the identical record at a given seed.
+    paths: dict[tuple[str, int | None], Path] = {}
+    for record, _, _, _ in scenarios:
+        for seed in seeds:
+            paths[(record, seed)] = args.data_dir / record
+    if not args.skip_transition:
+        scenarios.append((TRANSITION_KEY, TRANSITION_LABEL, 4.0, True))
+        for seed in seeds:
+            wave_seed = args.wave_seed if seed is None else args.wave_seed + seed
+            paths[(TRANSITION_KEY, seed)] = transition_record(
+                wave_seed, args.data_dir, tmpdir)
+
+    keys = [key for key, _, _, _ in scenarios]
+    stationary_keys = [key for key, _, _, seg in scenarios if not seg]
+    by_key = {key: (spectrum, hs, seg) for key, spectrum, hs, seg in scenarios}
+
+    with ThreadPoolExecutor(max_workers=max(1, args.jobs)) as pool:
+        futures = {
+            (family, key, value, seed): pool.submit(
+                run_one, family, paths[(key, seed)], env_var, value, seed,
+                by_key[key][2])
+            for family in families
+            for key in keys
+            for value in values
+            for seed in seeds
+        }
+        raw = {k: f.result() for k, f in futures.items()}
+
+    results = {
+        (family, key, value): {
+            field: sum(raw[(family, key, value, s)][field] for s in seeds) / len(seeds)
+            for field in FIELDS
+        }
+        for family in families
+        for key in keys
+        for value in values
+    }
+
+    rows = []
+    for family in families:
+        metrics = list(RATIO_METRICS)
+        if not args.skip_transition:
+            metrics += list(TRANSITION_RATIO_METRICS)
+
+        for metric, label in metrics:
+            transition_only = metric.startswith("seg_")
+            shown = [TRANSITION_KEY] if transition_only else keys
+            pooled_over = [TRANSITION_KEY] if transition_only else stationary_keys
+            print()
+            print(f"=== {family}: {label}, last {int(WINDOW_SEC)} s, "
+                  f"{env_var} vs {baseline} ===")
+            head = f"{'record':<12}{'Hs':>6}{baseline:>13}"
+            for value in others:
+                head += f"{value:>13}{'delta':>9}"
+            print(head)
+            for key in shown:
+                spectrum, hs, _ = by_key[key]
+                base = results[(family, key, baseline)][metric]
+                line = f"{spectrum:<12}{hs:>6.2f}{base:>13.4f}"
+                for value in others:
+                    got = results[(family, key, value)][metric]
+                    line += f"{got:>13.4f}{pct(got, base):>9}"
+                print(line)
+
+            tail = f"{'pooled ratio':<18}{'':>13}"
+            for value in others:
+                ratio, _, _ = summarize_ratio(
+                    paired_logs(raw, family, metric, value, baseline,
+                                pooled_over, seeds))
+                tail += f"{ratio:>12.4f}x{'':>9}"
+            print(tail)
+            if len(seeds) > 1:
+                ci = f"{'  paired 95% CI':<18}{'':>13}"
+                for value in others:
+                    _, lo, hi = summarize_ratio(
+                        paired_logs(raw, family, metric, value, baseline,
+                                    pooled_over, seeds))
+                    ci += f"{'[' + f'{lo:.4f}, {hi:.4f}' + ']':>22}"
+                print(ci)
+
+        for key in keys:
+            spectrum, hs, _ = by_key[key]
+            for value in values:
+                row = dict(results[(family, key, value)])
+                row.update(family=family, record=key, sea_state=spectrum,
+                           hs_m=hs, axis=args.axis, setting=value,
+                           seeds=len(seeds))
+                rows.append(row)
+
+    if args.csv:
+        with args.csv.open("w", newline="") as handle:
+            writer = csv.DictWriter(
+                handle,
+                fieldnames=["family", "sea_state", "hs_m", "record", "axis",
+                            "setting", "seeds", *FIELDS])
+            writer.writeheader()
+            writer.writerows(rows)
+        print(f"\nwrote {args.csv}")
+
+    tmpdir_holder.cleanup()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
OU-II and OU-III already derived tau, the sigma band's corners and the
sigma_a averaging horizon from WavePeriodEstimator's wave-band zero-crossing
period -- but only once that estimator reported isReady(), which does not
happen until 60-85 s into a run. Until then the operating point came from the
acceleration-band tracker, which measures a different band: on the two
smallest reference seas the filter is Live 40 s before the period estimator
is, and spent that time adapting on a frequency that barely moves with sea
state.

TunerFrequencySource::WaveBand, now the default in both families, closes that.
The estimator's own value is taken as soon as it is finite rather than at
isReady(), and before that a fixed 0.2 Hz wave-band prior stands in -- the
same constant SeaStateFusionFilter_TFG has always used in this position. The
tuning frequency's ceiling also moves off MAX_FREQ_HZ onto its own
MAX_TUNE_FREQ_HZ, so setFreqBounds() is a wave-direction knob again. Nothing
in the adaptation path reads the tracker at any instant of the run; the
tracker keeps its real job as the direction demodulator's carrier.

It costs nothing measurable: pooled vertical and 3D RMS both move by 0.00%
over the eight reference records and a controlled sea-state transition, worst
single record 0.11%, and no crossfade interval moves more than 0.07%.
tuner_coupling-test pins it by driving two filters that differ only in
TrackerType and requiring the operating point to be bit-identical while the
two trackers report 0.297 and 0.112 Hz.

The horizon that read is expressed in also had to be re-measured, because
its units changed with the band: K_periods = 2 meant about 4 s when it
multiplied an acceleration-band period and means 2*T_z = 5-17 s now. It is
now settable, and swept in docs/ou-sigma-horizon.md over 0.5 to 8 at six
seeds. It stays at 2.0: halving it costs 0.4-1.0% on the stationary ensemble
and 0.4% on a transition blend, so the shipped value is on the right side of
the trade, but lengthening it buys the crossfade interval only by selling the
settled sea after it, and the two cancel to within 0.2% on the whole window.

The OU-III pitch sentinel is re-cut 0.2211 -> 0.223 by the rule in
docs/quality-gate-regauge.md. One record moves 0.83% at the default seed
against a gate carrying half a percent; paired over five seeds and all eight
records the pitch ratio is 0.9999 [0.9989, 1.0010], so it is a re-draw and
not a pitch regression. No other limit moved.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011so7dJjaso5urFZ2NsZMyG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OU adaptation now uses wave-period estimates for time-scale tuning, with configurable frequency sources, priors, bounds, and variance horizons.
  * Acceleration-frequency tracking remains available for wave-direction estimation.
  * Added controls and diagnostics for tuning frequency and variance horizon settings.

* **Bug Fixes**
  * Improved startup behavior through configurable wave-frequency fallback handling.

* **Documentation**
  * Added guidance on tuning behavior, configuration, validation, and performance comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->