### PR TITLE
Add semiglobal practical stability proof to OU-III paper

### DIFF
--- a/doc/kalman_ou_iii/kalman_ou-w3d.tex
+++ b/doc/kalman_ou_iii/kalman_ou-w3d.tex
@@ -194,7 +194,12 @@ oscillatory displacement, integral displacement, and latent world acceleration.
 A zero pseudo-measurement on the integral state provides low-frequency
 regularization.  The core model admits analytic discrete-time propagation, and
 the normal Live recursion is locally input-to-state stable under explicit
-bounded-schedule, observability, covariance, and no-reset assumptions.
+bounded-schedule, observability, covariance, and no-reset assumptions.  The
+measurement-only startup observer additionally gives an almost-global,
+semiglobal practical attitude-capture extension: on every compact initial-tilt
+set separated from the antipodal gravity configuration, a quality-gated handoff
+enters the certified Live basin under explicit bounded-disturbance and handoff
+conditions.
 Sea-state adaptation is implemented as an exogenous measurement-only layer that
 estimates wave period and band-limited acceleration variance and schedules the
 OU prior and integral regularizer.  A paired ten-seed study spans four
@@ -225,6 +230,7 @@ extended Kalman filter, inertial navigation, IMU, marine Motion Reference Unit, 
 \input{w3d-analytic-coeff.tex-part}
 \input{w3d-kalm-up.tex-part}
 \input{w3d-iss-stability.tex-part}
+\input{w3d-semiglobal-stability.tex-part}
 
 % Part II: motivational analysis and chosen adaptation.
 \input{w3d-adaptation-motivation.tex-part}

--- a/doc/kalman_ou_iii/kalman_ou-w3d.tex
+++ b/doc/kalman_ou_iii/kalman_ou-w3d.tex
@@ -196,10 +196,10 @@ regularization.  The core model admits analytic discrete-time propagation, and
 the normal Live recursion is locally input-to-state stable under explicit
 bounded-schedule, observability, covariance, and no-reset assumptions.  The
 measurement-only startup observer additionally gives an almost-global,
-semiglobal practical attitude-capture extension: on every compact initial-tilt
-set separated from the antipodal gravity configuration, a quality-gated handoff
-enters the certified Live basin under explicit bounded-disturbance and handoff
-conditions.
+semiglobal practical attitude-capture extension: uniformly on every compact
+startup set contained in its desired almost-global domain, a quality-gated
+handoff enters the certified Live basin under explicit bounded-disturbance and
+handoff conditions.
 Sea-state adaptation is implemented as an exogenous measurement-only layer that
 estimates wave period and band-limited acceleration variance and schedules the
 OU prior and integral regularizer.  A paired ten-seed study spans four
@@ -235,7 +235,7 @@ extended Kalman filter, inertial navigation, IMU, marine Motion Reference Unit, 
 % Part II: motivational analysis and chosen adaptation.
 \input{w3d-adaptation-motivation.tex-part}
 \input{w3d-adaptation-literature-context.tex-part}
-% Complementary interpretation of the same applied 5/2 scaling.
+% Complementary interpretation of the supported low-cost 5/2 schedule.
 \input{w3d-adaptation-cadence-interpretation.tex-part}
 % Reduced physical-MSE prediction and operating-envelope comparison.
 \input{w3d-reduced-mse-envelope.tex-part}

--- a/doc/kalman_ou_iii/w3d-conclusion-summary.tex-part
+++ b/doc/kalman_ou_iii/w3d-conclusion-summary.tex-part
@@ -19,26 +19,12 @@ neighborhood.
 The adaptation layer separates sea time scale, OU-prior amplitude, and integral
 regularization.  The measured sea period sets $\tau$, the physical band-limited
 acceleration RMS is mapped to $\sigma_{aw}$, and the $S=0$ pseudo-measurement is
-interpreted through its closed-loop regularization corner.  The reduced Riccati
-model gives
-$r_S\propto\sqrt{q_{\mathrm{eff}}}\tau^{5/2}$ when
-$T_S\propto\tau$ and the normalized corner $\omega_R\tau$ is held fixed.  A
-separate cadence argument reaches the same $5/2$ period exponent by preserving
-the information rate of a cubic base scale as the pseudo-update interval grows.
-The amplitude-free coefficient-law experiment confirms the analytical
-pole-placement scale within its restricted family but rejects identifying
-$q_{\mathrm{eff}}$ with the raw accelerometer-noise floor alone: the
-amplitude-free schedule increases the primary normalized vertical RMS endpoint
-from $4.5081\%H_s$ to $4.8882\%H_s$, with paired increase
-$0.380\pm0.096$ percentage points, and worsens six of nine scored scenarios.
-Per-sea coefficient optima show that the missing regularizer amplitude varies
-systematically with sea state.  The applied
-$r_S\propto\sigma_{aw}\tau^{5/2}$ form is therefore retained, with
-$\sigma_{aw}$ interpreted as an empirical proxy for the sea-dependent
-low-frequency acceleration-error scale rather than as a consequence of OU
-spectral similarity.
-
-A complementary reduced physical-MSE calculation gives
+interpreted through its closed-loop regularization corner.  The earlier
+fixed-corner Riccati and cadence arguments give a useful reduced reference with
+an effective $\tau^{5/2}$ dependence when $T_S\propto\tau$, but they do not
+optimize the displacement tradeoff between low-frequency noise growth and
+physical-wave distortion.  The current SpectralMSE schedule instead uses the
+physical-MSE optimum
 \begin{equation}
 r_S^\star\propto
 q_{\mathrm{eff}}^{1/14}m_{-4}^{3/7}T_S^{-1/2}.
@@ -50,44 +36,40 @@ $T_S\propto\tau$, this becomes
 \begin{equation}
 \boxed{r_S^\star\propto\sigma_a^{6/7}\tau^{41/14}.}
 \end{equation}
-The resulting exponents, $6/7\simeq0.857$ and
-$41/14\simeq2.929$, are independently derived yet remain close to the applied
-$(1,5/2)$ pair over the calibrated envelope.  With both laws normalized at the
-$H_s=\SI{1.5}{m}$ operating point, the reduced-MSE schedule differs from the
-applied schedule by approximately $-12.8\%$, $0\%$, $+16.3\%$, and $+20.6\%$
-across the four calibrated JONSWAP points.  Because the ratio is proportional to
-$\sigma_{aw}^{-1/7}\tau^{3/7}$, the discrepancy is compressed by a seventh
-root.  This makes the reduced physical-MSE law a direct first-principles
-candidate for paired comparison rather than merely an asymptotic observation.
+Thus the deployed theoretical exponents are $6/7\simeq0.857$ and
+$41/14\simeq2.929$; the semiglobal stability result uses this law only through
+its bounded predictable scheduled values and does not rely on a
+$\sigma\tau^3$ adaptation relation.
 
-A second experiment tests the interpolation
-$R_{a,\mathrm{eff}}=R_{a,\mathrm{sensor}}+\beta_m\sigma_{aw}^2$.  It recovers
-the deterministic amplitude-free loss, but its optimum lies in the asymptotic
-regime where the sensor-floor contribution is at most about $0.3\%$ of
-$R_{a,\mathrm{eff}}$ over the tested seas.  The fitted law therefore reduces
-numerically to the same linear-$\sigma_{aw}$ dependence already used by the
-applied filter.  Its deterministic endpoint is slightly lower, but the paired
-ten-seed comparison is a dead tie: $4.5081\%H_s$ for the applied law versus
-$4.5078\%H_s$ for the fitted law, with paired difference
-$-0.0003\pm0.0146$ percentage points and no measurable attitude change.  Static
-amplitude refinement therefore provides no supported improvement over the
-current schedule.
+The exact spectral evaluation fixes the SpectralMSE coefficient analytically
+and the paired ten-seed comparison supports the resulting schedule.  Across the
+nine scored stationary-plus-transition scenarios ($n=90$ pairs), normalized
+vertical RMS changes from $4.508\%H_s$ for the supported low-cost cubic
+configuration to $4.482\%H_s$ for SpectralMSE, a pooled difference of
+$-0.026\,\%H_s$ with $95\,\%$ half-width $0.014$.  Four scenarios improve by
+more than their own interval, one degrades, and four are statistical ties.  The
+controlled transition also improves by $0.018\,\%H_s$, so the pooled gain is not
+purchased by a measured transient penalty.  SpectralMSE is therefore the
+default adaptation law outside the low-cost embedded configuration, while the
+cubic schedule remains a supported implementation option when transcendental
+cost dominates a sub-percent displacement difference.
 
