### PR TITLE
Add OU-III integrated direction RMS table

### DIFF
--- a/doc/kalman_ou_iii/w3d-wave-direction-results.tex-part
+++ b/doc/kalman_ou_iii/w3d-wave-direction-results.tex-part
@@ -72,16 +72,49 @@ separate travel-sense decision.
 \subsection{Integrated replay with OU--III attitude input}
 \label{sec:direction-ou3-integration}
 
-The deterministic traces above were originally produced in the integrated
-OU--III replay.  In that configuration the direction subsystem receives the
-levelled attitude/heading frame from the surrounding marine estimator after its
-startup handoff.  OU--III translational states, its integral pseudo-measurement,
-and its adaptive regularization variables are \emph{not} inputs to the
-direction algorithm.  Table~\ref{tab:direction-ou3-integration} therefore
-reproduces only the direction-relevant fields from the deterministic OU--III
-results table: upstream attitude RMS errors and the resulting direction/travel
-outputs.  It is integration evidence, not an OU--III performance claim for this
-paper.
+The reported ten-seed direction metrics were obtained from the adaptive OU--III
+integrated replay: the direction subsystem receives the levelled attitude and
+heading frame from the surrounding marine estimator after startup handoff.
+OU--III translational states, its integral pseudo-measurement, and its adaptive
+regularization variables are \emph{not} inputs to the direction algorithm.
+Table~\ref{tab:direction-ou3-rms} reports the wave-direction RMS errors from
+that integrated test, while Table~\ref{tab:direction-ou3-integration} gives the
+corresponding single-realization attitude and commitment diagnostics retained in
+the original OU--III results section.  This is integration evidence, not an
+OU--III performance claim for this paper.
+
+\begin{table}[t]
+  \centering
+  \caption{Wave-direction RMS errors in the ten-seed adaptive OU--III integrated
+  replay.  Entries are mean $\pm$ sample standard deviation across the ten seed
+  triplets, in degrees.}
+  \label{tab:direction-ou3-rms}
+  \footnotesize
+  \setlength{\tabcolsep}{3.0pt}
+  \renewcommand{\arraystretch}{1.06}
+  \begin{tabular}{@{}lrrr@{}}
+    \toprule
+    Case & $H_s$ [m] & Axis RMS & Directed RMS \\
+    \midrule
+    JONSWAP    & 0.27 & $13.78\pm0.98$ & $15.20\pm0.97$ \\
+    JONSWAP    & 1.50 & $12.03\pm0.53$ & $19.50\pm2.15$ \\
+    JONSWAP    & 4.00 & $11.44\pm0.55$ & $23.87\pm1.88$ \\
+    JONSWAP    & 8.50 & $11.27\pm0.39$ & $26.94\pm2.47$ \\
+    \addlinespace
+    PM--Stokes & 0.27 & $14.35\pm1.11$ & $14.42\pm1.31$ \\
+    PM--Stokes & 1.50 & $12.37\pm0.65$ & $15.10\pm0.79$ \\
+    PM--Stokes & 4.00 & $12.11\pm0.79$ & $15.78\pm1.17$ \\
+    PM--Stokes & 8.50 & $12.30\pm0.82$ & $16.60\pm1.34$ \\
+    \bottomrule
+  \end{tabular}
+\end{table}
+
+The directed RMS is intentionally much larger than the scenario-level circular
+mean error.  A small fraction of wrong travel-sense decisions produces errors
+near $180^\circ$ and therefore carries large quadratic weight in RMS, even
+though the truth-referenced travel-sense decision is correct for
+\OUValidationTravelCorrect\% of samples.  Reporting both metrics prevents the
+high correct-decision fraction from hiding those rare but severe sense flips.
 
 \begin{table}[t]
   \centering

--- a/tests/validation/test_wave_direction_charts.py
+++ b/tests/validation/test_wave_direction_charts.py
@@ -71,7 +71,11 @@ class WaveDirectionChartContractTests(unittest.TestCase):
         )
 
         self.assertIn(r"\label{tab:direction-ou3-integration}", results)
-        self.assertIn("integration evidence, not an OU--III performance claim", results)
+        normalized_results = " ".join(results.split())
+        self.assertIn(
+            "integration evidence, not an OU--III performance claim",
+            normalized_results,
+        )
         self.assertIn("OUValidationDirectionRMSE", results)
         self.assertNotIn("Z RMS", results)
         self.assertNotIn(r"Z\%$H_s$", results)

--- a/tests/validation/test_wave_direction_charts.py
+++ b/tests/validation/test_wave_direction_charts.py
@@ -1,5 +1,6 @@
 """Publication contract for figures and integrated validation in kalman-wave-dir.tex."""
 
