### PR TITLE
Experiment: measure physical-period rS adaptation optimum

### DIFF
--- a/.github/workflows/ou-rs-adaptation-optimum.yml
+++ b/.github/workflows/ou-rs-adaptation-optimum.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "tools/ou_rs_adaptation_optimum.py"
       - "tools/ou_rs_adaptation_optimum_run.py"
+      - "tools/ou_rs_adaptation_refine.py"
       - ".github/workflows/ou-rs-adaptation-optimum.yml"
   workflow_dispatch:
 
@@ -40,11 +41,11 @@ jobs:
             -exec cp -f {} plots/kalman_ou_ii/ \;
           test -f plots/kalman_ou_ii/wave_data_jonswap_H1.500_L50.710_A-30.00_P120.00.csv
 
-      - name: Run physical-period optimum experiment
+      - name: Run refined physical-period optimum experiment
         run: |
-          python3 -u tools/ou_rs_adaptation_optimum_run.py \
+          python3 -u tools/ou_rs_adaptation_refine.py \
             --stretch "0.85,0.925,1.0,1.075,1.15" \
-            --rs-factors "0.65,0.78,0.9,1.0,1.12,1.28,1.5" \
+            --rs-factors "0.25,0.35,0.45,0.55,0.65,0.78,0.9,1.05,1.2" \
             --wave-seeds "11,29,47" \
             --imu-seeds "101,211,307" \
             --init-seeds "1009,1103,1201" \