-The nonuniformity of that tie identifies a remaining design tradeoff.  The
-amplitude-coupled fit improves the two smallest stationary seas but worsens the
-controlled transition by $0.128\pm0.012$ percentage points, whereas the
-amplitude-free law worsens those stationary seas and improves the transition by
-$0.093\pm0.033$ percentage points.  Thus amplitude tracking buys stationary
-accuracy at a transient cost when the sea state changes.  Before adding another
-adaptation mechanism, Sec.~\ref{sec:adaptation-full-state-h2} formulates the
-physical displacement objective on the complete 21-state linearized closed
-loop.  It separates real sensor/bias noise from distortion of the physical wave
-and retains the attitude/gravity, bias, latent-acceleration, and periodic
-integral-update couplings omitted by the scalar reduction.  This model provides
-the appropriate next test of whether the residual difference between the
-reduced-MSE and applied laws, the observed near-linear amplitude dependence, and
-the stationary--transition tradeoff follow from the estimator dynamics rather
-than from an empirical coefficient choice.
+A separate interpolation experiment tests
+$R_{a,\mathrm{eff}}=R_{a,\mathrm{sensor}}+\beta_m\sigma_{aw}^2$.  Its optimum
+lies in the asymptotic regime where the sensor-floor contribution is at most
+about $0.3\%$ of $R_{a,\mathrm{eff}}$ over the tested seas, and its paired
+endpoint is effectively tied with the former amplitude-coupled schedule.  This
+experiment is therefore retained as evidence about the complete-filter
+acceleration-error scale rather than as the deployed regularizer law.
+
+The remaining analytical gap is no longer whether the reduced physical-MSE law
+beats the previous schedule on the tested ensemble; that comparison is now
+measured.  The open question is how the complete 21-state closed loop modifies
+the reduced exponents and coefficient once attitude/gravity leakage, gyro and
+accelerometer bias paths, OU-model mismatch, cross-covariance coupling, and the
+periodic integral update are all retained.  Section~\ref{sec:adaptation-full-state-h2}
+formulates that physical displacement objective and provides the natural next
+step from the reduced SpectralMSE law to a full-state theoretical optimum.
 
 Under the paired ten-seed stationary JONSWAP protocol, normalized vertical RMS
 displacement error is
@@ -125,22 +107,20 @@ global navigation position is claimed without external aiding.
 
 \subsection*{Future work}
 \begin{itemize}[leftmargin=1.25em]
-  \item \textbf{Reduced-MSE law and full-state physical $H_2$ analysis.}  First
-        compare
-        $r_S\propto\sigma_{aw}^{6/7}\tau^{41/14}$ directly against the applied
-        $r_S\propto\sigma_{aw}\tau^{5/2}$ law using an identical nominal anchor
-        or one-parameter gain normalization and the paired ten-seed protocol.
-        Then solve the periodic 21-state Riccati and physical-error recursions of
-        Sec.~\ref{sec:adaptation-full-state-h2} at the calibrated sea states and
-        compare their predicted minimizing amplitudes and local exponents with
-        the independent coefficient sweeps.  Extend the frozen-point
-        calculation to trajectory-linearized Jacobians to quantify the
-        amplitude-dependent attitude/gravity coupling.
+  \item \textbf{Full-state physical $H_2$ analysis.}  Solve the periodic
+        21-state Riccati and physical-error recursions of
+        Sec.~\ref{sec:adaptation-full-state-h2} at the calibrated sea states,
+        and compare their predicted minimizing amplitudes and local exponents
+        with the deployed SpectralMSE $6/7,41/14$ law and the independent
+        coefficient sweeps.  Extend the frozen-point calculation to
+        trajectory-linearized Jacobians to quantify amplitude-dependent
+        attitude/gravity coupling; retain the cubic schedule as the low-cost
+        embedded comparator rather than as the theoretical baseline.
   \item \textbf{Transition-aware regularizer amplitude.}  If the full-state
-        model supports the measured stationary--transition conflict, preserve
-        the steady-state regularizer mapping and test asymmetric or rate-limited
-        amplitude response during changing seas, scoring stationary and
-        transition ensembles jointly.
+        model predicts a stationary--transition conflict outside the currently
+        tested transition, preserve the steady-state regularizer mapping and
+        test asymmetric or rate-limited amplitude response during changing
+        seas, scoring stationary and transition ensembles jointly.
   \item \textbf{Reference-point and GNSS validation.}  Validate the lever-arm
         model at a surveyed nonzero offset and add GNSS-aided separation of slow
         absolute trajectory from bounded wave motion, including asynchronous

--- a/doc/kalman_ou_iii/w3d-conclusion-summary.tex-part
+++ b/doc/kalman_ou_iii/w3d-conclusion-summary.tex-part
@@ -7,9 +7,14 @@ and an integral-displacement state whose zero pseudo-measurement provides
 low-frequency drift control.  Under the bounded geometry, update-gap,
 covariance, finite residual-bias correlation-time, exogenous-schedule, and
 no-reset assumptions of Sec.~\ref{app:iss-stability}, the local homogeneous
-error recursion is uniformly exponentially stable and the nonlinear remainder
-admits a local ISS bound.  Startup and other hard reconfiguration events remain
-outside this result.
+Live error recursion is uniformly exponentially stable and the nonlinear
+remainder admits a local ISS bound.  The measurement-only Mahony bootstrap of
+Sec.~\ref{sec:semiglobal-stability} extends this to almost-global, semiglobal
+practical startup-attitude capture on compact subsets of the desired proxy
+domain, provided the quality-gated handoff enters the Live invariant
+neighborhood.  Later magnetic re-gauging and tilt re-lock remain separate hard
+maps unless their post-map states are independently shown to re-enter that
+neighborhood.
 
 The adaptation layer separates sea time scale, OU-prior amplitude, and integral
 regularization.  The measured sea period sets $\tau$, the physical band-limited

--- a/doc/kalman_ou_iii/w3d-init.tex-part
+++ b/doc/kalman_ou_iii/w3d-init.tex-part
@@ -44,9 +44,13 @@ and integral regularizer are enabled together.  Accelerometer-bias learning is
 held until the magnetic refinement below because bias and small tilt error are
 weakly separable in waves and the residual bias correlation time is long.
 
-The handoff is a hard initialization outside the Live-state ISS theorem of
-Sec.~\ref{app:iss-stability}; the theorem begins after state and covariance are
-seeded.
+The handoff is the basin-entry map analyzed in
+Sec.~\ref{sec:semiglobal-handoff}.  When the accepted proxy/magnetic errors and
+the remaining state mismatch satisfy
+Eq.~\eqref{eq:semiglobal-basin-entry}, the handoff lands inside the invariant
+neighborhood of the 21-state Live ISS theorem and
+Theorem~\ref{thm:semiglobal-proxy-live} applies.  A timeout-forced handoff that
+does not satisfy that condition remains outside the semiglobal result.
 
 \subsection{Two-stage magnetic reference}
 \label{sec:mag-two-stage}
@@ -66,14 +70,16 @@ from the already-live MEKF.
 Acceptance of the refined reference replaces the world magnetic reference,
 re-gauges yaw once, and releases accelerometer-bias learning.  This event occurs
 before the \SI{900}{s} scoring window but remains a discrete reconfiguration
-outside the continuous Live interval of the stability theorem.  The reported
-timing is an evaluated engineering tradeoff rather than a universal startup
-schedule.
+outside the uninterrupted Live interval.  It is covered by the semiglobal
+argument only when its post-map state is independently verified to re-enter
+Eq.~\eqref{eq:semiglobal-basin-entry}; otherwise it defines a new Live-interval
+boundary.  The reported timing is an evaluated engineering tradeoff rather
+than a universal startup schedule.
 
 \subsection{Live re-lock boundary}
 
 A sustained tilt inconsistency above $70^\circ$ for \SI{0.35}{s} can trigger a
 tilt-only re-lock that preserves yaw; a \SI{3}{s} cooldown limits repeated
 resets.  This safety reconfiguration is testable in implementation but, like
-startup and magnetic re-gauging, lies outside the local ISS theorem between
-reset events.
+magnetic re-gauging, is a separate hard map.  The stability result resumes after
+it only if the reset state satisfies the same Live-basin-entry condition.

--- a/doc/kalman_ou_iii/w3d-init.tex-part
+++ b/doc/kalman_ou_iii/w3d-init.tex-part
@@ -45,12 +45,17 @@ held until the magnetic refinement below because bias and small tilt error are
 weakly separable in waves and the residual bias correlation time is long.
 
 The handoff is the basin-entry map analyzed in
