### PR TITLE
Remove OU tuning chart from wave-direction paper

### DIFF
--- a/doc/kalman_ou_iii/w3d-frequency-tracking.tex-part
+++ b/doc/kalman_ou_iii/w3d-frequency-tracking.tex-part
@@ -52,16 +52,3 @@ Sec.~\ref{sec:direction} estimates both sine and cosine coefficients, so a
 constant carrier-phase offset does not bias the recovered propagation axis.
 Frequency-tracker alternatives are retained for implementation portability but
 are not compared in the direction-validation evidence reported here.
-
-\begin{figure}[!t]
-  \centering
-  \resizebox{\columnwidth}{!}{%
-    \input{w3d_ou3_jonswap_medium_tuner.pgf}%
-  }
-  \caption{Representative integrated frequency/tuning diagnostic for the
-  medium JONSWAP record.  The upper panel is the KalmANF carrier-frequency
-  trace used by the direction estimator.  The remaining panels are generated
-  by the shared OU--III motion-estimator pipeline and are shown only as context;
-  they are not inputs to the direction estimator.}
-  \label{fig:wave-dir-frequency-medium}
-\end{figure}

--- a/doc/kalman_ou_iii/w3d-wave-direction-config.tex-part
+++ b/doc/kalman_ou_iii/w3d-wave-direction-config.tex-part
@@ -5,9 +5,8 @@
 Table~\ref{tab:direction-implementation-gates} records the direction-specific
 settings used by the reported simulations.  These thresholds are validity and
 hysteresis safeguards rather than reference-trajectory fit parameters.  They
-were previously listed with the OU--III navigation-filter defaults; they belong
-to the direction subsystem because they govern the carrier tracker, axial
-acceptance, and travel-sense decision only.
+belong to the direction subsystem because they govern the carrier tracker,
+axial acceptance, and travel-sense decision only.
 
 \begin{table}[t]
 \centering

--- a/doc/kalman_ou_iii/w3d-wave-direction-results.tex-part
+++ b/doc/kalman_ou_iii/w3d-wave-direction-results.tex-part
@@ -47,10 +47,11 @@ can exchange names when that representative flips by $180^\circ$.
 
 Across the eight stationary JONSWAP and PM--Stokes seas, the pooled absolute
 circular-mean wave-axis error is
-\OUValidationDirectionAbsError{} degrees and the worst scenario is
-\OUValidationDirectionWorstAbsError{} degrees.  Truth-referenced travel sense
-is correct for \OUValidationTravelCorrect\% of samples, wrong for
-\OUValidationTravelWrong\%, and unresolved for
+\OUValidationDirectionAbsError{} degrees, the pooled sample-level axial RMS
+error is \OUValidationDirectionRMSE{} degrees, and the worst scenario-level
+absolute circular-mean error is \OUValidationDirectionWorstAbsError{} degrees.
+Truth-referenced travel sense is correct for \OUValidationTravelCorrect\% of
+samples, wrong for \OUValidationTravelWrong\%, and unresolved for
 \OUValidationTravelUnresolved\%.  The absolute error of the final directed
 estimate is \OUValidationTravelAbsError{} degrees under the aggregate metric
 reported by the committed validation bundle.
@@ -67,6 +68,54 @@ uncertainty and confidence are estimator metrics, while the final panel is the
 separate travel-sense decision.
 
 \input{w3d-wave-direction-charts.tex-part}
