### PR TITLE
Refresh OU-II and OU-III filtering literature

### DIFF
--- a/doc/kalman_ou_ii/ou2-dual-regularization-mse.tex
+++ b/doc/kalman_ou_ii/ou2-dual-regularization-mse.tex
@@ -10,6 +10,7 @@
 \usepackage{mathtools}
 \usepackage{siunitx}
 \usepackage[final]{microtype}
+\usepackage{cite}
 \usepackage[hidelinks]{hyperref}
 
 \newtheorem{theorem}{Theorem}
@@ -77,7 +78,32 @@ standard deviations are therefore not independent observation uncertainties;
 they are design parameters that trade drift suppression against distortion of
 real wave motion.
 
-The deployed adaptation was selected empirically and has the base form
+Marine virtual-reference methods provide a useful precedent for imposing such
+nonphysical constraints on inertial integration.  Bryne, Fossen, and Johansen
+augmented a marine INS observer with integrated vertical position and used a
+zero virtual measurement motivated by the zero long-time mean of vessel heave;
+the subsequent virtual-vertical-reference work developed this into a dedicated
+GNSS/INS aiding concept and validated it with low-cost MEMS inertial sensing on
+surface vessels \cite{Bryne2014,Bryne2015,Bryne2018,Rogne2021}.  Recent heave
+and height estimators continue to combine inertial measurements with explicit
+state-space filtering, including discrete-time Kalman reconstruction,
+fixed-order Kalman filtering with GNSS and virtual measurements, and cubature
+Kalman methods \cite{Reis2023,Overaas2025,Li2025}.  The present OU--II
+construction is not identical to these methods: it applies soft zero
+pseudo-measurements simultaneously to displacement and velocity and treats
+their covariances as regularization parameters to be scheduled with sea state.
+
+A parallel development in inertial navigation uses invariant or equivariant
+state errors on matrix Lie groups.  Invariant EKFs provide stable-observer
+properties for group-affine systems, while newer equivariant formulations
+incorporate inertial-sensor biases and position aiding
+\cite{BarrauBonnabel2017,Fornasier2022,VanGoor2023}.  Recent underwater
+INS/DVL studies have applied Lie-group error models together with robust or
+adaptive filtering \cite{Du2024,Qian2025}.  OU--II remains a quaternion MEKF;
+these geometric filters are cited as neighboring modern design families rather
+than as equivalent formulations of the estimator studied here.
+
+The applied adaptation was selected empirically and has the base form
 \begin{equation}
  r_{p,0}^{\mathrm{base}}=c_p\sigma_{aw}\tau^2,
  \qquad
@@ -166,12 +192,15 @@ The two continuous pseudo-observations have $\mat C=\Id$ and
  \mat R_c=\operatorname{diag}(\rho_p,\rho_v).
 \end{equation}
 The stabilizing covariance satisfies the Kalman--Bucy algebraic Riccati
-equation \cite{KalmanBucy1961,Jazwinski1970}
+equation \cite{KalmanBucy1961,Jazwinski1970,SarkkaSvensson2023,Anderson1971}
 \begin{equation}
  \mat A\mat P+\mat P\mat A^{\top}+\mat Q
  -\mat P\mat R_c^{-1}\mat P=0.
  \label{eq:care}
 \end{equation}
+The Riccati equation itself is standard filtering theory; the contribution
+below is its closed-form specialization and physical-MSE interpretation for
+the jointly regularized OU--II double-integrator chain.
 
 Define the two natural regularization frequencies
 \begin{equation}
@@ -628,7 +657,10 @@ repository coefficient sweeps show that $r_{v,0}$ affects roll/pitch more
 strongly than the displacement-only reduction predicts.  A full-state
 physical-$H_2$ calculation should retain attitude/gravity leakage, gyroscope
 and accelerometer bias, latent OU acceleration, and both pseudo channels before
-claiming that Eq.~\eqref{eq:theory-test-law} is the final optimal law.
+claiming that Eq.~\eqref{eq:theory-test-law} is the final optimal law.  Modern
+invariant and equivariant INS filters, and recent Lie-group SINS/DVL
+integrations, provide useful comparison points for that full-state analysis
+\cite{BarrauBonnabel2017,Fornasier2022,VanGoor2023,Du2024,Qian2025}.
 
 \section{Limitations}
 \label{sec:limitations}