-Sec.~\ref{sec:semiglobal-handoff}.  When the accepted proxy/magnetic errors and
-the remaining state mismatch satisfy
+Sec.~\ref{sec:semiglobal-handoff}.  The implemented gravity residual is a sine
+of the alignment angle, so it does not by itself distinguish the aligned and
+antipodal branches.  The semiglobal theorem therefore explicitly requires the
+accepted handoff to satisfy the aligned-branch condition
+Eq.~\eqref{eq:semiglobal-aligned-branch}; this is a theorem assumption, not an
+extra runtime gate claimed for the present implementation.  When that condition,
+the accepted proxy/magnetic errors, and the remaining state mismatch satisfy
 Eq.~\eqref{eq:semiglobal-basin-entry}, the handoff lands inside the invariant
 neighborhood of the 21-state Live ISS theorem and
 Theorem~\ref{thm:semiglobal-proxy-live} applies.  A timeout-forced handoff that
-does not satisfy that condition remains outside the semiglobal result.
+does not satisfy those conditions remains outside the semiglobal result.
 
 \subsection{Two-stage magnetic reference}
 \label{sec:mag-two-stage}

--- a/doc/kalman_ou_iii/w3d-intro.tex-part
+++ b/doc/kalman_ou_iii/w3d-intro.tex-part
@@ -27,12 +27,14 @@ The contributions are:
         gyro and residual accelerometer bias, and three exact OU-driven
         $[v,p,S,a_w]$ chains, with $S$ providing soft low-frequency drift
         control;
-  \item a local stability result for the normal Live recursion,
-        combining finite-horizon observability of the translational and
-        attitude--gyro-bias blocks, a finite-correlation residual-bias model,
-        bounded Riccati covariance, UES of the homogeneous error recursion,
-        and a local ISS bound under the assumptions of
-        Sec.~\ref{app:iss-stability};
+  \item a two-level stability result: finite-horizon observability,
+        finite-correlation residual-bias contraction, bounded Riccati
+        covariance, and UES yield local 21-state Live ISS, while the
+        independent Mahony startup observer gives an almost-global,
+        semiglobal practical attitude-capture extension into that Live basin
+        on compact initial-tilt sets separated from the antipodal gravity
+        configuration under the explicit handoff conditions of
+        Secs.~\ref{app:iss-stability} and \ref{sec:semiglobal-stability};
   \item an exogenous adaptation architecture that estimates wave time scale and
         acceleration level from measurement-only signals and schedules the OU
         prior and integral regularizer.  Scaling analysis identifies the
@@ -50,7 +52,7 @@ The contributions are:
 Here, $\vct p$ denotes bounded wave-induced motion about a local reference, not
 geodetic position; GNSS-aided absolute trajectory estimation is not evaluated.
 The evidence is primarily synthetic, and the ESP32--S3 exercise establishes
-source portability only.
-The startup and reconfiguration events remain outside
-the Live-state ISS theorem.
+source portability only.  The semiglobal result covers the first quality-gated
+proxy-to-Live handoff subject to an explicit Live-basin-entry condition; later
+magnetic re-gauging and tilt re-lock remain separate hard reconfiguration maps.
 Thermal-calibration performance is not evaluated.

--- a/doc/kalman_ou_iii/w3d-intro.tex-part
+++ b/doc/kalman_ou_iii/w3d-intro.tex-part
@@ -32,8 +32,8 @@ The contributions are:
         covariance, and UES yield local 21-state Live ISS, while the
         independent Mahony startup observer gives an almost-global,
         semiglobal practical attitude-capture extension into that Live basin
-        on compact initial-tilt sets separated from the antipodal gravity
-        configuration under the explicit handoff conditions of
+        uniformly on compact startup sets contained in the proxy's desired
+        almost-global domain under the explicit handoff conditions of
         Secs.~\ref{app:iss-stability} and \ref{sec:semiglobal-stability};
   \item an exogenous adaptation architecture that estimates wave time scale and
         acceleration level from measurement-only signals and schedules the OU

--- a/doc/kalman_ou_iii/w3d-semiglobal-stability.tex-part
+++ b/doc/kalman_ou_iii/w3d-semiglobal-stability.tex-part
@@ -138,9 +138,18 @@ $\alpha_{3,\epsilon}$ such that \cite{Khalil2002_NonlinearSystems}
 Here $|\cdot|_{\mathcal A_P}$ denotes distance to the desired reduced set.
 
 Let $\vct u_P$ collect bounded perturbations of the proxy vector field:
-wave-frequency specific force in the normalized gravity direction, gyro noise,
-slow bias/model mismatch, and finite-step discretization error.  Smoothness on
-the compact neighborhood gives a finite $L_\epsilon$ with
+wave-induced non-gravitational specific force in the normalized direction,
+gyro noise, slow bias/model mismatch, and the finite-step implementation
+defect.  Assume on the startup family that
+\begin{equation}
+0<f_{P,0}\le\|\vct f_b(t)\|\le f_{P,1}<\infty,
+\label{eq:semiglobal-proxy-force-bound}
+\end{equation}
+so normalization of the accelerometer vector is smooth and Lipschitz on the
+relevant compact set.  For the sampled implementation, take the step bound in
+Eq.~\eqref{eq:iss-step-tau-bounds} sufficiently small on that set that the
+consistent Mahony discretization error is included in $\vct u_P$.  Smoothness
+then gives a finite $L_\epsilon$ with
 \begin{equation}
 \dot V_\epsilon
 \le-\alpha_{3,\epsilon}(|\vct z_P|_{\mathcal A_P})
@@ -240,14 +249,18 @@ nonlinear remainder bound.
 \label{thm:semiglobal-proxy-live}
 Fix a compact $\mathcal K_{\epsilon,B_\beta}\subset\mathcal D_P$ as in
 Eq.~\eqref{eq:semiglobal-proxy-compact} and a compact family of physical startup
-conditions satisfying Eq.~\eqref{eq:semiglobal-handoff-E}.  Assume:
+conditions satisfying Eqs.~\eqref{eq:semiglobal-proxy-force-bound} and
+\eqref{eq:semiglobal-handoff-E}.  Assume:
 (i) the reduced proxy initial error belongs to
 $\mathcal K_{\epsilon,B_\beta}$;
-(ii) the bounded proxy perturbation is small enough for
+(ii) the bounded proxy perturbation and sample step are small enough for
 Eq.~\eqref{eq:semiglobal-proxy-iss} to reach an accepted gravity interval;
 (iii) the accepted gravity interval satisfies the aligned-branch condition
 \eqref{eq:semiglobal-aligned-branch};
-(iv) an accepted magnetic gauge satisfies the bound used in
+(iv) the auxiliary handoff channels---tuner readiness and, when required by the
+Live observability hypothesis, a noncollinear magnetic or equivalent vector
+reference---become ready within a finite time uniform over the chosen startup
+family, with heading error bounded as in
 Eq.~\eqref{eq:semiglobal-handoff-attitude};
 (v) the basin-entry inequality \eqref{eq:semiglobal-basin-entry} holds; and
 (vi) after handoff, the hypotheses of
@@ -281,18 +294,21 @@ neighborhood in Eq.~\eqref{eq:semiglobal-ultimate-bound}.
 Equation~\eqref{eq:semiglobal-proxy-iss} implies uniform convergence, up to the
 input-dependent practical radius, on the compact set
 $\mathcal K_{\epsilon,B_\beta}$.  Under assumption (ii), choose a finite time
-$T_H$ for which the right-hand side of
+$T_P$ for which the right-hand side of
 Eq.~\eqref{eq:semiglobal-proxy-iss} reaches the proxy accuracy required by an
 accepted gravity interval; compactness makes this choice uniform over the
 prescribed startup family.  Assumption (iii) selects the aligned branch of the
 sine gate, so Eqs.~\eqref{eq:semiglobal-sine-gate} and
 \eqref{eq:semiglobal-handoff-tilt} provide a genuine small-tilt bound rather
-than its antipodal alternative.  Assumption (iv) then bounds yaw, and
+than its antipodal alternative.  Assumption (iv) supplies a finite uniform time
+$T_A$ for the remaining handoff channels and bounds yaw.  Hence an accepted
+handoff exists no later than a finite family-dependent bound formed from
+$T_P$ and $T_A$, subject to the timeout qualification below, and
 Eq.~\eqref{eq:semiglobal-handoff-attitude} bounds the complete attitude error at
-the accepted handoff.  Together with Eq.~\eqref{eq:semiglobal-handoff-E},
-assumption (v) gives $\|\vct e_{k_H}\|\le r_H<r$.  Therefore the handoff lands
-inside the invariant neighborhood used in Theorem~\ref{thm:iss-21-local}.
-Applying Eq.~\eqref{eq:iss-local-bound} from $j=k_H$ gives
+that handoff.  Together with Eq.~\eqref{eq:semiglobal-handoff-E}, assumption
+(v) gives $\|\vct e_{k_H}\|\le r_H<r$.  Therefore the handoff lands inside the
+invariant neighborhood used in Theorem~\ref{thm:iss-21-local}.  Applying
+Eq.~\eqref{eq:iss-local-bound} from $j=k_H$ gives
 Eq.~\eqref{eq:semiglobal-live-bound}; taking the limit superior gives
 Eq.~\eqref{eq:semiglobal-ultimate-bound}.  Finally, the almost-global proxy
 result makes $\mathcal N_P$ measure zero, while the argument above is uniform