+
+\subsection{Integrated replay with OU--III attitude input}
+\label{sec:direction-ou3-integration}
+
+The deterministic traces above were originally produced in the integrated
+OU--III replay.  In that configuration the direction subsystem receives the
+levelled attitude/heading frame from the surrounding marine estimator after its
+startup handoff.  OU--III translational states, its integral pseudo-measurement,
+and its adaptive regularization variables are \emph{not} inputs to the
+direction algorithm.  Table~\ref{tab:direction-ou3-integration} therefore
+reproduces only the direction-relevant fields from the deterministic OU--III
+results table: upstream attitude RMS errors and the resulting direction/travel
+outputs.  It is integration evidence, not an OU--III performance claim for this
+paper.
+
+\begin{table}[t]
+  \centering
+  \caption{Direction-relevant results from the deterministic integrated OU--III
+  replay, scored over the final \SI{900}{s}.  R/P/Y are upstream attitude RMS
+  errors in degrees; $\bar\theta$ is the mean axial direction estimate.}
+  \label{tab:direction-ou3-integration}
+  \scriptsize
+  \setlength{\tabcolsep}{1.6pt}
+  \renewcommand{\arraystretch}{1.06}
+  \begin{tabular}{@{}lrrrrrl@{}}
+    \toprule
+    Case & $H_s$ & R & P & Y & $\bar\theta$ & T/A/U [\%] \\
+    \midrule
+    JONSWAP    & 0.27 & 0.28 & 0.17 & 1.06 &  31.5 & 0.0/96.9/3.1 \\
+    JONSWAP    & 1.50 & 0.26 & 0.15 & 1.05 & -28.5 & 96.7/0.9/2.4 \\
+    JONSWAP    & 4.00 & 0.49 & 0.33 & 1.04 &  31.0 & 1.2/96.5/2.3 \\
+    JONSWAP    & 8.50 & 0.45 & 0.44 & 0.71 & -25.9 & 94.4/1.7/3.9 \\
+    \addlinespace
+    PM--Stokes & 0.27 & 0.27 & 0.20 & 0.74 &  32.7 & 0.0/97.4/2.6 \\
+    PM--Stokes & 1.50 & 0.26 & 0.21 & 1.03 & -28.1 & 97.0/0.4/2.6 \\
+    PM--Stokes & 4.00 & 0.40 & 0.23 & 0.47 &  30.1 & 0.2/98.2/1.5 \\
+    PM--Stokes & 8.50 & 0.32 & 0.20 & 0.48 & -26.6 & 97.9/0.3/1.8 \\
+    \bottomrule
+  \end{tabular}
+  \vspace{1pt}
+
+  \parbox{0.98\columnwidth}{\scriptsize
+  T/A/U denotes the estimator's Toward/Away/Uncertain labels relative to its
+  chosen axial representative; it is a commitment diagnostic, not the
+  truth-referenced correctness rate reported above.  The deterministic table is
+  a single-realization integration check and is not interchangeable with the
+  ten-seed aggregate direction statistics.}
+\end{table}
 
 \subsection{Frequency and confidence interpretation}
 

--- a/tests/validation/test_wave_direction_charts.py
+++ b/tests/validation/test_wave_direction_charts.py
@@ -19,6 +19,9 @@ class WaveDirectionChartContractTests(unittest.TestCase):
         frequency = (DOC / "w3d-frequency-tracking.tex-part").read_text(
             encoding="utf-8"
         )
+        config = (DOC / "w3d-wave-direction-config.tex-part").read_text(
+            encoding="utf-8"
+        )
         charts = (DOC / "w3d-wave-direction-charts.tex-part").read_text(
             encoding="utf-8"
         )
@@ -40,12 +43,16 @@ class WaveDirectionChartContractTests(unittest.TestCase):
         ):
             self.assertIn(name, charts)
 
-        publication_sources = article + results + frequency + charts
+        publication_sources = article + results + frequency + config + charts
         self.assertNotIn("w3d_ou3_jonswap_medium_tuner.pgf", publication_sources)
-        self.assertNotIn("R_S", publication_sources)
-        self.assertNotIn("r_S", publication_sources)
-        self.assertNotIn("tau_applied", publication_sources)
-        self.assertNotIn("sigma_a_applied", publication_sources)
+        for token in ("R_S", "r_S", r"R_{S}", r"r_{S}", "tau_applied", "sigma_a_applied", "sigma_{aw}"):
+            self.assertNotIn(token, publication_sources)
+
+        # OU--III is allowed only where the paper explicitly reports the
+        # integrated replay that supplied its upstream attitude input.
+        non_integration_sources = article + frequency + config + charts
+        self.assertNotIn("OU--III", non_integration_sources)
+        self.assertIn(r"\subsection{Integrated replay with OU--III attitude input}", results)
 
         # IEEE conference output is two-column.  Publication plots stay inside
         # one column; no figure* or text-width scaling may creep back in.

--- a/tests/validation/test_wave_direction_charts.py
+++ b/tests/validation/test_wave_direction_charts.py
@@ -1,5 +1,6 @@
-"""Publication contract for generated figures in kalman-wave-dir.tex."""
+"""Publication contract for figures and integrated validation in kalman-wave-dir.tex."""
 
+import re
 import unittest
 from pathlib import Path
 
@@ -10,7 +11,7 @@ PLOTS = REPO_ROOT / "plots" / "kalman_ou_iii"
 
 
 class WaveDirectionChartContractTests(unittest.TestCase):