+import csv
 import re
 import unittest
 from pathlib import Path
@@ -8,6 +9,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DOC = REPO_ROOT / "doc" / "kalman_ou_iii"
 PLOTS = REPO_ROOT / "plots" / "kalman_ou_iii"
+VALIDATION_SUMMARY = REPO_ROOT / "reports" / "results" / "ou_validation" / "ou_validation_summary.csv"
 
 
 class WaveDirectionChartContractTests(unittest.TestCase):
@@ -93,6 +95,48 @@ class WaveDirectionChartContractTests(unittest.TestCase):
                 rf"{re.escape(roll)}\s*&\s*{re.escape(pitch)}\s*&\s*"
                 rf"{re.escape(yaw)}\s*&\s*{re.escape(theta)}\s*&\s*"
                 rf"{re.escape(tau)}"
+            )
+            self.assertRegex(results, expected)
+
+    def test_ou3_direction_rms_table_mirrors_ten_seed_summary(self):
+        results = (DOC / "w3d-wave-direction-results.tex-part").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn(r"\label{tab:direction-ou3-rms}", results)
+
+        scenario_labels = {
+            "stationary_jonswap_H0_270_L14_047_A30_00_P60_00": ("JONSWAP", "0.27"),
+            "stationary_jonswap_H1_500_L50_710_A_30_00_P120_00": ("JONSWAP", "1.50"),
+            "stationary_jonswap_H4_000_L112_766_A30_00_P30_00": ("JONSWAP", "4.00"),
+            "stationary_jonswap_H8_500_L202_839_A_30_00_P72_00": ("JONSWAP", "8.50"),
+            "stationary_pmstokes_H0_270_L14_047_A30_00_P60_00": ("PM--Stokes", "0.27"),
+            "stationary_pmstokes_H1_500_L50_710_A_30_00_P120_00": ("PM--Stokes", "1.50"),
+            "stationary_pmstokes_H4_000_L112_766_A30_00_P30_00": ("PM--Stokes", "4.00"),
+            "stationary_pmstokes_H8_500_L202_839_A_30_00_P72_00": ("PM--Stokes", "8.50"),
+        }
+        metrics = {}
+        with VALIDATION_SUMMARY.open(newline="", encoding="utf-8") as stream:
+            for row in csv.DictReader(stream):
+                scenario = row["scenario"]
+                if (
+                    scenario in scenario_labels
+                    and row["family"] == "OU_III"
+                    and row["mode"] == "Adaptive"
+                    and row["metric"] in {"dir_axis_rmse_deg", "dir_travel_rmse_deg"}
+                ):
+                    metrics[(scenario, row["metric"])] = (
+                        float(row["mean"]),
+                        float(row["std"]),
+                    )
+
+        self.assertEqual(len(metrics), 16)
+        for scenario, (case, hs) in scenario_labels.items():
+            axis_mean, axis_std = metrics[(scenario, "dir_axis_rmse_deg")]
+            travel_mean, travel_std = metrics[(scenario, "dir_travel_rmse_deg")]
+            expected = (
+                rf"{re.escape(case)}\s*&\s*{re.escape(hs)}\s*&\s*"
+                rf"\${axis_mean:.2f}\\pm{axis_std:.2f}\$\s*&\s*"
+                rf"\${travel_mean:.2f}\\pm{travel_std:.2f}\$"
             )
             self.assertRegex(results, expected)
 


### PR DESCRIPTION
## Summary
- follow up the merged #318 on a fresh branch from current `main`
- add the actual ten-seed wave-direction RMS error table from the committed `OU_III / Adaptive` validation summary
- report per-scenario axial RMS and directed RMS for all eight stationary JONSWAP and PM--Stokes cases
- explain why directed RMS is much larger than the circular-mean error: rare wrong travel-sense decisions carry near-180-degree errors and dominate the quadratic metric
- keep OU--III scoped only as the upstream attitude/heading source for this integrated validation subsection
- add a validation contract that reads `ou_validation_summary.csv` and verifies the table stays synchronized with the committed evidence

The OU-specific tuner chart and `R_S`/OU adaptation traces remain absent from the wave-direction paper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OU-III replay results to report ten-seed adaptive replay metrics.
  * Added axis and directed RMS error results across eight wave scenarios, including variability.
  * Clarified direction-system inputs and excluded state components.
  * Documented how rare incorrect travel-sense decisions can produce large directed errors.

* **Tests**
  * Added validation ensuring the documented RMS table matches ten-seed summary metrics.
  * Improved integration-table validation to handle formatting differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->