@@ -305,9 +321,9 @@ Almost-global convergence is not uniform as the undesired stable set is
 approached.  Therefore a fixed startup timeout cannot certify all compact sets
 approaching $\mathcal N_P$ simultaneously.  With the implemented \SI{150}{s}
 latest-handoff policy, Theorem~\ref{thm:semiglobal-proxy-live} applies to those
-compact sets and disturbance levels whose uniform gate-entry time is less than
-the effective timeout, or whenever a timeout-triggered handoff independently
-satisfies Eqs.~\eqref{eq:semiglobal-aligned-branch} and
+compact sets and disturbance levels whose uniform quality-handoff time is less
+than the effective timeout, or whenever a timeout-triggered handoff
+independently satisfies Eqs.~\eqref{eq:semiglobal-aligned-branch} and
 \eqref{eq:semiglobal-basin-entry}.  A timeout-forced handoff that does not
 satisfy those conditions is outside the theorem.
 

--- a/doc/kalman_ou_iii/w3d-semiglobal-stability.tex-part
+++ b/doc/kalman_ou_iii/w3d-semiglobal-stability.tex-part
@@ -114,7 +114,7 @@ measure-zero stable set of the undesired attitude equilibria
 
 Fix any compact startup set
 \begin{equation}
-\mathcal K_{\epsilon,B_\beta}\Subset\mathcal D_P,
+\mathcal K_{\epsilon,B_\beta}\subset\mathcal D_P,
 \qquad
 \operatorname{dist}(\mathcal K_{\epsilon,B_\beta},\mathcal N_P)\ge\epsilon>0,
 \qquad
@@ -167,17 +167,41 @@ $\mathcal N_P$.
 \label{sec:semiglobal-handoff}
 
 The proxy is not required to converge asymptotically before handoff.  It need
-only enter the basin in which the Live MEKF theorem applies.  Let $\eta_g$
-bound the angular difference between the normalized measured specific-force
-direction used by the startup gate and the true gravity direction during the
-accepted hold.  The implemented sine-angle gate
-$\|\widehat{\vct d}_P\times\widehat{\vct d}_{\rm meas}\|\le0.075$ implies the
-conservative true-tilt bound
+only enter the basin in which the Live MEKF theorem applies.  The implementation
+forms a sine residual from the predicted and low-pass measured rest-specific-
+force directions.  Write
+\begin{equation}
+\widehat{\vct s}_P=-\widehat{\vct d}_P,
+\qquad
+\widehat{\vct s}_{\rm meas}
+=\frac{\vct f_{\rm LP}}{\|\vct f_{\rm LP}\|}.
+\end{equation}
+The current gate requires
+\begin{equation}
+\|\widehat{\vct s}_P\times\widehat{\vct s}_{\rm meas}\|\le0.075.
+\label{eq:semiglobal-sine-gate}
+\end{equation}
+Because a sine residual is identical at angles $\alpha$ and $\pi-\alpha$,
+Eq.~\eqref{eq:semiglobal-sine-gate} by itself is not a branch certificate.  The
+semiglobal theorem therefore additionally assumes that an accepted handoff lies
+on the aligned branch,
+\begin{equation}
+\widehat{\vct s}_P^{\top}\widehat{\vct s}_{\rm meas}>0.
+\label{eq:semiglobal-aligned-branch}
+\end{equation}
+On that branch the angle between the two directions is at most
+$\sin^{-1}(0.075)$.  Let $\eta_g$ bound the angular difference between
+$\widehat{\vct s}_{\rm meas}$ and the true rest-specific-force direction
+$-\vct d$ during the accepted hold.  Then the spherical triangle inequality
+gives the conservative true-tilt bound
 \begin{equation}
 \theta_{H,\rm tilt}
 \le\sin^{-1}(0.075)+\eta_g.
 \label{eq:semiglobal-handoff-tilt}
 \end{equation}
+Thus the proof does not infer a small tilt merely from a small sine residual;
+it also requires the physically correct alignment branch.
+
 Let $\eta_m$ be a bound on the heading error supplied by an accepted magnetic
 gauge.  For example, if the true horizontal magnetic component has magnitude
 at least $B_{h,0}>0$ and the learned horizontal reference error is at most
@@ -214,18 +238,19 @@ nonlinear remainder bound.
 
 \begin{theorem}[Almost-global/semiglobal practical proxy-to-Live ISS]
 \label{thm:semiglobal-proxy-live}
-Fix a compact $\mathcal K_{\epsilon,B_\beta}\Subset\mathcal D_P$ as in
+Fix a compact $\mathcal K_{\epsilon,B_\beta}\subset\mathcal D_P$ as in
 Eq.~\eqref{eq:semiglobal-proxy-compact} and a compact family of physical startup
 conditions satisfying Eq.~\eqref{eq:semiglobal-handoff-E}.  Assume:
 (i) the reduced proxy initial error belongs to
 $\mathcal K_{\epsilon,B_\beta}$;
 (ii) the bounded proxy perturbation is small enough for
-Eq.~\eqref{eq:semiglobal-proxy-iss} to enter and remain inside the implemented
-quality gate;
-(iii) an accepted magnetic gauge satisfies the bound used in
+Eq.~\eqref{eq:semiglobal-proxy-iss} to reach an accepted gravity interval;
+(iii) the accepted gravity interval satisfies the aligned-branch condition
+\eqref{eq:semiglobal-aligned-branch};
+(iv) an accepted magnetic gauge satisfies the bound used in
 Eq.~\eqref{eq:semiglobal-handoff-attitude};
-(iv) the basin-entry inequality \eqref{eq:semiglobal-basin-entry} holds; and
-(v) after handoff, the hypotheses of
+(v) the basin-entry inequality \eqref{eq:semiglobal-basin-entry} holds; and
+(vi) after handoff, the hypotheses of
 Theorems~\ref{thm:iss-21-ues} and \ref{thm:iss-21-local} hold, including the
 bounded predictable SpectralMSE schedule and no hard reset on the analyzed Live
 interval.  Then there is a finite handoff index $k_H$, uniform over the chosen
@@ -257,15 +282,17 @@ Equation~\eqref{eq:semiglobal-proxy-iss} implies uniform convergence, up to the
 input-dependent practical radius, on the compact set
 $\mathcal K_{\epsilon,B_\beta}$.  Under assumption (ii), choose a finite time
 $T_H$ for which the right-hand side of
-Eq.~\eqref{eq:semiglobal-proxy-iss} is smaller than the proxy accuracy required
-by the gravity gate; compactness makes this choice uniform over the prescribed
-startup family.  Assumption (iii) then bounds yaw, and
-Eqs.~\eqref{eq:semiglobal-handoff-tilt}--\eqref{eq:semiglobal-handoff-attitude}
-bound the complete attitude error at the accepted handoff.  Together with
-Eq.~\eqref{eq:semiglobal-handoff-E}, assumption (iv) gives
-$\|\vct e_{k_H}\|\le r_H<r$.  Therefore the handoff lands inside the invariant
-neighborhood used in Theorem~\ref{thm:iss-21-local}.  Applying
-Eq.~\eqref{eq:iss-local-bound} from $j=k_H$ gives
+Eq.~\eqref{eq:semiglobal-proxy-iss} reaches the proxy accuracy required by an
+accepted gravity interval; compactness makes this choice uniform over the
+prescribed startup family.  Assumption (iii) selects the aligned branch of the
+sine gate, so Eqs.~\eqref{eq:semiglobal-sine-gate} and
+\eqref{eq:semiglobal-handoff-tilt} provide a genuine small-tilt bound rather
+than its antipodal alternative.  Assumption (iv) then bounds yaw, and
+Eq.~\eqref{eq:semiglobal-handoff-attitude} bounds the complete attitude error at
+the accepted handoff.  Together with Eq.~\eqref{eq:semiglobal-handoff-E},
+assumption (v) gives $\|\vct e_{k_H}\|\le r_H<r$.  Therefore the handoff lands
+inside the invariant neighborhood used in Theorem~\ref{thm:iss-21-local}.
+Applying Eq.~\eqref{eq:iss-local-bound} from $j=k_H$ gives
 Eq.~\eqref{eq:semiglobal-live-bound}; taking the limit superior gives
 Eq.~\eqref{eq:semiglobal-ultimate-bound}.  Finally, the almost-global proxy
 result makes $\mathcal N_P$ measure zero, while the argument above is uniform