@@ -687,15 +719,7 @@ next step is a paired multi-seed comparison of the analytical and implemented
 power laws followed by a full-state physical-$H_2$ analysis of the residual
 attitude and bias coupling.
 
-\begin{thebibliography}{9}
-\bibitem{KalmanBucy1961}
-R. E. Kalman and R. S. Bucy, ``New results in linear filtering and prediction
-theory,'' \emph{Journal of Basic Engineering}, vol. 83, no. 1, pp. 95--108,
-1961.
-
-\bibitem{Jazwinski1970}
-A. H. Jazwinski, \emph{Stochastic Processes and Filtering Theory}.
-New York, NY, USA: Academic Press, 1970.
-\end{thebibliography}
+\bibliographystyle{IEEEtran}
+\bibliography{ou2-modern}
 
 \end{document}

--- a/doc/kalman_ou_ii/ou2-modern.bib
+++ b/doc/kalman_ou_ii/ou2-modern.bib
@@ -1,0 +1,160 @@
+@article{KalmanBucy1961,
+    author  = {R. E. Kalman and R. S. Bucy},
+    title   = {New Results in Linear Filtering and Prediction Theory},
+    journal = {Journal of Basic Engineering},
+    year    = {1961},
+    volume  = {83},
+    number  = {1},
+    pages   = {95--108},
+    doi     = {10.1115/1.3658902}
+}
+
+@book{Jazwinski1970,
+    author    = {Andrew H. Jazwinski},
+    title     = {Stochastic Processes and Filtering Theory},
+    publisher = {Academic Press},
+    address   = {New York, NY, USA},
+    year      = {1970}
+}
+
+@book{SarkkaSvensson2023,
+    author    = {Simo S{\"a}rkk{\"a} and Lennart Svensson},
+    title     = {Bayesian Filtering and Smoothing},
+    edition   = {2},
+    publisher = {Cambridge University Press},
+    year      = {2023},
+    doi       = {10.1017/9781108917407}
+}
+
+@article{Anderson1971,
+    author  = {B. D. O. Anderson},
+    title   = {Stability Properties of {Kalman--Bucy} Filters},
+    journal = {Journal of the Franklin Institute},
+    year    = {1971},
+    volume  = {291},
+    number  = {2},
+    pages   = {137--144},
+    doi     = {10.1016/0016-0032(71)90016-0}
+}
+
+@inproceedings{Bryne2014,
+    author    = {Torleiv H{\aa}land Bryne and Thor I. Fossen and Tor Arne Johansen},
+    title     = {Nonlinear Observer with Time-Varying Gains for Inertial Navigation Aided by Satellite Reference Systems in Dynamic Positioning},
+    booktitle = {2014 22nd Mediterranean Conference on Control and Automation (MED)},
+    year      = {2014},
+    pages     = {1353--1360},
+    doi       = {10.1109/MED.2014.6961564}
+}
+
+@article{Bryne2015,
+    author  = {Torleiv H{\aa}land Bryne and Thor I. Fossen and Tor Arne Johansen},
+    title   = {A Virtual Vertical Reference Concept for {GNSS/INS} Applications at the Sea Surface},
+    journal = {IFAC-PapersOnLine},
+    year    = {2015},
+    volume  = {48},
+    number  = {16},
+    pages   = {127--133},
+    doi     = {10.1016/j.ifacol.2015.10.269}
+}
+
+@article{Bryne2018,
+    author  = {Torleiv H{\aa}land Bryne and Robert H. Rogne and Thor I. Fossen and Tor Arne Johansen},
+    title   = {A Virtual Vertical Reference Concept for Aided Inertial Navigation at the Sea Surface},
+    journal = {Control Engineering Practice},
+    year    = {2018},
+    volume  = {70},
+    pages   = {1--14},
+    doi     = {10.1016/j.conengprac.2017.09.009}
+}
+
+@article{Rogne2021,
+    author  = {Robert H. Rogne and Torleiv H{\aa}land Bryne and Thor I. Fossen and Tor Arne Johansen},
+    title   = {On the Usage of Low-Cost {MEMS} Sensors, Strapdown Inertial Navigation, and Nonlinear Estimation Techniques in Dynamic Positioning},
+    journal = {IEEE Journal of Oceanic Engineering},
+    year    = {2021},
+    volume  = {46},
+    number  = {1},
+    pages   = {24--39},
+    doi     = {10.1109/JOE.2020.2967094}
+}
+
+@article{Reis2023,
+    author  = {Joel Reis and Pedro Batista and Paulo Oliveira and Carlos Silvestre},
+    title   = {Discrete-Time {Kalman} Filter for Heave Motion Estimation},
+    journal = {Ocean Engineering},
+    year    = {2023},
+    volume  = {277},
+    pages   = {114240},
+    doi     = {10.1016/j.oceaneng.2023.114240}
+}
+
+@article{Overaas2025,
+    author  = {Henning {\O}veraas and Torleiv H{\aa}land Bryne and Tor Arne Johansen},
+    title   = {A Linear Time-Invariant {Kalman} Filter for Estimating Height in the Presence of Ocean Waves},
+    journal = {Ocean Engineering},
+    year    = {2025},
+    volume  = {320},
+    pages   = {120214},
+    doi     = {10.1016/j.oceaneng.2024.120214}
+}
+
+@article{Li2025,
+    author  = {Daoxi Li and Shuqing Wang and Donghong Ning and Jiajing Peng},
+    title   = {Heave Motion Estimation Based on the Cubature {Kalman} Filter Combined with Fast {Fourier} Transform of Acceleration Autocorrelation},
+    journal = {Ocean Engineering},
+    year    = {2025},
+    volume  = {336},
+    pages   = {121820},
+    doi     = {10.1016/j.oceaneng.2025.121820}
+}
+
+@article{BarrauBonnabel2017,
+    author  = {Axel Barrau and Silv{\`e}re Bonnabel},
+    title   = {The Invariant Extended {Kalman} Filter as a Stable Observer},
+    journal = {IEEE Transactions on Automatic Control},
+    year    = {2017},
+    volume  = {62},
+    number  = {4},
+    pages   = {1797--1812},
+    doi     = {10.1109/TAC.2016.2594085}
+}
+
+@inproceedings{Fornasier2022,
+    author    = {Alessandro Fornasier and Yonhon Ng and Robert Mahony and Stephan Weiss},
+    title     = {Equivariant Filter Design for Inertial Navigation Systems with Input Measurement Biases},
+    booktitle = {2022 International Conference on Robotics and Automation (ICRA)},
+    year      = {2022},
+    pages     = {12118--12125},
+    doi       = {10.1109/ICRA46639.2022.9811778}
+}
+
+@article{VanGoor2023,
+    author  = {Pieter van Goor and Tarek Hamel and Robert Mahony},
+    title   = {Constructive Equivariant Observer Design for Inertial Navigation},
+    journal = {IFAC-PapersOnLine},
+    year    = {2023},
+    volume  = {56},
+    number  = {2},
+    pages   = {2494--2499},
+    doi     = {10.1016/j.ifacol.2023.10.1229}
+}
+
+@article{Du2024,
+    author  = {Siyuan Du and Fengchi Zhu and Zhao Wang and Yulong Huang and Yonggang Zhang},
+    title   = {A Novel Lie Group Framework-Based Student's $t$ Robust Filter and Its Application to {INS/DVL} Tightly Integrated Navigation},
+    journal = {IEEE Transactions on Instrumentation and Measurement},
+    year    = {2024},
+    volume  = {73},
+    pages   = {1--21},
+    doi     = {10.1109/TIM.2024.3379400}
+}
+
+@article{Qian2025,
+    author  = {Leiyuan Qian and Lubin Chang and Kailong Li and Fangjun Qin and Tiangao Zhu and Penghua Gao},
+    title   = {The Optimized {SINS/DVL} Integration Based on $SE_3(3)$ Quaternion Error Model and Adaptive Estimator},
+    journal = {IEEE Transactions on Instrumentation and Measurement},
+    year    = {2025},
+    volume  = {74},
+    pages   = {1--20},
+    doi     = {10.1109/TIM.2025.3545191}
+}

--- a/doc/kalman_ou_iii/kalman_ou-w3d.tex
+++ b/doc/kalman_ou_iii/kalman_ou-w3d.tex
@@ -216,6 +216,7 @@ extended Kalman filter, inertial navigation, IMU, marine Motion Reference Unit, 
 
 % Part I: estimator mathematics.
 \input{w3d-intro.tex-part}
+\input{w3d-related-work-modern.tex-part}
 \input{w3d-nomenclature.tex-part}
 \input{w3d-state.tex-part}
 \input{w3d-meas.tex-part}
@@ -227,6 +228,7 @@ extended Kalman filter, inertial navigation, IMU, marine Motion Reference Unit, 
 
 % Part II: motivational analysis and chosen adaptation.
 \input{w3d-adaptation-motivation.tex-part}
+\input{w3d-adaptation-literature-context.tex-part}
 % Complementary interpretation of the same applied 5/2 scaling.
 \input{w3d-adaptation-cadence-interpretation.tex-part}
 % Reduced physical-MSE prediction and operating-envelope comparison.
@@ -254,6 +256,6 @@ The author declares no conflicts of interest and received no funding for this re
 
 \nocite{Kalman1960_Filtering,Jazwinski1970_Filtering,Maybeck1979_StochasticModels,Markley2003AttitudeError,UhlenbeckOrnstein1930_OU}
 \bibliographystyle{IEEEtran}
-\bibliography{w3d,w3d-iss,w3d-baselines}
+\bibliography{w3d,w3d-modern,w3d-iss,w3d-baselines}
 \balance
 \end{document}

--- a/doc/kalman_ou_iii/w3d-adaptation-literature-context.tex-part
+++ b/doc/kalman_ou_iii/w3d-adaptation-literature-context.tex-part
@@ -1,0 +1,36 @@
+\subsection{Filtering and virtual-reference precedent}
+\label{sec:adaptation-literature-context}
+
+The covariance equations used above are standard continuous-time
+Kalman--Bucy/Riccati constructions.  Modern treatments of Bayesian state-space
+filtering give the discrete and continuous filtering context, covariance
+propagation, and nonlinear Gaussian approximations used by EKF-type estimators
+\cite{SarkkaSvensson2023_BayesianFiltering}; classical stability results for
+the Kalman--Bucy filter relate bounded stabilizing Riccati solutions to
+observability and controllability conditions
+\cite{Anderson1971_KalmanBucyStability}.  Accordingly, the scalar Riccati
+solution in Sec.~\ref{sec:adaptation-strong-observation} and the reduced
+triple-integrator CARE in Sec.~\ref{sec:adaptation-regularizer-transfer} are
+applications of standard filtering theory to the particular OU and integration
+chains used here, rather than new Riccati results.
+
+The integral-state pseudo-measurement also has a direct marine precedent.  In
+the time-varying-gain nonlinear observer of Bryne, Fossen, and Johansen, the
+translational state is augmented by integrated vertical position and the poor
+GNSS height channel is replaced by the virtual measurement that this integrated
+height is zero in the long-term mean
+\cite{Bryne2014_TimeVaryingGNSSINS}.  The subsequent virtual-vertical-reference
+(VVR) studies formalized this sea-surface constraint for GNSS/INS aiding and
+extended it with an explicit VVR error model, including full-scale validation
+with a MEMS strapdown INS on an offshore vessel
+\cite{Bryne2015_VirtualVerticalReference,Bryne2018_VVRAidedINS}.
+
+The present $S=0$ construction should be read as related to, but distinct from,
+that VVR lineage.  The VVR is a vertical aid derived from the zero long-time
+mean of vessel heave relative to the sea surface.  Here, $S$ is a three-axis
+integral of the estimated oscillatory displacement and its zero
+pseudo-measurement is assigned a finite covariance and adaptive cadence so that
+it acts as a soft low-frequency spectral regularizer.  Thus the prior work
+supports the physical use of an integrated sea-surface constraint to arrest
+marine inertial drift; the Riccati and physical-MSE analyses in this article
+specify how that idea is embedded and tuned in the OU--III MEKF.

--- a/doc/kalman_ou_iii/w3d-modern.bib
+++ b/doc/kalman_ou_iii/w3d-modern.bib
@@ -1,0 +1,164 @@
+@book{SarkkaSvensson2023_BayesianFiltering,
+    author    = {Simo S{\"a}rkk{\"a} and Lennart Svensson},
+    title     = {Bayesian Filtering and Smoothing},
+    edition   = {2},
+    publisher = {Cambridge University Press},
+    year      = {2023},
+    doi       = {10.1017/9781108917407}
+}
+
+@article{Anderson1971_KalmanBucyStability,
+    author  = {B. D. O. Anderson},
+    title   = {Stability Properties of {Kalman--Bucy} Filters},
+    journal = {Journal of the Franklin Institute},
+    year    = {1971},
+    volume  = {291},
+    number  = {2},
+    pages   = {137--144},
+    doi     = {10.1016/0016-0032(71)90016-0}
+}
+
+@inproceedings{Bryne2014_TimeVaryingGNSSINS,
+    author    = {Torleiv H{\aa}land Bryne and Thor I. Fossen and Tor Arne Johansen},
+    title     = {Nonlinear Observer with Time-Varying Gains for Inertial Navigation Aided by Satellite Reference Systems in Dynamic Positioning},
+    booktitle = {2014 22nd Mediterranean Conference on Control and Automation (MED)},
+    year      = {2014},
+    pages     = {1353--1360},
+    doi       = {10.1109/MED.2014.6961564}
+}
+
+@article{Bryne2015_VirtualVerticalReference,
+    author  = {Torleiv H{\aa}land Bryne and Thor I. Fossen and Tor Arne Johansen},
+    title   = {A Virtual Vertical Reference Concept for {GNSS/INS} Applications at the Sea Surface},
+    journal = {IFAC-PapersOnLine},
+    year    = {2015},
+    volume  = {48},
+    number  = {16},
+    pages   = {127--133},
+    doi     = {10.1016/j.ifacol.2015.10.269}
+}
+
+@article{Bryne2018_VVRAidedINS,
+    author  = {Torleiv H{\aa}land Bryne and Robert H. Rogne and Thor I. Fossen and Tor Arne Johansen},
+    title   = {A Virtual Vertical Reference Concept for Aided Inertial Navigation at the Sea Surface},
+    journal = {Control Engineering Practice},
+    year    = {2018},
+    volume  = {70},
+    pages   = {1--14},
+    doi     = {10.1016/j.conengprac.2017.09.009}
+}
+
+@article{Bryne2017_INSObserverImplementation,
+    author  = {Torleiv H{\aa}land Bryne and Jakob Mahler Hansen and Robert Harald Rogne and Nadezda Sokolova and Thor I. Fossen and Tor Arne Johansen},
+    title   = {Nonlinear Observers for Integrated {INS/GNSS} Navigation: Implementation Aspects},
+    journal = {IEEE Control Systems Magazine},
+    year    = {2017},
+    volume  = {37},
+    number  = {3},
+    pages   = {59--86},
+    doi     = {10.1109/MCS.2017.2674458}
+}
+
+@article{Bryne2016_AttitudeHeaveMEMS,
+    author  = {Torleiv H{\aa}land Bryne and Robert H. Rogne and Thor I. Fossen and Tor Arne Johansen},
+    title   = {Attitude and Heave Estimation for Ships Using {MEMS}-Based Inertial Measurements},
+    journal = {IFAC-PapersOnLine},
+    year    = {2016},
+    volume  = {49},
+    number  = {23},
+    pages   = {568--575},
+    doi     = {10.1016/j.ifacol.2016.10.496}
+}
+
+@article{Bryne2017_AdaptiveWaveINS,
+    author  = {Torleiv H{\aa}land Bryne and Thor I. Fossen and Tor Arne Johansen},
+    title   = {Design of Inertial Navigation Systems for Marine Craft with Adaptive Wave Filtering Aided by Triple-Redundant Sensor Packages},
+    journal = {International Journal of Adaptive Control and Signal Processing},
+    year    = {2017},
+    volume  = {31},
+    number  = {4},
+    pages   = {522--544},
+    doi     = {10.1002/acs.2645}
+}
+
+@article{Rogne2021_LowCostMEMSDP,
+    author  = {Robert H. Rogne and Torleiv H{\aa}land Bryne and Thor I. Fossen and Tor Arne Johansen},
+    title   = {On the Usage of Low-Cost {MEMS} Sensors, Strapdown Inertial Navigation, and Nonlinear Estimation Techniques in Dynamic Positioning},
+    journal = {IEEE Journal of Oceanic Engineering},
+    year    = {2021},
+    volume  = {46},
+    number  = {1},
+    pages   = {24--39},
+    doi     = {10.1109/JOE.2020.2967094}
+}
+
+@article{Overaas2025_HeightKalman,
+    author  = {Henning {\O}veraas and Torleiv H{\aa}land Bryne and Tor Arne Johansen},
+    title   = {A Linear Time-Invariant {Kalman} Filter for Estimating Height in the Presence of Ocean Waves},
+    journal = {Ocean Engineering},
+    year    = {2025},
+    volume  = {320},
+    pages   = {120214},
+    doi     = {10.1016/j.oceaneng.2024.120214}
+}
+
+@article{BarrauBonnabel2017_IEKF,
+    author  = {Axel Barrau and Silv{\`e}re Bonnabel},
+    title   = {The Invariant Extended {Kalman} Filter as a Stable Observer},
+    journal = {IEEE Transactions on Automatic Control},
+    year    = {2017},
+    volume  = {62},
+    number  = {4},
+    pages   = {1797--1812},
+    doi     = {10.1109/TAC.2016.2594085}
+}
+
+@inproceedings{Fornasier2022_EquivariantINSBias,
+    author    = {Alessandro Fornasier and Yonhon Ng and Robert Mahony and Stephan Weiss},
+    title     = {Equivariant Filter Design for Inertial Navigation Systems with Input Measurement Biases},
+    booktitle = {2022 International Conference on Robotics and Automation (ICRA)},
+    year      = {2022},
+    pages     = {12118--12125},
+    doi       = {10.1109/ICRA46639.2022.9811778}
+}
+
+@article{VanGoor2023_EquivariantINS,
+    author  = {Pieter van Goor and Tarek Hamel and Robert Mahony},
+    title   = {Constructive Equivariant Observer Design for Inertial Navigation},
+    journal = {IFAC-PapersOnLine},
+    year    = {2023},
+    volume  = {56},
+    number  = {2},
+    pages   = {2494--2499},
+    doi     = {10.1016/j.ifacol.2023.10.1229}
+}
+
+@article{Du2024_LieGroupINSDVL,
+    author  = {Siyuan Du and Fengchi Zhu and Zhao Wang and Yulong Huang and Yonggang Zhang},
+    title   = {A Novel Lie Group Framework-Based Student's $t$ Robust Filter and Its Application to {INS/DVL} Tightly Integrated Navigation},
+    journal = {IEEE Transactions on Instrumentation and Measurement},
+    year    = {2024},
+    volume  = {73},
+    pages   = {1--21},
+    doi     = {10.1109/TIM.2024.3379400}
+}
+
+@article{Qian2025_SE33DVL,
+    author  = {Leiyuan Qian and Lubin Chang and Kailong Li and Fangjun Qin and Tiangao Zhu and Penghua Gao},
+    title   = {The Optimized {SINS/DVL} Integration Based on $SE_3(3)$ Quaternion Error Model and Adaptive Estimator},
+    journal = {IEEE Transactions on Instrumentation and Measurement},
+    year    = {2025},
+    volume  = {74},
+    pages   = {1--20},
+    doi     = {10.1109/TIM.2025.3545191}
+}
+
+@article{Maurer2026_LeftRightIEKF,
+    author  = {Finn G. Maurer and Erlend A. Basso and Henrik M. Schmidt-Didlaukies and Torleiv H{\aa}land Bryne},
+    title   = {Equivalence of Left- and Right-Invariant Extended {Kalman} Filters on Matrix Lie Groups},
+    journal = {IEEE Transactions on Automatic Control},
+    year    = {2026},
+    note    = {Early Access},
+    pages   = {1--8},
+    doi     = {10.1109/TAC.2026.3690028}
+}

--- a/doc/kalman_ou_iii/w3d-related-work-modern.tex-part
+++ b/doc/kalman_ou_iii/w3d-related-work-modern.tex-part
@@ -1,0 +1,43 @@
+\subsection{Relation to recent marine inertial estimation}
+\label{sec:recent-marine-inertial-work}
+
+The marine literature has moved beyond stand-alone heave filters toward
+integrated strapdown inertial estimation with explicit treatment of sensor
+bias, aiding quality, and vessel-specific constraints.  Nonlinear-observer
+work on surface vessels introduced virtual vertical references for aiding
+GNSS/INS integration and subsequently demonstrated full six-degree-of-freedom
+motion estimation with low-cost MEMS inertial sensors on operational offshore
+vessels \cite{Bryne2015_VirtualVerticalReference,Bryne2018_VVRAidedINS,
+Bryne2017_INSObserverImplementation,Rogne2021_LowCostMEMSDP}.  Related full-scale
+studies have addressed attitude and heave estimation from MEMS IMUs and
+adaptive wave filtering embedded in marine strapdown INS architectures
+\cite{Bryne2016_AttitudeHeaveMEMS,Bryne2017_AdaptiveWaveINS}.  More recent
+Kalman-based work continues this line: discrete-time heave reconstruction has
+been formulated with explicit observability and stability analysis, while a
+2025 fixed-order Kalman filter combines inertial, GNSS, and virtual
+measurements to estimate both wave-frequency heave and lower-frequency vessel
+height \cite{Reis2023_DiscreteKalmanHeave,Overaas2025_HeightKalman,
+Li2025_HeaveCKF}.
+
+In parallel, geometric state estimation has developed from invariant filtering
+on matrix Lie groups to equivariant formulations that include inertial-sensor
+biases.  The invariant EKF provides trajectory-independent error structures
+for an important class of group-affine systems
+\cite{BarrauBonnabel2017_IEKF}; later equivariant filters and observers extend
+this viewpoint to biased inertial navigation and position-aided INS
+\cite{Fornasier2022_EquivariantINSBias,VanGoor2023_EquivariantINS}.  Recent
+marine and underwater integrations apply Lie-group error models directly to
+INS/DVL fusion, including robust and adaptive estimators
+\cite{Du2024_LieGroupINSDVL,Qian2025_SE33DVL}.  Current work also continues to
+clarify implementation details specific to matrix-Lie-group EKFs, including
+covariance reparameterization after measurement updates
+\cite{Maurer2026_LeftRightIEKF}.
+
+The estimator developed here remains a quaternion MEKF rather than an
+invariant or equivariant full-state filter.  These geometric methods are
+therefore neighboring design families, not interchangeable formulations of
+the present algorithm.  Their relevance is that they provide a modern
+reference point for treating attitude, velocity, position, and bias jointly,
+whereas the contribution pursued here is different: an OU-driven marine
+translational prior, integral-state low-frequency regularization, and exogenous
+sea-state adaptation within a conventional error-state MEKF.


### PR DESCRIPTION
## Summary

Refreshes the literature grounding and related-work positioning of both OU-II and OU-III without changing estimator behavior.

### OU-III

- adds `w3d-modern.bib` with modern filtering and marine inertial references;
- adds a publication-style related-work subsection covering:
  - marine virtual vertical references and nonlinear INS/GNSS observers;
  - full-scale low-cost MEMS strapdown INS on surface vessels;
  - recent Kalman heave/height estimation;
  - invariant/equivariant inertial filtering;
  - recent Lie-group INS/DVL integration;
- adds a focused filtering/virtual-reference subsection that explicitly grounds the scalar and triple-integrator Riccati constructions in standard Kalman--Bucy theory;
- cites Särkkä and Svensson (2023) as a modern filtering reference and Anderson (1971) for Kalman--Bucy stability/Riccati context;
- uses Bryne, Fossen, and Johansen (MED 2014), the source suggested in the discussion, for the specific precedent of augmenting a marine observer with integrated vertical position and applying the virtual measurement that the integral is zero;
- distinguishes the later VVR work from the present 3-D finite-covariance `S=0` regularizer rather than implying the algorithms are identical;
- extends the bibliography through 2026, including Barrau--Bonnabel IEKF, biased-INS equivariant filtering, constructive equivariant observers, recent marine/underwater Lie-group INS/DVL filters, and the 2026 IEEE TAC left/right invariant-EKF equivalence result.

### OU-II

- replaces the two-entry inline bibliography with a dedicated `ou2-modern.bib`;
- adds the same marine virtual-reference lineage to motivate nonphysical constraints on inertial integration;
- adds recent Kalman heave/height and low-cost MEMS marine INS work to the introduction;
- adds invariant/equivariant and recent Lie-group SINS/DVL work as neighboring full-state estimation families;
- expands the CARE citation from only Kalman--Bucy/Jazwinski to include the modern Särkkä--Svensson text and Anderson's Kalman--Bucy stability result;
- explicitly states that the CARE itself is standard and that the paper's contribution is the closed-form dual-channel specialization and physical-MSE interpretation;
- updates reader-visible wording from `deployed adaptation` to `applied adaptation`.

## Positioning

The new references are attached to specific claims rather than added as uncited bibliography padding. The manuscripts now distinguish three lines of prior work:

1. classical/modern Kalman and Riccati filtering theory;
2. marine virtual-reference, MEMS INS, GNSS/INS, and heave estimation;
3. modern invariant/equivariant/Lie-group navigation filters.

The text explicitly states that the OU estimators remain quaternion MEKFs; the Lie-group papers are neighboring design families, not equivalent formulations.

## Scope

Documentation/manuscript only. No estimator code, parameters, evidence bundle, or validation thresholds are changed.