--- a/.github/workflows/ou-rs-adaptation-optimum.yml
+++ b/.github/workflows/ou-rs-adaptation-optimum.yml
@@ -1,0 +1,57 @@
+name: ou-rs-adaptation-optimum
+
+on:
+  pull_request:
+    paths:
+      - "tools/ou_rs_adaptation_optimum.py"
+      - ".github/workflows/ou-rs-adaptation-optimum.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  experiment:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends g++ make libeigen3-dev python3-numpy
+
+      - name: Download versioned simulation data
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download v1.1.3 \
+            --repo bareboat-necessities/oceanography-waves-lib \
+            --pattern sim-data-files.zip \
+            --clobber
+          mkdir -p plots/kalman_ou_ii
+          unzip -o sim-data-files.zip -d plots/kalman_ou_ii >/dev/null
+
+      - name: Run physical-period optimum experiment
+        run: |
+          python3 -u tools/ou_rs_adaptation_optimum.py \
+            --stretch "0.85,0.925,1.0,1.075,1.15" \
+            --rs-factors "0.65,0.78,0.9,1.0,1.12,1.28,1.5" \
+            --wave-seeds "11,29,47" \
+            --imu-seeds "101,211,307" \
+            --init-seeds "1009,1103,1201" \
+            --duration-sec 600 \
+            --window-sec 300 \
+            --jobs "$(nproc)" \
+            --bootstrap 2000 \
+            --output-dir reports/results/ou_rs_adaptation_optimum
+
+      - name: Upload result
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: ou-rs-adaptation-optimum
+          path: reports/results/ou_rs_adaptation_optimum/**
+          if-no-files-found: warn

--- a/.github/workflows/ou-rs-adaptation-optimum.yml
+++ b/.github/workflows/ou-rs-adaptation-optimum.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq --no-install-recommends g++ make libeigen3-dev python3-numpy
+          sudo apt-get install -y -qq --no-install-recommends g++ make libeigen3-dev python3-numpy unzip
 
       - name: Download versioned simulation data
         env:
@@ -32,8 +32,13 @@ jobs:
             --repo bareboat-necessities/oceanography-waves-lib \
             --pattern sim-data-files.zip \
             --clobber
-          mkdir -p plots/kalman_ou_ii
-          unzip -o sim-data-files.zip -d plots/kalman_ou_ii >/dev/null
+          rm -rf /tmp/ou-sim-data
+          mkdir -p /tmp/ou-sim-data plots/kalman_ou_ii
+          unzip -q sim-data-files.zip -d /tmp/ou-sim-data
+          find /tmp/ou-sim-data -type f \
+            \( -name 'wave_data_jonswap_*.csv' -o -name 'wave_data_pmstokes_*.csv' \) \
+            -exec cp -f {} plots/kalman_ou_ii/ \;
+          test -f plots/kalman_ou_ii/wave_data_jonswap_H1.500_L50.710_A-30.00_P120.00.csv
 
       - name: Run physical-period optimum experiment
         run: |

--- a/.github/workflows/ou-rs-adaptation-optimum.yml
+++ b/.github/workflows/ou-rs-adaptation-optimum.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "tools/ou_rs_adaptation_optimum.py"
+      - "tools/ou_rs_adaptation_optimum_run.py"
       - ".github/workflows/ou-rs-adaptation-optimum.yml"
   workflow_dispatch:
 
@@ -12,7 +13,7 @@ permissions:
 
 jobs:
   experiment:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:
       - name: Checkout
@@ -36,7 +37,7 @@ jobs:
 
       - name: Run physical-period optimum experiment
         run: |
-          python3 -u tools/ou_rs_adaptation_optimum.py \
+          python3 -u tools/ou_rs_adaptation_optimum_run.py \
             --stretch "0.85,0.925,1.0,1.075,1.15" \
             --rs-factors "0.65,0.78,0.9,1.0,1.12,1.28,1.5" \
             --wave-seeds "11,29,47" \

--- a/.github/workflows/ou-rs-candidate-full-validation.yml
+++ b/.github/workflows/ou-rs-candidate-full-validation.yml
@@ -1,0 +1,60 @@
+name: ou-rs-candidate-full-validation
+
+on:
+  pull_request:
+    paths:
+      - "tools/ou_rs_candidate_full_validation.py"
+      - ".github/workflows/ou-rs-candidate-full-validation.yml"
+      - "src/kalman_ou_iii/**"
+      - "tests/kalman_ou_iii/**"
+      - "tools/ou_validation.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  experiment:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends g++ make libeigen3-dev python3-numpy unzip
+
+      - name: Download versioned simulation data
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download v1.1.3 \
+            --repo bareboat-necessities/oceanography-waves-lib \
+            --pattern sim-data-files.zip \
+            --clobber
+          rm -rf /tmp/ou-sim-data
+          mkdir -p /tmp/ou-sim-data plots/kalman_ou_ii
+          unzip -q sim-data-files.zip -d /tmp/ou-sim-data
+          find /tmp/ou-sim-data -type f \
+            \( -name 'wave_data_jonswap_*.csv' -o -name 'wave_data_pmstokes_*.csv' \) \
+            -exec cp -f {} plots/kalman_ou_ii/ \;
+          test -f plots/kalman_ou_ii/wave_data_jonswap_H1.500_L50.710_A-30.00_P120.00.csv
+          test -f plots/kalman_ou_ii/wave_data_pmstokes_H8.500_L202.839_A-30.00_P72.00.csv
+
+      - name: Run deployed vs cubic vs fitted full validation
+        run: |
+          python3 -u tools/ou_rs_candidate_full_validation.py \
+            --jobs "$(nproc)" \
+            --shards 2 \
+            --bootstrap 5000 \
+            --output-dir reports/results/ou_rs_candidate_full_validation
+
+      - name: Upload result
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: ou-rs-candidate-full-validation
+          path: reports/results/ou_rs_candidate_full_validation/**
+          if-no-files-found: warn

--- a/.github/workflows/ou-rs-candidate-full-validation.yml
+++ b/.github/workflows/ou-rs-candidate-full-validation.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "tools/ou_rs_candidate_full_validation.py"
+      - "tools/ou_rs_candidate_full_validation_fixed.py"
       - ".github/workflows/ou-rs-candidate-full-validation.yml"
       - "src/kalman_ou_iii/**"
       - "tests/kalman_ou_iii/**"
@@ -45,7 +46,7 @@ jobs:
 
       - name: Run deployed vs cubic vs fitted full validation
         run: |
-          python3 -u tools/ou_rs_candidate_full_validation.py \
+          python3 -u tools/ou_rs_candidate_full_validation_fixed.py \
             --jobs "$(nproc)" \
             --shards 2 \
             --bootstrap 5000 \

--- a/.github/workflows/ou-rs-candidate-matrix.yml
+++ b/.github/workflows/ou-rs-candidate-matrix.yml
@@ -1,0 +1,59 @@
+name: ou-rs-candidate-matrix
+
+on:
+  pull_request:
+    paths:
+      - "tools/ou_rs_candidate_arm.py"
+      - ".github/workflows/ou-rs-candidate-matrix.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  candidate:
+    strategy:
+      fail-fast: false
+      matrix:
+        label: [cubic_p3, fitted_p2p9052]
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends g++ make libeigen3-dev python3-numpy unzip
+
+      - name: Download versioned simulation data
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download v1.1.3 \
+            --repo bareboat-necessities/oceanography-waves-lib \
+            --pattern sim-data-files.zip \
+            --clobber
+          rm -rf /tmp/ou-sim-data
+          mkdir -p /tmp/ou-sim-data plots/kalman_ou_ii
+          unzip -q sim-data-files.zip -d /tmp/ou-sim-data
+          find /tmp/ou-sim-data -type f \
+            \( -name 'wave_data_jonswap_*.csv' -o -name 'wave_data_pmstokes_*.csv' \) \
+            -exec cp -f {} plots/kalman_ou_ii/ \;
+
+      - name: Run candidate arm
+        run: |
+          python3 -u tools/ou_rs_candidate_arm.py \
+            --label "${{ matrix.label }}" \
+            --jobs "$(nproc)" \
+            --shards 2 \
+            --output-dir "reports/results/ou_rs_candidate_matrix/${{ matrix.label }}"
+
+      - name: Upload candidate rows
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: "ou-rs-${{ matrix.label }}"
+          path: "reports/results/ou_rs_candidate_matrix/${{ matrix.label }}/**"
+          if-no-files-found: warn

--- a/.github/workflows/ou-rs-cubic-normalization-sweep.yml
+++ b/.github/workflows/ou-rs-cubic-normalization-sweep.yml
@@ -1,0 +1,62 @@
+name: ou-rs-cubic-normalization-sweep
+
+on:
+  pull_request:
+    paths:
+      - "tools/ou_rs_cubic_normalization_arm.py"
+      - "tools/ou_rs_candidate_full_validation.py"
+      - "tools/ou_rs_candidate_full_validation_fixed.py"
+      - ".github/workflows/ou-rs-cubic-normalization-sweep.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  normalization:
+    strategy:
+      fail-fast: false
+      max-parallel: 7
+      matrix:
+        label: [r1161, r1300, r1400, r1500, r1600, r1700, r1860]
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends g++ make libeigen3-dev python3-numpy unzip
+
+      - name: Download versioned simulation data
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download v1.1.3 \
+            --repo bareboat-necessities/oceanography-waves-lib \
+            --pattern sim-data-files.zip \
+            --clobber
+          rm -rf /tmp/ou-sim-data
+          mkdir -p /tmp/ou-sim-data plots/kalman_ou_ii
+          unzip -q sim-data-files.zip -d /tmp/ou-sim-data
+          find /tmp/ou-sim-data -type f \
+            \( -name 'wave_data_jonswap_*.csv' -o -name 'wave_data_pmstokes_*.csv' \) \
+            -exec cp -f {} plots/kalman_ou_ii/ \;
+
+      - name: Run normalization arm
+        run: |
+          python3 -u tools/ou_rs_cubic_normalization_arm.py \
+            --label "${{ matrix.label }}" \
+            --jobs "$(nproc)" \
+            --shards 2 \
+            --output-dir "reports/results/ou_rs_cubic_normalization/${{ matrix.label }}"
+
+      - name: Upload normalization rows
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: "ou-rs-cubic-${{ matrix.label }}"
+          path: "reports/results/ou_rs_cubic_normalization/${{ matrix.label }}/**"
+          if-no-files-found: warn

--- a/reports/results/ou_rs_adaptation_optimum/summary.md
+++ b/reports/results/ou_rs_adaptation_optimum/summary.md
@@ -1,0 +1,67 @@
+# Physical-period r_S adaptation optimum
+
+This result is from the successful refinement of the dedicated full-MEKF experiment on draft PR #324, GitHub Actions run 31916274242 attempt 2 (job 95088661303), commit c869be0dbb6a12502f42bc51a5daf8c3782edb69.
+
+## Question
+
+Measure the adaptation exponent with respect to *physical sea period*, rather than perturbing the OU filter parameter on a fixed physical sea.
+
+The source is the JONSWAP Hs=1.5 m, L=50.710 m stationary record. Five physical time stretches s = {0.85, 0.925, 1.0, 1.075, 1.15} are constructed. Translational acceleration RMS is held fixed exactly (to numerical precision) while displacement and velocity obey p_s(t)=c s^2 p(t/s), v_s(t)=c s v(t/s), a_s(t)=c a(t/s). Attitude is time-stretched at fixed angular standard deviation and the body IMU is rebuilt, so attitude/gravity leakage remains present.
+
+At each stretch, tau_filter = tau_0 s, sigma_aw is fixed, and the effective r_S standard deviation actually entering Kalman3D_Wave_OU_III is swept independently. The wrapper's cadence information-rate factor is explicitly inverted when constructing the fixed-tuning command, so it cannot predetermine the measured exponent.
+
+Three matched wave/IMU/initialization seed triplets are used. Each replay is 600 s and the trailing 300 s is scored. The refined grid contains nine effective-r_S factors {0.25, 0.35, 0.45, 0.55, 0.65, 0.78, 0.9, 1.05, 1.2} around the deployed tau^2.5 centre, for 135 full-MEKF replays. At every stretch the optimum is interior to the refined grid.
+
+## Result
+
+For vertical displacement MSE,
+
+- p_tau = **3.0053**
+- seed-triplet bootstrap 95% descriptive interval: **2.6517 to 3.2844**
+
+For full 3-D displacement MSE,
+
+- p_tau = **2.9052**
+- seed-triplet bootstrap 95% descriptive interval: **2.8346 to 3.0276**
+
+The bootstrap interval is descriptive because there are only three independent seed triplets; the main evidence is the smooth interior optimum at all five physical-period points.
+
+### Vertical-MSE optima
+
+| physical stretch | effective r_S optimum [m s] | deployed tau^2.5 centre [m s] | optimum/deployed |
+|---:|---:|---:|---:|
+| 0.850 | 1.025892 | 1.241597 | 0.8263 |
+| 0.925 | 1.325828 | 1.533867 | 0.8644 |
+| 1.000 | 1.578124 | 1.863947 | 0.8467 |
+| 1.075 | 2.045023 | 2.233339 | 0.9157 |
+| 1.150 | 2.575293 | 2.643492 | 0.9742 |
+
+### Full-3-D-MSE optima
+
+| physical stretch | effective r_S optimum [m s] | deployed tau^2.5 centre [m s] | optimum/deployed |
+|---:|---:|---:|---:|
+| 0.850 | 0.741031 | 1.241597 | 0.5968 |
+| 0.925 | 0.941594 | 1.533867 | 0.6139 |
+| 1.000 | 1.160579 | 1.863947 | 0.6226 |
+| 1.075 | 1.448576 | 2.233339 | 0.6486 |
+| 1.150 | 1.790962 | 2.643492 | 0.6775 |
+
+## Local fitted laws
+
+Using the nominal calibration point tau_0 = 2.17904091 s and sigma_0 = 0.724445343 m/s^2, and combining this period experiment with the separately measured amplitude exponent p_sigma = 1, the fitted effective-input laws are
+
+- vertical objective: r_S,eff ~= **0.20968 sigma_aw tau^3.0053**
+- full 3-D objective: r_S,eff ~= **0.16671 sigma_aw tau^2.9052**
+
+The currently deployed wrapper instead produces r_S,eff ~= 0.36708 sigma_aw tau^2.5 at the filter input.
+
+If the current cadence normalization r_S,eff = r_S,base sqrt(T_S0/T_S), with T_S proportional to tau, is retained, then the equivalent *base-command* laws are
+
+- vertical objective: r_S,base ~= **0.19992 sigma_aw tau^3.5053**
+- full 3-D objective: r_S,base ~= **0.15895 sigma_aw tau^3.4052**
+
+Equivalently, removing the cadence information-rate renormalization and applying the effective law directly would avoid the extra +1/2 exponent in the base command.
+
+## Interpretation
+
+This local full-MEKF experiment rejects tau^2.5 as the optimum period dependence around the nominal JONSWAP sea. The vertical optimum is essentially cubic in physical period; the full-3-D optimum is slightly shallower but still close to cubic. The result is local to a self-similar period family around the nominal sea and should be confirmed on additional spectral families before being promoted to a universal adaptation law.

--- a/reports/results/ou_rs_candidate_full_validation/final-summary.md
+++ b/reports/results/ou_rs_candidate_full_validation/final-summary.md
@@ -1,0 +1,80 @@
+# Full paired validation of candidate effective-rS laws
+
+This report compares the current deployed OU-III adaptive regularizer against two candidate laws on the complete ten-seed validation suite. Production filter source was not changed; the candidate law is injected only by the experiment harness.
+
+## Protocol
+
+- 4 stationary JONSWAP seas + 4 stationary PM-Stokes seas + the standard non-stationary JONSWAP transition.
+- 10 identical predeclared wave-phase / IMU-noise / initialization seed triplets per scenario.
+- 1200 s replays; trailing 900 s scored; transition interval 420--780 s.
+- 90 paired rows per arm.
+- Candidate effective laws:
+  - cubic: rS_eff = 0.1548363522 sigma_aw tau^3
+  - fitted: rS_eff = 0.1667018769 sigma_aw tau^2.9052
+- Both candidates pass through the independently measured nominal full-3D optimum rS_eff = 1.160579 m s at tau = 2.17904091 s and sigma_aw = 0.724445343 m/s^2.
+- The existing adaptive tau(t), sigma_aw(t), and pseudo-measurement cadence are unchanged.
+
+The deployed, cubic, and fitted artifacts each contain exactly 90 unique paired rows. Pair keys match exactly. The maximum paired differences in tau_applied_s and sigma_applied_mps2 between deployed and either candidate are exactly zero. Simulator return-code / quality-gate patterns are also identical arm-to-arm, so the regularizer-law comparison does not alter which existing validation cases trip those gates.
+
+## Eight stationary seas
+
+Statistics below first average the eight stationary scenarios within each seed triplet and then compare the ten paired seed aggregates. Intervals are descriptive paired bootstrap 95% intervals over those ten seed aggregates.
+
+| metric | deployed | cubic p=3 | cubic change | fitted p=2.9052 | fitted change |
+|---|---:|---:|---:|---:|---:|
+| Z error [%Hs] | 4.4887 | 4.5307 | +0.0420 pp [ +0.0108, +0.0696 ] | 4.5410 | +0.0522 pp [ +0.0193, +0.0816 ] |
+| 3-D RMS [m] | 0.39519 | 0.37682 | -4.56% [ -5.40%, -3.83% ] | 0.37386 | -5.28% [ -6.34%, -4.35% ] |
+| X RMS | -- | -- | -2.55% | -- | -2.81% |
+| Y RMS | -- | -- | -8.58% | -- | -10.14% |
+| Z RMS | -- | -- | +1.54% | -- | +2.06% |
+| yaw RMS | -- | -- | +0.04% | -- | +0.04% |
+
+The 3-D RMS improvement has the same sign on all 10 seed aggregates for both candidates. Cubic improves 3-D RMS on all ten seeds in every one of the eight stationary scenarios. Fitted does the same.
+
+By spectral family, cubic changes 3-D RMS by -4.84% on JONSWAP and -4.25% on PM-Stokes. Fitted changes it by -5.79% on JONSWAP and -4.73% on PM-Stokes.
+
+### Per-scenario stationary 3-D RMS change
+
+| sea | cubic p=3 | fitted p=2.9052 | seeds improved |
+|---|---:|---:|---:|
+| JONSWAP Hs=0.27 m | -11.23% | -11.16% | 10/10 both |
+| JONSWAP Hs=1.50 m | -9.28% | -9.33% | 10/10 both |
+| JONSWAP Hs=4.00 m | -5.92% | -6.40% | 10/10 both |
+| JONSWAP Hs=8.50 m | -3.38% | -4.71% | 10/10 both |
+| PM-Stokes Hs=0.27 m | -10.76% | -10.71% | 10/10 both |
+| PM-Stokes Hs=1.50 m | -7.86% | -7.90% | 10/10 both |
+| PM-Stokes Hs=4.00 m | -5.41% | -5.64% | 10/10 both |
+| PM-Stokes Hs=8.50 m | -2.91% | -3.60% | 10/10 both |
+
+The corresponding cubic Z-error changes in percentage points of Hs are -0.0746, +0.0206, +0.0882, +0.0292 for the four JONSWAP seas and -0.0382, +0.1352, +0.1040, +0.0715 for PM-Stokes. Thus the stationary 3-D improvement is driven by the horizontal channels and is not a uniform all-axis improvement.
+
+## Cubic versus exact fitted exponent
+
+Comparing fitted p=2.9052 directly against cubic p=3 on the eight stationary seas:
+
+- fitted lowers 3-D RMS a further 0.764% [0.538%, 1.015%] relative to cubic, with the same sign on all ten seed aggregates;
+- fitted lowers Y RMS another 1.72%;
+- fitted lowers X RMS another 0.28%;
+- fitted raises Z RMS by 0.509% and raises Z error by 0.01025 percentage points of Hs relative to cubic, with the same sign on all ten seed aggregates.
+
+So the exact exponent buys a small additional horizontal/3-D improvement at a measurable additional vertical cost.
+
+## Non-stationary transition
+
+For the complete transition scoring window, cubic changes 3-D RMS by -0.218% (6/10 seed triplets improve) while increasing Z RMS by +4.26% (0/10 improve). Fitted changes 3-D RMS by -0.272% (6/10 improve) while increasing Z RMS by +5.54% (0/10 improve).
+
+Segmented transition results:
+
+| segment | cubic Z | cubic 3-D | fitted Z | fitted 3-D |
+|---|---:|---:|---:|---:|
+| start | +0.86% | -9.82% | +0.88% | -9.86% |
+| blend | +8.52% | +3.62% | +10.08% | +4.28% |
+| end | +2.13% | -1.53% | +3.30% | -1.89% |
+
+For cubic, the blend-segment Z degradation occurs on all 10 seeds and the blend 3-D degradation occurs on 9/10. For fitted, the corresponding blend results are also 10/10 Z worse and 9/10 3-D worse. At the end segment both candidates improve 3-D on all 10 seeds but worsen Z on all 10.
+
+## Interpretation
+
+The complete validation supports the physical-period result that a near-cubic effective law is much better for the stationary full-3D objective than the deployed tau^2.5 law. However, the nominal full-3D normalization found on the stationary calibration sea is too aggressive to be called a universal production optimum: it systematically sacrifices vertical accuracy and introduces a clear transient penalty during the transition blend.
+
+If the sole objective is stationary full-3D displacement RMS, fitted p=2.9052 is best of these three tested laws. If a simple law is desired, cubic p=3 captures most of that benefit with less vertical and transition damage. Neither candidate dominates the deployed law on all required metrics, so neither should replace the deployed default yet without a normalization / transient-scheduling follow-up experiment.

--- a/reports/results/ou_rs_cubic_normalization_sweep/final-summary.md
+++ b/reports/results/ou_rs_cubic_normalization_sweep/final-summary.md
@@ -1,0 +1,43 @@
+# Cubic effective-rS normalization sweep
+
+This experiment fixes the candidate adaptation law to
+
+\[
+r_{S,\mathrm{eff}} = K\,\sigma_{aw}\,\tau^3
+\]
+
+and varies only the normalization `K`. The full OU-III Adaptive suite is used: four stationary JONSWAP seas, four stationary PM-Stokes seas, the standard non-stationary transition, and the same ten predeclared paired seed triplets. Each arm contains 90 paired validation rows.
+
+The nominal reference point is `tau=2.17904091 s`, `sigma_aw=0.724445343 m/s^2`, so `rS_nom = 7.49552016 K`.
+
+## Results versus deployed law
+
+Negative percentages are improvements.
+
+| nominal effective rS [m s] | K | stationary 3-D | stationary Z | blend 3-D | blend Z | whole-transition 3-D | whole-transition Z |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1.1606 | 0.154836 | -4.56% | +1.54% | +3.62% | +8.52% | -0.22% | +4.26% |
+| 1.3000 | 0.173437 | -2.56% | +0.51% | +1.92% | +4.50% | +0.16% | +1.82% |
+| 1.4000 | 0.186778 | -0.80% | +0.22% | +1.26% | +2.25% | +0.90% | +0.65% |
+| 1.5000 | 0.200120 | +1.18% | +0.22% | +0.97% | +0.42% | +1.93% | -0.15% |
+| 1.6000 | 0.213461 | +3.33% | +0.46% | +1.00% | -1.05% | +3.22% | -0.62% |
+| 1.7000 | 0.226802 | +5.61% | +0.90% | +1.29% | -2.22% | +4.71% | -0.82% |
+| 1.8600 | 0.248148 | +9.48% | +1.95% | +2.20% | -3.55% | +7.42% | -0.68% |
+
+The repeated `rS_nom=1.160579` arm reproduces the prior cubic experiment exactly: paired values for X/Y/Z/3-D displacement, transition segments, tau and sigma are bit-for-bit identical.
+
+## Decisive finding
+
+A local quadratic fit through the middle normalization points gives:
+
+- stationary 3-D crosses deployed performance at approximately `rS_nom = 1.441 m s` (`K = 0.19223`); tighter values improve stationary 3-D, looser values worsen it;
+- transition-blend Z crosses deployed performance at approximately `rS_nom = 1.526 m s` (`K = 0.20355`); values below this worsen blend Z;
+- transition-blend 3-D has its fitted minimum near `rS_nom = 1.548 m s` (`K = 0.20657`), but even there remains approximately `+0.93%` worse than deployed.
+
+Therefore there is no constant cubic normalization that both preserves the stationary 3-D advantage and avoids the transition penalty. The required stationary-3-D and transition-Z regions do not overlap, and transition-blend 3-D remains worse throughout the tested cubic family.
+
+## Practical interpretation
+
+- If only stationary full-3D performance matters, the tighter cubic region is beneficial. `rS_nom=1.30` is a useful compromise: stationary 3-D improves 2.56% while stationary Z RMS worsens only 0.51%; all eight stationary sea-state mean 3-D results improve, with 79/80 individual sea/seed pairs improving.
+- If a single constant cubic law is forced across stationary and transition operation, about `rS_nom=1.50` is the least-bad balance among the tested points, but it still worsens stationary 3-D by 1.18% and transition-blend 3-D by 0.97%, so it does not justify replacing the deployed law.
+- The data support a two-regime design rather than another global normalization: use the tighter near-cubic law in settled/stationary conditions and relax/revert the regularizer during detected sea-state transitions. That transient scheduler requires its own paired validation before production use.

--- a/tools/ou_rs_adaptation_optimum.py
+++ b/tools/ou_rs_adaptation_optimum.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""Measure the full-MEKF r_S adaptation exponent against physical sea period.
+
+This is deliberately different from an OU-parameter sensitivity sweep.  The
+physical input record is time-stretched while translational acceleration RMS is
+held fixed.  At each stretch the OU time constant is moved with the physical
+period, sigma_aw is held fixed, and the *effective filter-input* r_S is swept
+independently.  The optimum r_S is then fitted versus physical period.
+
+The transformation is, axis by axis,
+
+    p_s(t) = c s^2 p(t/s),   v_s(t) = c s v(t/s),   a_s(t) = c a(t/s),
+
+with c chosen only to remove finite-record/interpolation RMS drift so the
+acceleration RMS equals the s=1 realization exactly.  Attitude is time-stretched
+at fixed angular amplitude and body IMU fields are rebuilt from the transformed
+world motion and attitude.
+
+The wrapper's Cubic law rescales the commanded/base r_S by sqrt(T_S0/T_S)
+before it reaches Kalman3D_Wave_OU_III.  This experiment therefore converts a
+desired filter-input r_S back to the command value before calling fixed tuning,
+so the quantity being optimized is unambiguous.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import os
+import tempfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any, Iterable
+
+import numpy as np
+
+import ou_validation as core
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SOURCE = REPO_ROOT / "plots/kalman_ou_ii/wave_data_jonswap_H1.500_L50.710_A-30.00_P120.00.csv"
+
+# Current nominal noise-free operating point of that record.  This is only the
+# centre of the sweep; no exponent is inferred from the old r_S law.
+TAU0 = 2.17904091
+SIGMA0 = 0.724445343
+RS_BASE0 = 2.62343205657498
+
+TS0 = 0.015
+TAU_TS0 = 1.1
+CT = TS0 / TAU_TS0
+TS_MIN = 0.005
+TS_MAX = 0.25
+
+
+def parse_floats(text: str) -> list[float]:
+    out = [float(x.strip()) for x in text.split(",") if x.strip()]
+    if not out or any((not math.isfinite(x) or x <= 0.0) for x in out):
+        raise argparse.ArgumentTypeError("expected positive finite comma-separated values")
+    return out
+
+
+def parse_ints(text: str) -> list[int]:
+    out = [int(x.strip()) for x in text.split(",") if x.strip()]
+    if not out:
+        raise argparse.ArgumentTypeError("expected comma-separated integers")
+    return out
+
+
+def pseudo_period(tau: float) -> float:
+    return min(max(CT * tau, TS_MIN), TS_MAX)
+
+
+def information_scale(tau: float) -> float:
+    return math.sqrt(TS0 / pseudo_period(tau))
+
+
+def interp_columns(source_t: np.ndarray, values: np.ndarray, query_t: np.ndarray) -> np.ndarray:
+    result = np.empty((query_t.size, values.shape[1]), dtype=np.float64)
+    for axis in range(values.shape[1]):
+        result[:, axis] = np.interp(query_t, source_t, values[:, axis])
+    return result
+
+
+def rms_zero_mean(x: np.ndarray) -> np.ndarray:
+    centred = x - np.mean(x, axis=0, keepdims=True)
+    return np.sqrt(np.mean(centred * centred, axis=0))
+
+
+def time_stretch_constant_accel(
+    columns: list[str],
+    phase_record: np.ndarray,
+    stretch: float,
+    duration_sec: float,
+) -> tuple[np.ndarray, dict[str, Any]]:
+    """Time-stretch one stationary realization at fixed acceleration amplitude."""
+
+    n = max(2, int(round(duration_sec / core.DT_SECONDS)))
+    if n > phase_record.shape[0]:
+        raise ValueError("duration exceeds source record")
+
+    time_idx = columns.index("time")
+    source_t = phase_record[:, time_idx]
+    target = phase_record[:n].copy()
+    target_t = target[:, time_idx]
+    t0 = float(source_t[0])
+    query_t = t0 + (target_t - t0) / stretch
+    if query_t[-1] > source_t[-1]:
+        raise ValueError(
+            f"stretch={stretch:g} with duration={duration_sec:g}s needs source t={query_t[-1]:g}, "
+            f"but source ends at {source_t[-1]:g}"
+        )
+
+    disp_i = core._column_indices(columns, ("disp_x", "disp_y", "disp_z"))
+    vel_i = core._column_indices(columns, ("vel_x", "vel_y", "vel_z"))
+    acc_i = core._column_indices(columns, ("acc_x", "acc_y", "acc_z"))
+    att_i = core._column_indices(columns, ("roll_deg", "pitch_deg", "yaw_deg"))
+
+    p_src = phase_record[:, disp_i]
+    v_src = phase_record[:, vel_i]
+    a_src = phase_record[:, acc_i]
+    th_src = phase_record[:, att_i]
+
+    p_q = interp_columns(source_t, p_src, query_t)
+    v_q = interp_columns(source_t, v_src, query_t)
+    a_q = interp_columns(source_t, a_src, query_t)
+    th_q = interp_columns(source_t, th_src, query_t)
+
+    # Reference amplitude is the same phase realization at s=1 over the same
+    # scored-duration precursor.  Renormalization is tiny but prevents a finite
+    # record from masquerading as a sigma_aw change when only period is intended.
+    ref_acc = phase_record[:n, acc_i]
+    ref_acc_rms = rms_zero_mean(ref_acc)
+    q_acc_rms = rms_zero_mean(a_q)
+    linear_gain = np.divide(
+        ref_acc_rms,
+        q_acc_rms,
+        out=np.ones_like(ref_acc_rms),
+        where=q_acc_rms > 1e-12,
+    )
+
+    p_mean = np.mean(p_q, axis=0, keepdims=True)
+    target[:, disp_i] = p_mean + (p_q - p_mean) * (stretch**2) * linear_gain
+    target[:, vel_i] = v_q * stretch * linear_gain
+    target[:, acc_i] = a_q * linear_gain
+
+    # Keep angular excursion fixed while changing its period.  This preserves
+    # the full MEKF's attitude/gravity-leakage mechanism instead of deleting it.
+    ref_att = phase_record[:n, att_i]
+    ref_att_std = rms_zero_mean(ref_att)
+    q_att_mean = np.mean(th_q, axis=0, keepdims=True)
+    q_att_std = rms_zero_mean(th_q)
+    att_gain = np.divide(
+        ref_att_std,
+        q_att_std,
+        out=np.ones_like(ref_att_std),
+        where=q_att_std > 1e-12,
+    )
+    target[:, att_i] = q_att_mean + (th_q - q_att_mean) * att_gain
+
+    target = core.rebuild_body_imu(columns, target)
+
+    out_acc_rms = rms_zero_mean(target[:, acc_i])
+    out_att_std = rms_zero_mean(target[:, att_i])
+    diag = {
+        "stretch": stretch,
+        "acc_rms_ref": ref_acc_rms.tolist(),
+        "acc_rms_out": out_acc_rms.tolist(),
+        "acc_rms_ratio": (out_acc_rms / ref_acc_rms).tolist(),
+        "att_std_ref": ref_att_std.tolist(),
+        "att_std_out": out_att_std.tolist(),
+        "att_std_ratio": np.divide(out_att_std, ref_att_std, out=np.ones_like(out_att_std), where=ref_att_std > 1e-12).tolist(),
+        "linear_gain": linear_gain.tolist(),
+        "att_gain": att_gain.tolist(),
+    }
+    return target, diag
+
+
+def mean_mse(rows: Iterable[dict[str, Any]], metric: str) -> float:
+    vals = np.asarray([float(r[metric]) for r in rows], dtype=np.float64)
+    return float(np.mean(vals * vals))
+
+
+def optimum_for_stretch(rows: list[dict[str, Any]], metric: str) -> dict[str, float]:
+    factors = sorted({float(r["rs_factor"]) for r in rows})
+    grouped = []
+    for factor in factors:
+        grp = [r for r in rows if math.isclose(float(r["rs_factor"]), factor, rel_tol=0.0, abs_tol=1e-12)]
+        grouped.append((factor, float(grp[0]["rs_input"]), mean_mse(grp, metric)))
+
+    y = np.asarray([g[2] for g in grouped])
+    j = int(np.argmin(y))
+    # Fit a local quadratic in log r_S. Five points when available, centred on
+    # the discrete minimum. This is the Hessian approximation required by the
+    # implicit-optimum derivative, not a global polynomial through the tails.
+    count = min(5, len(grouped))
+    lo = max(0, min(j - count // 2, len(grouped) - count))
+    local = grouped[lo:lo + count]
+    x = np.log(np.asarray([g[1] for g in local]))
+    yy = np.asarray([g[2] for g in local])
+    a, b, c = np.polyfit(x, yy, 2)
+    if not (math.isfinite(a) and a > 0.0):
+        xopt = math.log(grouped[j][1])
+    else:
+        xopt = -b / (2.0 * a)
+        xopt = float(np.clip(xopt, np.min(x), np.max(x)))
+    ropt = math.exp(xopt)
+    return {
+        "rs_opt": ropt,
+        "mse_opt_fit": float(a * xopt * xopt + b * xopt + c),
+        "curvature_log_rs": float(2.0 * a),
+        "discrete_rs": grouped[j][1],
+        "discrete_mse": grouped[j][2],
+    }
+
+
+def exponent_from_rows(rows: list[dict[str, Any]], metric: str) -> tuple[float, list[dict[str, float]]]:
+    opts: list[dict[str, float]] = []
+    for stretch in sorted({float(r["stretch"]) for r in rows}):
+        grp = [r for r in rows if math.isclose(float(r["stretch"]), stretch, rel_tol=0.0, abs_tol=1e-12)]
+        opt = optimum_for_stretch(grp, metric)
+        deployed = float(grp[0]["rs_input_deployed_center"])
+        opts.append({"stretch": stretch, "deployed_center": deployed, **opt, "opt_over_deployed": opt["rs_opt"] / deployed})
+    v = np.log(np.asarray([o["stretch"] for o in opts]))
+    u = np.log(np.asarray([o["rs_opt"] for o in opts]))
+    slope, intercept = np.polyfit(v, u, 1)
+    return float(slope), opts
+
+
+def bootstrap_exponent(rows: list[dict[str, Any]], metric: str, resamples: int, seed: int) -> dict[str, float]:
+    seed_ids = sorted({int(r["repetition"]) for r in rows})
+    if len(seed_ids) < 2 or resamples <= 0:
+        return {"bootstrap_low": math.nan, "bootstrap_high": math.nan, "bootstrap_median": math.nan}
+    by_seed = {sid: [r for r in rows if int(r["repetition"]) == sid] for sid in seed_ids}
+    rng = np.random.default_rng(seed)
+    values: list[float] = []
+    for _ in range(resamples):
+        draw = rng.choice(seed_ids, size=len(seed_ids), replace=True)
+        sample: list[dict[str, Any]] = []
+        for new_rep, sid in enumerate(draw):
+            for row in by_seed[int(sid)]:
+                copy = dict(row)
+                copy["repetition"] = new_rep
+                sample.append(copy)
+        try:
+            p, _ = exponent_from_rows(sample, metric)
+        except Exception:
+            continue
+        if math.isfinite(p):
+            values.append(p)
+    if not values:
+        return {"bootstrap_low": math.nan, "bootstrap_high": math.nan, "bootstrap_median": math.nan}
+    arr = np.asarray(values)
+    low, median, high = np.quantile(arr, (0.025, 0.5, 0.975))
+    return {"bootstrap_low": float(low), "bootstrap_high": float(high), "bootstrap_median": float(median)}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--stretch", type=parse_floats, default=parse_floats("0.85,0.925,1,1.075,1.15"))
+    parser.add_argument("--rs-factors", type=parse_floats, default=parse_floats("0.65,0.78,0.9,1,1.12,1.28,1.5"))
+    parser.add_argument("--wave-seeds", type=parse_ints, default=parse_ints("11,29,47"))
+    parser.add_argument("--imu-seeds", type=parse_ints, default=parse_ints("101,211,307"))
+    parser.add_argument("--init-seeds", type=parse_ints, default=parse_ints("1009,1103,1201"))
+    parser.add_argument("--duration-sec", type=float, default=600.0)
+    parser.add_argument("--window-sec", type=float, default=300.0)
+    parser.add_argument("--jobs", type=int, default=max(1, os.cpu_count() or 1))
+    parser.add_argument("--bootstrap", type=int, default=2000)
+    parser.add_argument("--output-dir", type=Path, default=REPO_ROOT / "reports/results/ou_rs_adaptation_optimum")
+    args = parser.parse_args()
+
+    if not (args.duration_sec > args.window_sec > 0.0):
+        parser.error("duration-sec must exceed positive window-sec")
+    if not (len(args.wave_seeds) == len(args.imu_seeds) == len(args.init_seeds)):
+        parser.error("wave/imu/init seed lists must have equal length")
+    if min(args.stretch) <= args.duration_sec / 1200.0:
+        parser.error("selected stretch/duration can run beyond the 1200 s source")
+    if not SOURCE.exists():
+        raise FileNotFoundError(f"missing released simulation record: {SOURCE}")
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    core.build_simulators(("OU_III",), None)
+
+    # Nominal effective r_S actually entering the MEKF, after cadence matching.
+    rs_input0 = RS_BASE0 * information_scale(TAU0)
+
+    rows: list[dict[str, Any]] = []
+    diagnostics: list[dict[str, Any]] = []
+
+    with tempfile.TemporaryDirectory(prefix="ou-rs-period-") as td:
+        temp = Path(td)
+        columns, source = core.read_wave_csv(SOURCE)
+
+        generated: dict[tuple[int, float], Path] = {}
+        for repetition, wave_seed in enumerate(args.wave_seeds):
+            phased = core.phase_randomize_wave(columns, source, wave_seed)
+            for stretch in args.stretch:
+                transformed, diag = time_stretch_constant_accel(columns, phased, stretch, args.duration_sec)
+                path = temp / f"period_s{stretch:.6f}_seed{wave_seed}.csv"
+                core.write_wave_csv(path, columns, transformed)
+                generated[(repetition, stretch)] = path
+                diagnostics.append({"repetition": repetition, "wave_seed": wave_seed, **diag})
+
+        tasks: list[tuple[int, float, float, Path]] = []
+        for repetition, _ in enumerate(args.wave_seeds):
+            for stretch in args.stretch:
+                for factor in args.rs_factors:
+                    tasks.append((repetition, stretch, factor, generated[(repetition, stretch)]))
+
+        def run_one(task: tuple[int, float, float, Path]) -> dict[str, Any]:
+            repetition, stretch, factor, path = task
+            tau = TAU0 * stretch
+            sigma = SIGMA0
+            # Centre the independent sweep on the currently deployed *input*
+            # exponent. The factor grid is independent, so the fit can reject it.
+            deployed_center = rs_input0 * stretch**2.5
+            desired_input = deployed_center * factor
+            scale = information_scale(tau)
+            base_command = desired_input / scale
+            point = core.TuningPoint(tau_s=tau, sigma_a_mps2=sigma, RS_ms=base_command)
+            metrics, gate, code = core.run_simulator(
+                "OU_III",
+                path,
+                args.window_sec,
+                args.imu_seeds[repetition],
+                args.init_seeds[repetition],
+                tuning_mode="fixed",
+                tuning_point=point,
+                aw_cov_sync="periodic",
+                write_timeseries=False,
+            )
+            return {
+                "repetition": repetition,
+                "wave_seed": args.wave_seeds[repetition],
+                "imu_seed": args.imu_seeds[repetition],
+                "init_seed": args.init_seeds[repetition],
+                "stretch": stretch,
+                "tau_filter": tau,
+                "sigma_filter": sigma,
+                "pseudo_period": pseudo_period(tau),
+                "information_scale": scale,
+                "rs_factor": factor,
+                "rs_input_deployed_center": deployed_center,
+                "rs_input": desired_input,
+                "rs_base_command": base_command,
+                "gate_pass": int(gate),
+                "return_code": code,
+                "disp_z_rms_m": float(metrics["disp_z_rms_m"]),
+                "disp_3d_rms_m": float(metrics["disp_3d_rms_m"]),
+                "roll_rms_deg": float(metrics.get("roll_rms_deg", math.nan)),
+                "pitch_rms_deg": float(metrics.get("pitch_rms_deg", math.nan)),
+                "yaw_rms_deg": float(metrics.get("yaw_rms_deg", math.nan)),
+                "accel_bias_3d_rms_mps2": float(metrics.get("accel_bias_3d_rms_mps2", math.nan)),
+            }
+
+        with ThreadPoolExecutor(max_workers=max(1, args.jobs)) as pool:
+            futures = [pool.submit(run_one, task) for task in tasks]
+            for i, future in enumerate(as_completed(futures), 1):
+                row = future.result()
+                rows.append(row)
+                print(
+                    f"[{i}/{len(futures)}] s={row['stretch']:.3f} "
+                    f"r={row['rs_factor']:.3f} rep={row['repetition']} "
+                    f"z={row['disp_z_rms_m']:.6f} 3d={row['disp_3d_rms_m']:.6f}",
+                    flush=True,
+                )
+
+    rows.sort(key=lambda r: (r["stretch"], r["rs_factor"], r["repetition"]))
+    raw_path = args.output_dir / "raw.csv"
+    with raw_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+    z_p, z_opts = exponent_from_rows(rows, "disp_z_rms_m")
+    d3_p, d3_opts = exponent_from_rows(rows, "disp_3d_rms_m")
+    z_boot = bootstrap_exponent(rows, "disp_z_rms_m", args.bootstrap, 20260815)
+    d3_boot = bootstrap_exponent(rows, "disp_3d_rms_m", args.bootstrap, 20260816)
+
+    summary = {
+        "definition": "effective filter-input r_S standard deviation versus physical period at fixed translational acceleration RMS",
+        "source": str(SOURCE.relative_to(REPO_ROOT)),
+        "duration_sec": args.duration_sec,
+        "window_sec": args.window_sec,
+        "stretches": args.stretch,
+        "rs_factors_about_deployed_2p5_center": args.rs_factors,
+        "seeds": [
+            {"wave": w, "imu": i, "init": n}
+            for w, i, n in zip(args.wave_seeds, args.imu_seeds, args.init_seeds)
+        ],
+        "nominal": {
+            "tau": TAU0,
+            "sigma": SIGMA0,
+            "rs_base": RS_BASE0,
+            "rs_input": rs_input0,
+        },
+        "vertical": {"p_tau": z_p, **z_boot, "optima": z_opts},
+        "three_d": {"p_tau": d3_p, **d3_boot, "optima": d3_opts},
+        "transform_diagnostics": diagnostics,
+    }
+    (args.output_dir / "summary.json").write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+
+    def table_lines(opts: list[dict[str, float]]) -> list[str]:
+        out = ["| stretch | rS optimum | deployed center | ratio |", "|---:|---:|---:|---:|"]
+        for o in opts:
+            out.append(
+                f"| {o['stretch']:.3f} | {o['rs_opt']:.6f} | {o['deployed_center']:.6f} | {o['opt_over_deployed']:.4f} |"
+            )
+        return out
+
+    md = [
+        "# Physical-period r_S optimum",
+        "",
+        "The physical record is time-stretched while acceleration RMS is held fixed; r_S is then independently re-optimized at every stretch.",
+        "",
+        f"**Vertical-MSE exponent:** p_tau = **{z_p:.4f}** (bootstrap 95% {z_boot['bootstrap_low']:.4f} to {z_boot['bootstrap_high']:.4f})",
+        f"**3-D-MSE exponent:** p_tau = **{d3_p:.4f}** (bootstrap 95% {d3_boot['bootstrap_low']:.4f} to {d3_boot['bootstrap_high']:.4f})",
+        "",
+        "## Vertical optimum",
+        "",
+        *table_lines(z_opts),
+        "",
+        "## 3-D optimum",
+        "",
+        *table_lines(d3_opts),
+        "",
+        "`rS optimum` is the standard deviation actually entering the MEKF after the wrapper's cadence information-rate normalization.",
+    ]
+    (args.output_dir / "summary.md").write_text("\n".join(md) + "\n", encoding="utf-8")
+    print("\n" + "\n".join(md), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ou_rs_adaptation_optimum_run.py
+++ b/tools/ou_rs_adaptation_optimum_run.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Runner for the physical-period r_S optimum experiment.
+
+Uses the transformations/fits in ou_rs_adaptation_optimum.py, but writes every
+synthetic record with a valid WaveFileNaming-compatible basename.  Under the
+fixed-acceleration time stretch p_s(t)=s^2 p(t/s), the physical displacement
+height and deep-water wavelength both scale as s^2 while period scales as s.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import os
+import tempfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any
+
+import ou_rs_adaptation_optimum as exp
+import ou_validation as core
+
+
+def physical_filename(stretch: float) -> str:
+    s2 = stretch * stretch
+    return (
+        f"wave_data_jonswap_H{1.5*s2:.3f}_L{50.710*s2:.3f}_"
+        "A-30.00_P120.00.csv"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--stretch", type=exp.parse_floats, default=exp.parse_floats("0.85,0.925,1,1.075,1.15"))
+    parser.add_argument("--rs-factors", type=exp.parse_floats, default=exp.parse_floats("0.65,0.78,0.9,1,1.12,1.28,1.5"))
+    parser.add_argument("--wave-seeds", type=exp.parse_ints, default=exp.parse_ints("11,29,47"))
+    parser.add_argument("--imu-seeds", type=exp.parse_ints, default=exp.parse_ints("101,211,307"))
+    parser.add_argument("--init-seeds", type=exp.parse_ints, default=exp.parse_ints("1009,1103,1201"))
+    parser.add_argument("--duration-sec", type=float, default=600.0)
+    parser.add_argument("--window-sec", type=float, default=300.0)
+    parser.add_argument("--jobs", type=int, default=max(1, os.cpu_count() or 1))
+    parser.add_argument("--bootstrap", type=int, default=2000)
+    parser.add_argument("--output-dir", type=Path, default=exp.REPO_ROOT / "reports/results/ou_rs_adaptation_optimum")
+    args = parser.parse_args()
+
+    if not (args.duration_sec > args.window_sec > 0.0):
+        parser.error("duration-sec must exceed positive window-sec")
+    if not (len(args.wave_seeds) == len(args.imu_seeds) == len(args.init_seeds)):
+        parser.error("wave/imu/init seed lists must have equal length")
+    if min(args.stretch) <= args.duration_sec / 1200.0:
+        parser.error("selected stretch/duration can run beyond the 1200 s source")
+    if not exp.SOURCE.exists():
+        raise FileNotFoundError(f"missing released simulation record: {exp.SOURCE}")
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    core.build_simulators(("OU_III",), None)
+    rs_input0 = exp.RS_BASE0 * exp.information_scale(exp.TAU0)
+
+    rows: list[dict[str, Any]] = []
+    diagnostics: list[dict[str, Any]] = []
+
+    with tempfile.TemporaryDirectory(prefix="ou-rs-period-") as td:
+        temp = Path(td)
+        columns, source = core.read_wave_csv(exp.SOURCE)
+        generated: dict[tuple[int, float], Path] = {}
+
+        for repetition, wave_seed in enumerate(args.wave_seeds):
+            phased = core.phase_randomize_wave(columns, source, wave_seed)
+            for stretch in args.stretch:
+                transformed, diag = exp.time_stretch_constant_accel(
+                    columns, phased, stretch, args.duration_sec
+                )
+                # Keep the basename parseable by WaveFileNaming.  Separate
+                # directories allow different phase realizations to share it.
+                path = (
+                    temp
+                    / f"seed_{wave_seed}"
+                    / f"stretch_{stretch:.6f}"
+                    / physical_filename(stretch)
+                )
+                core.write_wave_csv(path, columns, transformed)
+                generated[(repetition, stretch)] = path
+                diagnostics.append(
+                    {
+                        "repetition": repetition,
+                        "wave_seed": wave_seed,
+                        "filename": path.name,
+                        "declared_height_m": 1.5 * stretch * stretch,
+                        "declared_length_m": 50.710 * stretch * stretch,
+                        **diag,
+                    }
+                )
+
+        tasks: list[tuple[int, float, float, Path]] = [
+            (repetition, stretch, factor, generated[(repetition, stretch)])
+            for repetition in range(len(args.wave_seeds))
+            for stretch in args.stretch
+            for factor in args.rs_factors
+        ]
+
+        def run_one(task: tuple[int, float, float, Path]) -> dict[str, Any]:
+            repetition, stretch, factor, path = task
+            tau = exp.TAU0 * stretch
+            sigma = exp.SIGMA0
+            deployed_center = rs_input0 * stretch**2.5
+            desired_input = deployed_center * factor
+            info_scale = exp.information_scale(tau)
+            base_command = desired_input / info_scale
+            point = core.TuningPoint(
+                tau_s=tau,
+                sigma_a_mps2=sigma,
+                RS_ms=base_command,
+            )
+            metrics, gate, code = core.run_simulator(
+                "OU_III",
+                path,
+                args.window_sec,
+                args.imu_seeds[repetition],
+                args.init_seeds[repetition],
+                tuning_mode="fixed",
+                tuning_point=point,
+                aw_cov_sync="periodic",
+                write_timeseries=False,
+            )
+            return {
+                "repetition": repetition,
+                "wave_seed": args.wave_seeds[repetition],
+                "imu_seed": args.imu_seeds[repetition],
+                "init_seed": args.init_seeds[repetition],
+                "stretch": stretch,
+                "declared_height_m": 1.5 * stretch * stretch,
+                "declared_length_m": 50.710 * stretch * stretch,
+                "tau_filter": tau,
+                "sigma_filter": sigma,
+                "pseudo_period": exp.pseudo_period(tau),
+                "information_scale": info_scale,
+                "rs_factor": factor,
+                "rs_input_deployed_center": deployed_center,
+                "rs_input": desired_input,
+                "rs_base_command": base_command,
+                "gate_pass": int(gate),
+                "return_code": code,
+                "disp_z_rms_m": float(metrics["disp_z_rms_m"]),
+                "disp_3d_rms_m": float(metrics["disp_3d_rms_m"]),
+                "roll_rms_deg": float(metrics.get("roll_rms_deg", math.nan)),
+                "pitch_rms_deg": float(metrics.get("pitch_rms_deg", math.nan)),
+                "yaw_rms_deg": float(metrics.get("yaw_rms_deg", math.nan)),
+                "accel_bias_3d_rms_mps2": float(metrics.get("accel_bias_3d_rms_mps2", math.nan)),
+            }
+
+        with ThreadPoolExecutor(max_workers=max(1, args.jobs)) as pool:
+            pending = [pool.submit(run_one, task) for task in tasks]
+            for i, future in enumerate(as_completed(pending), 1):
+                row = future.result()
+                rows.append(row)
+                print(
+                    f"[{i}/{len(pending)}] s={row['stretch']:.3f} "
+                    f"r={row['rs_factor']:.3f} rep={row['repetition']} "
+                    f"z={row['disp_z_rms_m']:.6f} 3d={row['disp_3d_rms_m']:.6f}",
+                    flush=True,
+                )
+
+    rows.sort(key=lambda r: (r["stretch"], r["rs_factor"], r["repetition"]))
+    raw_path = args.output_dir / "raw.csv"
+    with raw_path.open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.DictWriter(stream, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+    z_p, z_opts = exp.exponent_from_rows(rows, "disp_z_rms_m")
+    d3_p, d3_opts = exp.exponent_from_rows(rows, "disp_3d_rms_m")
+    z_boot = exp.bootstrap_exponent(rows, "disp_z_rms_m", args.bootstrap, 20260815)
+    d3_boot = exp.bootstrap_exponent(rows, "disp_3d_rms_m", args.bootstrap, 20260816)
+
+    summary = {
+        "definition": "effective filter-input r_S std versus physical period at fixed translational acceleration RMS",
+        "source": str(exp.SOURCE.relative_to(exp.REPO_ROOT)),
+        "duration_sec": args.duration_sec,
+        "window_sec": args.window_sec,
+        "stretches": args.stretch,
+        "rs_factors_about_deployed_2p5_center": args.rs_factors,
+        "seeds": [
+            {"wave": w, "imu": i, "init": n}
+            for w, i, n in zip(args.wave_seeds, args.imu_seeds, args.init_seeds)
+        ],
+        "nominal": {
+            "tau": exp.TAU0,
+            "sigma": exp.SIGMA0,
+            "rs_base": exp.RS_BASE0,
+            "rs_input": rs_input0,
+        },
+        "vertical": {"p_tau": z_p, **z_boot, "optima": z_opts},
+        "three_d": {"p_tau": d3_p, **d3_boot, "optima": d3_opts},
+        "transform_diagnostics": diagnostics,
+    }
+    (args.output_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2) + "\n", encoding="utf-8"
+    )
+
+    def table(opts: list[dict[str, float]]) -> list[str]:
+        lines = [
+            "| stretch | rS optimum | deployed center | opt/deployed |",
+            "|---:|---:|---:|---:|",
+        ]
+        for o in opts:
+            lines.append(
+                f"| {o['stretch']:.3f} | {o['rs_opt']:.6f} | "
+                f"{o['deployed_center']:.6f} | {o['opt_over_deployed']:.4f} |"
+            )
+        return lines
+
+    md = [
+        "# Physical-period r_S optimum",
+        "",
+        "The physical JONSWAP realization is time-stretched while translational acceleration RMS is held fixed. Tau follows physical period; sigma_aw is fixed; effective filter-input r_S is independently swept.",
+        "",
+        f"**Vertical-MSE exponent:** p_tau = **{z_p:.4f}** (bootstrap 95% {z_boot['bootstrap_low']:.4f} to {z_boot['bootstrap_high']:.4f})",
+        f"**3-D-MSE exponent:** p_tau = **{d3_p:.4f}** (bootstrap 95% {d3_boot['bootstrap_low']:.4f} to {d3_boot['bootstrap_high']:.4f})",
+        "",
+        "## Vertical optimum",
+        "",
+        *table(z_opts),
+        "",
+        "## 3-D optimum",
+        "",
+        *table(d3_opts),
+        "",
+        "`rS optimum` is the standard deviation actually entering the MEKF after cadence information-rate normalization.",
+    ]
+    (args.output_dir / "summary.md").write_text("\n".join(md) + "\n", encoding="utf-8")
+    print("\n" + "\n".join(md), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ou_rs_adaptation_refine.py
+++ b/tools/ou_rs_adaptation_refine.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Fast refinement entry point for the physical-period r_S optimum sweep.
+
+The first pass showed the vertical optimum was interior, but the 3-D optimum
+reached the low-r_S edge.  Reuse the same experiment while compiling only the
+simulator target instead of every OU-III unit-test binary.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import ou_rs_adaptation_optimum_run as run
+
+
+def _build_simulator_only(families, eigen_dir):
+    if tuple(families) != ("OU_III",):
+        raise ValueError("refinement runner is OU_III-only")
+    command = ["make", "-B", "kalman_ou_iii-sim"]
+    if eigen_dir:
+        command.append(f"EIGEN_DIR={eigen_dir}")
+    subprocess.run(
+        command,
+        cwd=run.core.FAMILY_MAKE_DIR["OU_III"],
+        check=True,
+    )
+
+
+run.core.build_simulators = _build_simulator_only
+
+if __name__ == "__main__":
+    raise SystemExit(run.main())

--- a/tools/ou_rs_candidate_arm.py
+++ b/tools/ou_rs_candidate_arm.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Run one candidate arm of the full OU-III rS validation experiment."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import ou_rs_candidate_full_validation_fixed as fixed
+
+exp = fixed.exp
+
+CANDIDATES = {
+    "cubic_p3": (0.1548363522, 3.0),
+    "fitted_p2p9052": (0.1667018769, 2.9052),
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--label", choices=sorted(CANDIDATES), required=True)
+    parser.add_argument("--data-dir", type=Path, default=exp.REPO_ROOT / "plots/kalman_ou_ii")
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--jobs", type=int, default=4)
+    parser.add_argument("--shards", type=int, default=2)
+    args = parser.parse_args()
+
+    data_dir = args.data_dir.resolve()
+    output_dir = args.output_dir.resolve()
+    missing = [name for name in exp.SOURCE_FILES if not (data_dir / name).is_file()]
+    if missing:
+        raise FileNotFoundError("missing released simulation data: " + ", ".join(missing))
+    if args.shards < 2:
+        raise ValueError("use at least two shards so ou_validation stops after raw rows")
+
+    coeff, exponent = CANDIDATES[args.label]
+    original = exp.patch_experiment_branch()
+    try:
+        exp.run_arm(
+            args.label,
+            coeff,
+            exponent,
+            data_dir,
+            output_dir,
+            max(1, args.jobs),
+            args.shards,
+        )
+    finally:
+        exp.HEADER.write_text(original, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ou_rs_candidate_full_validation.py
+++ b/tools/ou_rs_candidate_full_validation.py
@@ -1,0 +1,572 @@
+#!/usr/bin/env python3
+"""Full paired validation of candidate OU-III effective r_S adaptation laws.
+
+This is an experiment runner, not a production filter change.  It patches an
+inactive compile-time branch into SeaStateFusionFilter_OU_III.h inside the CI
+working tree, compiles the simulator three times, and reuses the established
+ou_validation.py scenario/seed machinery in shard mode so no publication bundle
+is rewritten.
+
+Arms:
+  deployed        current effective law (about sigma_aw * tau^2.5)
+  cubic_p3        r_S,eff = 0.1548363522 * sigma_aw * tau^3
+  fitted_p2p9052  r_S,eff = 0.1667018769 * sigma_aw * tau^2.9052
+
+Both candidate normalizations pass through the independently measured full-3D
+optimum r_S,eff=1.160579 m*s at the nominal JONSWAP point
+(tau=2.17904091 s, sigma_aw=0.724445343 m/s^2).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import shutil
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+import numpy as np
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HEADER = REPO_ROOT / "src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h"
+MAKE_DIR = REPO_ROOT / "tests/kalman_ou_iii"
+VALIDATION = REPO_ROOT / "tools/ou_validation.py"
+
+SOURCE_FILES = (
+    "wave_data_jonswap_H0.270_L14.047_A30.00_P60.00.csv",
+    "wave_data_jonswap_H1.500_L50.710_A-30.00_P120.00.csv",
+    "wave_data_jonswap_H4.000_L112.766_A30.00_P30.00.csv",
+    "wave_data_jonswap_H8.500_L202.839_A-30.00_P72.00.csv",
+    "wave_data_pmstokes_H0.270_L14.047_A30.00_P60.00.csv",
+    "wave_data_pmstokes_H1.500_L50.710_A-30.00_P120.00.csv",
+    "wave_data_pmstokes_H4.000_L112.766_A30.00_P30.00.csv",
+    "wave_data_pmstokes_H8.500_L202.839_A-30.00_P72.00.csv",
+)
+NOMINAL_FILE = "wave_data_jonswap_H1.500_L50.710_A-30.00_P120.00.csv"
+TRANSITION_END_SOURCE = "wave_data_jonswap_H8.500_L202.839_A-30.00_P72.00.csv"
+
+ARMS: tuple[tuple[str, float | None, float | None], ...] = (
+    ("deployed", None, None),
+    ("cubic_p3", 0.1548363522, 3.0),
+    ("fitted_p2p9052", 0.1667018769, 2.9052),
+)
+
+PATCH_OLD = """        if (rs_law_ == RSAdaptationLaw::Cubic) {\n            return R_S_coeff_ * sigma * tau3;\n        }\n"""
+PATCH_NEW = """        if (rs_law_ == RSAdaptationLaw::Cubic) {\n#ifdef OU_III_EXPERIMENT_EFFECTIVE_RS_POWER\n            // Experiment-only branch.  The public/deployed source path remains\n            // unchanged when the macro is absent.  The wrapper stores a base\n            // r_S target and later multiplies it by sqrt(T0/TS).  Therefore a\n            // desired effective-input law K*sigma*tau^p has to be divided by\n            // that information-rate scale here.\n            const float TS_exp = pseudo_update_period_for_(tau);\n            if (std::isfinite(TS_exp) && TS_exp > 0.0f) {\n                const float info_scale_exp =\n                    std::sqrt(pseudo_update_fixed_period_s_ / TS_exp);\n                return OU_III_EXPERIMENT_EFFECTIVE_RS_COEFF * sigma *\n                    std::pow(tau, OU_III_EXPERIMENT_EFFECTIVE_RS_TAU_EXP) /\n                    info_scale_exp;\n            }\n#endif\n            return R_S_coeff_ * sigma * tau3;\n        }\n"""
+
+PAIR_KEYS = (
+    "scenario",
+    "wave_phase_seed",
+    "imu_noise_seed",
+    "initialization_seed",
+)
+SEED_KEYS = (
+    "wave_phase_seed",
+    "imu_noise_seed",
+    "initialization_seed",
+)
+
+
+def run(command: Sequence[str], *, env: Mapping[str, str] | None = None) -> None:
+    printable = " ".join(command)
+    print(f"+ {printable}", flush=True)
+    subprocess.run(
+        list(command),
+        cwd=REPO_ROOT,
+        env=None if env is None else dict(env),
+        check=True,
+    )
+
+
+def patch_experiment_branch() -> str:
+    original = HEADER.read_text(encoding="utf-8")
+    count = original.count(PATCH_OLD)
+    if count != 1:
+        raise RuntimeError(
+            f"expected exactly one Cubic-law patch point, found {count}"
+        )
+    HEADER.write_text(original.replace(PATCH_OLD, PATCH_NEW), encoding="utf-8")
+    return original
+
+
+def build_arm(coeff: float | None, exponent: float | None) -> None:
+    env = os.environ.copy()
+    if coeff is None:
+        env.pop("CPPFLAGS", None)
+    else:
+        env["CPPFLAGS"] = " ".join(
+            (
+                "-DOU_III_EXPERIMENT_EFFECTIVE_RS_POWER=1",
+                f"-DOU_III_EXPERIMENT_EFFECTIVE_RS_COEFF={coeff:.10g}f",
+                f"-DOU_III_EXPERIMENT_EFFECTIVE_RS_TAU_EXP={exponent:.10g}f",
+            )
+        )
+    run(
+        ("make", "-C", str(MAKE_DIR.relative_to(REPO_ROOT)), "-B", "kalman_ou_iii-sim"),
+        env=env,
+    )
+
+
+def validation_command(
+    data_dir: Path,
+    output_dir: Path,
+    shard_dir: Path,
+    shard_index: int,
+    shard_count: int,
+    jobs: int,
+) -> list[str]:
+    command = [
+        sys.executable,
+        str(VALIDATION.relative_to(REPO_ROOT)),
+        "--mode", "full",
+        "--data-dir", str(data_dir),
+        "--output-dir", str(output_dir),
+        "--families", "OU_III",
+        "--adaptation-modes", "Adaptive",
+        "--pmstokes-modes", "Adaptive",
+        "--duration-sec", "1200",
+        "--window-sec", "900",
+        "--transition-start-sec", "420",
+        "--transition-end-sec", "780",
+        "--nonstationary-start", str(data_dir / NOMINAL_FILE),
+        "--nonstationary-end", str(data_dir / TRANSITION_END_SOURCE),
+        "--nonstationary-end-height", "4.0",
+        "--bootstrap-resamples", "100",
+        "--stats-seed", "20260317",
+        "--jobs", str(jobs),
+        "--skip-build",
+        "--no-plots",
+        "--shard-count", str(shard_count),
+        "--shard-index", str(shard_index),
+        "--shard-dir", str(shard_dir),
+    ]
+    for name in SOURCE_FILES:
+        command.extend(("--stationary-input", str(data_dir / name)))
+    return command
+
+
+def run_arm(
+    label: str,
+    coeff: float | None,
+    exponent: float | None,
+    data_dir: Path,
+    output_root: Path,
+    jobs: int,
+    shard_count: int,
+) -> None:
+    print(f"\n=== ARM {label} ===", flush=True)
+    arm_dir = output_root / label
+    shard_dir = arm_dir / "shards"
+    shutil.rmtree(arm_dir, ignore_errors=True)
+    shard_dir.mkdir(parents=True, exist_ok=True)
+    build_arm(coeff, exponent)
+    for shard_index in range(shard_count):
+        run(
+            validation_command(
+                data_dir, arm_dir, shard_dir, shard_index, shard_count, jobs
+            )
+        )
+
+
+def load_rows(shard_dir: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    paths = sorted(shard_dir.glob("ou_validation_shard_*.json"))
+    if not paths:
+        raise FileNotFoundError(f"no validation shards in {shard_dir}")
+    for path in paths:
+        with path.open(encoding="utf-8") as stream:
+            rows.extend(json.load(stream))
+    rows = [
+        row for row in rows
+        if row.get("family") == "OU_III" and row.get("mode") == "Adaptive"
+    ]
+    keys = [tuple(row[key] for key in PAIR_KEYS) for row in rows]
+    if len(keys) != len(set(keys)):
+        raise RuntimeError(f"duplicate paired rows in {shard_dir}")
+    if len(rows) != 90:
+        raise RuntimeError(
+            f"expected 90 OU-III/Adaptive rows (9 scenarios x 10 seeds), got {len(rows)}"
+        )
+    return rows
+
+
+def row_index(rows: Iterable[Mapping[str, Any]]) -> dict[tuple[Any, ...], Mapping[str, Any]]:
+    return {tuple(row[key] for key in PAIR_KEYS): row for row in rows}
+
+
+def scenarios_for(rows: Sequence[Mapping[str, Any]], spectrum: str | None = None) -> list[str]:
+    names = sorted(
+        {
+            str(row["scenario"])
+            for row in rows
+            if str(row.get("scenario_kind")) == "stationary"
+            and (spectrum is None or str(row.get("spectrum")) == spectrum)
+        }
+    )
+    return names
+
+
+def seed_aggregates(
+    rows: Sequence[Mapping[str, Any]],
+    scenarios: Sequence[str],
+    metric: str,
+) -> dict[tuple[Any, ...], float]:
+    wanted = set(scenarios)
+    grouped: dict[tuple[Any, ...], list[float]] = defaultdict(list)
+    seen: dict[tuple[Any, ...], set[str]] = defaultdict(set)
+    for row in rows:
+        scenario = str(row["scenario"])
+        if scenario not in wanted:
+            continue
+        value = float(row.get(metric, math.nan))
+        if not math.isfinite(value):
+            continue
+        seed = tuple(row[key] for key in SEED_KEYS)
+        grouped[seed].append(value)
+        seen[seed].add(scenario)
+    result: dict[tuple[Any, ...], float] = {}
+    for seed, values in grouped.items():
+        if seen[seed] == wanted:
+            result[seed] = float(np.mean(values))
+    return result
+
+
+def percentile_interval(values: np.ndarray, rng: np.random.Generator, resamples: int) -> tuple[float, float]:
+    if values.size == 0:
+        return math.nan, math.nan
+    if values.size == 1:
+        return float(values[0]), float(values[0])
+    indices = rng.integers(0, values.size, size=(resamples, values.size))
+    means = values[indices].mean(axis=1)
+    low, high = np.quantile(means, (0.025, 0.975))
+    return float(low), float(high)
+
+
+def paired_summary(
+    baseline_rows: Sequence[Mapping[str, Any]],
+    arm_rows: Sequence[Mapping[str, Any]],
+    scenarios: Sequence[str],
+    metric: str,
+    rng: np.random.Generator,
+    resamples: int,
+) -> dict[str, Any]:
+    base = seed_aggregates(baseline_rows, scenarios, metric)
+    arm = seed_aggregates(arm_rows, scenarios, metric)
+    seeds = sorted(set(base).intersection(arm))
+    if not seeds:
+        return {"n": 0}
+    base_values = np.asarray([base[key] for key in seeds], dtype=np.float64)
+    arm_values = np.asarray([arm[key] for key in seeds], dtype=np.float64)
+    difference = arm_values - base_values
+    relative = 100.0 * difference / base_values
+    diff_low, diff_high = percentile_interval(difference, rng, resamples)
+    pct_low, pct_high = percentile_interval(relative, rng, resamples)
+    return {
+        "n": len(seeds),
+        "baseline_mean": float(base_values.mean()),
+        "arm_mean": float(arm_values.mean()),
+        "mean_difference": float(difference.mean()),
+        "difference_ci95_low": diff_low,
+        "difference_ci95_high": diff_high,
+        "mean_relative_change_pct": float(relative.mean()),
+        "relative_ci95_low_pct": pct_low,
+        "relative_ci95_high_pct": pct_high,
+        "improved_seeds": int(np.sum(difference < 0.0)),
+        "worsened_seeds": int(np.sum(difference > 0.0)),
+        "ties": int(np.sum(difference == 0.0)),
+    }
+
+
+def pairwise_max_abs_difference(
+    baseline_rows: Sequence[Mapping[str, Any]],
+    arm_rows: Sequence[Mapping[str, Any]],
+    metric: str,
+) -> float:
+    baseline = row_index(baseline_rows)
+    arm = row_index(arm_rows)
+    values: list[float] = []
+    for key in set(baseline).intersection(arm):
+        left = float(baseline[key].get(metric, math.nan))
+        right = float(arm[key].get(metric, math.nan))
+        if math.isfinite(left) and math.isfinite(right):
+            values.append(abs(right - left))
+    return max(values, default=math.nan)
+
+
+def gate_summary(rows: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    return {
+        "passes": sum(int(row.get("quality_gate_pass", 0)) for row in rows),
+        "total": len(rows),
+    }
+
+
+def fmt(value: float, digits: int = 4) -> str:
+    return "--" if not math.isfinite(value) else f"{value:.{digits}f}"
+
+
+def build_report(
+    all_rows: Mapping[str, Sequence[Mapping[str, Any]]],
+    output_root: Path,
+    resamples: int,
+) -> dict[str, Any]:
+    baseline = all_rows["deployed"]
+    js = scenarios_for(baseline, "jonswap")
+    pm = scenarios_for(baseline, "pmstokes")
+    stationary = sorted(js + pm)
+    transition = sorted(
+        {
+            str(row["scenario"])
+            for row in baseline
+            if str(row.get("scenario_kind")) == "nonstationary"
+        }
+    )
+    if len(js) != 4 or len(pm) != 4 or len(transition) != 1:
+        raise RuntimeError(
+            f"unexpected scenario set: {len(js)} JONSWAP, {len(pm)} PM-Stokes, "
+            f"{len(transition)} transition"
+        )
+
+    groups = {
+        "jonswap_stationary": js,
+        "pmstokes_stationary": pm,
+        "all_stationary": stationary,
+        "transition": transition,
+    }
+    metrics = (
+        "disp_x_rms_m",
+        "disp_y_rms_m",
+        "disp_z_rms_m",
+        "disp_3d_rms_m",
+        "disp_z_pct_hs",
+        "roll_rms_deg",
+        "pitch_rms_deg",
+        "yaw_rms_deg",
+    )
+    transition_metrics = (
+        "seg_start_disp_z_rms_m",
+        "seg_start_disp_3d_rms_m",
+        "seg_blend_disp_z_rms_m",
+        "seg_blend_disp_3d_rms_m",
+        "seg_end_disp_z_rms_m",
+        "seg_end_disp_3d_rms_m",
+    )
+
+    report: dict[str, Any] = {
+        "protocol": {
+            "arms": {
+                "deployed": "current adaptive law",
+                "cubic_p3": "rS_eff = 0.1548363522 sigma_aw tau^3",
+                "fitted_p2p9052": "rS_eff = 0.1667018769 sigma_aw tau^2.9052",
+            },
+            "stationary_scenarios": stationary,
+            "transition_scenario": transition[0],
+            "seed_triplets": 10,
+            "score_window_sec": 900,
+            "transition_sec": [420, 780],
+            "bootstrap_resamples": resamples,
+            "pairing": "identical wave, IMU-noise, and initialization seeds",
+        },
+        "arms": {},
+    }
+
+    for arm_index, (label, _, _) in enumerate(ARMS):
+        if label == "deployed":
+            continue
+        arm_rows = all_rows[label]
+        rng = np.random.default_rng(20260816 + arm_index)
+        arm_report: dict[str, Any] = {
+            "gates": gate_summary(arm_rows),
+            "groups": {},
+            "scenarios": {},
+            "transition_segments": {},
+            "tuner_invariance": {
+                "max_abs_tau_applied_s": pairwise_max_abs_difference(
+                    baseline, arm_rows, "tau_applied_s"
+                ),
+                "max_abs_sigma_applied_mps2": pairwise_max_abs_difference(
+                    baseline, arm_rows, "sigma_applied_mps2"
+                ),
+            },
+        }
+        for group_name, scenario_names in groups.items():
+            arm_report["groups"][group_name] = {
+                metric: paired_summary(
+                    baseline, arm_rows, scenario_names, metric, rng, resamples
+                )
+                for metric in metrics
+            }
+        for scenario in stationary + transition:
+            arm_report["scenarios"][scenario] = {
+                metric: paired_summary(
+                    baseline, arm_rows, [scenario], metric, rng, resamples
+                )
+                for metric in ("disp_z_pct_hs", "disp_3d_rms_m")
+            }
+        for metric in transition_metrics:
+            arm_report["transition_segments"][metric] = paired_summary(
+                baseline, arm_rows, transition, metric, rng, resamples
+            )
+        report["arms"][label] = arm_report
+
+    report["baseline_gates"] = gate_summary(baseline)
+
+    output_root.mkdir(parents=True, exist_ok=True)
+    (output_root / "summary.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    lines = [
+        "# Full-suite effective-r_S candidate validation",
+        "",
+        "Paired full OU-III Adaptive validation: four stationary JONSWAP seas, four stationary PM-Stokes seas, and the standard 1.5 m -> 4.0 m non-stationary transition; ten predeclared wave/IMU/initialization seed triplets; 1200 s records with the trailing 900 s scored.",
+        "",
+        "Candidate laws are applied to the effective r_S standard deviation that reaches the MEKF; the existing tau-scaled pseudo-measurement cadence is unchanged.",
+        "",
+        "| arm | all-8 Z [%Hs] deployed | arm | paired delta [pp] | all-8 3D [m] deployed | arm | paired change [%] | improved 3D seeds |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for label, _, _ in ARMS:
+        if label == "deployed":
+            continue
+        group = report["arms"][label]["groups"]["all_stationary"]
+        z = group["disp_z_pct_hs"]
+        d3 = group["disp_3d_rms_m"]
+        lines.append(
+            f"| {label} | {fmt(z['baseline_mean'],3)} | {fmt(z['arm_mean'],3)} | "
+            f"{fmt(z['mean_difference'],3)} [{fmt(z['difference_ci95_low'],3)}, {fmt(z['difference_ci95_high'],3)}] | "
+            f"{fmt(d3['baseline_mean'],4)} | {fmt(d3['arm_mean'],4)} | "
+            f"{fmt(d3['mean_relative_change_pct'],2)} [{fmt(d3['relative_ci95_low_pct'],2)}, {fmt(d3['relative_ci95_high_pct'],2)}] | "
+            f"{d3['improved_seeds']}/10 |"
+        )
+
+    lines.extend(("", "## Stationary-family aggregates", ""))
+    lines.extend((
+        "| arm | family | delta X [%] | delta Y [%] | delta Z [%] | delta 3D [%] | delta yaw [%] |",
+        "|---|---|---:|---:|---:|---:|---:|",
+    ))
+    for label, _, _ in ARMS:
+        if label == "deployed":
+            continue
+        for group_name in ("jonswap_stationary", "pmstokes_stationary", "all_stationary"):
+            group = report["arms"][label]["groups"][group_name]
+            lines.append(
+                f"| {label} | {group_name} | "
+                f"{fmt(group['disp_x_rms_m']['mean_relative_change_pct'],2)} | "
+                f"{fmt(group['disp_y_rms_m']['mean_relative_change_pct'],2)} | "
+                f"{fmt(group['disp_z_rms_m']['mean_relative_change_pct'],2)} | "
+                f"{fmt(group['disp_3d_rms_m']['mean_relative_change_pct'],2)} | "
+                f"{fmt(group['yaw_rms_deg']['mean_relative_change_pct'],2)} |"
+            )
+
+    lines.extend(("", "## Per-scenario displacement", ""))
+    lines.extend((
+        "| arm | scenario | delta Z [%Hs pp] | delta 3D [%] | improved 3D seeds |",
+        "|---|---|---:|---:|---:|",
+    ))
+    for label, _, _ in ARMS:
+        if label == "deployed":
+            continue
+        for scenario in stationary + transition:
+            item = report["arms"][label]["scenarios"][scenario]
+            lines.append(
+                f"| {label} | {scenario} | "
+                f"{fmt(item['disp_z_pct_hs']['mean_difference'],3)} | "
+                f"{fmt(item['disp_3d_rms_m']['mean_relative_change_pct'],2)} | "
+                f"{item['disp_3d_rms_m']['improved_seeds']}/10 |"
+            )
+
+    lines.extend(("", "## Transition segments", ""))
+    lines.extend((
+        "| arm | segment | delta Z [%] | delta 3D [%] |",
+        "|---|---|---:|---:|",
+    ))
+    for label, _, _ in ARMS:
+        if label == "deployed":
+            continue
+        seg = report["arms"][label]["transition_segments"]
+        for name in ("start", "blend", "end"):
+            lines.append(
+                f"| {label} | {name} | "
+                f"{fmt(seg[f'seg_{name}_disp_z_rms_m']['mean_relative_change_pct'],2)} | "
+                f"{fmt(seg[f'seg_{name}_disp_3d_rms_m']['mean_relative_change_pct'],2)} |"
+            )
+
+    lines.extend(("", "## Controls", ""))
+    lines.append(
+        f"Deployed quality gates: {report['baseline_gates']['passes']}/{report['baseline_gates']['total']}."
+    )
+    for label, _, _ in ARMS:
+        if label == "deployed":
+            continue
+        arm = report["arms"][label]
+        inv = arm["tuner_invariance"]
+        lines.append(
+            f"- {label}: gates {arm['gates']['passes']}/{arm['gates']['total']}; "
+            f"max paired |delta tau_applied|={fmt(inv['max_abs_tau_applied_s'],9)} s; "
+            f"max paired |delta sigma_applied|={fmt(inv['max_abs_sigma_applied_mps2'],9)} m/s^2."
+        )
+
+    (output_root / "summary.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print("\n" + "\n".join(lines), flush=True)
+    return report
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=REPO_ROOT / "plots/kalman_ou_ii",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=REPO_ROOT / "reports/results/ou_rs_candidate_full_validation",
+    )
+    parser.add_argument("--jobs", type=int, default=max(1, min(8, os.cpu_count() or 1)))
+    parser.add_argument("--shards", type=int, default=2)
+    parser.add_argument("--bootstrap", type=int, default=5000)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    data_dir = args.data_dir.resolve()
+    output_root = args.output_dir.resolve()
+    missing = [name for name in SOURCE_FILES if not (data_dir / name).is_file()]
+    if missing:
+        raise FileNotFoundError("missing released simulation data: " + ", ".join(missing))
+    if args.shards < 2:
+        raise ValueError("use at least two shards so ou_validation stops after raw rows")
+
+    output_root.mkdir(parents=True, exist_ok=True)
+    original = patch_experiment_branch()
+    try:
+        for label, coeff, exponent in ARMS:
+            run_arm(
+                label,
+                coeff,
+                exponent,
+                data_dir,
+                output_root,
+                max(1, args.jobs),
+                args.shards,
+            )
+        all_rows = {
+            label: load_rows(output_root / label / "shards")
+            for label, _, _ in ARMS
+        }
+        build_report(all_rows, output_root, args.bootstrap)
+    finally:
+        HEADER.write_text(original, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ou_rs_candidate_full_validation_fixed.py
+++ b/tools/ou_rs_candidate_full_validation_fixed.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Compatibility launcher for the full rS candidate validation experiment.
+
+The original experiment runner formats an integral exponent as the invalid C++
+literal ``3f``.  Keep the experiment definition unchanged and override only the
+compile-macro formatter so integral-valued exponents are emitted as ``3.0f``.
+"""
+
+from __future__ import annotations
+
+import os
+
+import ou_rs_candidate_full_validation as exp
+
+
+def build_arm(coeff: float | None, exponent: float | None) -> None:
+    env = os.environ.copy()
+    if coeff is None:
+        env.pop("CPPFLAGS", None)
+    else:
+        exponent_literal = f"{float(exponent):.10g}"
+        if "." not in exponent_literal and "e" not in exponent_literal.lower():
+            exponent_literal += ".0"
+        env["CPPFLAGS"] = " ".join(
+            (
+                "-DOU_III_EXPERIMENT_EFFECTIVE_RS_POWER=1",
+                f"-DOU_III_EXPERIMENT_EFFECTIVE_RS_COEFF={coeff:.10g}f",
+                f"-DOU_III_EXPERIMENT_EFFECTIVE_RS_TAU_EXP={exponent_literal}f",
+            )
+        )
+    exp.run(
+        (
+            "make",
+            "-C",
+            str(exp.MAKE_DIR.relative_to(exp.REPO_ROOT)),
+            "-B",
+            "kalman_ou_iii-sim",
+        ),
+        env=env,
+    )
+
+
+exp.build_arm = build_arm
+
+if __name__ == "__main__":
+    raise SystemExit(exp.main())

--- a/tools/ou_rs_cubic_normalization_arm.py
+++ b/tools/ou_rs_cubic_normalization_arm.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Run one full-suite cubic effective-rS normalization arm.
+
+This is an experiment-only launcher.  It reuses the established OU-III full
+validation harness and keeps the effective law exponent fixed at p_tau=3 and
+p_sigma=1.  Only the normalization K in
+
+    rS_eff = K * sigma_aw * tau^3
+
+changes between arms.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import ou_rs_candidate_full_validation_fixed as fixed
+
+exp = fixed.exp
+
+# Coefficients are anchored to the independently measured nominal point
+# tau=2.17904091 s, sigma_aw=0.724445343 m/s^2.  Labels encode the nominal
+# effective rS target in m*s.
+CANDIDATES = {
+    "r1161": (0.1548363522, 1.160579),
+    "r1300": (0.1734369292, 1.300000),
+    "r1400": (0.1867782315, 1.400000),
+    "r1500": (0.2001195337, 1.500000),
+    "r1600": (0.2134608359, 1.600000),
+    "r1700": (0.2268021382, 1.700000),
+    "r1860": (0.2481482218, 1.860000),
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--label", choices=sorted(CANDIDATES), required=True)
+    parser.add_argument(
+        "--data-dir", type=Path, default=exp.REPO_ROOT / "plots/kalman_ou_ii"
+    )
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--jobs", type=int, default=4)
+    parser.add_argument("--shards", type=int, default=2)
+    args = parser.parse_args()
+
+    data_dir = args.data_dir.resolve()
+    output_dir = args.output_dir.resolve()
+    missing = [name for name in exp.SOURCE_FILES if not (data_dir / name).is_file()]
+    if missing:
+        raise FileNotFoundError(
+            "missing released simulation data: " + ", ".join(missing)
+        )
+    if args.shards < 2:
+        raise ValueError("use at least two shards so ou_validation stops after raw rows")
+
+    coeff, nominal_r = CANDIDATES[args.label]
+    print(
+        f"CUBIC_NORMALIZATION_ARM label={args.label} K={coeff:.10f} "
+        f"nominal_rS_eff={nominal_r:.6f} exponent=3",
+        flush=True,
+    )
+
+    original = exp.patch_experiment_branch()
+    try:
+        exp.run_arm(
+            args.label,
+            coeff,
+            3.0,
+            data_dir,
+            output_dir,
+            max(1, args.jobs),
+            args.shards,
+        )
+    finally:
+        exp.HEADER.write_text(original, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Temporary experiment branch to measure the full OU-III MEKF optimum of effective filter-input r_S as the *physical sea period* is time-stretched at fixed acceleration RMS. The source JONSWAP Hs=1.5 m record is phase-randomized, transformed with p~s^2, v~s, a~1, and attitude time-stretched at fixed angular amplitude. At each stretch, tau follows the physical period, sigma_aw stays fixed, and effective r_S is independently swept. CI uploads raw and fitted exponent results. This PR is for the experiment only; do not merge as-is.