@@ -279,9 +306,20 @@ approached.  Therefore a fixed startup timeout cannot certify all compact sets
 approaching $\mathcal N_P$ simultaneously.  With the implemented \SI{150}{s}
 latest-handoff policy, Theorem~\ref{thm:semiglobal-proxy-live} applies to those
 compact sets and disturbance levels whose uniform gate-entry time is less than
-the effective timeout, or whenever the timeout policy does not bypass the
-quality conditions used above.  A timeout-forced handoff that violates
-Eq.~\eqref{eq:semiglobal-basin-entry} is outside the theorem.
+the effective timeout, or whenever a timeout-triggered handoff independently
+satisfies Eqs.~\eqref{eq:semiglobal-aligned-branch} and
+\eqref{eq:semiglobal-basin-entry}.  A timeout-forced handoff that does not
+satisfy those conditions is outside the theorem.
+
+\paragraph{Implementation note on the branch certificate}
+The current implementation computes the gravity alignment residual from the
+cross-product norm and does not separately test the dot-product sign in
+Eq.~\eqref{eq:semiglobal-aligned-branch}.  In normal startup the Mahony proxy is
+seeded from the measured accelerometer direction, so the aligned branch is the
+intended operating branch; nevertheless, a sine-only residual is not by itself
+a formal certificate of that fact.  Equation~\eqref{eq:semiglobal-aligned-branch}
+is therefore an explicit theorem assumption rather than an asserted property
+of the present gate.
 
 \paragraph{Later reconfiguration}
 The theorem certifies the first quality-gated proxy-to-MEKF handoff and each

