### PR TITLE
Drop the body-Z proxy and the tracker-driven operating point

### DIFF
--- a/docs/ou-ii-ou-iii-parity.md
+++ b/docs/ou-ii-ou-iii-parity.md
@@ -34,8 +34,11 @@ before subtraction, rather than being subtracted as a broadband constant.
 Two things changed together here, exactly as they did in OU-III: the band
 itself, and the tuner's input signal moving from the raw body-Z proxy to the
 complementary-levelled vertical acceleration. `setWaveBandTuning(false)` /
-`W3D_TUNING_BAND=acceleration` bypasses both, so the old broadband path stays
-available as a coherent ablation.
+`W3D_TUNING_BAND=acceleration` bypassed both while the legacy path existed; the
+figures below were measured against it. Both are gone now — the operating point
+is a wave-band quantity unconditionally, and no consumer of a vertical
+acceleration reads the body-Z proxy any more — so the comparison is history
+rather than a switch.
 
 ### 2. The pseudo-measurement cadence is self-similar in `tau`
 
@@ -365,10 +368,12 @@ make -C tests/kalman_ou_ii build
 # deployed default, eight scored records
 W3D_WRITE_TIMESERIES=0 W3D_COLLECT_ALL_GATES=1 ./kalman_ou_ii-sim
 
-# the three ablations that decompose the change
+# the two ablations that still decompose the change
 W3D_STARTUP_INIT=staged_mekf W3D_PSEUDO_CADENCE=fixed ./kalman_ou_ii-sim   # sigma band only
 W3D_STARTUP_INIT=staged_mekf ./kalman_ou_ii-sim                            # + tau cadence
