### PR TITLE
Derive OU-II dual-channel physical-MSE adaptation laws

### DIFF
--- a/doc/kalman_ou_ii/ou2-dual-regularization-mse.tex
+++ b/doc/kalman_ou_ii/ou2-dual-regularization-mse.tex
@@ -1,0 +1,701 @@
+\documentclass[conference]{IEEEtran}
+
+\usepackage{iftex}
+\ifPDFTeX
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\fi
+\usepackage{amsmath,amssymb,amsthm,bm}
+\usepackage{booktabs}
+\usepackage{mathtools}
+\usepackage{siunitx}
+\usepackage[final]{microtype}
+\usepackage[hidelinks]{hyperref}
+
+\newtheorem{theorem}{Theorem}
+\newtheorem{corollary}{Corollary}
+\newtheorem{remark}{Remark}
+\newcommand{\vct}[1]{\bm{#1}}
+\newcommand{\mat}[1]{\bm{#1}}
+\newcommand{\R}{\mathbb{R}}
+\newcommand{\Id}{\mat I}
+
+\title{Physical-MSE Scaling of Dual Pseudo-Measurement Regularization\\
+in an OU-Driven Marine Inertial MEKF}
+
+\author{\IEEEauthorblockN{Mikhail S. Grushinskiy}
+\IEEEauthorblockA{Independent Researcher, USA, Fair Lawn\\
+Bareboat Necessities GitHub Project\\
+Email: mgrouch@users.github.com}}
+
+\begin{document}
+\maketitle
+
+\begin{abstract}
+A marine inertial multiplicative extended Kalman filter (MEKF) with a latent
+Ornstein--Uhlenbeck (OU) acceleration state uses zero pseudo-measurements on
+both displacement and velocity to suppress low-frequency integration drift.
+The implemented adaptation schedules the corresponding pseudo-measurement
+standard deviations as $r_{p,0}\propto\sigma_{aw}\tau^2$ and
+$r_{v,0}\propto\sigma_{aw}\tau$, followed by a common cadence normalization.
+This note derives a reduced physical mean-square-error (MSE) model for the two
+pseudo channels jointly rather than treating them as independent penalties.
+The associated two-state Kalman--Bucy algebraic Riccati equation admits a
+closed-form solution parameterized by a position regularization frequency and
+a dimensionless velocity-to-position strength ratio.  A weak-regularization
+expansion separates residual-acceleration drift from distortion of the physical
+wave.  For a fixed-shape sea and an approximately sea-independent low-frequency
+posterior acceleration-error intensity, joint MSE minimization predicts the
+base laws
+$r_{p,0}^\star\propto\sigma_a^{4/5}\tau^{12/5}$ and
+$r_{v,0}^\star\propto\sigma_a^{4/5}\tau^{7/5}$.
+The two laws differ from the implemented powers by the same weak common factor,
+and their ratio satisfies
+$(r_{p,0}^\star/r_{v,0}^\star)^2=(3/2)M_{-2}/M_0$.
+Consequently, the theory predicts $r_{p,0}^\star/r_{v,0}^\star\propto\tau$,
+which matches the implemented relative period scaling exactly.  Evaluation on
+the finite-band reference spectra places the theoretical coefficient ratio near
+the implemented value.  The derivation supplies testable adaptation exponents
+without fitting them to the existing schedule, while its reduced displacement
+objective does not capture the full attitude and bias coupling of the MEKF.
+\end{abstract}
+
+\begin{IEEEkeywords}
+Kalman filter, inertial navigation, marine motion estimation,
+Ornstein--Uhlenbeck process, pseudo-measurement, regularization, mean-square
+error, heave estimation.
+\end{IEEEkeywords}
+
+\section{Introduction}
+
+Low-frequency drift is the central difficulty in displacement estimation from
+inertial acceleration.  The OU--II estimator considered here regularizes this
+integration chain with two nonphysical zero pseudo-measurements: one on
+world-frame displacement $p$ and one on world-frame velocity $v$.  The two
+channels are applied on the same periodic pseudo-update tick.  Their configured
+standard deviations are therefore not independent observation uncertainties;
+they are design parameters that trade drift suppression against distortion of
+real wave motion.
+
+The deployed adaptation was selected empirically and has the base form
+\begin{equation}
+ r_{p,0}^{\mathrm{base}}=c_p\sigma_{aw}\tau^2,
+ \qquad
+ r_{v,0}^{\mathrm{base}}=c_v\sigma_{aw}\tau,
+ \label{eq:implemented-base}
+\end{equation}
+with current coefficients $c_p=0.65$ and $c_v=1.30$.  Here $\tau$ is the OU
+correlation time and $\sigma_{aw}$ is the stationary standard deviation of the
+latent OU acceleration prior.  Both pseudo channels use the same
+cadence-normalization factor
+\begin{equation}
+ r_{j}=r_{j,0}^{\mathrm{base}}
+ \sqrt{\frac{T_0}{T_S}},
+ \qquad j\in\{p,v\},
+ \label{eq:cadence-normalization}
+\end{equation}
+where the pseudo-update period satisfies $T_S\propto\tau$ away from safety
+clamps.  This normalization preserves the continuous-equivalent information
+density associated with a given base value.
+
+Equation~\eqref{eq:implemented-base} has the correct dimensions and performs
+well empirically, but dimensional consistency alone does not identify the
+powers of $\sigma_{aw}$ and $\tau$.  The purpose of this note is to derive those
+powers from a physical displacement-MSE criterion.  The analysis follows the
+same distinction used in the OU--III regularization study: the internal Kalman
+covariance of a filter that treats a zero pseudo-measurement as if it were a
+physical observation is not itself the physical wave-estimation error.  A
+useful design objective must include both residual stochastic drift and the
+bias introduced by suppressing the real wave signal.
+
+\section{Implemented OU--II Regularization Structure}
+\label{sec:implementation}
+
+With gyroscope and accelerometer biases enabled, the complete OU--II MEKF has
+local error coordinates containing attitude, gyroscope bias, velocity,
+displacement, latent OU acceleration, and accelerometer bias.  The present
+analysis isolates the low-frequency translational subproblem
+\begin{equation}
+ \dot p=v,\qquad \dot v=n_a,
+ \label{eq:double-integrator}
+\end{equation}
+where $n_a$ denotes the residual acceleration error presented to the integration
+chain after acceleration estimation.  At frequencies below its posterior
+correlation rate, approximate $n_a$ as white with two-sided intensity
+$q_{\mathrm{eff}}$, abbreviated below as $q$.
+
+The position and velocity pseudo-measurements are both zero.  If their discrete
+standard deviations are $r_p$ and $r_v$ and the common update period is $T_S$,
+the corresponding continuous-equivalent measurement-noise densities are
+\begin{equation}
+ \rho_p=r_p^2T_S,
+ \qquad
+ \rho_v=r_v^2T_S.
+ \label{eq:continuous-densities}
+\end{equation}
+Under Eq.~\eqref{eq:cadence-normalization},
+\begin{equation}
+ \rho_p=(r_{p,0}^{\mathrm{base}})^2T_0,
+ \qquad
+ \rho_v=(r_{v,0}^{\mathrm{base}})^2T_0,
+ \label{eq:base-density-equivalence}
+\end{equation}
+so the theoretical scaling of the continuous densities maps directly to the
+base adaptation laws.
+
+\section{Exact Dual-Channel Riccati Reduction}
+\label{sec:care}
+
+Consider the continuous model
+\begin{equation}
+ \dot{\vct x}=\mat A\vct x+\mat B n_a,
+ \qquad
+ \vct x=\begin{bmatrix}p&v\end{bmatrix}^{\top},
+ \label{eq:state-model}
+\end{equation}
+with
+\begin{equation}
+ \mat A=\begin{bmatrix}0&1\\0&0\end{bmatrix},
+ \qquad
+ \mat B=\begin{bmatrix}0\\1\end{bmatrix},
+ \qquad
+ \mat Q=q\mat B\mat B^{\top}.
+\end{equation}
+The two continuous pseudo-observations have $\mat C=\Id$ and
+\begin{equation}
+ \mat R_c=\operatorname{diag}(\rho_p,\rho_v).
+\end{equation}
+The stabilizing covariance satisfies the Kalman--Bucy algebraic Riccati
+equation \cite{KalmanBucy1961,Jazwinski1970}
+\begin{equation}
+ \mat A\mat P+\mat P\mat A^{\top}+\mat Q
+ -\mat P\mat R_c^{-1}\mat P=0.
+ \label{eq:care}
+\end{equation}
+
+Define the two natural regularization frequencies
+\begin{equation}
+ \omega_p:=\left(\frac{q}{\rho_p}\right)^{1/4},
+ \qquad
+ \omega_v:=\left(\frac{q}{\rho_v}\right)^{1/2},
+ \label{eq:natural-frequencies}
+\end{equation}
+and the dimensionless relative velocity strength
+\begin{equation}
+ \chi:=\left(\frac{\omega_v}{\omega_p}\right)^2.
+ \label{eq:chi}
+\end{equation}
+
+\begin{theorem}[Dual-channel CARE solution]
+For $q,\rho_p,\rho_v>0$, the stabilizing solution of
+Eq.~\eqref{eq:care} is
+\begin{equation}
+ \boxed{
+ \mat P=\frac{q}{1+\chi}
+ \begin{bmatrix}
+ \dfrac{\sqrt{2+\chi}}{\omega_p^3} & \dfrac{1}{\omega_p^2}\\[2.5mm]
+ \dfrac{1}{\omega_p^2} & \dfrac{\sqrt{2+\chi}}{\omega_p}
+ \end{bmatrix}.}
+ \label{eq:P-solution}
+\end{equation}
+The corresponding continuous pseudo-measurement gain
+$\mat K=\mat P\mat R_c^{-1}$ is
+\begin{equation}
+ \boxed{
+ \mat K=
+ \begin{bmatrix}
+ \dfrac{\omega_p\sqrt{2+\chi}}{1+\chi} &
+ \dfrac{\chi}{1+\chi}\\[2.5mm]
+ \dfrac{\omega_p^2}{1+\chi} &
+ \dfrac{\omega_p\chi\sqrt{2+\chi}}{1+\chi}
+ \end{bmatrix}.}
+ \label{eq:K-solution}
+\end{equation}
+\end{theorem}
+
+The result shows explicitly that the two pseudo channels do not generate two
+independent scalar corners.  They alter the same second-order closed loop, and
+$\chi$ determines how much of the regularization is supplied through the
+velocity channel.
+
+If physical acceleration $a$ is injected into the model dynamics, the
+acceleration-to-estimated-displacement transfer of the reduced closed loop is
+\begin{equation}
+ \boxed{
+ H_{pa}(s)=
+ \frac{1}{1+\chi}
+ \frac{1}{s^2+\omega_p\sqrt{2+\chi}\,s+\omega_p^2}.}
+ \label{eq:Hpa}
+\end{equation}
+Define the reconstruction transfer relative to ideal double integration,
+\begin{equation}
+ G(s):=s^2H_{pa}(s).
+ \label{eq:G}
+\end{equation}
+Then
+\begin{equation}
+ \lim_{\omega\rightarrow\infty}G(j\omega)=\frac{1}{1+\chi}.
+ \label{eq:high-frequency-gain}
+\end{equation}
+Thus a finite velocity pseudo strength introduces a broadband attenuation
+component in addition to the low-frequency drift corner.  This distinction is
+consistent with the empirical observation that the position pseudo channel
+primarily controls displacement error, whereas the velocity pseudo channel has
+stronger interaction with attitude and bias estimation in the complete MEKF.
+
+\section{Physical Displacement MSE}
+\label{sec:mse}
+
+The physical objective is written as
+\begin{equation}
+ J=J_n+J_w,
+ \label{eq:J-split}
+\end{equation}
+where $J_n$ is the displacement variance generated by residual acceleration
+noise and $J_w$ is the error caused by reshaping the real wave signal.
+
+\subsection{Residual-noise contribution}
+
+The squared $H_2$ norm of Eq.~\eqref{eq:Hpa} gives the exact reduced noise
+variance
+\begin{equation}
+ \boxed{
+ J_n=
+ \frac{q}
+ {2\omega_p^3(1+\chi)^2\sqrt{2+\chi}}.}
+ \label{eq:Jnoise-exact}
+\end{equation}
+For weak velocity regularization, $\chi\ll1$,
+\begin{equation}
+ J_n=
+ \frac{q}{2\sqrt{2}\,\omega_p^3}
+ \left(1-\frac94\chi+O(\chi^2)\right).
+ \label{eq:Jnoise-expansion}
+\end{equation}
+The negative first-order term explains the purpose of the $v=0$ channel in the
+reduced model: modest velocity regularization reduces low-frequency stochastic
+drift.
+
+\subsection{Wave-distortion contribution}
+
+Let $S_p^{(2)}(\omega)$ be the two-sided physical displacement spectrum and
+define
+\begin{equation}
+ M_0:=\frac{1}{2\pi}\int_{-\infty}^{\infty}
+ S_p^{(2)}(\omega)\,d\omega,
+ \label{eq:M0}
+\end{equation}
+\begin{equation}
+ M_{-2}:=\frac{1}{2\pi}\int_{-\infty}^{\infty}
+ \omega^{-2}S_p^{(2)}(\omega)\,d\omega.
+ \label{eq:Mminus2}
+\end{equation}
+The physical wave error is
+\begin{equation}
+ J_w=\frac{1}{2\pi}\int_{-\infty}^{\infty}
+ |G(j\omega)-1|^2S_p^{(2)}(\omega)\,d\omega.
+ \label{eq:Jwave-exact}
+\end{equation}
+When the regularization corner lies below the principal wave band and
+$\chi\ll1$, expansion of Eq.~\eqref{eq:G} gives
+\begin{equation}
+ \boxed{
+ J_w\simeq M_0\chi^2+2M_{-2}\omega_p^2.}
+ \label{eq:Jwave-asymptotic}
+\end{equation}
+The two terms have different physical meanings.  The $\omega_p^2$ term is the
+leading displacement distortion caused by the position regularization corner;
+the $\chi^2M_0$ term is the leading broadband attenuation caused by the velocity
+pseudo channel.
+
+Combining Eqs.~\eqref{eq:Jnoise-expansion} and
+\eqref{eq:Jwave-asymptotic} yields the reduced joint objective
+\begin{equation}
+ \boxed{
+ J\simeq
+ \frac{q}{2\sqrt{2}\,\omega_p^3}
+ \left(1-\frac94\chi\right)
+ +2M_{-2}\omega_p^2+M_0\chi^2.}
+ \label{eq:J-reduced}
+\end{equation}
+
+\section{Joint MSE-Optimal Scaling}
+\label{sec:optimal-scaling}
+
+To leading order, optimize Eq.~\eqref{eq:J-reduced} first with respect to
+$\omega_p$ and then with respect to $\chi$.
+
+\begin{theorem}[Weak-regularization joint optimum]
+In the regime used to obtain Eq.~\eqref{eq:J-reduced}, the stationary point
+satisfies
+\begin{equation}
+ \boxed{
+ (\omega_p^\star)^5
+ =\frac{3q}{8\sqrt{2}\,M_{-2}},}
+ \label{eq:wp-opt}
+\end{equation}
+and
+\begin{equation}
+ \boxed{
+ \chi^\star
+ =\frac{9q}
+ {16\sqrt{2}\,M_0(\omega_p^\star)^3}.}
+ \label{eq:chi-opt}
+\end{equation}
+\end{theorem}
+
+For a fixed-shape, period-scaled physical acceleration spectrum, write
+\begin{equation}
+ S_a^{(2)}(\omega;\sigma_a,\tau)
+ =\sigma_a^2\tau\,\Phi_a(\omega\tau),
+ \label{eq:Sa-similarity}
+\end{equation}
+where $\sigma_a$ is a physical acceleration RMS scale.  Since
+$S_p^{(2)}=S_a^{(2)}/\omega^4$, similarity gives
+\begin{equation}
+ M_0\propto\sigma_a^2\tau^4,
+ \qquad
+ M_{-2}\propto\sigma_a^2\tau^6.
+ \label{eq:moment-scaling}
+\end{equation}
+Substitution into Eqs.~\eqref{eq:wp-opt}--\eqref{eq:chi-opt} gives
+\begin{equation}
+ \omega_p^\star
+ \propto q^{1/5}\sigma_a^{-2/5}\tau^{-6/5},
+ \label{eq:wp-scaling}
+\end{equation}
+\begin{equation}
+ \chi^\star
+ \propto q^{2/5}\sigma_a^{-4/5}\tau^{-2/5},
+ \label{eq:chi-scaling}
+\end{equation}
+and therefore
+\begin{equation}
+ \omega_v^\star=\omega_p^\star\sqrt{\chi^\star}
+ \propto q^{2/5}\sigma_a^{-4/5}\tau^{-7/5}.
+ \label{eq:wv-scaling}
+\end{equation}
+
+Using Eq.~\eqref{eq:natural-frequencies}, the corresponding continuous
+pseudo-measurement densities are
+\begin{equation}
+ \rho_p^\star
+ \propto q^{1/5}\sigma_a^{8/5}\tau^{24/5},
+ \label{eq:rhop-scaling}
+\end{equation}
+\begin{equation}
+ \rho_v^\star
+ \propto q^{1/5}\sigma_a^{8/5}\tau^{14/5}.
+ \label{eq:rhov-scaling}
+\end{equation}
+Equation~\eqref{eq:base-density-equivalence} then yields the central base-law
+prediction
+\begin{equation}
+ \boxed{
+ r_{p,0}^{\mathrm{base},\star}
+ \propto q^{1/10}\sigma_a^{4/5}\tau^{12/5},}
+ \label{eq:rp-base-opt}
+\end{equation}
+\begin{equation}
+ \boxed{
+ r_{v,0}^{\mathrm{base},\star}
+ \propto q^{1/10}\sigma_a^{4/5}\tau^{7/5}.}
+ \label{eq:rv-base-opt}
+\end{equation}
+If the strong direct-acceleration-observation regime makes $q$ approximately
+independent of sea amplitude to leading order, the two adaptation laws reduce
+to
+\begin{equation}
+ \boxed{
+ r_{p,0}^{\mathrm{base},\star}
+ \propto\sigma_a^{4/5}\tau^{12/5},
+ \qquad
+ r_{v,0}^{\mathrm{base},\star}
+ \propto\sigma_a^{4/5}\tau^{7/5}.}
+ \label{eq:strong-observation-laws}
+\end{equation}
+Neither exponent pair is fitted to the implemented schedule.
+
+\section{Comparison with the Implemented Adaptation}
+\label{sec:comparison}
+
+Table~\ref{tab:powers} compares the reduced physical-MSE powers with the
+implemented OU--II laws.  The per-update rows include the common
+$T_S\propto\tau$ cadence normalization of Eq.~\eqref{eq:cadence-normalization}.
+
+\begin{table}[t]
+\caption{Implemented and reduced-MSE adaptation powers.}
+\label{tab:powers}
+\centering
+\footnotesize
+\begin{tabular}{@{}lll@{}}
+\toprule
+Quantity & Implemented & Reduced physical MSE \\
+\midrule
+$r_{p,0}^{\mathrm{base}}$
+ & $\sigma_a\tau^2$
+ & $\sigma_a^{4/5}\tau^{12/5}$ \\
+$r_{v,0}^{\mathrm{base}}$
+ & $\sigma_a\tau$
+ & $\sigma_a^{4/5}\tau^{7/5}$ \\
+$r_p$ per update
+ & $\sigma_a\tau^{3/2}$
+ & $\sigma_a^{4/5}\tau^{19/10}$ \\
+$r_v$ per update
+ & $\sigma_a\tau^{1/2}$
+ & $\sigma_a^{4/5}\tau^{9/10}$ \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+The discrepancy is the same in both channels.  After absorbing fixed
+coefficients,
+\begin{equation}
+ \boxed{
+ \frac{r_{p,\mathrm{MSE}}}{r_{p,\mathrm{impl}}}
+ \propto
+ \frac{r_{v,\mathrm{MSE}}}{r_{v,\mathrm{impl}}}
+ \propto
+ q^{1/10}\sigma_a^{-1/5}\tau^{2/5}.}
+ \label{eq:common-correction}
+\end{equation}
+For approximately constant $q$,
+\begin{equation}
+ \frac{r_{\mathrm{MSE}}}{r_{\mathrm{impl}}}
+ \propto\left(\frac{\tau^2}{\sigma_a}\right)^{1/5}.
+ \label{eq:fifth-root-correction}
+\end{equation}
+The fifth root makes the shape difference weak over a finite operating range.
+
+The common wave-band tuner has the following OU--II fixed operating points for
+the four JONSWAP calibration records:
+$(\tau,\sigma_{aw})=(1.247,0.333)$,
+$(2.179,0.683)$,
+$(3.590,1.061)$, and $(4.222,1.340)$ in SI units.  Because the mapping from the
+physical acceleration RMS to $\sigma_{aw}$ is a fixed multiplicative factor, it
+cancels in a normalized comparison.  Normalizing
+Eq.~\eqref{eq:fifth-root-correction} at the $H_s=\SI{1.5}{m}$ point gives
+Table~\ref{tab:envelope}.
+
+\begin{table}[t]
+\caption{Reduced-MSE/common implemented shape ratio over the calibrated
+JONSWAP envelope, normalized at $H_s=\SI{1.5}{m}$.}
+\label{tab:envelope}
+\centering
+\footnotesize
+\begin{tabular}{@{}lrr@{}}
+\toprule
+$H_s$ (m) & MSE/implemented & Difference \\
+\midrule
+0.27 & 0.924 & $-7.6\%$ \\
+1.50 & 1.000 & $0.0\%$ \\
+4.00 & 1.118 & $+11.8\%$ \\
+8.50 & 1.139 & $+13.9\%$ \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+Thus the first-principles power laws produce pseudo standard deviations within
+approximately $-8\%$ to $+14\%$ of the implemented shape over the calibrated
+JONSWAP range when both are given the same nominal anchor.  This comparison is
+in configured pseudo-measurement standard deviation; it does not imply the same
+percentage change in displacement RMS.
+
+\section{A Stronger Prediction: the Position-to-Velocity Ratio}
+\label{sec:ratio}
+
+The relative channel scaling is more tightly identified than the common
+amplitude scale because the unknown $q$ cancels.
+
+\begin{corollary}[Optimal pseudo-channel ratio]
+At the weak-regularization optimum,
+\begin{equation}
+ \boxed{
+ \left(\frac{r_{p,0}^{\star}}{r_{v,0}^{\star}}\right)^2
+ =\frac{3}{2}\frac{M_{-2}}{M_0}.}
+ \label{eq:ratio-exact}
+\end{equation}
+\end{corollary}
+
+For a fixed normalized sea shape,
+$M_{-2}/M_0\propto\tau^2$, hence
+\begin{equation}
+ \boxed{
+ \frac{r_{p,0}^{\star}}{r_{v,0}^{\star}}\propto\tau.}
+ \label{eq:ratio-tau}
+\end{equation}
+This is exactly the relative period scaling of the implemented pair,
+\begin{equation}
+ \frac{r_{p,0}^{\mathrm{impl}}}{r_{v,0}^{\mathrm{impl}}}
+ =\frac{c_p}{c_v}\tau
+ =0.500\,\tau.
+ \label{eq:implemented-ratio}
+\end{equation}
+
+For an ideal infinite-band Pierson--Moskowitz spectrum, the spectral moments can
+be integrated analytically and Eq.~\eqref{eq:ratio-exact} gives
+\begin{equation}
+ \frac{r_{p,0}^{\star}}{r_{v,0}^{\star}}
+ =\sqrt{\frac{3}{4\pi}}\,\tau
+ \simeq0.489\,\tau,
+ \label{eq:pm-ratio}
+\end{equation}
+when $\tau=T_z/2$.  For an ideal JONSWAP spectrum with peak-enhancement factor
+$\gamma=3.3$, numerical moment integration gives approximately
+\begin{equation}
+ \frac{r_{p,0}^{\star}}{r_{v,0}^{\star}}
+ \simeq0.465\,\tau.
+ \label{eq:jonswap-ratio}
+\end{equation}
+The actual simulator uses finite $0.02$--$0.8$ Hz spectra.  Evaluating the same
+moment ratio on those underlying first-order spectra over the four reference
+periods gives coefficient ratios approximately $0.43$--$0.49$ across the
+JONSWAP and PM families.  The implemented value $0.500$ is therefore slightly
+looser on the position channel relative to velocity, but it is close to the
+reduced physical-MSE prediction without having been obtained from
+Eq.~\eqref{eq:ratio-exact}.
+
+This agreement is more informative than agreement of either absolute
+coefficient alone.  The ratio follows from the spectral distribution of the
+physical displacement and is independent of the assumed residual-acceleration
+intensity $q$ and of the common cadence normalization.
+
+\section{Interpretation for OU--II Adaptation}
+\label{sec:interpretation}
+
+The reduced theory suggests that the empirical OU--II law has captured the
+geometry of the two-channel regularizer more accurately than its simple powers
+might imply.  Three observations are notable.
+
+First, the physical-MSE amplitude exponent is $4/5$, already close to the
+implemented linear dependence on $\sigma_{aw}$.  As in the OU--III analysis,
+a modest difference in exponent produces only a weak schedule difference over
+the tested sea-state range.
+
+Second, the theoretical period powers exceed the implemented powers by the
+same $2/5$ in both base channels:
+\begin{equation}
+ \frac{12}{5}-2=\frac{7}{5}-1=\frac25.
+\end{equation}
+Consequently, the theory does not ask for a different relative period law
+between the two pseudo channels.  It asks only for a common multiplicative
+shape correction.
+
+Third, the exact relative law
+$r_{p,0}/r_{v,0}\propto\tau$ is already present in the implementation.  The
+current coefficient ratio $0.65/1.30=0.5$ is also near the spectral value
+predicted by the reduced MSE.  This explains why independent empirical sweeps
+identify both coefficients sharply while still finding their best region close
+to the existing pair.
+
+\section{Testable Predictions and Next Study}
+\label{sec:next-study}
+
+The reduced analysis produces a direct experiment rather than another free
+exponent search.  Compare the existing laws
+\begin{equation}
+ r_{p,0}\propto\sigma_{aw}\tau^2,
+ \qquad
+ r_{v,0}\propto\sigma_{aw}\tau
+ \label{eq:current-test-law}
+\end{equation}
+against
+\begin{equation}
+ \boxed{
+ r_{p,0}\propto\sigma_{aw}^{4/5}\tau^{12/5},
+ \qquad
+ r_{v,0}\propto\sigma_{aw}^{4/5}\tau^{7/5}.}
+ \label{eq:theory-test-law}
+\end{equation}
+Both candidate pairs should use the same nominal calibration record and the
+same one-parameter common gain normalization.  The ratio between the two
+channels should not be re-fitted independently unless the experiment is
+explicitly testing the spectral-ratio prediction.  The primary comparison
+should use paired multi-seed stationary seas, with the controlled transition
+reported separately because the existing tuning studies show a distinct
+stationary--transient tradeoff.
+
+A second test can remove the empirical channel ratio entirely by using
+Eq.~\eqref{eq:ratio-exact} with the measured or versioned displacement spectrum
+to set $r_{p,0}/r_{v,0}$ and fitting only one overall regularization scale.  If
+that constrained schedule performs comparably to the present two-coefficient
+law, it would reduce the steady-state OU--II regularizer from two fitted gains
+to one global normalization plus measured sea moments.
+
+The next analytical layer should then use the complete OU--II MEKF
+linearization.  This is especially important for the velocity pseudo channel:
+repository coefficient sweeps show that $r_{v,0}$ affects roll/pitch more
+strongly than the displacement-only reduction predicts.  A full-state
+physical-$H_2$ calculation should retain attitude/gravity leakage, gyroscope
+and accelerometer bias, latent OU acceleration, and both pseudo channels before
+claiming that Eq.~\eqref{eq:theory-test-law} is the final optimal law.
+
+\section{Limitations}
+\label{sec:limitations}
+
+The derivation is a low-frequency reduced model.  It assumes that the residual
+acceleration error entering the integration chain can be approximated as white
+over the regularization band and that the pseudo-measurement corner is below
+the dominant physical wave band.  The power laws are obtained from the
+$\chi\ll1$ and weak-distortion expansion; the exact transfer in
+Eq.~\eqref{eq:Hpa} remains valid outside that asymptotic step, but the closed
+form MSE optimum does not.
+
+The displacement objective omits attitude, magnetic, gyroscope-bias, and
+accelerometer-bias penalties.  In the full MEKF, both pseudo-measurements act
+through covariance cross-couplings, and the velocity channel in particular can
+change attitude estimation.  The use of a scalar $q$ also suppresses the large
+axis dependence caused by gravity leakage.  Finally, the moment comparison to
+JONSWAP and PM uses the underlying first-order finite-band spectra; nonlinear
+Stokes harmonics in the simulated trajectories are not represented in those
+reference moment constants.
+
+These limitations affect the absolute optimum and may shift the exponents, but
+they do not remove the principal structural result that the two pseudo channels
+must be optimized jointly and that their leading relative period dependence is
+set by physical spectral moments.
+
+\section{Conclusion}
+
+A joint physical-MSE analysis of the OU--II displacement and velocity zero
+pseudo-measurements gives a closed-form reduced Riccati model and a direct
+adaptation prediction.  In the strong direct-acceleration-observation limit,
+the base pseudo standard deviations scale as
+\begin{equation}
+ \boxed{
+ r_{p,0}^{\star}\propto\sigma_a^{4/5}\tau^{12/5},
+ \qquad
+ r_{v,0}^{\star}\propto\sigma_a^{4/5}\tau^{7/5}.}
+\end{equation}
+The implemented $\sigma_a\tau^2$ and $\sigma_a\tau$ laws differ from these by
+the same fifth-root correction and remain within roughly $-8\%$ to $+14\%$ of
+the theoretical shape over the calibrated JONSWAP operating range after a
+common nominal normalization.
+
+More strongly, the reduced optimum predicts
+\begin{equation}
+ \boxed{
+ \left(r_{p,0}^{\star}/r_{v,0}^{\star}\right)^2
+ =(3/2)M_{-2}/M_0,}
+\end{equation}
+which gives $r_{p,0}^{\star}/r_{v,0}^{\star}\propto\tau$.  The implemented
+coefficient ratio produces $0.500\tau$, close to the approximately
+$0.43$--$0.49\tau$ range obtained from the finite-band reference spectra.
+Thus the existing two-channel law lies near a first-principles physical-MSE
+schedule in both exponent space and relative channel strength.  The appropriate
+next step is a paired multi-seed comparison of the analytical and implemented
+power laws followed by a full-state physical-$H_2$ analysis of the residual
+attitude and bias coupling.
+
+\begin{thebibliography}{9}
+\bibitem{KalmanBucy1961}
+R. E. Kalman and R. S. Bucy, ``New results in linear filtering and prediction
+theory,'' \emph{Journal of Basic Engineering}, vol. 83, no. 1, pp. 95--108,
+1961.
+
+\bibitem{Jazwinski1970}
+A. H. Jazwinski, \emph{Stochastic Processes and Filtering Theory}.
+New York, NY, USA: Academic Press, 1970.
+\end{thebibliography}
+
+\end{document}


### PR DESCRIPTION
## Summary

Adds a standalone IEEE-style LaTeX theory note for OU-II dual pseudo-measurement regularization:

- `doc/kalman_ou_ii/ou2-dual-regularization-mse.tex`
- derives the reduced two-state continuous-equivalent model for the jointly applied `p=0` and `v=0` pseudo-measurements;
- solves the dual-channel Kalman--Bucy CARE in closed form using a position corner `omega_p` and relative velocity strength `chi`;
- derives the exact reduced acceleration-to-displacement transfer and residual-noise H2 variance;
- separates residual stochastic drift from physical wave distortion;
- obtains the weak-regularization MSE-optimal base laws
  - `r_p0* ~ q_eff^(1/10) sigma_a^(4/5) tau^(12/5)`
  - `r_v0* ~ q_eff^(1/10) sigma_a^(4/5) tau^(7/5)`;
- in the strong direct-acceleration-observation limit, compares these with the implemented `sigma_aw tau^2` and `sigma_aw tau` laws;
- shows both theoretical laws differ from the implemented pair by the same fifth-root shape factor, so their relative channel scaling is unchanged;
- derives the stronger coefficient-ratio prediction
  `(r_p0*/r_v0*)^2 = (3/2) M_-2/M_0`, hence `r_p0*/r_v0* ~ tau` for fixed-shape seas;
- compares the resulting spectral ratio with the implemented `0.65/1.30 = 0.500` coefficient ratio;
- evaluates the analytical-vs-implemented common shape over the calibrated JONSWAP operating points, giving approximately `-7.6%` to `+13.9%` after nominal anchoring;
- proposes a paired multi-seed comparison of the analytical `(4/5,12/5)` / `(4/5,7/5)` laws against the current `(1,2)` / `(1,1)` pair, followed by a full-state physical-H2 analysis if a residual difference remains.

## Interpretation

The reduced theory predicts that the current OU-II adaptation is already close to the physical-MSE optimum in two independent ways: the individual powers differ only by a weak common correction, and the relative `p`-versus-`v` period law is predicted exactly. The note does not claim that the reduced displacement-only objective captures the complete MEKF optimum; it explicitly flags the observed attitude sensitivity of the velocity pseudo channel as requiring a later full-state treatment.

## Validation

The existing build workflow compiles every `*.tex` under `doc/kalman_ou_ii`, so the new standalone document is covered by the normal LaTeX build job. No estimator behavior is changed in this PR.