### PR TITLE
Restore reduced MSE and horizontal analysis with explicit scope

### DIFF
--- a/doc/kalman_ou_iii/adaptive-integral-state-regularization.tex
+++ b/doc/kalman_ou_iii/adaptive-integral-state-regularization.tex
@@ -35,11 +35,12 @@
 
 \newtheorem{theorem}{Theorem}
 \newtheorem{proposition}{Proposition}
+\newtheorem{corollary}{Corollary}
 \theoremstyle{remark}
 \newtheorem{remark}{Remark}
 
 \title{Adaptive Integral-State Regularization for Drift-Bounded Inertial Motion Estimation\\
-\large Sea-State Scaling and Empirical Tuning (draft)}
+\large Sea-State Scaling, Reduced-Order Analysis, and Empirical Tuning (draft)}
 \author{%
   \IEEEauthorblockN{Mikhail S. Grushinskiy}
   \IEEEauthorblockA{Independent Researcher, USA, Fair Lawn\\
@@ -59,24 +60,27 @@ virtual $S=0$ observation whose covariance is adapted to sea state.  The virtual
 observation is treated as a regularizer rather than a physical sensor.
 Ornstein--Uhlenbeck (OU) similarity establishes the natural third-integral scale
 $\sigma_a\tau^3$, and periodic Riccati similarity shows why dimensional scaling
-alone cannot determine correction strength.  A scalar drift-band model is then
-used only as an illustrative mechanism: it relates the virtual-measurement
-variance to a low-frequency regularization bandwidth and exposes the competing
-effects of drift rejection and physical-signal distortion.  The reduced model
-is not claimed to determine the optimum of the complete attitude/bias-coupled
-MEKF.  The deployed adaptation schedule is therefore justified empirically.
-Paired multi-seed simulations show that linear amplitude scheduling is favored
-over the tested alternatives, that the integral-regularization channel carries
-most of the adaptation benefit, and that isotropic three-axis regularization is
-adequate across the tested directional sea states.  The main design conclusion
-is that theory supplies physically reasonable scaling and mechanism, while the
-full-estimator experiments select the practical schedule.
+alone cannot determine correction strength.  A reduced scalar drift--distortion
+model gives a closed-form optimum \emph{within that model}; its main value here
+is mechanistic rather than prescriptive.  It shows that preferred regularizer
+strength depends only weakly on drift-band acceleration intensity, while the
+remaining error is much more sensitive to the disturbance itself.  The complete
+attitude/bias-coupled MEKF violates several assumptions of the reduction, so the
+deployed schedule is selected empirically.  Paired multi-seed simulations favor
+linear amplitude scheduling and show that the integral-regularization channel
+carries most of the adaptive benefit.  Horizontal drift-band acceleration error
+is roughly two orders of magnitude larger than the vertical channel in the
+tested stationary records, yet isotropic integral regularization remains
+adequate in the tested directional simulations.  The combined result is a
+physically scaled, empirically justified adaptation law and a design priority:
+reduce the horizontal low-frequency error source rather than automatically
+regularizing the horizontal axes harder.
 \end{abstract}
 
 \begin{IEEEkeywords}
 inertial motion estimation, drift regularization, pseudo-measurement, virtual
 measurement, Kalman filter, Ornstein--Uhlenbeck process, adaptive filtering,
-heave, sea-state adaptation
+heave, sea-state adaptation, bias--variance tradeoff
 \end{IEEEkeywords}
 
 \section{Introduction}
@@ -109,23 +113,24 @@ bounded oscillatory motion should not develop an unbounded third integral.  It
 is therefore better understood as \emph{integral-state regularization} than as a
 sensor measurement.
 
-This paper asks a deliberately narrower question than an exact optimal-control
-treatment of the complete marine MEKF: how should the regularizer be scaled
-across sea states so that its tuning remains physically sensible, and what
-evidence supports the implemented schedule?  The surrounding MEKF includes
-attitude, gyro bias, accelerometer bias, translational OU states, and their
-cross-covariances.  A scalar chain can illuminate the role of $r_S$, but it
-cannot reproduce that complete covariance feedback.
+Two distinct questions follow.  First, how should the regularizer scale when the
+motion amplitude and time scale change?  Second, does the much larger horizontal
+inertial drift imply that the horizontal virtual observation should be stronger?
+A dimensional argument alone answers neither.  The gain depends on the predicted
+covariance as well as $R_S$, while a stronger false zero observation suppresses
+both unwanted drift and wanted low-frequency motion.
 
-The contributions are therefore separated into theory and evidence.  The paper
-(i) derives the OU similarity scale of the integral state; (ii) identifies the
-dimensionless groups of the periodic Riccati map and the corresponding
-low-frequency regularization bandwidth; (iii) presents a reduced drift--signal
-distortion model as an illustrative mechanism rather than a production tuning
-law; (iv) uses paired full-estimator experiments to justify the practical
-amplitude schedule and to identify the integral anchor as the dominant adaptive
-channel; and (v) shows that isotropic integral regularization is adequate across
-the tested directional three-axis simulations.
+The contributions are separated deliberately into exact reduced-order analysis
+and complete-estimator evidence.  The paper (i) derives the OU similarity scale
+of the integral state; (ii) identifies the dimensionless groups of the periodic
+Riccati map and the corresponding regularization bandwidth; (iii) derives a
+closed-form drift--distortion optimum for a stated scalar continuous model and
+uses its exponents only as mechanistic sensitivities; (iv) states explicitly why
+that optimum is not the optimum of the full attitude/bias-coupled MEKF; (v) uses
+paired full-estimator experiments to justify the practical adaptation schedule;
+and (vi) combines measured horizontal drift intensity with the reduced-model
+sensitivity and directional simulations to explain why isotropic integral
+regularization is a reasonable choice despite much larger horizontal drift.
 
 \section{Integral-State Regularization Model}
 \label{sec:model}
@@ -150,8 +155,8 @@ scalar variance becomes
  \mat R_S=\diag(r_{S,x}^2,r_{S,y}^2,r_{S,z}^2).
  \label{eq:RS3}
 \end{equation}
-The implementation parameterizes the adaptation in the standard-deviation
-scale $r_S$.
+The implementation parameterizes adaptation in the standard-deviation scale
+$r_S$.
 
 \subsection{The virtual observation is deliberately mis-specified}
 
@@ -163,9 +168,9 @@ The zero observation introduces the mismatch
 \end{equation}
 Reducing $R_S$ increases the authority of the drift anchor, but it also
 increases the estimator response to this mismatch.  Thus a useful regularizer
-must balance drift rejection against distortion of wanted motion.  This
-tradeoff is real, but its exact optimum depends on the complete estimator and
-motion statistics.
+must balance drift rejection against distortion of wanted motion.  That trade is
+real even though the exact optimum depends on the complete estimator and motion
+statistics.
 
 \section{Similarity and the Meaning of the Cubic Scale}
 \label{sec:similarity}
@@ -204,8 +209,8 @@ A self-similar virtual-measurement standard deviation may therefore be written
  \label{eq:cubic}
 \end{equation}
 Equation~\eqref{eq:cubic} is a \emph{coordinate-scale statement}.  It does not
-prove that this is the optimal Kalman tuning.  In particular, free triple
-integration of a stationary OU acceleration does not have a stationary
+prove that cubic scaling is the optimal Kalman tuning.  In particular, free
+triple integration of stationary OU acceleration does not have a stationary
 variance because the OU spectrum remains nonzero at zero frequency.
 
 \subsection{Periodic Riccati similarity}
@@ -247,16 +252,17 @@ effective scaling
 \end{equation}
 when the cadence schedule is unclipped.
 
-This algebra explains how the deployed exponent arises from a cubic state scale
-plus cadence renormalization.  It does \emph{not} establish that $5/2$ is an
-MSE-optimal exponent.  The coefficient and the decision to retain this schedule
-are empirical design choices validated in the complete estimator.
+This algebra explains how the deployed exponent arises from a cubic coordinate
+scale plus cadence renormalization.  It does \emph{not} establish that $5/2$ is
+an MSE-optimal exponent.  The coefficient and the decision to retain this
+schedule are empirical design choices validated in the complete estimator.
 
-\section{Illustrative Drift-Band Reduction}
+\section{Reduced Drift-Band Analysis}
 \label{sec:riccati}
 
-The following reduction is included to explain mechanism and sensitivity.  It
-is not used to compute the deployed MEKF tuning.
+The following analysis is exact for the stated reduced model.  Its purpose is to
+expose the mechanism and logarithmic sensitivities of the virtual measurement;
+it is not used as a calibration oracle for the complete MEKF.
 
 At frequencies well below the posterior acceleration correlation rate, suppose
 the residual acceleration error can be approximated as white with two-sided
@@ -270,9 +276,8 @@ reference expression
  \label{eq:qeff-care}
 \end{equation}
 where $r_a\simeq R_a\Delta t$ is a continuous-equivalent accelerometer noise
-density.  In the complete inertial estimator, however, the actual low-frequency
-error also contains model mismatch, residual bias, and attitude-to-gravity
-leakage.
+density.  In the complete inertial estimator, the actual low-frequency error
+also contains model mismatch, residual bias, and attitude-to-gravity leakage.
 
 Reorder the integrated states as $x_d=[S,p,v]^T$ and approximate the periodic
 $S$ updates by a continuous observation with noise density
@@ -288,31 +293,53 @@ The corresponding continuous algebraic Riccati equation has gain
  \omega_R=\left(\frac{q_{\rm eff}}{R_ST_S}\right)^{1/6}.}
  \label{eq:omegaR}
 \end{equation}
-Thus the virtual-measurement variance acts as a low-frequency regularization
-bandwidth through a weak sixth-root dependence.
+The closed-loop polynomial is
+\begin{equation}
+ s^3+2\omega_Rs^2+2\omega_R^2s+\omega_R^3
+ =(s+\omega_R)(s^2+\omega_Rs+\omega_R^2).
+ \label{eq:poles}
+\end{equation}
+Thus the virtual-measurement variance sets a genuine low-frequency
+regularization bandwidth through a weak sixth-root dependence.
 
-\subsection{An illustrative drift--signal tradeoff}
+\subsection{Reduced-model drift--distortion optimum}
 
 With the reduced gain in \eqref{eq:omegaR}, the position-error transfer from
 residual acceleration is
 \begin{equation}
- T_{pe}(s)=\frac{s+2\omega_R}{D(s)},\qquad
+ T_{pe}(s)=\frac{s+2\omega_R}{D(s)},
+ \qquad
  D(s)=s^3+2\omega_Rs^2+2\omega_R^2s+\omega_R^3,
  \label{eq:Tpe}
 \end{equation}
-while the false zero observation produces a response to the physical
-$S^{\rm true}$ process.  For a white drift-band acceleration intensity and
-desired motion concentrated above the regularization corner, define
+and the transfer from the true $S$ process is
+\begin{equation}
+ T_{pS}(s)=-\frac{s(2\omega_R^2s+\omega_R^3)}{D(s)}.
+ \label{eq:TpS}
+\end{equation}
+For white low-frequency acceleration-error intensity $q_{\rm eff}$, the drift
+term contributes
+\begin{equation}
+ \mathrm{MSE}_{p,\rm drift}
+ =\frac{3q_{\rm eff}}{2\omega_R^3}.
+ \label{eq:drift-mse}
+\end{equation}
+For desired motion concentrated above the regularization corner, define
 \begin{equation}
  m_{-4}=\int_{\Omega_{\rm wave}}
  \frac{S_p^{\rm true}(\omega)}{\omega^4}\,d\omega.
  \label{eq:m4}
 \end{equation}
+The leading high-separation leakage term from \eqref{eq:TpS} is
+\begin{equation}
+ \mathrm{MSE}_{p,\rm signal}\simeq4m_{-4}\omega_R^4.
+ \label{eq:signal-mse}
+\end{equation}
 
-\begin{proposition}[Reduced drift--distortion minimizer]
-\label{prop:reduced-tradeoff}
-Under the scalar, continuous, spectrally separated assumptions above, the
-illustrative position-error cost
+\begin{theorem}[Reduced-model MSE optimum]
+\label{thm:reduced-mse}
+Under the scalar, continuous and spectrally separated assumptions above, the
+reduced cost
 \begin{equation}
  J_{\rm red}(\omega_R)
  =\frac{3q_{\rm eff}}{2\omega_R^3}
@@ -321,57 +348,102 @@ illustrative position-error cost
 \end{equation}
 has the unique positive minimizer
 \begin{equation}
- (\omega_{R,\rm red})^7
- =\frac{9}{32}\frac{q_{\rm eff}}{m_{-4}},
+ \boxed{
+ (\omega_{R,\rm red}^{\star})^7
+ =\frac{9}{32}\frac{q_{\rm eff}}{m_{-4}}.}
  \label{eq:wred}
 \end{equation}
-or, equivalently,
+Equivalently, the reduced-model optimal pseudo-measurement standard deviation is
 \begin{equation}
- r_{S,\rm red}
+ \boxed{
+ r_{S,\rm red}^{\star}
  =\left(\frac{32}{9}\right)^{3/7}
- q_{\rm eff}^{1/14}m_{-4}^{3/7}T_S^{-1/2}.
+ q_{\rm eff}^{1/14}m_{-4}^{3/7}T_S^{-1/2}.}
  \label{eq:rsred}
 \end{equation}
-\end{proposition}
+The minimized reduced cost scales as
+\begin{equation}
+ J_{\rm red}^{\star}
+ \propto q_{\rm eff}^{4/7}m_{-4}^{3/7}.
+ \label{eq:jredmin}
+\end{equation}
+\end{theorem}
 
 \begin{proof}
-Differentiate \eqref{eq:mse-total} with respect to $\omega_R$ and solve the
-single positive stationary point.  The second derivative is positive there;
-substitution into \eqref{eq:omegaR} gives \eqref{eq:rsred}.
+Differentiating \eqref{eq:mse-total} gives
+$-(9/2)q_{\rm eff}\omega_R^{-4}+16m_{-4}\omega_R^3=0$, yielding
+\eqref{eq:wred}; the second derivative is positive there.  Substitution into
+$r_S=\sqrt{q_{\rm eff}/(T_S\omega_R^6)}$, obtained from
+\eqref{eq:omegaR}, gives \eqref{eq:rsred}.  Substitution into
+\eqref{eq:mse-total} gives \eqref{eq:jredmin}.
 \end{proof}
 
-The proposition is useful qualitatively: stronger drift and stronger physical
-low-frequency motion push the preferred regularization in opposite directions,
-and $R_S$ influences the correction bandwidth only weakly.  Its notation is
-deliberately separated from any full-estimator optimum because the reduced
-minimizer is not asserted to be the optimum of the complete MEKF.
+The exponents are the most useful part of the theorem.  Within the reduced
+model, the preferred $r_S$ changes with drift intensity only as
+$q_{\rm eff}^{1/14}$, whereas the desired-motion moment enters as
+$m_{-4}^{3/7}$.  An order-of-magnitude error in $q_{\rm eff}$ changes the
+reduced-model optimal $r_S$ by only
+$10^{1/14}\simeq1.18$.  At the same reduced optimum, residual position MSE
+scales as $q_{\rm eff}^{4/7}$: its logarithmic exponent with respect to the
+disturbance is eight times the exponent with which the disturbance changes the
+tuning ratio.  The model therefore predicts an important asymmetry: a large
+drift source can be a major performance problem without demanding a
+proportionally stronger integral anchor.
+
+\subsection{Amplitude scaling inside the reduced model}
+
+For a fixed-shape amplitude sweep with unchanged cadence, suppose
+\begin{equation}
+ q_{\rm eff}\propto\sigma_{aw}^{m},
+ \qquad m_{-4}\propto\sigma_{aw}^{2}.
+ \label{eq:amp-assump}
+\end{equation}
+Then \eqref{eq:rsred} gives the reduced-model relation
+\begin{equation}
+ r_{S,\rm red}^{\star}\propto\sigma_{aw}^{p_{\rm red}},
+ \qquad p_{\rm red}=\frac{m+12}{14}.
+ \label{eq:p-red-law}
+\end{equation}
+This relation is useful for interpreting plausible amplitude powers, but the
+unknown full-estimator $q_{\rm eff}$ is not inferred from it.  The deployed
+amplitude exponent is selected directly by the full-estimator ablation in
+\cref{sec:adaptation-study}.
 
 \subsection{Where the analytical logic stops}
+\label{sec:analysis-limit}
 
-The reduced minimizer is not a production tuning law for four specific reasons.
+The theorem is an optimum of $J_{\rm red}$, not of the complete MEKF.  Five
+specific differences matter.
 
 First, the scalar chain removes attitude error, gyro bias, accelerometer bias,
 and the cross-covariances that couple those states to $S$.  In the implemented
 MEKF, an $S=0$ update acts through the full covariance column associated with
-$S$, so changing $R_S$ can indirectly change attitude and bias corrections.
+$S$, so changing $R_S$ can indirectly alter attitude and bias corrections.
 
-Second, $q_{\rm eff}$ is not an exogenous white-noise intensity in the complete
-filter.  Horizontal gravity leakage, residual bias, model mismatch, and the
-filter's own covariance feedback all contribute to the low-frequency error.
+Second, $R_S$ is a \emph{design covariance}, not the variance of a physical noise
+sample injected into the actual estimator.  The implementation forms the false
+innovation from $-\hat S$; no random $n_S$ is generated.  Consequently the
+filter-internal Riccati covariance and the actual estimation-error covariance
+need not coincide under this deliberately mis-specified observation.  A Kalman
+covariance optimum is therefore not automatically an actual-error optimum.
 
-Third, \eqref{eq:rsc} replaces discrete periodic pseudo-updates by a continuous
-information approximation and \eqref{eq:mse-total} assumes spectral separation
-between the drift corner and the desired wave band.  Neither approximation is
-exact during finite-rate operation or changing sea states.
+Third, $q_{\rm eff}$ is not an exogenous scalar white-noise intensity in the
+complete filter.  Horizontal gravity leakage, residual bias, model mismatch,
+and covariance feedback all contribute to the low-frequency error and can
+change with the operating point.
 
-Fourth, the full objective is three-dimensional and nonstationary operation
-matters.  A stationary scalar minimizer does not account for adaptation lag,
-time-varying wave spectra, or heading-dependent partition of physical surge and
-sway.
+Fourth, \eqref{eq:rsc} replaces discrete periodic pseudo-updates by a continuous
+information approximation, while \eqref{eq:signal-mse} assumes separation
+between the correction corner and desired wave energy.  These approximations
+are accurate only in their intended regime.
 
-Consequently, the reduced model establishes mechanism and plausible scaling
-only.  It does not analytically determine the deployed coefficient or exponent;
-those are evaluated in the complete estimator.
+Fifth, the complete objective is three-dimensional and operation is often
+nonstationary.  Adaptation lag, changing spectra, and heading-dependent
+partition of surge and sway are absent from the stationary scalar model.
+
+These limitations explain why the reduced theorem is retained as analysis but
+not used to claim that the deployed $\tau^{5/2}$ law is analytically optimal.
+The full-estimator experiments remain the tuning authority.
 
 \section{Empirical Adaptation-Law Evidence}
 \label{sec:adaptation-study}
@@ -412,8 +484,10 @@ $p=1.5$  & 4.817 & $+0.070\pm0.016$ & 0.660 \\
 The best tested amplitude schedule is linear in $\sigma_{aw}$.  Removing
 amplitude dependence costs $0.300$ percentage points of $H_s$ in the pooled
 vertical metric and also worsens 3D RMS.  This result is used directly as
-empirical support for the deployed amplitude factor.  It is not inverted to
-claim a particular hidden power law for $q_{\rm eff}$.
+empirical support for the deployed amplitude factor.  The reduced relation
+\eqref{eq:p-red-law} provides context for why powers near unity are plausible,
+but it is not inverted to identify a hidden physical exponent for the full
+MEKF.
 
 \subsection{The regularizer channel carries most of the adaptive benefit}
 
@@ -484,17 +558,16 @@ sensor and attitude-error floor, normalization by $H_s$ necessarily
 deteriorates.  This is an observability/noise limit rather than evidence that
 the regularizer should simply be made stronger.
 
-\subsection{What is and is not justified by the experiments}
+\subsection{What the experiments justify}
 
 The empirical results support the deployed schedule as a practical,
 properly-scaled adaptation law over the tested envelope.  They do not establish
-a universal mathematical optimum.  In particular, alternative period scalings
-can improve a stationary objective yet fail to improve the nonstationary
-transition objective.  For that reason the deployed law is retained on
-full-estimator evidence rather than replaced by the stationary minimizer of a
-reduced model.
+a universal mathematical optimum.  In particular, stationary tuning changes
+need not transfer unchanged to nonstationary transitions.  The deployed law is
+therefore retained on full-estimator evidence rather than identified with the
+minimum of $J_{\rm red}$.
 
-\section{Three-Axis Regularization}
+\section{Horizontal Drift: Strong Disturbance, Weak Tuning Lever}
 \label{sec:axes}
 
 The vertical and horizontal channels do not have identical low-frequency error
@@ -508,40 +581,77 @@ $\delta\vct\theta$ leaks gravity into horizontal acceleration approximately as
 \end{equation}
 The vertical channel does not contain the same first-order
 $g\,\delta\theta$ term.  Without GNSS or another horizontal kinematic reference,
-residual horizontal bias is also less observable.
+residual horizontal bias is also less observable.  It is therefore physically
+reasonable to expect $q_{\rm eff,H}\gg q_{\rm eff,z}$.
 
-A larger horizontal drift source does not by itself imply that the horizontal
-$S=0$ anchor should be stronger.  The anchor also acts on real horizontal
-motion, and the split of physical motion between world $x$ and $y$ depends on
-wave direction.
+That expectation is visible in the stationary simulation diagnostics.  Across
+eight calibration seas, the geometric-mean measured drift-band intensity ratios
+were approximately
+\begin{equation}
+ \frac{q_{{\rm eff},x}}{q_{{\rm eff},z}}=65.4,
+ \qquad
+ \frac{q_{{\rm eff},y}}{q_{{\rm eff},z}}=102.3.
+ \label{eq:q-horizontal-ratios}
+\end{equation}
+These measurements are used here only to quantify the disturbance imbalance;
+they are not used to infer universal production values of $r_{S,x}$ and
+$r_{S,y}$.
 
-\subsection{Why separate numerical $x/y$ optima are not claimed}
+\subsection{Why two orders of magnitude in drift do not imply two orders of magnitude in tuning}
 
-The available simulations contain a limited set of wave headings.  Surge and
-sway ranges in world coordinates therefore depend strongly on the chosen
-directional samples.  An apparent numerical optimum for $r_{S,x}$ relative to
-$r_{S,y}$ would mix estimator behavior with that sampling geometry and should
-not be generalized as an intrinsic axis law.
+The reduced theorem gives a useful explanation.  Holding the desired-motion
+moment and cadence fixed, a drift-intensity ratio $Q$ changes the reduced-model
+optimal standard deviation only by $Q^{1/14}$.  The measured ratios in
+\eqref{eq:q-horizontal-ratios} would therefore correspond to factors of only
+about $1.35$ and $1.39$ from the drift term alone.  Even a full decade of error
+in $q_{\rm eff}$ changes this factor by only about 18\%.
 
-This is especially important when one horizontal setting improves $x$ while
-another improves $y$: that trade can simply reflect how the simulated wave
-energy projects onto the world axes.  The present evidence is not rich enough
-in direction to support separate universal $x$ and $y$ regularizer coefficients.
+The physical-motion term is more influential: $m_{-4}$ enters
+\eqref{eq:rsred} with exponent $3/7$.  For horizontal motion this matters
+especially because surge and sway energy projected onto world $x$ and $y$
+changes with wave heading.  Consequently, sparse directional simulations cannot
+support a universal numerical $x/y$ optimum: the apparent preferred ratio would
+mix estimator behavior with the chosen directional geometry.
 
-\subsection{Supported horizontal conclusion}
+This is the point at which the older axis-specific numerical interpretation must
+stop.  The $1/14$ sensitivity is a valid property of the reduced model; specific
+production ratios inferred from a small set of headings are not.
 
-The robust conclusion is simpler.  Across the tested directional records,
-deliberately unequal integral regularization did not provide a consistent
-three-dimensional advantage, while isotropic integral regularization performed
-adequately.  The implementation therefore uses the same integral-regularization
-scale on all three axes.
+\subsection{The stronger design implication}
 
-This should not be read as a claim that horizontal drift is isotropic or small.
-Equation~\eqref{eq:tilt-leak} predicts the opposite.  It means only that, with
-the present evidence, the appropriate response to larger horizontal inertial
-error is not an unsupported axis-specific tightening of the false $S=0$
-observation.  Better attitude estimation, accelerometer-bias observability,
-GNSS, or another horizontal reference attacks the disturbance itself.
+The same reduced theorem gives a second, more consequential sensitivity.  At
+its own reduced optimum,
+\begin{equation}
+ J_{\rm red}^{\star}\propto q_{\rm eff}^{4/7},
+\end{equation}
+whereas the tuning itself varies as $q_{\rm eff}^{1/14}$.  Thus the logarithmic
+sensitivity of residual reduced-model error to the disturbance is eight times
+the sensitivity with which that disturbance moves the preferred regularizer.
+This does not prove an exact full-MEKF RMS law, but it explains why
+``regularize the noisy axis harder'' is a weak response to a large horizontal
+drift source.
+
+The engineering lever with the larger physical effect is to reduce
+$q_{\rm eff,H}$ itself: improve tilt estimation, improve accelerometer-bias
+observability, add GNSS velocity/position or another horizontal reference, or
+otherwise suppress the low-frequency acceleration error before integration.
+The integral anchor still bounds drift, but it cannot substitute for
+observability without eventually attenuating real motion.
+
+\subsection{Full-estimator evidence for isotropic regularization}
+
+The full-estimator directional experiments provide a separate empirical result.
+Deliberately unequal integral regularization did not produce a consistent
+three-dimensional advantage; changes that helped one world horizontal axis
+could hurt the other as directional wave energy moved between $x$ and $y$.
+Within the tested headings, isotropic integral regularization therefore performs
+adequately and avoids an unsupported axis-specific tuning law.
+
+This is the central horizontal finding: the disturbance is strongly
+non-isotropic in magnitude relative to vertical, yet the evidence does not
+support correspondingly strong regularizer anisotropy.  The reduced analysis
+explains why that outcome is plausible, while the full MEKF experiments decide
+the practical choice.
 
 \section{Additional Mechanistic Checks}
 \label{sec:checks}
@@ -580,58 +690,63 @@ a poor input to an adaptive drift regularizer.
 
 The results suggest a practical hierarchy.
 
-First, separate the natural state scale, the correction bandwidth, and the
+First, separate the natural coordinate scale, the reduced-model optimum, and the
 full-estimator tuning.  The scale $\sigma_a\tau^3$ follows from OU similarity.
-The reduced Riccati model explains how $R_S$ changes low-frequency correction
-bandwidth.  Neither result alone determines the complete-MEKF optimum.
+The reduced theorem exactly minimizes $J_{\rm red}$ under its stated
+assumptions.  Neither result alone determines the complete-MEKF optimum.
 
 Second, state the pseudo-update cadence together with any $r_S$ law.  A change
 in update frequency changes the information delivered by the virtual
 observation even when its per-update variance is unchanged.
 
-Third, estimate the time scale from the physical wave band.  Because the
-regularizer has a strong time-scale dependence, systematic period-estimation
-error is amplified by the scheduler.
+Third, use the reduced theorem for sensitivity, not for unsupported precision.
+Its weak $q_{\rm eff}^{1/14}$ dependence explains why a very large drift source
+does not require a proportional change in regularizer strength; its
+$q_{\rm eff}^{4/7}$ minimized-error dependence explains why reducing the source
+itself matters much more.
 
-Fourth, select the final coefficient and schedule using full-estimator,
-multi-seed, stationary and transition experiments.  In this work the analytical
-models constrain a reasonable family; the empirical studies decide which member
-is retained.
+Fourth, estimate the sea-state time scale from the physical wave band and select
+the final schedule using full-estimator, multi-seed, stationary and transition
+experiments.  In this work the analytical models constrain and explain a
+reasonable family; the empirical studies decide which member is retained.
 
-Finally, do not infer an axis-specific regularizer merely from the fact that
-horizontal inertial drift is larger.  With limited directional sampling,
-separate $x/y$ optima are not identifiable as general properties.  Isotropic
-regularization is the supported choice for the tested data.
+Finally, do not infer universal $x/y$ coefficients from sparse directional
+records.  Surge and sway projection changes with heading.  The supported result
+is that isotropic integral regularization performs adequately in the tested
+three-axis simulations, not that a particular pair of axis ratios has been
+analytically or numerically established.
 
 \section{Scope and Limitations}
 \label{sec:limitations}
 
-The analytical reduction assumes a scalar linear inertial chain, a separated
-low-frequency drift band, and a pseudo-update cadence fast enough to admit a
-continuous-information approximation.  The full marine MEKF contains attitude,
-gyro-bias, accelerometer-bias, translational-state, and cross-covariance
-couplings that are not represented in the closed-form CARE.
+The reduced theorem assumes a scalar linear inertial chain, white drift-band
+acceleration error, a separated desired-motion band, and a pseudo-update cadence
+fast enough to admit a continuous-information approximation.  Under those
+assumptions the minimizer in \cref{thm:reduced-mse} is mathematically well
+defined.  The limitations concern transfer of that result to the full estimator,
+not the internal algebra of the reduced theorem.
 
-Those omissions are not minor details for tuning.  The $S=0$ correction acts
-through the complete covariance, low-frequency acceleration error is partly
-endogenous to the estimator, and nonstationary transitions violate the
-stationary spectral assumptions used in the reduced cost.  The reduced
-drift--distortion proposition should therefore be read only as an illustrative
-mechanism.  It is not asserted to predict the optimum of the complete nonlinear
-estimator, and the deployed law is not presented as a theorem-derived optimum.
+The full marine MEKF contains attitude, gyro-bias, accelerometer-bias,
+translational-state, and cross-covariance couplings absent from the reduction.
+Moreover, because $S=0$ is a deliberately false observation and no random
+pseudo-measurement noise is actually drawn, the filter's internal covariance is
+not generally identical to the true estimation-error covariance.  The quantity
+$q_{\rm eff}$ is partly endogenous to attitude and bias errors, and transitions
+violate the stationary spectral assumptions.  These are precisely the points at
+which the analytical logic falls short of a complete-MEKF optimality claim.
 
-The directional dataset is also insufficient to identify separate universal
-world-$x$ and world-$y$ regularizer scales.  Their physical motion amplitudes
-depend on wave heading, and the present simulations sample only a limited set of
-directions.  A genuine directional anisotropy study would require substantially
-broader heading coverage, preferably including crossing seas and independent
-kinematic reference information.
+The horizontal diagnostic also has an important sampling limitation.  The
+measured drift-band intensity ratios establish that horizontal inertial error is
+large, but the available headings do not identify universal world-$x$ and
+world-$y$ desired-motion moments.  Therefore the diagnostic supports the
+weak-sensitivity argument and the need for better horizontal observability, but
+not a universal numerical $r_{S,x}/r_{S,y}$ law.
 
 No claim is made that the $S=0$ virtual observation is optimal for all marine
 motions.  Sustained maneuver acceleration, long-period swell, crossing seas,
 and non-wave translation can violate the bounded zero-mean integral model.  The
 appropriate response is full-estimator validation over the intended operating
-envelope, not extrapolation of the reduced scalar minimizer.
+envelope, not extrapolation of the scalar minimizer beyond its assumptions.
 
 \section{Reproducibility}
 
@@ -639,39 +754,39 @@ The full paired adaptation study is produced by
 \texttt{tools/ou\_validation.py}; local sensitivity and transition stress are
 produced by \texttt{tools/ou\_robustness.py}; and the amplitude-exponent family
 by \texttt{tools/ou\_rs\_law\_ablation.py}.  The reduced drift--distortion
-calculation remains available in \texttt{tools/rs\_law\_bias\_variance.py} as an
-illustrative analytical check, not as a calibration oracle.  The committed
-statistical bundles retain seed triplets, source/input hashes, raw rows, derived
-summary tables, and paired effects.
+calculation is represented by \texttt{tools/rs\_law\_bias\_variance.py}.  The
+axis diagnostic \texttt{tools/ou\_axis\_rs\_optimum.py} is used here only for
+its measured drift-band quantities, not as an oracle for production $x/y$
+regularizer ratios.  The committed statistical bundles retain seed triplets,
+source/input hashes, raw rows, derived summary tables, and paired effects.
 
 \section{Conclusion}
 
 Integral-state pseudo-measurements provide a useful middle ground between free
-inertial integration and hard position/velocity zeroing.  The natural
-third-integral scale
-\[
- \boxed{\sigma_a\tau^3}
-\]
-gives the physically appropriate state scaling, while the pseudo-update cadence
-controls how the virtual observation's information is delivered.  The
-implemented cadence renormalization converts the cubic base scale into the
-effective dependence $r_S\propto\sigma_a\tau^{5/2}$ away from clamps.
+inertial integration and hard position/velocity zeroing.  OU similarity gives
+the natural third-integral coordinate scale $\sigma_a\tau^3$, and explicit
+pseudo-update cadence accounting converts the deployed cubic base scale into the
+effective dependence $r_S\propto\sigma_a\tau^{5/2}$ away from clamps.  That
+scheduler is physically motivated but empirically selected; it is not presented
+as the exact optimum of the full MEKF.
 
-That relation is a sensible, physically scaled scheduler; it is not presented
-as the analytical optimum of the complete MEKF.  The practical justification
-for retaining it is empirical: the tested linear amplitude dependence performs
-best among the evaluated amplitude schedules, and adaptation of the integral
-regularizer carries most of the observed improvement.  The reduced Riccati and
-drift--distortion models explain why a finite regularization bandwidth exists
-and why drift rejection competes with signal preservation, but they remain
-illustrative.
+The reduced drift--distortion theorem remains valuable.  Within its stated
+model, it shows that the preferred regularizer depends only weakly on
+low-frequency drift intensity, while minimized residual error depends much more
+strongly on that disturbance.  This distinction explains an otherwise
+counterintuitive three-axis result.  In the tested stationary records,
+horizontal drift-band acceleration intensity is about two orders of magnitude
+above the vertical channel, yet the full-estimator evidence does not justify a
+correspondingly stronger horizontal anchor.  Isotropic integral regularization
+performs adequately across the tested headings.
 
-For horizontal motion, the supported finding is similarly modest and useful:
-larger horizontal inertial error does not require a separately tuned horizontal
-anchor in the tested data.  Because surge and sway depend on wave direction and
-the directional sample is limited, separate world-axis optima are not claimed.
-Isotropic integral regularization performs adequately and avoids introducing an
-unsupported directional tuning law.
+The design implication is therefore stronger than a tuning recommendation.
+When horizontal performance is limited by gravity leakage and weak bias
+observability, changing $R_S$ is a relatively weak lever: it trades drift
+suppression against real horizontal motion.  Improving tilt, bias observability,
+or adding external horizontal kinematic information attacks the disturbance
+itself.  Theory explains that hierarchy; the full-estimator experiments determine
+the practical adaptation law.
 
 \bibliographystyle{IEEEtran}
 \bibliography{w3d}

--- a/tests/validation/test_integral_regularization_paper.py
+++ b/tests/validation/test_integral_regularization_paper.py
@@ -4,19 +4,16 @@ import re
 import unittest
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DOC = REPO_ROOT / "doc" / "kalman_ou_iii"
 PAPER = DOC / "adaptive-integral-state-regularization.tex"
 
 
 def compact(text: str) -> str:
-    """Normalize source wrapping without changing LaTeX tokens."""
     return " ".join(text.split())
 
 
 def prose(text: str) -> str:
-    """Normalize wrapping and simple emphasis markup for prose assertions."""
     flat = compact(text)
     return re.sub(r"\\(?:emph|textbf|textit)\{([^{}]*)\}", r"\1", flat)
 
@@ -28,74 +25,81 @@ class IntegralRegularizationPaperTests(unittest.TestCase):
         cls.flat = compact(cls.text)
         cls.prose = prose(cls.text)
 
-    def test_paper_has_standalone_publication_scope(self):
+    def test_scope(self):
         self.assertIn(
-            "Adaptive Integral-State Regularization for Drift-Bounded Inertial Motion Estimation",
+            "Sea-State Scaling, Reduced-Order Analysis, and Empirical Tuning",
             self.flat,
         )
-        self.assertIn("Sea-State Scaling and Empirical Tuning", self.flat)
-        self.assertIn("integral-state regularization", self.prose.lower())
         self.assertIn("regularizer rather than a physical sensor", self.prose)
-        self.assertIn(r"\bibliography{w3d}", self.text)
 
-    def test_similarity_theorem_is_scaling_not_optimality_claim(self):
+    def test_similarity_theorem(self):
         self.assertIn(r"\label{thm:similarity}", self.text)
         self.assertIn(r"\boxed{\sigma_a\tau^3}", self.text)
         self.assertIn("coordinate-scale statement", self.prose)
-        self.assertIn("does not prove that this is the optimal Kalman tuning", self.prose)
 
-    def test_reduced_tradeoff_is_explicitly_illustrative(self):
-        self.assertIn(r"\label{prop:reduced-tradeoff}", self.text)
-        self.assertIn(r"\frac{3q_{\rm eff}}{2\omega_R^3}", self.text)
-        self.assertIn(r"4m_{-4}\omega_R^4", self.text)
-        self.assertIn(r"q_{\rm eff}^{1/14}m_{-4}^{3/7}T_S^{-1/2}", self.text)
-        self.assertIn("not asserted to be the optimum of the complete MEKF", self.prose)
-        self.assertIn("Where the analytical logic stops", self.flat)
-
-    def test_deployed_law_is_empirical_not_theorem_derived(self):
-        self.assertIn(r"r_S\propto\sigma_a\tau^{5/2}", self.text)
-        self.assertIn("The coefficient and the decision to retain this schedule", self.flat)
-        self.assertIn("are empirical design choices", self.flat)
-        self.assertIn("full-estimator evidence", self.flat)
-        self.assertNotIn(r"\label{thm:mse-opt}", self.text)
-        self.assertNotIn(r"r_S^\star", self.text)
-
-    def test_amplitude_exponent_ablation_matches_committed_study(self):
-        self.assertIn(r"\label{tab:p-ablation}", self.text)
-        for row in (
-            r"$p=0$    & 5.047 & $+0.300\pm0.071$ & 0.712",
-            r"$p=0.5$  & 4.823 & $+0.076\pm0.025$ & 0.670",
-            r"$\mathbf{p=1}$ & \textbf{4.747} & --- & \textbf{0.651}",
-            r"$p=1.25$ & 4.779 & $+0.032\pm0.012$ & 0.653",
-            r"$p=1.5$  & 4.817 & $+0.070\pm0.016$ & 0.660",
+    def test_reduced_mse_theorem_is_restored(self):
+        for token in (
+            r"\label{thm:reduced-mse}",
+            r"\frac{3q_{\rm eff}}{2\omega_R^3}",
+            r"4m_{-4}\omega_R^4",
+            r"\frac{9}{32}\frac{q_{\rm eff}}{m_{-4}}",
+            r"q_{\rm eff}^{1/14}m_{-4}^{3/7}T_S^{-1/2}",
+            r"q_{\rm eff}^{4/7}m_{-4}^{3/7}",
         ):
-            self.assertIn(row, self.text)
-        self.assertNotIn(r"p=\frac{m+12}{14}", self.text)
+            self.assertIn(token, self.text)
+        self.assertIn("optimum of $J_{\\rm red}$, not of the complete MEKF", self.flat)
+
+    def test_analysis_limit_is_specific(self):
+        self.assertIn("Where the analytical logic stops", self.flat)
+        self.assertIn("design covariance", self.prose)
+        self.assertIn("no random $n_S$ is generated", self.flat)
+        self.assertIn(
+            "filter-internal Riccati covariance and the actual estimation-error covariance",
+            self.flat,
+        )
+        self.assertIn("full-estimator experiments remain the tuning authority", self.flat)
+
+    def test_deployed_law_remains_empirical(self):
+        self.assertIn(r"r_S\propto\sigma_a\tau^{5/2}", self.text)
+        self.assertIn(
+            "empirical design choices validated in the complete estimator", self.flat
+        )
+        self.assertNotIn("deployed law is analytically optimal", self.prose.lower())
+
+    def test_amplitude_ablation(self):
+        self.assertIn(r"\label{tab:p-ablation}", self.text)
+        self.assertIn(
+            r"$\mathbf{p=1}$ & \textbf{4.747} & --- & \textbf{0.651}",
+            self.text,
+        )
+        self.assertIn(r"p_{\rm red}=\frac{m+12}{14}", self.text)
         self.assertIn("used directly as empirical support", self.flat)
 
-    def test_channel_ablation_keeps_rs_as_the_dominant_adaptive_channel(self):
+    def test_channel_ablation(self):
         self.assertIn(r"\label{tab:channel-ablation}", self.text)
-        for row in (
-            r"$H_s=0.27$ m & 5.13 & 5.13 & 15.82 & 15.72",
-            r"$H_s=4.00$ m & 4.85 & 4.84 & 7.05 & 7.02",
-            r"$H_s=8.50$ m & 4.03 & 4.02 & 11.28 & 11.14",
-            r"Transition    & 4.66 & 4.65 & 8.82 & 8.90",
-        ):
-            self.assertIn(row, self.text)
+        self.assertIn(r"Transition    & 4.66 & 4.65 & 8.82 & 8.90", self.text)
         self.assertIn("adaptive integral anchor is", self.flat)
 
-    def test_awkward_local_sensitivity_table_is_removed(self):
+    def test_awkward_sensitivity_table_stays_removed(self):
         self.assertNotIn(r"\label{tab:sensitivity}", self.text)
-        self.assertIn("A separate local sensitivity sweep reaches the same mechanistic conclusion", self.flat)
 
-    def test_horizontal_claim_is_isotropic_and_direction_limited(self):
-        self.assertIn(r"\section{Three-Axis Regularization}", self.text)
-        self.assertIn("limited set of wave headings", self.flat)
-        self.assertIn("separate universal $x$ and $y$ regularizer coefficients", self.flat)
-        self.assertIn("isotropic integral regularization performed adequately", self.flat)
-        self.assertIn("same integral-regularization scale on all three axes", self.flat)
+    def test_horizontal_diagnostic_and_mechanism_are_preserved(self):
+        self.assertIn(r"\label{eq:q-horizontal-ratios}", self.text)
+        self.assertIn("65.4", self.text)
+        self.assertIn("102.3", self.text)
+        self.assertIn(r"q_{\rm eff}^{1/14}", self.text)
+        self.assertIn("eight times the sensitivity", self.flat)
+        self.assertIn("reduce $q_{\\rm eff,H}$ itself", self.flat)
 
-    def test_legacy_horizontal_tuning_and_axis_optimum_are_removed(self):
+    def test_horizontal_claim_is_direction_limited_and_isotropic(self):
+        self.assertIn(
+            "sparse directional simulations cannot support a universal numerical $x/y$ optimum",
+            self.flat,
+        )
+        self.assertIn("isotropic integral regularization therefore performs adequately", self.flat)
+        self.assertIn("full MEKF experiments decide the practical choice", self.flat)
+
+    def test_legacy_axis_optimum_does_not_return(self):
         for token in (
             r"\rho_{xy}",
             r"\label{eq:axis-opt}",
@@ -104,23 +108,10 @@ class IntegralRegularizationPaperTests(unittest.TestCase):
             r"\label{tab:ssigma}",
             "1.138",
             "0.861",
-            "historical horizontal factor",
         ):
             self.assertNotIn(token, self.text)
 
-    def test_abstract_contains_no_reduced_optimum_numbers(self):
-        abstract = self.text.split(r"\begin{abstract}", 1)[1].split(r"\end{abstract}", 1)[0]
-        for token in (
-            r"q_{\rm eff}^{1/14}",
-            r"m_{-4}^{3/7}",
-            "1.138",
-            "0.861",
-            "two orders of magnitude",
-        ):
-            self.assertNotIn(token, abstract)
-        self.assertIn("justified empirically", abstract)
-
-    def test_two_column_paper_does_not_use_full_width_tables(self):
+    def test_two_column(self):
         self.assertNotIn(r"\begin{table*}", self.text)
         self.assertNotIn(r"\begin{figure*}", self.text)
 


### PR DESCRIPTION
## What changed

- Restores the reduced drift--distortion MSE theorem instead of deleting it.
- Keeps the exact reduced-model results
  - `J_red = 3 q_eff /(2 omega_R^3) + 4 m_-4 omega_R^4`,
  - `r_{S,red}^* ∝ q_eff^(1/14) m_-4^(3/7) T_S^(-1/2)`, and
  - `J_red^* ∝ q_eff^(4/7) m_-4^(3/7)`.
- Reframes those equations correctly: they are exact for the stated scalar/continuous/spectrally separated reduced model, but are not asserted to be the optimum of the full MEKF.
- Adds a specific explanation of where transfer to the full MEKF fails: attitude/bias cross-covariances, the false `S=0` observation, `R_S` being a design covariance with no random pseudo-measurement draw, endogenous low-frequency error, discrete periodic updates, spectral separation, three-dimensional coupling, and nonstationarity.
- Restores the key horizontal mechanism. The paper again reports the measured horizontal drift-band intensity imbalance (`q_x/q_z ≈ 65.4`, `q_y/q_z ≈ 102.3`) and explains why the reduced-model tuning reacts only weakly through the `1/14` exponent while reduced residual error reacts much more strongly through `4/7`.
- Uses that mechanism to motivate the design priority of reducing horizontal low-frequency acceleration error itself (tilt, bias observability, GNSS/other references) rather than simply tightening the integral anchor.
- Keeps the important correction from the previous PR: no universal numerical `x/y` optimum is inferred from the limited directional simulations. The old `1.138/0.861` ratios and legacy horizontal tuning history remain removed.
- Keeps the practical adaptation law empirical. The deployed effective `r_S ∝ sigma_a tau^(5/2)` schedule is physically motivated by the cubic state scale plus cadence renormalization, but is not claimed to be theorem-optimal.
- Updates the publication contract to require the restored reduced theorem and horizontal mechanism while continuing to forbid the unsupported axis-specific optimum claims.

## Why

The previous cleanup correctly removed an overclaim, but it also removed too much of the analysis that made the result interesting. The right boundary is not to discard the reduced theorem; it is to state precisely what it optimizes and where its assumptions stop. This hybrid keeps the analytical insight while leaving production tuning authority with the complete-estimator experiments.

## Validation

- Rewritten manuscript compiles locally with `pdflatex` to a 6-page IEEE PDF (bibliography unresolved locally because the repository `.bib` was not materialized, but LaTeX syntax and layout pass).
- Updated publication contract passes 12/12 local checks.
- PR changes only the standalone manuscript and its publication contract; production filter code and tuning are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the technical paper with a precisely scoped scalar analysis, closed-form tuning results, sensitivity findings, and explicit limitations.
  * Added empirical results covering adaptive integral-state behavior, amplitude scheduling, horizontal diagnostics, and isotropic regularization.
  * Updated design, reproducibility, and conclusion sections to emphasize full-estimator validation and practical error reduction.

* **Tests**
  * Updated validation coverage for revised terminology, analytical claims, empirical findings, and horizontal-diagnostic conclusions.
  * Removed checks for outdated axis-specific optimization content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->