-W3D_TUNING_BAND=acceleration ./kalman_ou_ii-sim                            # legacy broadband path
+
+# the legacy broadband arm (W3D_TUNING_BAND=acceleration) was removed with the
+# tracker-driven operating point; the simulator now rejects that variable.
 ```
 
 The ensemble figures above come from replaying each configuration under

--- a/docs/ou-iii-adaptation-and-travel-sense.md
+++ b/docs/ou-iii-adaptation-and-travel-sense.md
@@ -185,8 +185,9 @@ deterministic single-seed protocol of `tools/ou_sim_table.py`. The second one
 is now the default; ratios below are still taken against attitude levelling,
 since the question is what changed relative to it.
 
-**`body_z`** is the raw proxy the frequency tracker already runs on. It opens
-the loop and is not usable:
+**`body_z`** was the raw proxy the frequency tracker then ran on. It opens the
+loop and is not usable, which is why it has since been deleted rather than left
+selectable — the numbers below are what it cost while it existed:
 
 | filter | vertical RMS | 3D RMS | worst record |
 | --- | --- | --- | --- |
@@ -234,8 +235,8 @@ horizontal acceleration.
 
 ### The same signal in the frequency tracker
 
-The tracker has the same two signals available (`W3D_FREQ_TRACKER_INPUT`,
-`setFreqTrackerInput()`), and the question is worth asking on its own terms
+The tracker then had the same two signals available (`W3D_FREQ_TRACKER_INPUT`,
+`setFreqTrackerInput()`), and the question was worth asking on its own terms
 because the tracker frequency is also the direction demodulator's carrier.
 Both signals are measurement-only, so neither choice touches the loop. Six
 seeds per record, paired on the realization:
@@ -266,8 +267,9 @@ The levelled signal is the default here regardless. Nothing in the measurement
 argues for it and nothing argues against it, so the tie is broken on structure:
 one vertical acceleration then serves every consumer in the filter - period
 estimator, frequency tracker, stillness detector - instead of two signals whose
-difference has to be justified at each call site. `body_z` remains selectable,
-and the ablation is what the table above reports. Note that the numbers quoted
+difference has to be justified at each call site. That structural argument is
+now the whole story: `body_z` has been deleted, so the table above is what the
+ablation cost while it was still selectable. Note that the numbers quoted
 elsewhere for the `Leveled` wave-period ablation shifted slightly with this
 change (`tau` ratio 1.28 -> 1.25), because that ablation now runs against a
 levelled tracker input too.
@@ -339,8 +341,8 @@ rather than from the simulator, so it is a default to override, not a constant.
 The claim that has to survive scrutiny is that the displacement improvement
 comes from the wave band and not from this. Decomposed on the four stationary
 JONSWAP records (3D RMS in metres; "old band" is the acceleration-band
-operating point restored through `W3D_TUNING_BAND=acceleration`, with the
-raised clamps in both arms):
+operating point, restored at the time through `W3D_TUNING_BAND=acceleration`
+and since removed, with the raised clamps in both arms):
 
 | record | old band, old prior | old band, new prior | wave band, old prior | wave band, new prior |
 | --- | --- | --- | --- | --- |
@@ -410,8 +412,9 @@ regularizer. It is the same failure with a smaller multiplier.
 
 `WavePeriodEstimator` is now wired into `SeaStateFusionFilter_OU_II` exactly as
 it is in OU-III: fed the leveled vertical acceleration the direction stage
-already forms, consulted only once it reports ready, and ablatable back to the
-old behaviour with `setWaveBandTuning(false)` / `W3D_TUNING_BAND=acceleration`.
+already forms, consulted only once it reports ready, and — while the legacy
+path existed — ablatable back to the old behaviour with
+`setWaveBandTuning(false)` / `W3D_TUNING_BAND=acceleration`.
 The estimator itself is unchanged and shared, so the `T_z` accuracy table in
 section 1.6 applies unaltered, as does the input study beside it -
 `setWavePeriodInput()` exists on both filters and the eight-record numbers for
@@ -644,8 +647,10 @@ smoke mode and never produces numbers anyone cites.
 
 Section 1.7. Without it the family comparison confounds the extra
 integral-displacement state with the spectral band the two filters are tuned
-from. `W3D_TUNING_BAND=acceleration` restores the old OU-II behaviour so the
-change stays ablatable on both sides of the comparison.
+from. `W3D_TUNING_BAND=acceleration` restored the old OU-II behaviour, keeping
+the change ablatable on both sides of the comparison while that path existed;
+it has since been removed, together with the tracker-driven operating point and
+every body-Z consumer, so the wave band is now the only path.
 
 ### Still open
 

--- a/docs/ou-sigma-horizon.md
+++ b/docs/ou-sigma-horizon.md
@@ -69,14 +69,20 @@ tracker's output frequency.
 
 ## 2. The replacement
 
-`TunerFrequencySource::WaveBand`, now the default in both families, changes two
-things at once, so a third value exists to separate them:
+The wave-band source changed two things at once, and while it was selectable
+two further values existed to separate them:
 
 | source | before the estimator has a value | when it has one |
 | --- | --- | --- |
 | `TrackerFallback` (legacy) | tracker output | at `isReady()` |
 | `WaveBandGated` (ablation) | 0.2 Hz prior | at `isReady()` |
 | `WaveBand` (deployed) | 0.2 Hz prior | as soon as it is finite |
+
+`TunerFrequencySource` has since been removed along with every path from the
+acceleration-band tracker into the adaptation: the bottom row is what both
+families now do unconditionally, and the two rows above it are history rather
+than options.  The measurements in the sections below were taken while all
+three were selectable.
 
 The prior is a constant because that is what makes the schedule exogenous at
 every instant of the run rather than only after the gate clears — a constant is
@@ -291,7 +297,6 @@ New API on both filters, and the environment overrides the simulators read:
 
 | setter | environment variable |
 | --- | --- |
-| `setTunerFrequencySource()` | `W3D_TUNER_FREQ_SOURCE` |
 | `setTuneFreqPriorHz()` | `OU_TUNE_FREQ_PRIOR_HZ` |
 | `setTuneFreqBounds()` | — |
 | `setSigmaVarianceKPeriods()` | `OU_SIGMA_VAR_K_PERIODS` |

--- a/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
+++ b/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
@@ -29,10 +29,10 @@
       correction.  The time scale those laws are built on comes from
       WavePeriodEstimator, not from the acceleration-band frequency tracker,
       at every instant of the run: before that estimator has a value a fixed
-      wave-band prior stands in rather than the tracker (see
-      TunerFrequencySource).  See "Where" below.  The variance channel first
-      applies a period-scaled measurement-only wave band, and averages its
-      variance over a horizon of K wave periods.
+      wave-band prior stands in rather than the tracker, and the tracker has no
+      path into the adaptation at all.  See "Where" below.  The variance
+      channel first applies a period-scaled measurement-only wave band, and
+      averages its variance over a horizon of K wave periods.
 
   Where
   – τ (tau):  OU process time constant = ½ · T_z, half the zero-crossing period
@@ -74,8 +74,6 @@
      the transfer shape is therefore fixed in f/f_tune, which is the condition
      the σₐ similarity argument needs.  The bench noise floor is referred
      through that band's own time-varying coefficients before subtraction.
-     setWaveBandTuning(false) bypasses both the band and the wave-band period,
-     which keeps the old broadband path available as a coherent ablation.
 
   3. THE PSEUDO-MEASUREMENT CADENCE IS SELF-SIMILAR IN τ, AND THE
      REGULARIZERS FOLLOW IT.  One pseudo update has covariance r²; at one
@@ -619,14 +617,6 @@ private:
         time_ += dt;
         startup_stage_t_ += dt;
 
-
-        // BODY-Z-based proxy used as a measurement-only fallback.
-        // This is NOT true world/inertial vertical acceleration; it is only a
-        // body-Z residual that behaves like up-positive vertical motion when the
-        // platform is near-level:
-        //   acc.z() ~ -g at rest  => proxy ~ 0
-        const float a_z_body_proxy = acc.z() + g_std;
-
         // Private Mahony observer for the wave-period estimator, the default
         // sigma channel and the startup attitude.  It is fed the raw gyro and
         // accelerometer, before the MEKF sees them, so that the levelling it
@@ -686,39 +676,24 @@ private:
             }
         }
 
-        // Up-positive BODY-Z proxy used as fallback by measurement-only paths.
-        // Not true world vertical unless the platform is close to level.
-        a_body_z_up_proxy_ = -a_z_body_proxy;
-
-        // Default levelled vertical measurement shared by the frequency
-        // tracker, the wave-period estimator, and the sigma channel.  It comes
-        // from a private complementary observer and therefore does not read
-        // any MEKF state.  Until that observer is ready, use the body-Z proxy.
-        const float a_vert_measurement = vertical_accel_comp_.isReady()
-            ? vertical_accel_comp_.verticalAccelUpMs2()
-            : a_body_z_up_proxy_;
-
-        // Vertical acceleration the tracker runs on.  Both choices are
-        // measurement-only, and they are RMS-equivalent: levelling buys here
-        // none of what it buys the period estimator, because the tracker is
-        // not integrated and so never sees the 1/omega^4 weighting that makes
-        // sub-band gravity leakage matter downstream.  The levelled signal is
-        // the default anyway, so that one vertical acceleration serves every
-        // consumer in the filter.
-        const float a_vert_for_tracker =
-            (freq_tracker_input_ == FreqTrackerInputSource::Complementary)
-                ? a_vert_measurement
-                : a_body_z_up_proxy_;
+        // The one levelled vertical measurement every consumer in this filter
+        // reads: the frequency tracker and its stillness detector, the
+        // wave-period estimator, and the sigma channel.  It comes from the
+        // private Mahony observer and therefore reads no MEKF state.  The
+        // observer is seeded from the first accelerometer sample, so the value
+        // is usable immediately; its isReady() gate is about settled period
+        // *statistics*, which is a stricter requirement than a usable tilt.
+        const float a_vert_measurement = vertical_accel_comp_.verticalAccelUpMs2();
 
         // LPF on the tracker input
-        const float a_body_z_up_lp = freq_input_lpf_.step(a_vert_for_tracker, dt);
+        const float a_vert_lp = freq_input_lpf_.step(a_vert_measurement, dt);
 
         // Raw freq from tracker
-        const float f_tracker = static_cast<float>(tracker_policy_.run(a_body_z_up_lp, dt));
+        const float f_tracker = static_cast<float>(tracker_policy_.run(a_vert_lp, dt));
         f_raw = f_tracker;
 
         // Stillness detector shares the tracker's input, as it always has.
-        const float f_after_still = freq_stillness_.step(a_body_z_up_lp, dt, f_tracker);
+        const float f_after_still = freq_stillness_.step(a_vert_lp, dt, f_tracker);
 
         // Fast & slow smoothed frequencies
         float f_fast = freq_fast_smoother_.update(f_after_still);
@@ -730,21 +705,20 @@ private:
         freq_hz_      = f_fast;   // demod / direction
         freq_hz_slow_ = f_slow;   // tuner / moments
 
-        // Tuner gets vertical accel, and the wave-band frequency when the
-        // period estimator has settled.  That single substitution fixes both
-        // halves of the old operating point: tau stops being derived from an
-        // acceleration-band frequency that barely moves with the sea state, and
-        // the tuner's variance horizon (a few periods) stops being shorter than
-        // one wave period, which was biasing sigma_aw low.
+        // Tuner gets vertical accel and the wave-band frequency.  That single
+        // substitution fixed both halves of the old operating point: tau is no
+        // longer derived from an acceleration-band frequency that barely moves
+        // with the sea state, and the tuner's variance horizon (a few periods)
+        // is no longer shorter than one wave period, which was biasing
+        // sigma_aw low.  The acceleration-band tracker reaches none of it; it
+        // stays where it is needed, as the wave-direction demodulator carrier.
         //
-        // The variance channel now sees the same exogenous levelled
-        // acceleration the wave-period estimator does, but only after a
-        // period-scaled band-pass.  The band is inside update_tuner because its
-        // corners use the tuner's own lagged/smoothed wave frequency.  Turning
-        // wave-band tuning off deliberately bypasses that band so the old
-        // broadband variance path remains available as a clean ablation.
+        // The variance channel sees the same exogenous levelled acceleration
+        // the wave-period estimator does, but only after a period-scaled
+        // band-pass.  The band is inside update_tuner because its corners use
+        // the tuner's own lagged/smoothed wave frequency.
         if (enable_tuner_) {
-            update_tuner(dt, a_vert_measurement, tuner_frequency_hz_(f_after_still));
+            update_tuner(dt, a_vert_measurement, tuner_frequency_hz_());
         }
 
         // R_p0/R_v0 are committed with the rest of the staged online
@@ -782,9 +756,10 @@ private:
         //
         // Levelled, because double integration weights a spectrum by
         // 1/omega^4, so the sub-band gravity leakage a tilting platform puts
-        // into the body-Z proxy dominates the elevation proxy.  Fed the raw
-        // body-Z proxy the estimator reports 6.8-10.0 s whatever the sea does,
-        // against a truth of 2.4-8.7 s, and vertical RMS degrades 2.5x.
+        // into a raw body-Z residual dominates the elevation proxy.  Fed that
+        // residual the estimator reports 6.8-10.0 s whatever the sea does,
+        // against a truth of 2.4-8.7 s, and vertical RMS degrades 2.5x.  That
+        // is why no body-Z path is left in this filter.
         //
         // Exogenous, because levelling with the filter's own attitude closes a
         // loop: a 0.25 rad attitude displacement moved the reported period
@@ -798,9 +773,9 @@ private:
         // so it is a pure function of the measurements.  It costs nothing --
         // over the eight reference records it matches the old attitude-levelled
         // input to within 0.2% of vertical RMS -- and it is the default.
-        // setWavePeriodInput() still reaches the other two for ablation;
-        // tests/kalman_ou_iii/tuner_coupling-test.cpp asserts the default is
-        // exogenous bit-for-bit and bounds the Leveled path's gain.
+        // setWavePeriodInput() still reaches the attitude-levelled one for
+        // ablation; tests/kalman_ou_iii/tuner_coupling-test.cpp asserts the
+        // default is exogenous bit-for-bit and bounds the Leveled path's gain.
         wave_period_.update(dt, wave_period_input_ms2_(direction_accel));
 
         dir_filter_.update(direction_accel.forward_ms2,
@@ -985,7 +960,7 @@ public:
     float getSigmaWaveBandHighRatio() const noexcept { return sigma_wave_band_.highRatio(); }
     float getSigmaBandNoiseStd() const noexcept { return band_noise_floor_sigma_(); }
 
-    // Configure LPF on BODY-Z proxy for tracker input
+    // Configure LPF on the levelled vertical acceleration the tracker runs on
     void setFreqInputCutoffHz(float fc) { freq_input_lpf_.setCutoff(fc); }
 
     void enableClamp(bool flag = true) { enable_clamp_ = flag; }
@@ -1260,13 +1235,15 @@ public:
         return (freq_hz_slow_ > 1e-6f) ? 1.0f / freq_hz_slow_ : NAN;
     }
 
-    // Variance after the period-scaled sigma band in the default mode; the
-    // legacy broadband variance when setWaveBandTuning(false).
+    // Variance measured after the period-scaled sigma band.
     inline float getAccelVariance() const noexcept { return tuner_.getAccelVariance(); }
 
-    // Returns the BODY-Z-based up-positive fallback proxy.
-    // This is not a true world/inertial vertical acceleration estimate.
-    inline float getAccelVertical() const noexcept { return a_body_z_up_proxy_; }
+    // Up-positive vertical acceleration from the private Mahony observer: the
+    // signal the tracker, the wave-period estimator and the sigma channel all
+    // run on.  Measurement-only -- it reads no filter state.
+    inline float getAccelVertical() const noexcept {
+        return vertical_accel_comp_.verticalAccelUpMs2();
+    }
 
     inline float getHeaveAbs() const noexcept {
         if (!mekf_) return NAN;
@@ -1295,23 +1272,11 @@ public:
     inline float getWavePeriodSec() const noexcept { return wave_period_.getPeriodSec(); }
     inline bool wavePeriodReady() const noexcept { return wave_period_.isReady(); }
 
-    // Drive the operating point from the wave band (default) or from the
-    // acceleration-band tracker, which is what the filter did before and is
-    // kept so the change can be ablated rather than assumed.  The legacy mode
-    // also bypasses the period-scaled sigma band so this remains a coherent
-    // old-versus-new tuning-path comparison.
-    void setWaveBandTuning(bool flag) {
-        if (wave_band_tuning_ != flag) sigma_wave_band_.reset();
-        wave_band_tuning_ = flag;
-    }
-    bool waveBandTuning() const noexcept { return wave_band_tuning_; }
-
     // Select which vertical acceleration drives the wave-period estimator.
     // Complementary (default) levels with the private Mahony observer and is
     // measurement-only, so the tuner is outside the estimator's loop.  Leveled
     // is the older behaviour, which levels with the main filter's attitude and
-    // closes that loop; BodyZ is measurement-only but unlevelled.  See the call
-    // site in updateTime for what each one costs.
+    // closes that loop.  See the call site in updateTime for what it costs.
     void setWavePeriodInput(WavePeriodInputSource source) {
         wave_period_input_ = source;
     }
@@ -1319,35 +1284,11 @@ public:
         return wave_period_input_;
     }
 
-    // Select which vertical acceleration the frequency tracker runs on.
-    // Complementary (default) is the levelled signal from the private Mahony
-    // observer; BodyZ is the raw proxy, kept for ablation.  Both are
-    // measurement-only, and the two are RMS-equivalent on the reference
-    // records; the default is the levelled one so that every consumer of a
-    // vertical acceleration in this filter reads the same signal.
-    void setFreqTrackerInput(FreqTrackerInputSource source) {
-        freq_tracker_input_ = source;
-    }
-    FreqTrackerInputSource freqTrackerInput() const noexcept {
-        return freq_tracker_input_;
-    }
-
     // Gains of the private Mahony observer that levels the default input.
     // two_kp sets the accelerometer-to-gyro correction corner, which must stay
     // below the wave band; see VerticalAccelComplementary.h.
     void setWavePeriodComplementaryGains(float two_kp, float two_ki) {
         vertical_accel_comp_.setGains(two_kp, two_ki);
-    }
-
-    // Where the tuning frequency comes from.  WaveBand (default) keeps the
-    // whole adaptation path -- sigma band corners, sigma_a horizon, tau -- off
-    // the acceleration-band frequency tracker at every instant of the run; the
-    // other two are ablations.  See TunerFrequencySource.
-    void setTunerFrequencySource(TunerFrequencySource source) {
-        tuner_freq_source_ = source;
-    }
-    TunerFrequencySource tunerFrequencySource() const noexcept {
-        return tuner_freq_source_;
     }
 
     // Wave-band frequency used before WavePeriodEstimator has a value.
@@ -1416,7 +1357,7 @@ private:
     // is time varying, so the gain has to come from the filter's own state
     // rather than from a closed-form transfer function.
     float band_noise_floor_sigma_() const noexcept {
-        if (!wave_band_tuning_ || !sigma_wave_band_.isReady()) {
+        if (!sigma_wave_band_.isReady()) {
             return acc_noise_floor_sigma_;
         }
         const float gain = sigma_wave_band_.whiteNoiseVarianceGain();
@@ -1590,16 +1531,15 @@ private:
         float f_for_sigma_band = tuner_.isFreqReady()
             ? tuner_.getFrequencyHz()
             : freq_hz_for_tuner;
-        const float f_tune_floor = wave_band_tuning_ ? min_tune_freq_hz_ : min_freq_hz_;
-        const float f_tune_ceil = wave_band_tuning_ ? max_tune_freq_hz_ : max_freq_hz_;
+        const float f_tune_floor = min_tune_freq_hz_;
+        const float f_tune_ceil = max_tune_freq_hz_;
         if (!std::isfinite(f_for_sigma_band) || f_for_sigma_band < f_tune_floor) {
             f_for_sigma_band = f_tune_floor;
         }
         f_for_sigma_band = std::min(f_for_sigma_band, f_tune_ceil);
 
-        const float a_for_variance = wave_band_tuning_
-            ? sigma_wave_band_.step(a_vertical_measurement, dt, f_for_sigma_band)
-            : a_vertical_measurement;
+        const float a_for_variance =
+            sigma_wave_band_.step(a_vertical_measurement, dt, f_for_sigma_band);
 
         tuner_.update(dt, a_for_variance, freq_hz_for_tuner);
 
@@ -1714,51 +1654,38 @@ private:
         }
     }
 
-    // Vertical acceleration the wave-period estimator is driven by.  Each
-    // measurement-only source falls back to the body-Z proxy while it is
-    // unusable, which is what the leveled source already does when heading is
-    // not yet resolved.
+    // Vertical acceleration the wave-period estimator is driven by.  The
+    // leveled ablation falls back to the complementary observer while heading
+    // is not yet resolved, so the estimator is never fed a body-frame residual.
     float wave_period_input_ms2_(
         const wave_direction::HeadingFrameAcceleration<float>& leveled) const
     {
+        const float a_comp = vertical_accel_comp_.verticalAccelUpMs2();
         switch (wave_period_input_) {
-            case WavePeriodInputSource::BodyZ:
-                return a_body_z_up_proxy_;
-            case WavePeriodInputSource::Complementary:
-                return vertical_accel_comp_.isReady()
-                           ? vertical_accel_comp_.verticalAccelUpMs2()
-                           : a_body_z_up_proxy_;
             case WavePeriodInputSource::Leveled:
+                return leveled.heading_valid ? leveled.up_ms2 : a_comp;
+            case WavePeriodInputSource::Complementary:
             default:
-                return leveled.heading_valid ? leveled.up_ms2
-                                             : a_body_z_up_proxy_;
+                return a_comp;
         }
     }
 
     // The frequency the whole adaptation path runs on: the sigma band's
-    // corners, the sigma_a averaging horizon, and tau.
+    // corners, the sigma_a averaging horizon, and tau.  It is a wave-band
+    // quantity and nothing else; the acceleration-band tracker never reaches
+    // it, at any instant of the run.
     //
-    // Under the deployed WaveBand source it never reads tracker_hz.  The
-    // estimator's own value is taken as soon as it exists rather than at
+    // The estimator's own value is taken as soon as it exists rather than at
     // isReady(): the readiness gate wants a settled *statistic*, and it does
     // not clear until 60-85 s into a run, whereas a value that has survived the
     // integrator settling transient is already a far better wave-band estimate
-    // than a constant.  Before that the fixed prior stands in.  Both are
-    // exogenous, so the schedule is a pure function of the measurements at
+    // than a constant.  Before that the fixed wave-band prior stands in.  Both
+    // are exogenous, so the schedule is a pure function of the measurements at
     // every instant of the run rather than only after the gate clears.
-    float tuner_frequency_hz_(float tracker_hz) const {
-        if (!wave_band_tuning_) return tracker_hz;
-
+    float tuner_frequency_hz_() const {
         const float wave_hz = wave_period_.getFrequencyHz();
-        const bool usable =
-            std::isfinite(wave_hz) && wave_hz > 0.0f &&
-            (tuner_freq_source_ == TunerFrequencySource::WaveBand ||
-             wave_period_.isReady());
-        if (usable) return wave_hz;
-
-        return (tuner_freq_source_ == TunerFrequencySource::TrackerFallback)
-                   ? tracker_hz
-                   : tune_freq_prior_hz_;
+        if (std::isfinite(wave_hz) && wave_hz > 0.0f) return wave_hz;
+        return tune_freq_prior_hz_;
     }
 
     void resetTrackingState_() {
@@ -1874,7 +1801,6 @@ private:
     float freq_hz_slow_ = FREQ_GUESS;
     float f_raw         = FREQ_GUESS;
 
-    float a_body_z_up_proxy_ = 0.0f;  // BODY-Z-based up-positive proxy used by tracker/tuner logic.
 
     bool enable_clamp_ = true;
     bool enable_tuner_ = true;
@@ -1892,10 +1818,7 @@ private:
     float pseudo_update_period_max_s_ = PSEUDO_UPDATE_PERIOD_MAX_S_DEFAULT;
     float pseudo_update_fixed_period_s_ = PSEUDO_UPDATE_PERIOD_NOMINAL_S;
 
-    bool  wave_band_tuning_       = true;
     WavePeriodInputSource wave_period_input_ = WavePeriodInputSource::Complementary;
-    FreqTrackerInputSource freq_tracker_input_ = FreqTrackerInputSource::Complementary;
-    TunerFrequencySource tuner_freq_source_ = TunerFrequencySource::WaveBand;
     float tune_freq_prior_hz_     = TUNE_FREQ_PRIOR_HZ;
     float min_tune_freq_hz_       = MIN_TUNE_FREQ_HZ;
     float max_tune_freq_hz_       = MAX_TUNE_FREQ_HZ;

--- a/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
+++ b/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
@@ -25,14 +25,14 @@
       the spectral peak and barely moves as the sea grows.  Tuning therefore
       reads WavePeriodEstimator, and reads it at every instant of the run --
       before that estimator has a value, a fixed wave-band prior stands in
-      rather than the tracker.  See TunerFrequencySource.
+      rather than the tracker.  The tracker has no path into the adaptation.
 
     • Dual-stage frequency smoothing of the tracker:
           – Fast 1st-order IIR (≈ few s, ~90% step) for demodulation / direction
           – Slow 1st-order IIR (≈ longer s, ~90% step) reported as getPeriodSec()
 
     • Online auto-tuning of Kalman filter parameters (τ, σₐ, Rₛ) through
-      SeaStateAutoTuner.  The default OU-III variance channel first applies a
+      SeaStateAutoTuner.  The OU-III variance channel first applies a
       period-scaled measurement-only wave band, then estimates acceleration
       variance over a horizon of K wave periods, and applies the σₐ·τ³
       regularization law.
@@ -563,13 +563,6 @@ private:
         time_ += dt;
         startup_stage_t_ += dt;
 
-        // BODY-Z-based proxy used as a measurement-only fallback.
-        // This is NOT a true vertical acceleration estimate; it is only a
-        // body-Z residual that behaves like up-positive vertical motion when the
-        // platform is near-level:
-        //   acc.z() ~ -g at rest  => proxy ~ 0
-        const float a_z_body_proxy = acc.z() + g_std;
-
         // Private Mahony observer for the wave-period estimator and default
         // sigma channel. It is fed raw gyro and accelerometer before the MEKF
         // sees them, so its levelled vertical acceleration remains a pure
@@ -627,25 +620,17 @@ private:
             }
         }
 
-        // Up-positive BODY-Z proxy used as fallback by measurement-only paths.
-        // Not true world vertical unless the platform is close to level.
-        a_body_z_up_proxy_ = -a_z_body_proxy;
-
-        // Default levelled vertical measurement shared by the frequency
-        // tracker, the wave-period estimator, and the sigma channel.  It comes
-        // from a private complementary observer and therefore does not read
-        // any MEKF state.  Until that observer is ready, use the body-Z proxy.
-        const float a_vert_measurement = vertical_accel_comp_.isReady()
-            ? vertical_accel_comp_.verticalAccelUpMs2()
-            : a_body_z_up_proxy_;
-
-        const float a_vert_for_tracker =
-            (freq_tracker_input_ == FreqTrackerInputSource::Complementary)
-                ? a_vert_measurement
-                : a_body_z_up_proxy_;
+        // The one levelled vertical measurement every consumer in this filter
+        // reads: the frequency tracker and its stillness detector, the
+        // wave-period estimator, and the sigma channel.  It comes from the
+        // private Mahony observer and therefore reads no MEKF state.  The
+        // observer is seeded from the first accelerometer sample, so the value
+        // is usable immediately; its isReady() gate is about settled period
+        // *statistics*, which is a stricter requirement than a usable tilt.
+        const float a_vert_measurement = vertical_accel_comp_.verticalAccelUpMs2();
 
         // LPF on the tracker input
-        const float a_vert_lp = freq_input_lpf_.step(a_vert_for_tracker, dt);
+        const float a_vert_lp = freq_input_lpf_.step(a_vert_measurement, dt);
 
         // Raw freq from tracker
         const float f_tracker = static_cast<float>(tracker_policy_.run(a_vert_lp, dt));
@@ -664,14 +649,12 @@ private:
         freq_hz_      = f_fast;   // demod / direction
         freq_hz_slow_ = f_slow;   // tuner / moments
 
-        // The default sigma channel now sees the same exogenous levelled
-        // acceleration used by the wave-period estimator, but only after a
-        // period-scaled band-pass.  The band is inside update_tuner because its
-        // corners use the tuner's own lagged/smoothed wave frequency.  Turning
-        // wave-band tuning off deliberately bypasses that band so the old
-        // broadband variance path remains available as a clean ablation.
+        // The sigma channel sees the same exogenous levelled acceleration
+        // used by the wave-period estimator, but only after a period-scaled
+        // band-pass.  The band is inside update_tuner because its corners use
+        // the tuner's own lagged/smoothed wave frequency.
         if (enable_tuner_) {
-            update_tuner(dt, a_vert_measurement, tuner_frequency_hz_(f_after_still));
+            update_tuner(dt, a_vert_measurement, tuner_frequency_hz_());
         }
 
         // R_S is committed with the rest of the staged online schedule at
@@ -709,9 +692,10 @@ private:
         //
         // Levelled, because double integration weights a spectrum by
         // 1/omega^4, so the sub-band gravity leakage a tilting platform puts
-        // into the body-Z proxy dominates the elevation proxy.  Fed the raw
-        // body-Z proxy the estimator reports 6.8-10.0 s whatever the sea does,
-        // against a truth of 2.4-8.7 s, and vertical RMS degrades 2.5x.
+        // into a raw body-Z residual dominates the elevation proxy.  Fed that
+        // residual the estimator reports 6.8-10.0 s whatever the sea does,
+        // against a truth of 2.4-8.7 s, and vertical RMS degrades 2.5x.  That
+        // is why no body-Z path is left in this filter.
         //
         // Exogenous, because levelling with the filter's own attitude closes a
         // loop: a 0.25 rad attitude displacement moved the reported period
@@ -725,7 +709,8 @@ private:
         // so it is a pure function of the measurements.  It costs nothing --
         // over the eight reference records it matches the old attitude-levelled
         // input to within 0.2% of vertical RMS -- and it is the default.
-        // setWavePeriodInput() still reaches the other two for ablation;
+        // setWavePeriodInput() still reaches the attitude-levelled one for
+        // ablation;
         // tests/kalman_ou_iii/tuner_coupling-test.cpp asserts the default is
         // exogenous bit-for-bit and bounds the Leveled path's gain.
         wave_period_.update(dt, wave_period_input_ms2_(direction_accel));
@@ -1245,12 +1230,15 @@ public:
         return (freq_hz_slow_ > 1e-6f) ? 1.0f / freq_hz_slow_ : NAN;
     }
 
-    // Variance after the period-scaled sigma band in the default mode; the
-    // legacy broadband variance when setWaveBandTuning(false).
+    // Variance measured after the period-scaled sigma band.
     inline float getAccelVariance() const noexcept { return tuner_.getAccelVariance(); }
 
-    // Returns the BODY-Z-based up-positive fallback proxy.
-    inline float getAccelVertical() const noexcept { return a_body_z_up_proxy_; }
+    // Up-positive vertical acceleration from the private Mahony observer: the
+    // signal the tracker, the wave-period estimator and the sigma channel all
+    // run on.  Measurement-only -- it reads no filter state.
+    inline float getAccelVertical() const noexcept {
+        return vertical_accel_comp_.verticalAccelUpMs2();
+    }
 
     inline float getHeaveAbs() const noexcept { if (!mekf_) return NAN; return std::fabs(mekf_->get_position().z()); }
 
@@ -1276,23 +1264,11 @@ public:
     inline float getWavePeriodSec() const noexcept { return wave_period_.getPeriodSec(); }
     inline bool wavePeriodReady() const noexcept { return wave_period_.isReady(); }
 
-    // Drive the operating point from the wave band (default) or from the
-    // acceleration-band tracker, which is what the filter did before and is
-    // kept so the change can be ablated rather than assumed.  The legacy mode
-    // also bypasses the period-scaled sigma band so this remains a coherent
-    // old-versus-new tuning-path comparison.
-    void setWaveBandTuning(bool flag) {
-        if (wave_band_tuning_ != flag) sigma_wave_band_.reset();
-        wave_band_tuning_ = flag;
-    }
-    bool waveBandTuning() const noexcept { return wave_band_tuning_; }
-
     // Select which vertical acceleration drives the wave-period estimator.
     // Complementary (default) levels with the private Mahony observer and is
     // measurement-only, so the tuner is outside the estimator's loop.  Leveled
     // is the older behaviour, which levels with the main filter's attitude and
-    // closes that loop; BodyZ is measurement-only but unlevelled.  See the call
-    // site in updateTime for what each one costs.
+    // closes that loop.  See the call site in updateTime for what it costs.
     void setWavePeriodInput(WavePeriodInputSource source) {
         wave_period_input_ = source;
     }
@@ -1300,33 +1276,11 @@ public:
         return wave_period_input_;
     }
 
-    // Select which vertical acceleration the frequency tracker runs on.
-    // Complementary (default) is the levelled signal from the private Mahony
-    // observer; BodyZ is the raw proxy, kept for ablation.  Both are
-    // measurement-only.
-    void setFreqTrackerInput(FreqTrackerInputSource source) {
-        freq_tracker_input_ = source;
-    }
-    FreqTrackerInputSource freqTrackerInput() const noexcept {
-        return freq_tracker_input_;
-    }
-
     // Gains of the private Mahony observer that levels the default input.
     // two_kp sets the accelerometer-to-gyro correction corner, which must stay
     // below the wave band; see VerticalAccelComplementary.h.
     void setWavePeriodComplementaryGains(float two_kp, float two_ki) {
         vertical_accel_comp_.setGains(two_kp, two_ki);
-    }
-
-    // Where the tuning frequency comes from.  WaveBand (default) keeps the
-    // whole adaptation path -- sigma band corners, sigma_a horizon, tau -- off
-    // the acceleration-band frequency tracker at every instant of the run; the
-    // other two are ablations.  See TunerFrequencySource.
-    void setTunerFrequencySource(TunerFrequencySource source) {
-        tuner_freq_source_ = source;
-    }
-    TunerFrequencySource tunerFrequencySource() const noexcept {
-        return tuner_freq_source_;
     }
 
     // Wave-band frequency used before WavePeriodEstimator has a value.
@@ -1393,7 +1347,7 @@ private:
     using StillnessAdapter = seastate::common::StillnessAdapter;
 
     float band_noise_floor_sigma_() const noexcept {
-        if (!wave_band_tuning_ || !sigma_wave_band_.isReady()) {
+        if (!sigma_wave_band_.isReady()) {
             return acc_noise_floor_sigma_;
         }
         const float gain = sigma_wave_band_.whiteNoiseVarianceGain();
@@ -1635,16 +1589,15 @@ private:
         float f_for_sigma_band = tuner_.isFreqReady()
             ? tuner_.getFrequencyHz()
             : freq_hz_for_tuner;
-        const float f_tune_floor = wave_band_tuning_ ? min_tune_freq_hz_ : min_freq_hz_;
-        const float f_tune_ceil = wave_band_tuning_ ? max_tune_freq_hz_ : max_freq_hz_;
+        const float f_tune_floor = min_tune_freq_hz_;
+        const float f_tune_ceil = max_tune_freq_hz_;
         if (!std::isfinite(f_for_sigma_band) || f_for_sigma_band < f_tune_floor) {
             f_for_sigma_band = f_tune_floor;
         }
         f_for_sigma_band = std::min(f_for_sigma_band, f_tune_ceil);
 
-        const float a_for_variance = wave_band_tuning_
-            ? sigma_wave_band_.step(a_vertical_measurement, dt, f_for_sigma_band)
-            : a_vertical_measurement;
+        const float a_for_variance =
+            sigma_wave_band_.step(a_vertical_measurement, dt, f_for_sigma_band);
 
         tuner_.update(dt, a_for_variance, freq_hz_for_tuner);
 
@@ -1765,51 +1718,38 @@ private:
         }
     }
 
-    // Vertical acceleration the wave-period estimator is driven by.  Each
-    // measurement-only source falls back to the body-Z proxy while it is
-    // unusable, which is what the leveled source already does when heading is
-    // not yet resolved.
+    // Vertical acceleration the wave-period estimator is driven by.  The
+    // leveled ablation falls back to the complementary observer while heading
+    // is not yet resolved, so the estimator is never fed a body-frame residual.
     float wave_period_input_ms2_(
         const wave_direction::HeadingFrameAcceleration<float>& leveled) const
     {
+        const float a_comp = vertical_accel_comp_.verticalAccelUpMs2();
         switch (wave_period_input_) {
-            case WavePeriodInputSource::BodyZ:
-                return a_body_z_up_proxy_;
-            case WavePeriodInputSource::Complementary:
-                return vertical_accel_comp_.isReady()
-                           ? vertical_accel_comp_.verticalAccelUpMs2()
-                           : a_body_z_up_proxy_;
             case WavePeriodInputSource::Leveled:
+                return leveled.heading_valid ? leveled.up_ms2 : a_comp;
+            case WavePeriodInputSource::Complementary:
             default:
-                return leveled.heading_valid ? leveled.up_ms2
-                                             : a_body_z_up_proxy_;
+                return a_comp;
         }
     }
 
     // The frequency the whole adaptation path runs on: the sigma band's
-    // corners, the sigma_a averaging horizon, and tau.
+    // corners, the sigma_a averaging horizon, and tau.  It is a wave-band
+    // quantity and nothing else; the acceleration-band tracker never reaches
+    // it, at any instant of the run.
     //
-    // Under the deployed WaveBand source it never reads tracker_hz.  The
-    // estimator's own value is taken as soon as it exists rather than at
+    // The estimator's own value is taken as soon as it exists rather than at
     // isReady(): the readiness gate wants a settled *statistic*, and it does
     // not clear until 60-85 s into a run, whereas a value that has survived the
     // integrator settling transient is already a far better wave-band estimate
-    // than a constant.  Before that the fixed prior stands in.  Both are
-    // exogenous, so the schedule is a pure function of the measurements at
+    // than a constant.  Before that the fixed wave-band prior stands in.  Both
+    // are exogenous, so the schedule is a pure function of the measurements at
     // every instant of the run rather than only after the gate clears.
-    float tuner_frequency_hz_(float tracker_hz) const {
-        if (!wave_band_tuning_) return tracker_hz;
-
+    float tuner_frequency_hz_() const {
         const float wave_hz = wave_period_.getFrequencyHz();
-        const bool usable =
-            std::isfinite(wave_hz) && wave_hz > 0.0f &&
-            (tuner_freq_source_ == TunerFrequencySource::WaveBand ||
-             wave_period_.isReady());
-        if (usable) return wave_hz;
-
-        return (tuner_freq_source_ == TunerFrequencySource::TrackerFallback)
-                   ? tracker_hz
-                   : tune_freq_prior_hz_;
+        if (std::isfinite(wave_hz) && wave_hz > 0.0f) return wave_hz;
+        return tune_freq_prior_hz_;
     }
 
     void resetTrackingState_() {
@@ -1919,8 +1859,6 @@ private:
     float freq_hz_slow_  = FREQ_GUESS;
     float f_raw          = FREQ_GUESS;
 
-    float a_body_z_up_proxy_ = 0.0f;
-
     bool enable_clamp_ = true;
     bool enable_tuner_ = true;
     bool online_tune_apply_pending_ = false;
@@ -1960,10 +1898,7 @@ private:
         std::pow(2.0f * R_S_ACCEL_NOISE_DENSITY_DEFAULT, 1.0f / 14.0f);
     float rs_sigma_exponent_ = 0.0f;
 
-    bool  wave_band_tuning_       = true;
     WavePeriodInputSource wave_period_input_ = WavePeriodInputSource::Complementary;
-    FreqTrackerInputSource freq_tracker_input_ = FreqTrackerInputSource::Complementary;
-    TunerFrequencySource tuner_freq_source_ = TunerFrequencySource::WaveBand;
     float tune_freq_prior_hz_     = TUNE_FREQ_PRIOR_HZ;
     float min_tune_freq_hz_       = MIN_TUNE_FREQ_HZ;
     float max_tune_freq_hz_       = MAX_TUNE_FREQ_HZ;

--- a/src/tuner/SeaStateAutoTuner.h
+++ b/src/tuner/SeaStateAutoTuner.h
@@ -19,35 +19,14 @@
       because that band barely moves with sea state; fed the wave-band
       zero-crossing period it becomes a genuine multiple of the wave period and
       stretches from about 5 s on a short chop to 17 s on a developed swell.
-      The clamps below therefore have to admit that whole span, and the
-      defaults are documented in docs/ou-sigma-horizon.md.
+      The wave band is what the filters feed it -- the acceleration-band
+      tracker no longer reaches the adaptation path at all -- so the clamps
+      below have to admit that whole span, and the defaults are documented in
+      docs/ou-sigma-horizon.md.
 */
 
 #include <cmath>
 #include <algorithm>
-
-// Where the tuning frequency the OU adaptation runs on comes from.
-//
-// WaveBand is the deployed choice: the operating point is a property of the
-// wave band, so it is read from WavePeriodEstimator alone and, before that
-// estimator has settled, from a fixed wave-band prior.  Nothing in the
-// adaptation path then reads the acceleration-band frequency tracker, which
-// stays where it is needed -- as the carrier of the wave-direction
-// demodulator.
-//
-// TrackerFallback is the previous behaviour, kept as an ablation: the same
-// wave-band frequency once the period estimator is ready, but the tracker's
-// output for the first minute or so of every run.
-//
-// WaveBandGated separates the two things WaveBand changes at once.  It drops
-// the tracker exactly like WaveBand but keeps the legacy readiness gate, so
-// comparing the three attributes the effect to "no tracker" or to "adopt the
-// period estimator as soon as it has a value" rather than to their sum.
-enum class TunerFrequencySource {
-    WaveBand,         // wave-period estimator as soon as it has a value, then a prior
-    WaveBandGated,    // ablation: same, but only once the estimator reports ready
-    TrackerFallback,  // legacy: acceleration-band tracker until the estimator is ready
-};
 
 struct DebiasedEMA {
     float value  = 0.0f;

--- a/src/tuner/SeaStateFusionTunerCommon.h
+++ b/src/tuner/SeaStateFusionTunerCommon.h
@@ -59,7 +59,7 @@ struct StillnessAdapter {
         }
     }
 
-    float step(float a_z_body_proxy_lp, float dt, float freq_in) {
+    float step(float a_vert_up_lp, float dt, float freq_in) {
         if (!(dt > 0.0f) || !std::isfinite(freq_in)) {
             return freq_in;
         }
@@ -69,7 +69,7 @@ struct StillnessAdapter {
             freq_init  = true;
         }
 
-        const float a_norm      = a_z_body_proxy_lp / gravity_std_;
+        const float a_norm      = a_vert_up_lp / gravity_std_;
         const float inst_energy = a_norm * a_norm;
 
         energy_ema = (1.0f - energy_alpha) * energy_ema + energy_alpha * inst_energy;

--- a/src/tuner/VerticalAccelComplementary.h
+++ b/src/tuner/VerticalAccelComplementary.h
@@ -20,9 +20,10 @@
   it is not usable: double integration weights a spectrum by 1/omega^4, so the
   gravity a tilting platform leaks into body Z swamps the elevation proxy.  Fed
   the body-Z proxy the estimator reports 6.8-10.0 s whatever the sea does,
-  against a truth of 2.4-8.7 s.
+  against a truth of 2.4-8.7 s.  That is why it was removed rather than kept
+  as a fallback: the filters have no body-Z path left.
 
-  This class is the third option, and the deployed one: level with an attitude
+  This class is the option the filters run on: level with an attitude
   solution that is also a pure function of the measurements.  It runs its own
   Mahony observer on the raw gyro and accelerometer - never the calibrated or
   bias-corrected values, never any filter state - and reports
@@ -67,25 +68,13 @@
 #include "ahrs/Mahony_AHRS.h"
 
 // Which vertical acceleration the wave-period estimator is driven by.
-// Complementary is the default; the other two are kept for ablation.
+// Complementary is the default and the only measurement-only choice; Leveled
+// is kept for ablation.  The raw body-Z proxy -(acc.z + g) is no longer an
+// option anywhere in the filters: every consumer of a vertical acceleration
+// now reads this observer, for the reasons in the note above.
 enum class WavePeriodInputSource {
     Leveled,        // heading-frame up from the main filter's attitude
-    BodyZ,          // raw -(acc.z + g) proxy, the frequency tracker's input
     Complementary,  // private Mahony observer; levelled and measurement-only
-};
-
-// Which vertical acceleration the frequency tracker - and the stillness
-// detector that shares its input - is driven by.  Both choices are
-// measurement-only, so neither closes a loop; they differ in whether the
-// platform's tilt is removed first, and on the reference records they are
-// RMS-equivalent.  Levelling does not buy here what it buys the period
-// estimator: the tracker is not integrated, so it never sees the 1/omega^4
-// weighting that makes sub-band gravity leakage fatal downstream.  The
-// levelled signal is nevertheless the default, so that a single vertical
-// acceleration serves every consumer in the filter.
-enum class FreqTrackerInputSource {
-    BodyZ,          // raw -(acc.z + g) proxy, kept for ablation
-    Complementary,  // private Mahony observer; levelled
 };
 
 class VerticalAccelComplementary {

--- a/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
+++ b/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
@@ -265,25 +265,20 @@ public:
                 filter.mekf().set_Q_bacc_rw(Eigen::Vector3f::Constant(v));
             }
 
-            // Where the tuning frequency comes from before the wave-period
-            // estimator has a value.  "wave_band" is the deployed source and
-            // never reads the acceleration-band tracker; "wave_band_gated"
-            // keeps the legacy readiness gate but still never reads it;
-            // "tracker_fallback" is the previous behaviour.
-            if (const char* src = std::getenv("W3D_TUNER_FREQ_SOURCE")) {
-                const std::string value = src;
-                if (value == "wave_band") {
-                    filter.setTunerFrequencySource(TunerFrequencySource::WaveBand);
-                } else if (value == "wave_band_gated") {
-                    filter.setTunerFrequencySource(
-                        TunerFrequencySource::WaveBandGated);
-                } else if (value == "tracker_fallback") {
-                    filter.setTunerFrequencySource(
-                        TunerFrequencySource::TrackerFallback);
-                } else {
+            // Knobs that no longer exist.  tau and the sigma band are
+            // wave-band quantities at every instant of the run, and every
+            // consumer of a vertical acceleration reads the private Mahony
+            // observer.  A stale sweep script must fail here rather than
+            // silently reporting the deployed configuration as an ablation.
+            for (const char* removed : {"W3D_TUNER_FREQ_SOURCE",
+                                        "W3D_TUNING_BAND",
+                                        "W3D_FREQ_TRACKER_INPUT"}) {
+                if (std::getenv(removed) != nullptr) {
                     throw std::runtime_error(
-                        "W3D_TUNER_FREQ_SOURCE must be wave_band, "
-                        "wave_band_gated or tracker_fallback");
+                        std::string(removed) +
+                        " was removed: the tuning frequency is always the wave"
+                        " band and the frequency tracker always runs on the"
+                        " complementary observer");
                 }
             }
 
@@ -306,53 +301,21 @@ public:
                 }
             }
 
-            // Ablate the wave-band operating point back to the
-            // acceleration-band frequency the filter used before.
-            if (const char* band = std::getenv("W3D_TUNING_BAND")) {
-                const std::string value = band;
-                if (value == "acceleration") {
-                    filter.setWaveBandTuning(false);
-                } else if (value != "wave") {
-                    throw std::runtime_error(
-                        "W3D_TUNING_BAND must be wave or acceleration");
-                }
-            }
-
             // Ablate the wave-period estimator's input away from the
             // complementary-levelled default.  "leveled" restores the older
             // behaviour, which levels with the attitude solution and so closes
-            // the tuner coupling; "body_z" is the raw proxy, measurement-only
-            // like the default but unlevelled.
+            // the tuner coupling.
             if (const char* src = std::getenv("W3D_WAVE_PERIOD_INPUT")) {
                 const std::string value = src;
-                if (value == "body_z") {
-                    filter.setWavePeriodInput(WavePeriodInputSource::BodyZ);
-                } else if (value == "complementary") {
+                if (value == "complementary") {
                     filter.setWavePeriodInput(
                         WavePeriodInputSource::Complementary);
                 } else if (value == "leveled") {
                     filter.setWavePeriodInput(WavePeriodInputSource::Leveled);
                 } else {
                     throw std::runtime_error(
-                        "W3D_WAVE_PERIOD_INPUT must be leveled, body_z or "
+                        "W3D_WAVE_PERIOD_INPUT must be leveled or "
                         "complementary");
-                }
-            }
-
-            // Ablate the frequency tracker's input from the raw body-Z proxy
-            // (default) to the levelled signal from the private Mahony
-            // observer.  Both are measurement-only; this changes the tracker
-            // frequency and so the direction demodulator's carrier.
-            if (const char* src = std::getenv("W3D_FREQ_TRACKER_INPUT")) {
-                const std::string value = src;
-                if (value == "complementary") {
-                    filter.setFreqTrackerInput(
-                        FreqTrackerInputSource::Complementary);
-                } else if (value == "body_z") {
-                    filter.setFreqTrackerInput(FreqTrackerInputSource::BodyZ);
-                } else {
-                    throw std::runtime_error(
-                        "W3D_FREQ_TRACKER_INPUT must be body_z or complementary");
                 }
             }
 

--- a/tests/kalman_ou_iii/kalman_ou_iii-sim.cpp
+++ b/tests/kalman_ou_iii/kalman_ou_iii-sim.cpp
@@ -254,25 +254,20 @@ public:
                 filter.mekf().set_Q_bacc_rw(Eigen::Vector3f::Constant(v));
             }
 
-            // Where the tuning frequency comes from before the wave-period
-            // estimator has a value.  "wave_band" is the deployed source and
-            // never reads the acceleration-band tracker; "wave_band_gated"
-            // keeps the legacy readiness gate but still never reads it;
-            // "tracker_fallback" is the previous behaviour.
-            if (const char* src = std::getenv("W3D_TUNER_FREQ_SOURCE")) {
-                const std::string value = src;
-                if (value == "wave_band") {
-                    filter.setTunerFrequencySource(TunerFrequencySource::WaveBand);
-                } else if (value == "wave_band_gated") {
-                    filter.setTunerFrequencySource(
-                        TunerFrequencySource::WaveBandGated);
-                } else if (value == "tracker_fallback") {
-                    filter.setTunerFrequencySource(
-                        TunerFrequencySource::TrackerFallback);
-                } else {
+            // Knobs that no longer exist.  tau and the sigma band are
+            // wave-band quantities at every instant of the run, and every
+            // consumer of a vertical acceleration reads the private Mahony
+            // observer.  A stale sweep script must fail here rather than
+            // silently reporting the deployed configuration as an ablation.
+            for (const char* removed : {"W3D_TUNER_FREQ_SOURCE",
+                                        "W3D_TUNING_BAND",
+                                        "W3D_FREQ_TRACKER_INPUT"}) {
+                if (std::getenv(removed) != nullptr) {
                     throw std::runtime_error(
-                        "W3D_TUNER_FREQ_SOURCE must be wave_band, "
-                        "wave_band_gated or tracker_fallback");
+                        std::string(removed) +
+                        " was removed: the tuning frequency is always the wave"
+                        " band and the frequency tracker always runs on the"
+                        " complementary observer");
                 }
             }
 
@@ -295,53 +290,21 @@ public:
                 }
             }
 
-            // Ablate the wave-band operating point back to the
-            // acceleration-band frequency the filter used before.
-            if (const char* band = std::getenv("W3D_TUNING_BAND")) {
-                const std::string value = band;
-                if (value == "acceleration") {
-                    filter.setWaveBandTuning(false);
-                } else if (value != "wave") {
-                    throw std::runtime_error(
-                        "W3D_TUNING_BAND must be wave or acceleration");
-                }
-            }
-
             // Ablate the wave-period estimator's input away from the
             // complementary-levelled default.  "leveled" restores the older
             // behaviour, which levels with the attitude solution and so closes
-            // the tuner coupling; "body_z" is the raw proxy, measurement-only
-            // like the default but unlevelled.
+            // the tuner coupling.
             if (const char* src = std::getenv("W3D_WAVE_PERIOD_INPUT")) {
                 const std::string value = src;
-                if (value == "body_z") {
-                    filter.setWavePeriodInput(WavePeriodInputSource::BodyZ);
-                } else if (value == "complementary") {
+                if (value == "complementary") {
                     filter.setWavePeriodInput(
                         WavePeriodInputSource::Complementary);
                 } else if (value == "leveled") {
                     filter.setWavePeriodInput(WavePeriodInputSource::Leveled);
                 } else {
                     throw std::runtime_error(
-                        "W3D_WAVE_PERIOD_INPUT must be leveled, body_z or "
+                        "W3D_WAVE_PERIOD_INPUT must be leveled or "
                         "complementary");
-                }
-            }
-
-            // Ablate the frequency tracker's input from the raw body-Z proxy
-            // (default) to the levelled signal from the private Mahony
-            // observer.  Both are measurement-only; this changes the tracker
-            // frequency and so the direction demodulator's carrier.
-            if (const char* src = std::getenv("W3D_FREQ_TRACKER_INPUT")) {
-                const std::string value = src;
-                if (value == "complementary") {
-                    filter.setFreqTrackerInput(
-                        FreqTrackerInputSource::Complementary);
-                } else if (value == "body_z") {
-                    filter.setFreqTrackerInput(FreqTrackerInputSource::BodyZ);
-                } else {
-                    throw std::runtime_error(
-                        "W3D_FREQ_TRACKER_INPUT must be body_z or complementary");
                 }
             }
 

--- a/tests/kalman_ou_iii/tuner_coupling-test.cpp
+++ b/tests/kalman_ou_iii/tuner_coupling-test.cpp
@@ -20,7 +20,8 @@
 //    every estimator state leaves the reported period and operating point
 //    bit-for-bit unchanged.
 //
-//    WavePeriodInputSource::Leveled is the older behaviour, kept for ablation,
+//    WavePeriodInputSource::Leveled is the older behaviour, the only ablation
+//    left on this axis,
 //    and it does close the loop: it feeds direction_accel.up_ms2, which uses
 //    the attitude estimate, so delta_theta -> wave period -> tau, sigma_a,
 //    r_S -> filter gains -> delta_theta is a real feedback path. It reaches
@@ -227,7 +228,7 @@ bool test_default_frequency_channel_is_exogenous() {
     ok &= check(nominal.isAdaptiveLive(),
                 "the tuner must reach its live stage, or this test proves nothing");
     ok &= check(nominal.wavePeriodReady(),
-                "the period must have settled, or the body-Z fallback is what "
+                "the period must have settled, or the wave-band prior is what "
                 "is being measured");
 
     displace_state(displaced, /*attitude=*/true, /*linear=*/true);
@@ -271,9 +272,9 @@ bool test_default_frequency_channel_is_exogenous() {
 // only thing this can detect is a tracker dependence.
 //
 // The comparison is made at 30 s, well before the wave-period estimator is
-// ready: under the previous TrackerFallback source that is exactly the window
-// in which the tracker set the sigma band's corners, the sigma_a averaging
-// horizon and tau, and this check fails on it.
+// ready: that is exactly the window in which the removed tracker-fallback
+// source let the tracker set the sigma band's corners, the sigma_a averaging
+// horizon and tau, and this check fails on any such path returning.
 bool test_operating_point_is_tracker_independent() {
     bool ok = true;
 
@@ -281,9 +282,6 @@ bool test_operating_point_is_tracker_independent() {
     SeaStateFusionFilter_OU_III<TrackerType::ARANOVSKIY> aranovskiy;
     bring_up(kalmanf);
     bring_up(aranovskiy);
-
-    ok &= check(kalmanf.tunerFrequencySource() == TunerFrequencySource::WaveBand,
-                "the default tuning-frequency source must be the wave-band one");
 
     constexpr int EARLY = 240 * 30;
     run(kalmanf, 0, EARLY);

--- a/tools/ou_sigma_horizon_study.py
+++ b/tools/ou_sigma_horizon_study.py
@@ -1,22 +1,14 @@
 #!/usr/bin/env python3
-"""Decouple the OU adaptation path from the acceleration-band frequency tracker,
-and measure what the sigma_a averaging horizon is worth once it has.
+"""Measure what the sigma_a averaging horizon is worth on the wave-band
+operating point.
 
-Two questions, one harness, because they are the same question asked twice.
-
-``--axis source`` varies where the tuning frequency comes from
-(``W3D_TUNER_FREQ_SOURCE``).  Both OU families already read the wave-band
-zero-crossing period from ``WavePeriodEstimator`` once that estimator reports
-ready, but that gate does not clear until 60-85 s into a run, and until it does
-the operating point -- the sigma band's corners, the sigma_a averaging horizon,
-and tau -- was taken from the acceleration-band tracker:
-
-  ``tracker_fallback``   the previous behaviour and the baseline of this axis.
-  ``wave_band_gated``    the tracker replaced by a fixed wave-band prior, with
-                         the legacy readiness gate left alone.  Isolates "stop
-                         reading the tracker" from the change below.
-  ``wave_band``          (shipped) the same, and the estimator's own value
-                         adopted as soon as it exists rather than at isReady().
+Both OU families take the whole operating point -- the sigma band's corners,
+the sigma_a averaging horizon, and tau -- from the wave-band zero-crossing
+period of ``WavePeriodEstimator``, adopting the estimator's own value as soon
+as it exists and standing a fixed wave-band prior in before that.  The
+acceleration-band frequency tracker has no path into the adaptation, so the
+``source`` axis this harness used to sweep (``W3D_TUNER_FREQ_SOURCE``, with its
+``tracker_fallback`` and ``wave_band_gated`` arms) is gone with it.
 
 ``--axis k_periods`` varies the sigma_a averaging horizon
 (``OU_SIGMA_VAR_K_PERIODS``), which ``SeaStateAutoTuner`` expresses in periods
@@ -54,7 +46,7 @@ single-realization protocol of ``tools/ou_sim_table.py`` and is bit-identical to
 it.  Every ratio is against the axis baseline on the identical realization.
 
 Usage:
-  tools/ou_sigma_horizon_study.py --axis source --seeds 6
+  tools/ou_sigma_horizon_study.py --seeds 6
   tools/ou_sigma_horizon_study.py --axis k_periods --seeds 6 --csv k.csv
 """
 
@@ -119,14 +111,8 @@ SEGMENTS = (
 )
 
 # axis -> (env var, values, baseline).  The baseline is the denominator of every
-# ratio.  On the source axis it is deliberately the *old* behaviour, because
-# the question that axis answers is what dropping the tracker changed.
+# ratio.
 AXES = {
-    "source": (
-        "W3D_TUNER_FREQ_SOURCE",
-        ("tracker_fallback", "wave_band_gated", "wave_band"),
-        "tracker_fallback",
-    ),
     "k_periods": (
         "OU_SIGMA_VAR_K_PERIODS",
         ("0.5", "1", "2", "3", "4", "6", "8"),
@@ -295,7 +281,7 @@ def paired_logs(raw, family, metric, value, baseline, keys, seeds) -> list[float
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--axis", choices=sorted(AXES), default="source")
+    ap.add_argument("--axis", choices=sorted(AXES), default="k_periods")
     ap.add_argument("--values", help="comma-separated override of the axis values")
     ap.add_argument("--baseline", help="override the ratio denominator")
     ap.add_argument("--family", choices=sorted(FAMILIES), action="append")

--- a/tools/ou_wave_period_input_study.py
+++ b/tools/ou_wave_period_input_study.py
@@ -1,13 +1,10 @@
 #!/usr/bin/env python3
 """Compare the vertical-acceleration inputs the OU-II / OU-III filters can use.
 
-Two places in the filter consume a vertical acceleration, and each has more than
-one signal available.  This tool replays the eight reference records under every
-choice, for both filters, and reports the RMS errors and the direction metrics
-side by side.
-
-``--axis wave_period`` (default) varies what drives ``WavePeriodEstimator``,
-which sets the OU operating point:
+``--axis wave_period`` varies what drives ``WavePeriodEstimator``, which sets
+the OU operating point.  This tool replays the eight reference records under
+each choice, for both filters, and reports the RMS errors and the direction
+metrics side by side:
 
   ``leveled``            the heading-frame up component, i.e. the accelerometer
                          rotated by the filter's own attitude solution.  It
@@ -15,31 +12,16 @@ which sets the OU operating point:
                          state, so the tuner is inside a loop.  This is what
                          the filter shipped before ``complementary``.
 
-  ``body_z``             the raw body-Z proxy ``-(acc.z + g)`` that the
-                         frequency tracker runs on.  It never touches the
-                         attitude solution, so the loop is open, but a tilting
-                         platform leaks gravity into it below the wave band,
-                         where double integration weights the spectrum by
-                         1/omega^4.
-
   ``complementary``      (shipped) levelled with a private Mahony observer
-                         running on the raw gyro and accelerometer.  Also a
-                         pure function of the measurements, so the loop is
-                         equally open, but levelled, so the leakage is removed
+                         running on the raw gyro and accelerometer.  A pure
+                         function of the measurements, so the loop is open,
+                         and levelled, so sub-band gravity leakage is removed
                          rather than accepted.
 
-``--axis freq_tracker`` varies what drives the frequency tracker, and with it
-the stillness detector that shares its input.  The tracker frequency is the
-direction demodulator's carrier, so this axis moves the direction estimates as
-well as the displacement RMS:
-
-  ``body_z``             (shipped) the raw proxy.
-  ``complementary``      the same levelled signal as above.
-
-Both choices on this axis are measurement-only, so neither closes a loop.
-Levelling is not obviously right here the way it is for the period estimator:
-the tracker output is not integrated, so it does not suffer the 1/omega^4
-weighting that makes sub-band gravity leakage fatal downstream.
+The raw body-Z proxy ``-(acc.z + g)`` was a third choice here, and a second
+choice for the frequency tracker.  Both are gone: every consumer of a vertical
+acceleration in the filters now reads the private Mahony observer, so there is
+no longer a ``freq_tracker`` axis to sweep.
 
 The default protocol is the deterministic one of ``tools/ou_sim_table.py``: one
 realization per record, default seeds, the final 900 s of a 20-minute replay.
@@ -47,11 +29,11 @@ It is not the ten-seed ensemble study and must not be quoted interchangeably
 with it.  ``--seeds N`` replicates each record over N seeds and reports a
 paired confidence interval alongside the pooled ratio, which is necessary
 whenever the effect being measured is smaller than the record-to-record
-scatter -- as it is on the ``freq_tracker`` axis.
+scatter.
 
 Usage:
   tools/ou_wave_period_input_study.py
-  tools/ou_wave_period_input_study.py --axis freq_tracker --seeds 6
+  tools/ou_wave_period_input_study.py --seeds 6
 """
 
 from __future__ import annotations
@@ -88,19 +70,14 @@ RECORDS = (
 )
 
 # axis -> (env var, inputs, baseline).  The baseline is the denominator of every
-# ratio; on the wave_period axis it is deliberately *not* the shipped value,
-# because the question that axis answers is what the shipped value changed
-# relative to attitude levelling.
+# ratio, and it is deliberately *not* the shipped value, because the question
+# this axis answers is what the shipped value changed relative to attitude
+# levelling.
 AXES = {
     "wave_period": (
         "W3D_WAVE_PERIOD_INPUT",
-        ("leveled", "body_z", "complementary"),
+        ("leveled", "complementary"),
         "leveled",
-    ),
-    "freq_tracker": (
-        "W3D_FREQ_TRACKER_INPUT",
-        ("body_z", "complementary"),
-        "body_z",
     ),
 }
 


### PR DESCRIPTION
Every consumer of a vertical acceleration in OU-II and OU-III now reads the
private Mahony observer (VerticalAccelComplementary): the frequency tracker
and the stillness detector that shares its input, the wave-period estimator,
and the sigma channel. The raw -(acc.z + g) body-Z residual was measurement-
only but unlevelled, and a tilting platform leaks sub-band gravity into it,
which double integration weights by 1/omega^4; it is gone, along with
FreqTrackerInputSource and WavePeriodInputSource::BodyZ. The observer is
seeded from the first accelerometer sample, so the levelled value is usable
immediately and no fallback is needed while its isReady() gate -- which is
about settled period statistics -- is still low. The Leveled wave-period
ablation stays, now falling back to the observer when heading is unresolved.
SeaStateFusionFilter_TFG already read the observer everywhere and is
unchanged.

tau, the sigma band corners and the sigma_a horizon are wave-band quantities
unconditionally. TunerFrequencySource and setWaveBandTuning() are removed
from both OU families: the tuning frequency is WavePeriodEstimator's as soon
as it is finite, and the fixed wave-band prior before that, so the
acceleration-band tracker has no path into the adaptation at any instant of
the run. It stays where it is needed, as the wave-direction demodulator's
carrier.

The simulators reject W3D_TUNER_FREQ_SOURCE, W3D_TUNING_BAND and
W3D_FREQ_TRACKER_INPUT rather than ignoring them, so a stale sweep script
fails instead of reporting the deployed configuration as an ablation.
tools/ou_wave_period_input_study.py loses its freq_tracker axis and its
body_z arm; tools/ou_sigma_horizon_study.py loses its source axis. The design
notes keep their measured numbers and now say which arms no longer exist.

Deterministic last-900 s results are unchanged to the precision
doc/kalman_ou_iii/w3d-sim-results-generated.tex-part reports, on all eight
reference records.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XkYqMNkutFa6ZEZBnPojsK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Standardized tuning and frequency tracking on wave-period measurements and levelled acceleration.
  * Removed obsolete body-Z, acceleration-band, tracker-fallback, and selectable tuner-source options.
  * Wave-period configuration now supports only leveled and complementary inputs.
  * Simulators now reject removed environment overrides with clear errors.
  * Updated diagnostics to report levelled acceleration and band-filtered variance.

* **Documentation & Tools**
  * Updated investigation records and study tools to reflect the remaining configuration options and supported ablations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->