-    def test_direction_article_uses_generated_single_column_pgfs(self):
+    def test_direction_article_uses_only_direction_pgfs(self):
         article = (DOC / "kalman-wave-dir.tex").read_text(encoding="utf-8")
         results = (DOC / "w3d-wave-direction-results.tex-part").read_text(
             encoding="utf-8"
@@ -29,25 +30,64 @@ class WaveDirectionChartContractTests(unittest.TestCase):
         self.assertIn(r"\providecommand{\mathdefault}[1]{#1}", article)
         self.assertIn(r"\input{w3d-wave-direction-charts.tex-part}", results)
 
-        # The existing plot pipeline creates these two PGF families before the
-        # LaTeX step; the publication must consume them rather than duplicate
-        # plotting logic in the manuscript.
+        # The shared plot pipeline still creates both direction and OU tuning
+        # diagnostics, but this publication consumes only the direction family.
         self.assertIn('finalize_plot(fig, outbase, "_dir")', plotter)
-        self.assertIn('finalize_plot(fig, outbase, "_tuner")', plotter)
         for name in (
             "w3d_ou3_jonswap_medium_dir.pgf",
             "w3d_ou3_jonswap_low_dir.pgf",
             "w3d_ou3_pmstokes_medium_dir.pgf",
         ):
             self.assertIn(name, charts)
-        self.assertIn("w3d_ou3_jonswap_medium_tuner.pgf", frequency)
+
+        publication_sources = article + results + frequency + charts
+        self.assertNotIn("w3d_ou3_jonswap_medium_tuner.pgf", publication_sources)
+        self.assertNotIn("R_S", publication_sources)
+        self.assertNotIn("r_S", publication_sources)
+        self.assertNotIn("tau_applied", publication_sources)
+        self.assertNotIn("sigma_a_applied", publication_sources)
 
         # IEEE conference output is two-column.  Publication plots stay inside
         # one column; no figure* or text-width scaling may creep back in.
-        figure_sources = charts + frequency
-        self.assertNotIn(r"\begin{figure*}", figure_sources)
-        self.assertNotIn(r"\textwidth", figure_sources)
-        self.assertEqual(figure_sources.count(r"\resizebox{\columnwidth}{!}"), 4)
+        self.assertNotIn(r"\begin{figure*}", charts)
+        self.assertNotIn(r"\textwidth", charts)
+        self.assertEqual(charts.count(r"\resizebox{\columnwidth}{!}"), 3)
+
+    def test_integrated_ou3_table_is_scoped_and_mirrors_committed_results(self):
+        results = (DOC / "w3d-wave-direction-results.tex-part").read_text(
+            encoding="utf-8"
+        )
+        source = (DOC / "w3d-sim-results-generated.tex-part").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn(r"\label{tab:direction-ou3-integration}", results)
+        self.assertIn("integration evidence, not an OU--III performance claim", results)
+        self.assertIn("OUValidationDirectionRMSE", results)
+        self.assertNotIn("Z RMS", results)
+        self.assertNotIn(r"Z\%$H_s$", results)
+
+        row_pattern = re.compile(
+            r"^\s*(JONSWAP|PM--Stokes)\s*&\s*([0-9.]+)\s*&\s*"
+            r"[0-9.]+\s*&\s*[0-9.]+\s*&\s*"
+            r"([0-9.]+)\s*&\s*([0-9.]+)\s*&\s*([0-9.]+)\s*&\s*"
+            r"(-?[0-9.]+)\s*&\s*([0-9.]+/[0-9.]+/[0-9.]+)\s*\\\\$",
+            re.MULTILINE,
+        )
+        rows = row_pattern.findall(source)
+        self.assertEqual(len(rows), 8)
+
+        # Copy only the upstream attitude RMS and direction fields.  If the
+        # committed deterministic evidence changes, this table must be restated
+        # rather than silently drifting out of sync.
+        for case, hs, roll, pitch, yaw, theta, tau in rows:
+            expected = re.compile(
+                rf"{re.escape(case)}\s*&\s*{re.escape(hs)}\s*&\s*"
+                rf"{re.escape(roll)}\s*&\s*{re.escape(pitch)}\s*&\s*"
+                rf"{re.escape(yaw)}\s*&\s*{re.escape(theta)}\s*&\s*"
+                rf"{re.escape(tau)}"
+            )
+            self.assertRegex(results, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove the entire OU--III frequency/tuner PGF from `kalman-wave-dir.tex`; the wave-direction paper no longer shows `R_S`, OU time-constant, or OU amplitude/tuning traces
- keep the KalmANF method description without importing an OU-specific diagnostic figure
- remove the historical OU--III note from the direction-gate configuration section
- add a scoped `Integrated replay with OU--III attitude input` subsection to the direction results
- reproduce only the direction-relevant fields from the committed deterministic OU--III results table: upstream roll/pitch/yaw RMS, mean axial direction, and T/A/U state fractions for all eight JONSWAP/PM--Stokes cases
- report the existing ten-seed pooled direction RMSE macro alongside the primary circular-mean direction metrics
- update the publication contract so the wave-direction article cannot re-import the tuner PGF or OU-specific `R_S`/`tau`/`sigma_aw` material, and so the integration table stays synchronized with the generated deterministic evidence

## Scope
OU--III is mentioned only as the upstream attitude source for that integrated replay. Its translational states, pseudo-measurement regularization, and adaptive tuning are explicitly outside the wave-direction method.