--- a/doc/kalman_ou_iii/w3d-semiglobal-stability.tex-part
+++ b/doc/kalman_ou_iii/w3d-semiglobal-stability.tex-part
@@ -1,0 +1,286 @@
+\section{Almost-Global Startup Capture and Semiglobal Practical Extension}
+\label{sec:semiglobal-stability}
+
+The Live-state result of Sec.~\ref{app:iss-stability} is necessarily local in
+MEKF coordinates: the attitude error is represented by a three-vector chart and
+the nonlinear remainder is absorbed only inside an invariant neighborhood.
+The deployed estimator nevertheless does not ask the MEKF itself to recover
+from an arbitrary startup attitude.  Before handoff, the MEKF is untouched and
+a measurement-only Mahony observer supplies tilt while the magnetic-reference
+logic establishes the yaw gauge.  This section uses that architecture to extend
+the result from a local Live theorem to an almost-global, semiglobal practical
+proxy-to-Live statement.  ``Semiglobal'' here refers to arbitrary compact
+startup-attitude sets separated from the antipodal gravity configuration; it
+does not claim semiglobal convergence of an already-running MEKF from arbitrary
+21-state errors.
+
+\subsection{Compatibility with the deployed physical-MSE schedule}
+\label{sec:semiglobal-mse-schedule}
+
+The stability argument does not require a particular monomial relationship
+between the scheduled OU and pseudo-measurement parameters.  It requires only
+the predictable, positive compact bounds of
+Eqs.~\eqref{eq:iss-step-tau-bounds}--\eqref{eq:iss-tuning-bounds}.  For the
+deployed SpectralMSE regularizer, the physical-MSE calculation gives
+\begin{equation}
+ r_{S,\star}
+ =C_J q_{\rm eff}^{1/14}\,
+ \widehat\sigma_{a,B}^{\,6/7}\,
+ \tau_\star^{24/7}T_S^{-1/2},
+\label{eq:semiglobal-mse-schedule}
+\end{equation}
+which is Eq.~\eqref{eq:adapt-mse-applied-form}.  Away from the cadence clamps,
+$T_S=c_T\tau$ and therefore
+\begin{equation}
+ r_{S,\star}\propto
+ q_{\rm eff}^{1/14}\widehat\sigma_{a,B}^{\,6/7}
+ \tau^{41/14}.
+\label{eq:semiglobal-mse-powers}
+\end{equation}
+The exponents $6/7$ and $41/14$ are the theoretical physical-MSE exponents;
+no $\sigma\tau^3$ adaptation relation is used in this proof.
+
+To see why adaptation remains admissible, first suppose the unclipped inputs of
+Eq.~\eqref{eq:semiglobal-mse-schedule} lie in positive compact intervals,
+\begin{equation}
+0<\underline q\le q_{\rm eff}\le\overline q,
+\quad
+0<\underline\sigma_B\le\widehat\sigma_{a,B}\le\overline\sigma_B,
+\quad
+0<\underline T_S\le T_S\le\overline T_S.
+\end{equation}
+Together with Eq.~\eqref{eq:iss-step-tau-bounds}, monotonicity gives
+\begin{align}
+\underline r_{S,\rm MSE}
+&=C_J\underline q^{1/14}\underline\sigma_B^{6/7}
+  \underline\tau^{24/7}\overline T_S^{-1/2},\\
+\overline r_{S,\rm MSE}
+&=C_J\overline q^{1/14}\overline\sigma_B^{6/7}
+  \overline\tau^{24/7}\underline T_S^{-1/2}.
+\end{align}
+Thus $0<\underline r_{S,\rm MSE}\le r_{S,\star}
+\le\overline r_{S,\rm MSE}<\infty$.  The implementation further clips the
+regularizer to a strictly positive finite interval and applies only positive
+bounded cadence normalization.  Consequently the same conclusion holds even
+when a near-still analytical target approaches zero.  Exponential smoothing is
+a convex update between the previous applied value and the bounded target, so
+it preserves the enclosure.  Hence the SpectralMSE law changes the numerical
+compact set over which Theorem~\ref{thm:iss-21-ues} is uniform, not the
+structure of its proof.
+
+\subsection{Reduced proxy attitude error}
+\label{sec:semiglobal-proxy}
+
+Let $\vct d\in\mathbb S^2$ denote the true body-frame direction of world down
+and let $\widehat{\vct d}_P\in\mathbb S^2$ be the direction predicted by the
+startup proxy.  Only tilt is observable from this channel, so define
+\begin{equation}
+\theta_P=\cos^{-1}(\widehat{\vct d}_P^{\top}\vct d),
+\qquad 0\le\theta_P\le\pi,
+\label{eq:semiglobal-tilt-error}
+\end{equation}
+and let $\widetilde{\vct\beta}_{\perp}$ be the component of proxy gyro-bias
+error perpendicular to $\vct d$.  Rotation about $\vct d$ and the corresponding
+parallel bias component are gauge variables for the gravity-only proxy and are
+not included in the reduced error
+\begin{equation}
+\vct z_P=(\widehat{\vct d}_P,\widetilde{\vct\beta}_{\perp}).
+\end{equation}
+The desired set is
+\begin{equation}
+\mathcal A_P=\{\widehat{\vct d}_P=\vct d,
+               \widetilde{\vct\beta}_{\perp}=0\},
+\end{equation}
+whereas the antipodal gravity configuration
+$\widehat{\vct d}_P=-\vct d$ is the undesired critical set of the smooth
+single-vector correction.  The latter has measure zero in the physical
+attitude space once yaw is treated as a gauge.
+
+In the disturbance-free case, the reduced dynamics induced by
+Eq.~\eqref{eq:proxy-mahony} are the standard nonlinear complementary-filter
+dynamics on the observable gravity quotient.  The Mahony construction gives
+almost-global asymptotic convergence to $\mathcal A_P$, with the antipodal
+critical set excluded \cite{Mahony2008NonlinearComplementary}.  This standard
+result can be converted into the uniform compact-set statement needed here.
+For any $\epsilon>0$ and $B_\beta<\infty$, define
+\begin{equation}
+\mathcal K_{\epsilon,B_\beta}
+=\{\theta_P\le\pi-\epsilon,
+    \|\widetilde{\vct\beta}_{\perp}\|\le B_\beta\}.
+\label{eq:semiglobal-proxy-compact}
+\end{equation}
+Every such compact set lies strictly inside the domain of attraction of
+$\mathcal A_P$.  A converse Lyapunov theorem therefore supplies, on a compact
+forward neighborhood of $\mathcal K_{\epsilon,B_\beta}$, a smooth function
+$V_\epsilon$ and class-$\mathcal K$ functions
+$\alpha_{1,\epsilon}$, $\alpha_{2,\epsilon}$, and
+$\alpha_{3,\epsilon}$ such that
+\begin{equation}
+\alpha_{1,\epsilon}(|\vct z_P|_{\mathcal A_P})
+\le V_\epsilon
+\le\alpha_{2,\epsilon}(|\vct z_P|_{\mathcal A_P}),
+\qquad
+\dot V_\epsilon
+\le-\alpha_{3,\epsilon}(|\vct z_P|_{\mathcal A_P}).
+\label{eq:semiglobal-proxy-converse}
+\end{equation}
+Here $|\cdot|_{\mathcal A_P}$ denotes distance to the desired reduced set.
+
+Let $\vct u_P$ collect bounded perturbations of the proxy vector field:
+wave-frequency specific force in the normalized gravity direction, gyro noise,
+slow bias/model mismatch, and discretization error.  Smoothness on the compact
+neighborhood gives a finite $L_\epsilon$ with
+\begin{equation}
+\dot V_\epsilon
+\le-\alpha_{3,\epsilon}(|\vct z_P|_{\mathcal A_P})
+   +L_\epsilon\|\vct u_P\|.
+\label{eq:semiglobal-proxy-perturbed}
+\end{equation}
+The comparison lemma then yields class-$\mathcal{KL}$ and class-$\mathcal K$
+functions $\beta_\epsilon$ and $\gamma_\epsilon$ such that, for sufficiently
+small bounded perturbations that keep the trajectory in that compact
+neighborhood,
+\begin{equation}
+|\vct z_P(t)|_{\mathcal A_P}
+\le
+\beta_\epsilon(|\vct z_P(0)|_{\mathcal A_P},t)
++\gamma_\epsilon(\|\vct u_P\|_\infty).
+\label{eq:semiglobal-proxy-iss}
+\end{equation}
+This is the semiglobal practical-ISS property of the startup tilt observer:
+the bound is uniform on every prescribed
+$\mathcal K_{\epsilon,B_\beta}$, while its constants need not remain uniform as
+$\epsilon\downarrow0$ and the antipodal set is approached.
+
+\subsection{Quality gate as a basin-entry map}
+\label{sec:semiglobal-handoff}
+
+The proxy is not required to converge asymptotically before handoff.  It need
+only enter the basin in which the Live MEKF theorem applies.  Let
+$\eta_g$ bound the angular difference between the normalized measured
+specific-force direction used by the startup gate and the true gravity
+direction during the accepted hold.  The implemented sine-angle gate
+$\|\widehat{\vct d}_P\times\widehat{\vct d}_{\rm meas}\|\le0.075$ implies the
+conservative true-tilt bound
+\begin{equation}
+\theta_{H,\rm tilt}
+\le\sin^{-1}(0.075)+\eta_g.
+\label{eq:semiglobal-handoff-tilt}
+\end{equation}
+Let $\eta_m$ be a bound on the heading error supplied by an accepted magnetic
+gauge.  For example, if the true horizontal magnetic component has magnitude
+at least $B_{h,0}>0$ and the learned horizontal reference error is at most
+$\delta B_h<B_{h,0}$, then one may take
+$\eta_m=\sin^{-1}(\delta B_h/B_{h,0})$.  By the geodesic triangle inequality,
+\begin{equation}
+d_{\SO(3)}(\widetilde{\mat R}_H,\mat I)
+\le\overline\theta_H
+:=\sin^{-1}(0.075)+\eta_g+\eta_m.
+\label{eq:semiglobal-handoff-attitude}
+\end{equation}
+Thus, provided $\overline\theta_H<\pi$, the principal MEKF attitude-error
+coordinate exists at handoff and satisfies
+$\|\delta\vct\theta_H\|\le\overline\theta_H$.
+
+Let $\vct e_{E,H}$ collect the remaining handoff errors in gyro bias,
+$v,p,S,a_w$, and residual accelerometer bias, and suppose the physical startup
+scenario gives the finite bound
+\begin{equation}
+\|\vct e_{E,H}\|\le B_H.
+\label{eq:semiglobal-handoff-E}
+\end{equation}
+Let $r$ be any invariant Live radius admitted by the proof of
+Theorem~\ref{thm:iss-21-local}.  A sufficient basin-entry condition is
+\begin{equation}
+r_H:=\sqrt{\overline\theta_H^2+B_H^2}<r.
+\label{eq:semiglobal-basin-entry}
+\end{equation}
+This condition is deliberately explicit.  The proxy removes the almost-global
+attitude-initialization obstruction; it does not manufacture a theorem for
+arbitrarily large translational or bias errors at the handoff.  Those states
+must enter the same local Live neighborhood as required by the existing
+21-state nonlinear remainder bound.
+
+\begin{theorem}[Almost-global/semiglobal practical proxy-to-Live ISS]
+\label{thm:semiglobal-proxy-live}
+Fix $\epsilon>0$, $B_\beta<\infty$, and a compact family of physical startup
+conditions satisfying Eq.~\eqref{eq:semiglobal-handoff-E}.  Assume:
+(i) the reduced proxy initial error belongs to
+$\mathcal K_{\epsilon,B_\beta}$;
+(ii) the bounded proxy perturbation is small enough for
+Eq.~\eqref{eq:semiglobal-proxy-iss} to enter and remain inside the implemented
+quality gate;
+(iii) an accepted magnetic gauge satisfies the bound used in
+Eq.~\eqref{eq:semiglobal-handoff-attitude};
+(iv) the basin-entry inequality \eqref{eq:semiglobal-basin-entry} holds; and
+(v) after handoff, the hypotheses of
+Theorems~\ref{thm:iss-21-ues} and \ref{thm:iss-21-local} hold, including the
+bounded predictable SpectralMSE schedule and no hard reset on the analyzed Live
+interval.  Then there is a finite handoff index $k_H$, uniform over the chosen
+compact startup family, and constants $C\ge1$, $0<\lambda<1$, and
+$\Gamma<\infty$ such that for every $k\ge k_H$,
+\begin{equation}
+\boxed{
+\|\vct e_k\|
+\le C\lambda^{k-k_H}r_H
+ +\Gamma\sup_{k_H\le i<k}\|\vct d_i\| .}
+\label{eq:semiglobal-live-bound}
+\end{equation}
+For zero Live disturbance and exact accepted references, the post-handoff error
+converges to zero.  For bounded deterministic disturbance,
+\begin{equation}
+\limsup_{k\to\infty}\|\vct e_k\|
+\le\Gamma\|\vct d\|_\infty.
+\label{eq:semiglobal-ultimate-bound}
+\end{equation}
+Because $\epsilon>0$ is arbitrary, the startup attraction domain covers every
+compact initial-tilt set except the antipodal critical set; hence the attitude
+capture is almost global and semiglobal on compact subsets, while the bounded
+input produces a practical ultimate neighborhood.
+\end{theorem}
+
+\begin{proof}
+Equation~\eqref{eq:semiglobal-proxy-iss} implies uniform convergence, up to the
+input-dependent practical radius, on the compact set
+$\mathcal K_{\epsilon,B_\beta}$.  Under assumption (ii), choose a finite time
+$T_H$ for which the right-hand side of
+Eq.~\eqref{eq:semiglobal-proxy-iss} is smaller than the proxy accuracy required
+by the gravity gate; compactness makes this choice uniform over the prescribed
+startup family.  Assumption (iii) then bounds yaw, and
+Eqs.~\eqref{eq:semiglobal-handoff-tilt}--\eqref{eq:semiglobal-handoff-attitude}
+bound the complete attitude error at the accepted handoff.  Together with
+Eq.~\eqref{eq:semiglobal-handoff-E}, assumption (iv) gives
+$\|\vct e_{k_H}\|\le r_H<r$.  Therefore the handoff lands inside the invariant
+neighborhood used in Theorem~\ref{thm:iss-21-local}.  Applying
+Eq.~\eqref{eq:iss-local-bound} from $j=k_H$ gives
+Eq.~\eqref{eq:semiglobal-live-bound}; taking the limit superior gives
+Eq.~\eqref{eq:semiglobal-ultimate-bound}.  Finally, the excluded antipodal set
+has measure zero and every compact subset of its complement is contained in
+some $\mathcal K_{\epsilon,B_\beta}$, which gives the almost-global/semiglobal
+qualification.
+\end{proof}
+
+\paragraph{Finite startup timeout}
+Almost-global convergence is not uniform as the antipodal set is approached.
+Therefore a fixed startup timeout cannot certify all
+$\epsilon\downarrow0$ simultaneously.  With the implemented \SI{150}{s}
+latest-handoff policy, Theorem~\ref{thm:semiglobal-proxy-live} applies to those
+compact sets and disturbance levels whose uniform gate-entry time is less than
+the effective timeout, or whenever the timeout policy does not bypass the
+quality conditions used above.  A timeout-forced handoff that violates
+Eq.~\eqref{eq:semiglobal-basin-entry} is outside the theorem.
+
+\paragraph{Later reconfiguration}
+The theorem certifies the first quality-gated proxy-to-MEKF handoff and each
+subsequent uninterrupted Live interval satisfying the standing assumptions.
+The second magnetic re-gauging and the $70^\circ$ tilt re-lock remain separate
+hard maps.  They are covered only if their post-map state is independently
+verified to satisfy Eq.~\eqref{eq:semiglobal-basin-entry}; otherwise they remain
+boundaries between certified Live intervals rather than part of the present
+proof.
+
+\paragraph{Stochastic qualification}
+As in Sec.~\ref{app:iss-stability}, the ISS statements above are deterministic
+bounded-input statements.  Gaussian process and measurement noise do not have
+an almost-sure finite infinite-horizon supremum; corresponding stochastic
+claims require mean-square or finite-horizon high-probability bounds.

--- a/doc/kalman_ou_iii/w3d-semiglobal-stability.tex-part
+++ b/doc/kalman_ou_iii/w3d-semiglobal-stability.tex-part
@@ -9,8 +9,8 @@ from an arbitrary startup attitude.  Before handoff, the MEKF is untouched and
 a measurement-only Mahony observer supplies tilt while the magnetic-reference
 logic establishes the yaw gauge.  This section uses that architecture to extend
 the result from a local Live theorem to an almost-global, semiglobal practical
-proxy-to-Live statement.  ``Semiglobal'' here refers to arbitrary compact
-startup-attitude sets separated from the antipodal gravity configuration; it
+proxy-to-Live statement.  ``Semiglobal'' means uniformity on any prescribed
+compact startup set contained in the desired proxy domain of attraction; it
 does not claim semiglobal convergence of an already-running MEKF from arbitrary
 21-state errors.
 
@@ -86,35 +86,46 @@ not included in the reduced error
 \begin{equation}
 \vct z_P=(\widehat{\vct d}_P,\widetilde{\vct\beta}_{\perp}).
 \end{equation}
-The desired set is
+The desired reduced set is
 \begin{equation}
 \mathcal A_P=\{\widehat{\vct d}_P=\vct d,
-               \widetilde{\vct\beta}_{\perp}=0\},
+               \widetilde{\vct\beta}_{\perp}=0\}.
 \end{equation}
-whereas the antipodal gravity configuration
-$\widehat{\vct d}_P=-\vct d$ is the undesired critical set of the smooth
-single-vector correction.  The latter has measure zero in the physical
-attitude space once yaw is treated as a gauge.
+The smooth single-vector correction also has the undesired antipodal critical
+set $\mathcal U_P$ associated with
+$\widehat{\vct d}_P=-\vct d$.  With integral bias estimation, the set that must
+be excluded from the desired domain is rigorously the stable set of those
+undesired critical points, not merely the critical points themselves.  Denote
+that measure-zero set by
+\begin{equation}
+\mathcal N_P:=W^s(\mathcal U_P),
+\qquad
+\mathcal D_P:=\bigl(\mathbb S^2\times\mathbb R^2\bigr)\setminus\mathcal N_P.
+\label{eq:semiglobal-proxy-domain}
+\end{equation}
 
 In the disturbance-free case, the reduced dynamics induced by
 Eq.~\eqref{eq:proxy-mahony} are the standard nonlinear complementary-filter
 dynamics on the observable gravity quotient.  The Mahony construction gives
-almost-global asymptotic convergence to $\mathcal A_P$, with the antipodal
-critical set excluded \cite{Mahony2008NonlinearComplementary}.  This standard
-result can be converted into the uniform compact-set statement needed here.
-For any $\epsilon>0$ and $B_\beta<\infty$, define
+almost-global asymptotic convergence to $\mathcal A_P$; equivalently,
+$\mathcal D_P$ is the desired domain of attraction and its complement is the
+measure-zero stable set of the undesired attitude equilibria
+\cite{Mahony2008NonlinearComplementary}.
+
+Fix any compact startup set
 \begin{equation}
-\mathcal K_{\epsilon,B_\beta}
-=\{\theta_P\le\pi-\epsilon,
-    \|\widetilde{\vct\beta}_{\perp}\|\le B_\beta\}.
+\mathcal K_{\epsilon,B_\beta}\Subset\mathcal D_P,
+\qquad
+\operatorname{dist}(\mathcal K_{\epsilon,B_\beta},\mathcal N_P)\ge\epsilon>0,
+\qquad
+\|\widetilde{\vct\beta}_{\perp}\|\le B_\beta<\infty.
 \label{eq:semiglobal-proxy-compact}
 \end{equation}
-Every such compact set lies strictly inside the domain of attraction of
-$\mathcal A_P$.  A converse Lyapunov theorem therefore supplies, on a compact
-forward neighborhood of $\mathcal K_{\epsilon,B_\beta}$, a smooth function
-$V_\epsilon$ and class-$\mathcal K$ functions
+Because this compact set lies strictly inside the domain of attraction, a
+converse Lyapunov theorem supplies, on a compact forward neighborhood, a smooth
+function $V_\epsilon$ and class-$\mathcal K$ functions
 $\alpha_{1,\epsilon}$, $\alpha_{2,\epsilon}$, and
-$\alpha_{3,\epsilon}$ such that
+$\alpha_{3,\epsilon}$ such that \cite{Khalil2002_NonlinearSystems}
 \begin{equation}
 \alpha_{1,\epsilon}(|\vct z_P|_{\mathcal A_P})
 \le V_\epsilon
@@ -128,15 +139,15 @@ Here $|\cdot|_{\mathcal A_P}$ denotes distance to the desired reduced set.
 
 Let $\vct u_P$ collect bounded perturbations of the proxy vector field:
 wave-frequency specific force in the normalized gravity direction, gyro noise,
-slow bias/model mismatch, and discretization error.  Smoothness on the compact
-neighborhood gives a finite $L_\epsilon$ with
+slow bias/model mismatch, and finite-step discretization error.  Smoothness on
+the compact neighborhood gives a finite $L_\epsilon$ with
 \begin{equation}
 \dot V_\epsilon
 \le-\alpha_{3,\epsilon}(|\vct z_P|_{\mathcal A_P})
    +L_\epsilon\|\vct u_P\|.
 \label{eq:semiglobal-proxy-perturbed}
 \end{equation}
-The comparison lemma then yields class-$\mathcal{KL}$ and class-$\mathcal K$
+Standard comparison then yields class-$\mathcal{KL}$ and class-$\mathcal K$
 functions $\beta_\epsilon$ and $\gamma_\epsilon$ such that, for sufficiently
 small bounded perturbations that keep the trajectory in that compact
 neighborhood,
@@ -148,18 +159,18 @@ neighborhood,
 \label{eq:semiglobal-proxy-iss}
 \end{equation}
 This is the semiglobal practical-ISS property of the startup tilt observer:
-the bound is uniform on every prescribed
-$\mathcal K_{\epsilon,B_\beta}$, while its constants need not remain uniform as
-$\epsilon\downarrow0$ and the antipodal set is approached.
+the bound is uniform on every prescribed compact subset of $\mathcal D_P$, but
+its constants need not remain uniform as that set approaches
+$\mathcal N_P$.
 
 \subsection{Quality gate as a basin-entry map}
 \label{sec:semiglobal-handoff}
 
 The proxy is not required to converge asymptotically before handoff.  It need
-only enter the basin in which the Live MEKF theorem applies.  Let
-$\eta_g$ bound the angular difference between the normalized measured
-specific-force direction used by the startup gate and the true gravity
-direction during the accepted hold.  The implemented sine-angle gate
+only enter the basin in which the Live MEKF theorem applies.  Let $\eta_g$
+bound the angular difference between the normalized measured specific-force
+direction used by the startup gate and the true gravity direction during the
+accepted hold.  The implemented sine-angle gate
 $\|\widehat{\vct d}_P\times\widehat{\vct d}_{\rm meas}\|\le0.075$ implies the
 conservative true-tilt bound
 \begin{equation}
@@ -197,13 +208,14 @@ r_H:=\sqrt{\overline\theta_H^2+B_H^2}<r.
 \end{equation}
 This condition is deliberately explicit.  The proxy removes the almost-global
 attitude-initialization obstruction; it does not manufacture a theorem for
-arbitrarily large translational or bias errors at the handoff.  Those states
-must enter the same local Live neighborhood as required by the existing
-21-state nonlinear remainder bound.
+arbitrarily large translational or bias errors at handoff.  Those states must
+enter the same local Live neighborhood required by the existing 21-state
+nonlinear remainder bound.
 
 \begin{theorem}[Almost-global/semiglobal practical proxy-to-Live ISS]
 \label{thm:semiglobal-proxy-live}
-Fix $\epsilon>0$, $B_\beta<\infty$, and a compact family of physical startup
+Fix a compact $\mathcal K_{\epsilon,B_\beta}\Subset\mathcal D_P$ as in
+Eq.~\eqref{eq:semiglobal-proxy-compact} and a compact family of physical startup
 conditions satisfying Eq.~\eqref{eq:semiglobal-handoff-E}.  Assume:
 (i) the reduced proxy initial error belongs to
 $\mathcal K_{\epsilon,B_\beta}$;
@@ -233,10 +245,11 @@ converges to zero.  For bounded deterministic disturbance,
 \le\Gamma\|\vct d\|_\infty.
 \label{eq:semiglobal-ultimate-bound}
 \end{equation}
-Because $\epsilon>0$ is arbitrary, the startup attraction domain covers every
-compact initial-tilt set except the antipodal critical set; hence the attitude
-capture is almost global and semiglobal on compact subsets, while the bounded
-input produces a practical ultimate neighborhood.
+Because every compact subset of the almost-global domain $\mathcal D_P$ is
+admissible, the startup attraction property is semiglobal on that domain; since
+its complement $\mathcal N_P$ has measure zero, the attitude-capture statement
+is almost global.  Bounded inputs enlarge the target to the practical
+neighborhood in Eq.~\eqref{eq:semiglobal-ultimate-bound}.
 \end{theorem}
 
 \begin{proof}
@@ -254,16 +267,16 @@ $\|\vct e_{k_H}\|\le r_H<r$.  Therefore the handoff lands inside the invariant
 neighborhood used in Theorem~\ref{thm:iss-21-local}.  Applying
 Eq.~\eqref{eq:iss-local-bound} from $j=k_H$ gives
 Eq.~\eqref{eq:semiglobal-live-bound}; taking the limit superior gives
-Eq.~\eqref{eq:semiglobal-ultimate-bound}.  Finally, the excluded antipodal set
-has measure zero and every compact subset of its complement is contained in
-some $\mathcal K_{\epsilon,B_\beta}$, which gives the almost-global/semiglobal
-qualification.
+Eq.~\eqref{eq:semiglobal-ultimate-bound}.  Finally, the almost-global proxy
+result makes $\mathcal N_P$ measure zero, while the argument above is uniform
+on every compact subset of $\mathcal D_P$.  This gives the claimed
+almost-global/semiglobal qualification.
 \end{proof}
 
 \paragraph{Finite startup timeout}
-Almost-global convergence is not uniform as the antipodal set is approached.
-Therefore a fixed startup timeout cannot certify all
-$\epsilon\downarrow0$ simultaneously.  With the implemented \SI{150}{s}
+Almost-global convergence is not uniform as the undesired stable set is
+approached.  Therefore a fixed startup timeout cannot certify all compact sets
+approaching $\mathcal N_P$ simultaneously.  With the implemented \SI{150}{s}
 latest-handoff policy, Theorem~\ref{thm:semiglobal-proxy-live} applies to those
 compact sets and disturbance levels whose uniform gate-entry time is less than
 the effective timeout, or whenever the timeout policy does not bypass the

--- a/tests/validation/test_ou_semiglobal_stability.py
+++ b/tests/validation/test_ou_semiglobal_stability.py
@@ -37,6 +37,7 @@ class OUIIISemiglobalStabilityContractTests(unittest.TestCase):
         proof = _read("w3d-semiglobal-stability.tex-part")
         for marker in (
             r"\mathcal K_{\epsilon,B_\beta}",
+            r"\mathcal N_P:=W^s(\mathcal U_P)",
             "antipodal",
             r"\cite{Mahony2008NonlinearComplementary}",
             r"\label{thm:semiglobal-proxy-live}",
@@ -51,6 +52,9 @@ class OUIIISemiglobalStabilityContractTests(unittest.TestCase):
         startup = _read("w3d-init.tex-part")
         self.assertIn("0.075", proof)
         self.assertIn(r"\SI{150}{s}", proof)
+        self.assertIn(r"\label{eq:semiglobal-aligned-branch}", proof)
+        self.assertIn("sine-only residual is not by itself", proof)
+        self.assertIn(r"\eqref{eq:semiglobal-aligned-branch}", startup)
         self.assertIn(r"\eqref{eq:semiglobal-basin-entry}", startup)
         self.assertIn(r"\ref{thm:semiglobal-proxy-live}", startup)
 

--- a/tests/validation/test_ou_semiglobal_stability.py
+++ b/tests/validation/test_ou_semiglobal_stability.py
@@ -1,0 +1,59 @@
+"""Semantic contract for the OU--III semiglobal stability extension."""
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOC = REPO_ROOT / "doc" / "kalman_ou_iii"
+
+
+def _read(name: str) -> str:
+    return (DOC / name).read_text(encoding="utf-8")
+
+
+class OUIIISemiglobalStabilityContractTests(unittest.TestCase):
+    def test_main_article_wires_semiglobal_extension_after_live_iss(self):
+        main = _read("kalman_ou-w3d.tex")
+        local = r"\input{w3d-iss-stability.tex-part}"
+        semiglobal = r"\input{w3d-semiglobal-stability.tex-part}"
+        adaptation = r"\input{w3d-adaptation-motivation.tex-part}"
+        self.assertIn(semiglobal, main)
+        self.assertLess(main.index(local), main.index(semiglobal))
+        self.assertLess(main.index(semiglobal), main.index(adaptation))
+
+    def test_extension_uses_spectral_mse_schedule_not_cubic_adaptation(self):
+        proof = _read("w3d-semiglobal-stability.tex-part")
+        for marker in (
+            r"\label{eq:semiglobal-mse-schedule}",
+            r"\widehat\sigma_{a,B}^{\,6/7}",
+            r"\tau^{41/14}",
+            r"\label{eq:semiglobal-mse-powers}",
+        ):
+            self.assertIn(marker, proof)
+        self.assertIn("no $\\sigma\\tau^3$ adaptation relation", proof)
+
+    def test_extension_is_explicitly_almost_global_not_global_ekf(self):
+        proof = _read("w3d-semiglobal-stability.tex-part")
+        for marker in (
+            r"\mathcal K_{\epsilon,B_\beta}",
+            "antipodal",
+            r"\cite{Mahony2008NonlinearComplementary}",
+            r"\label{thm:semiglobal-proxy-live}",
+            r"\ref{thm:iss-21-local}",
+            r"\label{eq:semiglobal-basin-entry}",
+        ):
+            self.assertIn(marker, proof)
+        self.assertIn("does not claim semiglobal convergence", proof)
+
+    def test_implemented_handoff_and_timeout_are_part_of_scope(self):
+        proof = _read("w3d-semiglobal-stability.tex-part")
+        startup = _read("w3d-init.tex-part")
+        self.assertIn("0.075", proof)
+        self.assertIn(r"\SI{150}{s}", proof)
+        self.assertIn(r"\eqref{eq:semiglobal-basin-entry}", startup)
+        self.assertIn(r"\ref{thm:semiglobal-proxy-live}", startup)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an almost-global / semiglobal practical proxy-to-Live stability extension to the main OU-III article
- retain the existing 21-state Live UES/local ISS proof as the certified post-handoff core
- use the measurement-only Mahony startup observer to obtain uniform practical capture on arbitrary compact startup sets contained in its desired almost-global domain; the excluded set is the measure-zero stable set of the undesired antipodal attitude equilibria
- turn the startup gravity/magnetic handoff into an explicit Live-basin-entry condition
- make the deployed SpectralMSE regularizer explicit in the stability argument: `r_S ~ q_eff^(1/14) sigma_a,B^(6/7) tau^(24/7) T_S^(-1/2)`, hence the theoretical `tau^(41/14)` dependence away from cadence clamps; no `sigma*tau^3` adaptation relation is used
- align the conclusion with the current SpectralMSE default; the cubic schedule is described only as the supported low-cost embedded configuration
- state the limits precisely: arbitrary 21-state MEKF initialization, timeout-forced bad handoff, magnetic re-gauging, and tilt re-lock are not silently promoted to global convergence
- add a publication contract test pinning the theorem wiring, MSE exponents, almost-global domain, and handoff assumptions

## Mathematical scope
The new theorem is semiglobal with respect to every compact startup set inside the Mahony proxy's desired almost-global domain and practical with respect to bounded proxy/Live disturbances. The handoff must land inside the already-proved local 21-state Live invariant neighborhood.

The current implementation's gravity gate uses a sine residual, `||s_hat x s_meas||`, so it cannot by itself distinguish aligned from antipodal directions. The theorem therefore explicitly assumes the accepted handoff lies on the aligned branch (`s_hat^T s_meas > 0`) and documents that this is a proof assumption rather than a runtime guarantee of the present sine-only gate. A timeout-forced handoff is covered only if it independently satisfies the aligned-branch and Live-basin conditions.

## Validation
The branch was created directly from the then-current `main` head (`d4c01d344ab77d5a43fb87d7c2972448aa674fce`) and has remained based on that head with no behind commits at the last comparison. Local `make all` is unavailable in this runtime because the GitHub CLI/network clone path is unavailable; the repository PR workflows are running the full build/validation.