### PR TITLE
Refine semiglobal Live basin with block-structured ISS

### DIFF
--- a/doc/kalman_ou_iii/w3d-block-local-iss.tex-part
+++ b/doc/kalman_ou_iii/w3d-block-local-iss.tex-part
@@ -58,11 +58,20 @@ $\widetilde M\ge1$ and the same $0<\rho<1$ such that
 The numerical size of a certified basin depends on the selected physical
 scales, as it must; the stability property itself does not.
 
+For the structural remainder statement, index the sampled recursion at the
+post-prediction, pre-correction phase of each IMU sample.  From such an index,
+the sample applies the accepted accelerometer, magnetometer, and $S$ updates
+and their MEKF reset, followed by the next exact prediction.  This is only a
+phase convention for the same Live recursion; all one-step transition matrices
+are uniformly bounded on the standing compact set, so the UES property above
+is unchanged.  The convention matters because the exact prediction contains
+the linear chain $v\rightarrow p\rightarrow S$: its effect belongs in the
+homogeneous transition rather than being hidden inside a nonlinear remainder.
+
 \begin{lemma}[Remainder depends directly only on the sensitive block]
 \label{lem:iss-block-remainder}
-For the prediction, accelerometer update, magnetometer update, $S=0$
-pseudo-update, additive-state injection, and MEKF attitude reset used by the
-normal Live recursion, the scaled nonlinear error map can be written
+With the post-prediction indexing above, the scaled normal-Live error map can be
+written
 \begin{equation}
 \vct z_{k+1}
 =\widetilde{\mat A}^{\rm cl}_k\vct z_k
@@ -86,20 +95,30 @@ No smallness condition on $\vct z_\ell$ is needed for this remainder bound.
 \end{lemma}
 
 \begin{proof}
-The OU--III prediction is exactly linear in the additive
-$[v,p,S,a_w,b_a]$ coordinates, while the attitude/gyro-bias propagation is the
-only nonlinear prediction map.  The accelerometer model
-Eq.~\eqref{eq:acc-meas-jacobians} depends on attitude, $a_w$, and $b_a$ but not
-on $v$ or $p$; the magnetometer model depends only on attitude; and the
-integral pseudo-measurement Eq.~\eqref{eq:HS-selector} depends on $S$ but not on
-$v$ or $p$.  Additive-state injection is exact.  The remaining nonlinear
-operation is the quaternion injection/reset of
-Eqs.~\eqref{eq:quat-error-injection}--\eqref{eq:mekf-reset-covariance}; its
-attitude correction is driven by the same accelerometer, magnetometer, and $S$
-residuals and therefore again has no direct $v$ or $p$ dependence.  After the
-first-order terms are collected in $\widetilde{\mat A}^{\rm cl}_k$, Taylor's
-theorem on the compact accepted-update geometry gives the uniform quadratic
-bound \eqref{eq:iss-block-remainder}.
+At the chosen phase, every measurement residual presented to the correction
+map is independent of $v$ and $p$: the accelerometer model
+Eq.~\eqref{eq:acc-meas-jacobians} depends on attitude, $a_w$, and $b_a$; the
+magnetometer model depends only on attitude; and the integral
+pseudo-measurement Eq.~\eqref{eq:HS-selector} depends on $S$.  Additive-state
+injection is exact.  The quaternion injection/reset of
+Eqs.~\eqref{eq:quat-error-injection}--\eqref{eq:mekf-reset-covariance} is
+nonlinear, but its attitude correction is driven by those same residuals and
+therefore is a function of the sensitive coordinates only.  Consequently the
+post-correction attitude/gyro-bias coordinates, and every nonlinear part of the
+post-correction additive coordinates, depend nonlinearly only on
+$\vct z_{\xi,k}$; $v,p$ enter that correction map only through the homogeneous
+linearized state transformation.
+
+The prediction that closes the indexed step is exactly linear in the additive
+$[v,p,S,a_w,b_a]$ coordinates.  It can therefore carry the homogeneous
+$v,p$ error into the next $S$ coordinate, and that coupling is retained in
+$\widetilde{\mat A}^{\rm cl}_k$.  Its only nonlinear part is the
+attitude/gyro-bias error propagation, whose arguments after the preceding
+correction are already functions of the sensitive block alone.  Hence, after
+all first-order terms are collected in $\widetilde{\mat A}^{\rm cl}_k$, the
+remaining one-step nonlinear term has no direct $\vct z_\ell$ argument.
+Taylor's theorem on the compact accepted-update geometry then gives the uniform
+quadratic bound \eqref{eq:iss-block-remainder}.
 
 The inclusion of $S$ in $\vct z_\xi$ is essential.  Although the $S=0$
 measurement is itself linear, its Kalman gain can have attitude rows through

--- a/doc/kalman_ou_iii/w3d-block-local-iss.tex-part
+++ b/doc/kalman_ou_iii/w3d-block-local-iss.tex-part
@@ -62,11 +62,20 @@ For the structural remainder statement, index the sampled recursion at the
 post-prediction, pre-correction phase of each IMU sample.  From such an index,
 the sample applies the accepted accelerometer, magnetometer, and $S$ updates
 and their MEKF reset, followed by the next exact prediction.  This is only a
-phase convention for the same Live recursion; all one-step transition matrices
-are uniformly bounded on the standing compact set, so the UES property above
-is unchanged.  The convention matters because the exact prediction contains
-the linear chain $v\rightarrow p\rightarrow S$: its effect belongs in the
-homogeneous transition rather than being hidden inside a nonlinear remainder.
+phase convention for the same Live recursion.  If $\widetilde\Phi_k$ denotes
+the scaled homogeneous prediction transition, the bounds on $h_k$, $\tau$,
+$\tau_b$, and $\|\widehat\omega\|$ imply uniform bounds on both
+$\widetilde\Phi_k$ and $\widetilde\Phi_k^{-1}$: the rotational block is a
+matrix exponential, the OU factors are strictly positive on the compact
+parameter set, and the integrated kinematic block is triangular with identity
+diagonal blocks.  Therefore the pre-correction and post-correction transition
+products differ only by uniformly bounded endpoint factors
+$\widetilde\Phi_k$ and $\widetilde\Phi_j^{-1}$.  UES is consequently preserved
+under this phase shift, with a changed multiplicative constant and the same
+exponential rate $\rho$.  The convention matters because the exact prediction
+contains the linear chain $v\rightarrow p\rightarrow S$: its effect belongs in
+the homogeneous transition rather than being hidden inside a nonlinear
+remainder.
 
 \begin{lemma}[Remainder depends directly only on the sensitive block]
 \label{lem:iss-block-remainder}

--- a/doc/kalman_ou_iii/w3d-block-local-iss.tex-part
+++ b/doc/kalman_ou_iii/w3d-block-local-iss.tex-part
@@ -94,8 +94,8 @@ on $v$ or $p$; the magnetometer model depends only on attitude; and the
 integral pseudo-measurement Eq.~\eqref{eq:HS-selector} depends on $S$ but not on
 $v$ or $p$.  Additive-state injection is exact.  The remaining nonlinear
 operation is the quaternion injection/reset of
-Eqs.~\eqref{eq:mekf-reset-jacobian}--\eqref{eq:mekf-reset-cov}; its attitude
-correction is driven by the same accelerometer, magnetometer, and $S$
+Eqs.~\eqref{eq:quat-error-injection}--\eqref{eq:mekf-reset-covariance}; its
+attitude correction is driven by the same accelerometer, magnetometer, and $S$
 residuals and therefore again has no direct $v$ or $p$ dependence.  After the
 first-order terms are collected in $\widetilde{\mat A}^{\rm cl}_k$, Taylor's
 theorem on the compact accepted-update geometry gives the uniform quadratic

--- a/doc/kalman_ou_iii/w3d-block-local-iss.tex-part
+++ b/doc/kalman_ou_iii/w3d-block-local-iss.tex-part
@@ -1,0 +1,206 @@
+\subsection{Block-Structured Refinement of the Live Basin}
+\label{sec:iss-block-basin}
+
+The Euclidean ball used in Theorem~\ref{thm:iss-21-local} is a sufficient
+local neighborhood, but it is not structurally sharp for the deployed MEKF.
+It also assigns a numerical radius to coordinates with different physical
+units.  This subsection refines that statement in two ways.  First, it fixes a
+positive coordinate scaling and works with a dimensionless norm.  Second, it
+uses the exact update structure to identify which coordinates enter nonlinear
+remainders directly.
+
+Let fixed positive scales
+$s_\theta,s_{bg},s_v,s_p,s_S,s_{aw},s_{ba}$ be chosen once for the proof, with
+the corresponding physical units.  Define the nonlinear-sensitive and
+kinematic-only scaled coordinates
+\begin{align}
+\vct z_{\xi}
+&=\mat D_\xi
+\begin{bmatrix}
+\delta\vct\theta\\
+\delta\vct b_g\\
+\delta\vct S\\
+\delta\vct a_w\\
+\delta\vct b_a
+\end{bmatrix},
+&
+\mat D_\xi
+&=\operatorname{diag}\!\left(
+ s_\theta^{-1}\mat I_3,
+ s_{bg}^{-1}\mat I_3,
+ s_S^{-1}\mat I_3,
+ s_{aw}^{-1}\mat I_3,
+ s_{ba}^{-1}\mat I_3\right),
+\label{eq:iss-block-xi}\\
+\vct z_{\ell}
+&=\mat D_\ell
+\begin{bmatrix}
+\delta\vct v\\
+\delta\vct p
+\end{bmatrix},
+&
+\mat D_\ell
+&=\operatorname{diag}\!\left(
+ s_v^{-1}\mat I_3,
+ s_p^{-1}\mat I_3\right).
+\label{eq:iss-block-ell}
+\end{align}
+Thus $\vct z=[\vct z_\xi^\top,\vct z_\ell^\top]^\top$ is a fixed
+nonsingular linear reparameterization of the 21-state local error and is
+dimensionless.  Uniform exponential stability is invariant under this fixed
+change of coordinates: Theorem~\ref{thm:iss-21-ues} implies constants
+$\widetilde M\ge1$ and the same $0<\rho<1$ such that
+\begin{equation}
+\|\widetilde\Psi(k,j)\|
+\le\widetilde M\rho^{k-j}.
+\label{eq:iss-block-ues}
+\end{equation}
+The numerical size of a certified basin depends on the selected physical
+scales, as it must; the stability property itself does not.
+
+\begin{lemma}[Remainder depends directly only on the sensitive block]
+\label{lem:iss-block-remainder}
+For the prediction, accelerometer update, magnetometer update, $S=0$
+pseudo-update, additive-state injection, and MEKF attitude reset used by the
+normal Live recursion, the scaled nonlinear error map can be written
+\begin{equation}
+\vct z_{k+1}
+=\widetilde{\mat A}^{\rm cl}_k\vct z_k
+ +\widetilde{\vct\varphi}_k(\vct z_{\xi,k})
+ +\widetilde{\mat G}_k\vct d_k,
+\label{eq:iss-block-recursion}
+\end{equation}
+where $\widetilde{\vct\varphi}_k$ has no direct dependence on
+$\vct z_\ell$.  On the compact Live geometry of
+Eqs.~\eqref{eq:iss-vector-magnitude-bounds}--\eqref{eq:iss-vector-geometry},
+there exist $r_\xi>0$ and $c_\xi<\infty$ such that, uniformly in the admissible
+schedule,
+\begin{equation}
+\|\widetilde{\vct\varphi}_k(\vct z_\xi)\|
+\le c_\xi\|\vct z_\xi\|^2,
+\qquad
+\|\vct z_\xi\|\le r_\xi.
+\label{eq:iss-block-remainder}
+\end{equation}
+No smallness condition on $\vct z_\ell$ is needed for this remainder bound.
+\end{lemma}
+
+\begin{proof}
+The OU--III prediction is exactly linear in the additive
+$[v,p,S,a_w,b_a]$ coordinates, while the attitude/gyro-bias propagation is the
+only nonlinear prediction map.  The accelerometer model
+Eq.~\eqref{eq:acc-meas-jacobians} depends on attitude, $a_w$, and $b_a$ but not
+on $v$ or $p$; the magnetometer model depends only on attitude; and the
+integral pseudo-measurement Eq.~\eqref{eq:HS-selector} depends on $S$ but not on
+$v$ or $p$.  Additive-state injection is exact.  The remaining nonlinear
+operation is the quaternion injection/reset of
+Eqs.~\eqref{eq:mekf-reset-jacobian}--\eqref{eq:mekf-reset-cov}; its attitude
+correction is driven by the same accelerometer, magnetometer, and $S$
+residuals and therefore again has no direct $v$ or $p$ dependence.  After the
+first-order terms are collected in $\widetilde{\mat A}^{\rm cl}_k$, Taylor's
+theorem on the compact accepted-update geometry gives the uniform quadratic
+bound \eqref{eq:iss-block-remainder}.
+
+The inclusion of $S$ in $\vct z_\xi$ is essential.  Although the $S=0$
+measurement is itself linear, its Kalman gain can have attitude rows through
+cross-covariance, and the resulting quaternion injection has a quadratic
+reset remainder.  Hence the deployed architecture does not support the same
+claim with $S$ moved into $\vct z_\ell$.
+\end{proof}
+
+Let $\mat E_\xi$ and $\mat E_\ell$ select the two scaled blocks.  From
+Eq.~\eqref{eq:iss-block-ues}, possibly enlarging constants, there are finite
+$M_{\xi\xi}\ge1$, $M_{\xi\ell}\ge0$, and $M_\xi\ge1$ such that
+\begin{align}
+\|\mat E_\xi\widetilde\Psi(k,j)\mat E_\xi^\top\|
+&\le M_{\xi\xi}\rho^{k-j},\\
+\|\mat E_\xi\widetilde\Psi(k,j)\mat E_\ell^\top\|
+&\le M_{\xi\ell}\rho^{k-j},\\
+\|\mat E_\xi\widetilde\Psi(k,j)\|
+&\le M_\xi\rho^{k-j}.
+\label{eq:iss-block-projected-gains}
+\end{align}
+The constant $M_{\xi\ell}$ is the homogeneous transient gain from initial
+velocity/position error into the nonlinear-sensitive coordinates.  It is
+finite by UES, but it is not generally zero because the exact chain
+$v\rightarrow p\rightarrow S$ can carry a kinematic error into the
+$S$ pseudo-update.
+
+\begin{theorem}[Block-local ISS of the 21-state Live error dynamics]
+\label{thm:iss-block-local}
+Assume Theorem~\ref{thm:iss-21-ues}, Lemma~\ref{lem:iss-block-remainder}, and a
+uniform scaled disturbance gain
+$\|\widetilde{\mat G}_k\|\le\overline G_z$.  Choose $0<r<r_\xi$ and define
+\begin{equation}
+\nu:=\frac{M_\xi c_\xi r}{1-\rho}.
+\label{eq:iss-block-small-gain}
+\end{equation}
+If $\nu<1$ and, at some Live index $j$,
+\begin{equation}
+M_{\xi\xi}\|\vct z_{\xi,j}\|
++M_{\xi\ell}\|\vct z_{\ell,j}\|
++\frac{M_\xi\overline G_z}{1-\rho}\|\vct d\|_{\infty,[j,\infty)}
+<(1-\nu)r,
+\label{eq:iss-block-basin}
+\end{equation}
+then $\|\vct z_{\xi,k}\|<r$ for every $k\ge j$.  Moreover there exist
+$C_z\ge1$, $0<\lambda_z<1$, and $\Gamma_z<\infty$ such that
+\begin{equation}
+\boxed{
+\|\vct z_k\|
+\le C_z\lambda_z^{k-j}
+\bigl(\|\vct z_{\xi,j}\|+\|\vct z_{\ell,j}\|\bigr)
++\Gamma_z\|\vct d\|_{\infty,[j,k)} .}
+\label{eq:iss-block-local-bound}
+\end{equation}
+Thus local smallness is required for the nonlinear-sensitive tube, not for a
+single unscaled 21-state Euclidean ball.
+\end{theorem}
+
+\begin{proof}
+Project variation of constants for Eq.~\eqref{eq:iss-block-recursion} onto the
+sensitive block.  For $k\ge j$, Eqs.~\eqref{eq:iss-block-projected-gains} and
+\eqref{eq:iss-block-remainder} give, as long as
+$\|\vct z_{\xi,i}\|\le r$,
+\begin{align}
+\|\vct z_{\xi,k}\|
+&\le \rho^{k-j}
+ \left(M_{\xi\xi}\|\vct z_{\xi,j}\|
+      +M_{\xi\ell}\|\vct z_{\ell,j}\|\right)\\
+&\quad+M_\xi c_\xi
+ \sum_{i=j}^{k-1}\rho^{k-1-i}\|\vct z_{\xi,i}\|^2
+ +\frac{M_\xi\overline G_z}{1-\rho}
+  \|\vct d\|_{\infty,[j,k)}.
+\label{eq:iss-block-voc}
+\end{align}
+Under the bootstrap hypothesis $\|\vct z_{\xi,i}\|\le r$, the nonlinear
+convolution is at most
+$M_\xi c_\xi r^2/(1-\rho)=\nu r$.  The strict entrance condition
+\eqref{eq:iss-block-basin} therefore maps the closed sensitive tube into its
+interior.  Induction closes the invariant-tube argument and proves
+$\|\vct z_{\xi,k}\|<r$ for all $k\ge j$.
+
+Inside that tube,
+$\|\widetilde{\vct\varphi}_k\|\le c_\xi r\|\vct z_{\xi,k}\|$.  The projected
+Volterra inequality then has linear convolution gain
+$M_\xi c_\xi r$; Eq.~\eqref{eq:iss-block-small-gain} is exactly
+$M_\xi c_\xi r<1-\rho$.  Standard discrete convolution comparison therefore
+gives an exponential rate that may be chosen strictly above
+$\rho+M_\xi c_\xi r$ and below one, together with a finite disturbance gain.
+Substitution in the full variation-of-constants formula and
+Eq.~\eqref{eq:iss-block-ues} yields
+Eq.~\eqref{eq:iss-block-local-bound}.
+\end{proof}
+
+\begin{remark}[What Phase 1 does and does not remove]
+\label{rem:iss-block-phase1}
+The refinement removes $v$ and $p$ from the coordinates whose nonlinear
+remainder must be locally small.  It does \emph{not} certify arbitrarily large
+velocity or position error: their homogeneous transient into $S$ is measured by
+$M_{\xi\ell}$ in Eq.~\eqref{eq:iss-block-basin}.  Nor does it remove $S$ from
+the local block.  A stronger claim would require an additional structural
+change or proof, such as constraining the $S$-to-attitude cross-gain or defining
+a handoff map that resets and decouples the integral channel.  The present
+result is therefore the strongest block separation supported by the deployed
+measurement and reset architecture without changing code.
+\end{remark}

--- a/doc/kalman_ou_iii/w3d-init.tex-part
+++ b/doc/kalman_ou_iii/w3d-init.tex-part
@@ -54,12 +54,15 @@ same two directions, and an accepted handoff satisfies the aligned-branch
 condition Eq.~\eqref{eq:semiglobal-aligned-branch} of the semiglobal theorem.
 The \SI{150}{s} timeout is held to that same test, so a forced handoff is
 delayed rather than accepted on the antipodal branch; it does not test the
-residual magnitude, so it certifies the branch and not the tilt bound.  When the
-branch condition, the accepted proxy/magnetic errors, and the remaining state
-mismatch satisfy Eq.~\eqref{eq:semiglobal-basin-entry}, the handoff lands inside
-the invariant neighborhood of the 21-state Live ISS theorem and
-Theorem~\ref{thm:semiglobal-proxy-live} applies.  A timeout-forced handoff whose
-state mismatch does not satisfy Eq.~\eqref{eq:semiglobal-basin-entry} remains
+residual magnitude, so it certifies the branch and not the tilt bound.  The
+Phase-1 basin refinement separates the dimensionless nonlinear-sensitive block
+$[\delta\theta,\delta b_g,\delta S,\delta a_w,\delta b_a]$ from the kinematic
+$[\delta v,\delta p]$ block.  When the accepted proxy/magnetic bounds, the two
+handoff-block bounds, and the declared bounded Live disturbance satisfy
+Eq.~\eqref{eq:semiglobal-basin-entry}, the handoff enters the invariant
+sensitive tube of Theorem~\ref{thm:iss-block-local}, and
+Theorem~\ref{thm:semiglobal-proxy-live} applies.  A timeout-forced handoff that
+does not independently satisfy Eq.~\eqref{eq:semiglobal-basin-entry} remains
 outside the semiglobal result.
 
 \subsection{Two-stage magnetic reference}

--- a/doc/kalman_ou_iii/w3d-init.tex-part
+++ b/doc/kalman_ou_iii/w3d-init.tex-part
@@ -60,7 +60,8 @@ $[\delta\theta,\delta b_g,\delta S,\delta a_w,\delta b_a]$ from the kinematic
 $[\delta v,\delta p]$ block.  When the accepted proxy/magnetic bounds, the two
 handoff-block bounds, and the declared bounded Live disturbance satisfy
 Eq.~\eqref{eq:semiglobal-basin-entry}, the handoff enters the invariant
-sensitive tube of Theorem~\ref{thm:iss-block-local}, and
+sensitive tube of the block-local ISS theorem,
+Theorem~\ref{thm:iss-block-local}, and
 Theorem~\ref{thm:semiglobal-proxy-live} applies.  A timeout-forced handoff that
 does not independently satisfy Eq.~\eqref{eq:semiglobal-basin-entry} remains
 outside the semiglobal result.

--- a/doc/kalman_ou_iii/w3d-semiglobal-stability.tex-part
+++ b/doc/kalman_ou_iii/w3d-semiglobal-stability.tex-part
@@ -1,18 +1,22 @@
+\input{w3d-block-local-iss.tex-part}
+
 \section{Almost-Global Startup Capture and Semiglobal Practical Extension}
 \label{sec:semiglobal-stability}
 
 The Live-state result of Sec.~\ref{app:iss-stability} is necessarily local in
 MEKF coordinates: the attitude error is represented by a three-vector chart and
 the nonlinear remainder is absorbed only inside an invariant neighborhood.
-The deployed estimator nevertheless does not ask the MEKF itself to recover
-from an arbitrary startup attitude.  Before handoff, the MEKF is untouched and
-a measurement-only Mahony observer supplies tilt while the magnetic-reference
-logic establishes the yaw gauge.  This section uses that architecture to extend
-the result from a local Live theorem to an almost-global, semiglobal practical
-proxy-to-Live statement.  ``Semiglobal'' means uniformity on any prescribed
-compact startup set contained in the desired proxy domain of attraction; it
-does not claim semiglobal convergence of an already-running MEKF from arbitrary
-21-state errors.
+Theorem~\ref{thm:iss-21-local} gives a convenient sufficient 21-state ball,
+while Theorem~\ref{thm:iss-block-local} sharpens that ball using the exact
+measurement and reset structure.  The deployed estimator nevertheless does not
+ask the MEKF itself to recover from an arbitrary startup attitude.  Before
+handoff, the MEKF is untouched and a measurement-only Mahony observer supplies
+tilt while the magnetic-reference logic establishes the yaw gauge.  This
+section uses that architecture to extend the result from a local Live theorem
+to an almost-global, semiglobal practical proxy-to-Live statement.
+``Semiglobal'' means uniformity on any prescribed compact startup set contained
+in the desired proxy domain of attraction; it does not claim semiglobal
+convergence of an already-running MEKF from arbitrary 21-state errors.
 
 \subsection{Compatibility with the deployed physical-MSE schedule}
 \label{sec:semiglobal-mse-schedule}
@@ -172,7 +176,7 @@ the bound is uniform on every prescribed compact subset of $\mathcal D_P$, but
 its constants need not remain uniform as that set approaches
 $\mathcal N_P$.
 
-\subsection{Quality gate as a basin-entry map}
+\subsection{Quality gate as a block-structured basin-entry map}
 \label{sec:semiglobal-handoff}
 
 The proxy is not required to converge asymptotically before handoff.  It need
@@ -229,31 +233,73 @@ Thus, provided $\overline\theta_H<\pi$, the principal MEKF attitude-error
 coordinate exists at handoff and satisfies
 $\|\delta\vct\theta_H\|\le\overline\theta_H$.
 
-Let $\vct e_{E,H}$ collect the remaining handoff errors in gyro bias,
-$v,p,S,a_w$, and residual accelerometer bias, and suppose the physical startup
-scenario gives the finite bound
+For the remaining sensitive coordinates, suppose the physical startup family
+provides finite bounds
 \begin{equation}
-\|\vct e_{E,H}\|\le B_H.
-\label{eq:semiglobal-handoff-E}
+\|\delta\vct b_{g,H}\|\le B_{g,H},\quad
+\|\delta\vct S_H\|\le B_{S,H},\quad
+\|\delta\vct a_{w,H}\|\le B_{aw,H},\quad
+\|\delta\vct b_{a,H}\|\le B_{a,H},
+\label{eq:semiglobal-handoff-sensitive-bounds}
 \end{equation}
-Let $r$ be any invariant Live radius admitted by the proof of
-Theorem~\ref{thm:iss-21-local}.  A sufficient basin-entry condition is
+and let
 \begin{equation}
-r_H:=\sqrt{\overline\theta_H^2+B_H^2}<r.
+\|\delta\vct v_H\|\le B_{v,H},\qquad
+\|\delta\vct p_H\|\le B_{p,H}
+\label{eq:semiglobal-handoff-kinematic-bounds}
+\end{equation}
+bound the kinematic-only coordinates.  With the fixed scales of
+Eqs.~\eqref{eq:iss-block-xi}--\eqref{eq:iss-block-ell}, define the dimensionless
+handoff bounds
+\begin{align}
+B_{\xi,H}
+&:=\left[
+ \left(\frac{\overline\theta_H}{s_\theta}\right)^2
+ +\left(\frac{B_{g,H}}{s_{bg}}\right)^2
+ +\left(\frac{B_{S,H}}{s_S}\right)^2
+ +\left(\frac{B_{aw,H}}{s_{aw}}\right)^2
+ +\left(\frac{B_{a,H}}{s_{ba}}\right)^2
+ \right]^{1/2},\\
+B_{\ell,H}
+&:=\left[
+ \left(\frac{B_{v,H}}{s_v}\right)^2
+ +\left(\frac{B_{p,H}}{s_p}\right)^2
+ \right]^{1/2}.
+\label{eq:semiglobal-handoff-block-bounds}
+\end{align}
+Then $\|\vct z_{\xi,H}\|\le B_{\xi,H}$ and
+$\|\vct z_{\ell,H}\|\le B_{\ell,H}$.
+
+Let $\overline d_L$ bound the deterministic Live disturbance on the certified
+interval.  Choose the sensitive-tube radius $r$ and small-gain margin $\nu$ of
+Theorem~\ref{thm:iss-block-local}.  A sufficient block-structured basin-entry
+condition is
+\begin{equation}
+\boxed{
+r_H^{\rm blk}:=
+M_{\xi\xi}B_{\xi,H}
++M_{\xi\ell}B_{\ell,H}
++\frac{M_\xi\overline G_z}{1-\rho}\,\overline d_L
+<(1-\nu)r .}
 \label{eq:semiglobal-basin-entry}
 \end{equation}
-This condition is deliberately explicit.  The proxy removes the almost-global
-attitude-initialization obstruction; it does not manufacture a theorem for
-arbitrarily large translational or bias errors at handoff.  Those states must
-enter the same local Live neighborhood required by the existing 21-state
-nonlinear remainder bound.
+This replaces the earlier unscaled 21-state Euclidean-ball condition.  It does
+not require $v$ and $p$ themselves to lie inside the same local radius as the
+nonlinear coordinates; only their induced homogeneous transient into the
+sensitive block is charged through $M_{\xi\ell}$.  The result is not a claim of
+arbitrarily large translational capture: $M_{\xi\ell}$ is generally nonzero,
+and $S$ remains in the sensitive block because its pseudo-measurement can
+produce an attitude correction through Kalman cross-covariance.  This is the
+block separation supported by the deployed architecture without changing the
+filter.
 
 \begin{theorem}[Almost-global/semiglobal practical proxy-to-Live ISS]
 \label{thm:semiglobal-proxy-live}
 Fix a compact $\mathcal K_{\epsilon,B_\beta}\subset\mathcal D_P$ as in
 Eq.~\eqref{eq:semiglobal-proxy-compact} and a compact family of physical startup
-conditions satisfying Eqs.~\eqref{eq:semiglobal-proxy-force-bound} and
-\eqref{eq:semiglobal-handoff-E}.  Assume:
+conditions satisfying Eqs.~\eqref{eq:semiglobal-proxy-force-bound},
+\eqref{eq:semiglobal-handoff-sensitive-bounds}, and
+\eqref{eq:semiglobal-handoff-kinematic-bounds}.  Assume:
 (i) the reduced proxy initial error belongs to
 $\mathcal K_{\epsilon,B_\beta}$;
 (ii) the bounded proxy perturbation and sample step are small enough for
@@ -265,25 +311,27 @@ Live observability hypothesis, a noncollinear magnetic or equivalent vector
 reference---become ready within a finite time uniform over the chosen startup
 family, with heading error bounded as in
 Eq.~\eqref{eq:semiglobal-handoff-attitude};
-(v) the basin-entry inequality \eqref{eq:semiglobal-basin-entry} holds; and
-(vi) after handoff, the hypotheses of
-Theorems~\ref{thm:iss-21-ues} and \ref{thm:iss-21-local} hold, including the
-bounded predictable SpectralMSE schedule and no hard reset on the analyzed Live
-interval.  Then there is a finite handoff index $k_H$, uniform over the chosen
-compact startup family, and constants $C\ge1$, $0<\lambda<1$, and
-$\Gamma<\infty$ such that for every $k\ge k_H$,
+(v) the block basin-entry inequality \eqref{eq:semiglobal-basin-entry} holds for
+a declared Live disturbance bound $\overline d_L$; and
+(vi) after handoff, the hypotheses of Theorems~\ref{thm:iss-21-ues} and
+\ref{thm:iss-block-local} hold, including the bounded predictable SpectralMSE
+schedule and no hard reset on the analyzed Live interval.  Then there is a
+finite handoff index $k_H$, uniform over the chosen compact startup family, and
+constants $C_z\ge1$, $0<\lambda_z<1$, and $\Gamma_z<\infty$ such that for every
+$k\ge k_H$,
 \begin{equation}
 \boxed{
-\|\vct e_k\|
-\le C\lambda^{k-k_H}r_H
- +\Gamma\sup_{k_H\le i<k}\|\vct d_i\| .}
+\|\vct z_k\|
+\le C_z\lambda_z^{k-k_H}
+ \bigl(B_{\xi,H}+B_{\ell,H}\bigr)
+ +\Gamma_z\sup_{k_H\le i<k}\|\vct d_i\| .}
 \label{eq:semiglobal-live-bound}
 \end{equation}
 For zero Live disturbance and exact accepted references, the post-handoff error
 converges to zero.  For bounded deterministic disturbance,
 \begin{equation}
-\limsup_{k\to\infty}\|\vct e_k\|
-\le\Gamma\|\vct d\|_\infty.
+\limsup_{k\to\infty}\|\vct z_k\|
+\le\Gamma_z\|\vct d\|_\infty.
 \label{eq:semiglobal-ultimate-bound}
 \end{equation}
 Because every compact subset of the almost-global domain $\mathcal D_P$ is
@@ -309,10 +357,12 @@ $T_A$ for the remaining handoff channels and bounds yaw.  Hence an accepted
 handoff exists no later than a finite family-dependent bound formed from
 $T_P$ and $T_A$, subject to the timeout qualification below, and
 Eq.~\eqref{eq:semiglobal-handoff-attitude} bounds the complete attitude error at
-that handoff.  Together with Eq.~\eqref{eq:semiglobal-handoff-E}, assumption
-(v) gives $\|\vct e_{k_H}\|\le r_H<r$.  Therefore the handoff lands inside the
-invariant neighborhood used in Theorem~\ref{thm:iss-21-local}.  Applying
-Eq.~\eqref{eq:iss-local-bound} from $j=k_H$ gives
+that handoff.  Equations~\eqref{eq:semiglobal-handoff-sensitive-bounds}--
+\eqref{eq:semiglobal-handoff-block-bounds} then give the two scaled handoff
+bounds.  Assumption (v) is exactly the invariant-tube entrance condition of
+Theorem~\ref{thm:iss-block-local}, so the handoff enters the sensitive Live tube
+even when the admissible $v,p$ block is larger than that tube.  Applying
+Eq.~\eqref{eq:iss-block-local-bound} from $j=k_H$ gives
 Eq.~\eqref{eq:semiglobal-live-bound}; taking the limit superior gives
 Eq.~\eqref{eq:semiglobal-ultimate-bound}.  Finally, the almost-global proxy
 result makes $\mathcal N_P$ measure zero, while the argument above is uniform
@@ -332,10 +382,10 @@ independently satisfies Eqs.~\eqref{eq:semiglobal-aligned-branch} and
 timeout-forced handoff until Eq.~\eqref{eq:semiglobal-aligned-branch} holds, so
 the branch half of that qualification is enforced rather than assumed; because
 the antipodal set is not attracting for the accel-corrected proxy, this delays
-the forced handoff by a bounded interval rather than suppressing it.  The forced
-path does not test the residual magnitude, so it certifies the branch and not
-the tilt bound of Eq.~\eqref{eq:semiglobal-handoff-tilt}: a timeout-forced
-handoff that does not independently satisfy
+the forced handoff by a bounded interval rather than suppressing it.  The
+forced path does not test the residual magnitude, so it certifies the branch
+and not the tilt bound of Eq.~\eqref{eq:semiglobal-handoff-tilt}: a
+timeout-forced handoff that does not independently satisfy
 Eq.~\eqref{eq:semiglobal-basin-entry} is outside the theorem.
 
 \paragraph{Implementation note on the branch certificate}

--- a/tests/validation/test_ou_semiglobal_stability.py
+++ b/tests/validation/test_ou_semiglobal_stability.py
@@ -55,7 +55,7 @@ class OUIIISemiglobalStabilityContractTests(unittest.TestCase):
             r"\label{eq:semiglobal-basin-entry}",
         ):
             self.assertIn(marker, proof)
-        self.assertIn("does not claim semiglobal convergence", proof)
+        self.assertIn("does not claim semiglobal convergence", _flat(proof))
 
     def test_phase1_uses_block_structured_dimensionless_live_basin(self):
         block = _read("w3d-block-local-iss.tex-part")

--- a/tests/validation/test_ou_semiglobal_stability.py
+++ b/tests/validation/test_ou_semiglobal_stability.py
@@ -57,6 +57,41 @@ class OUIIISemiglobalStabilityContractTests(unittest.TestCase):
             self.assertIn(marker, proof)
         self.assertIn("does not claim semiglobal convergence", proof)
 
+    def test_phase1_uses_block_structured_dimensionless_live_basin(self):
+        block = _read("w3d-block-local-iss.tex-part")
+        semiglobal = _read("w3d-semiglobal-stability.tex-part")
+
+        self.assertTrue(
+            semiglobal.startswith(r"\input{w3d-block-local-iss.tex-part}"),
+            "block-local refinement must be inserted before Section XII",
+        )
+        for marker in (
+            r"\label{lem:iss-block-remainder}",
+            r"\label{thm:iss-block-local}",
+            r"\label{eq:iss-block-basin}",
+            r"\delta\vct S",
+            r"\delta\vct v",
+            r"\delta\vct p",
+            r"M_{\xi\ell}",
+        ):
+            self.assertIn(marker, block)
+
+        self.assertIn("dimensionless", block)
+        self.assertIn("no direct dependence on", block)
+        self.assertIn("does \\emph{not} certify arbitrarily large", block)
+        self.assertIn("Nor does it remove $S$ from", block)
+
+        for marker in (
+            r"B_{\xi,H}",
+            r"B_{\ell,H}",
+            r"M_{\xi\ell}B_{\ell,H}",
+            r"\overline d_L",
+            r"\ref{thm:iss-block-local}",
+        ):
+            self.assertIn(marker, semiglobal)
+        self.assertIn("replaces the earlier unscaled 21-state Euclidean-ball condition", semiglobal)
+        self.assertIn("$S$ remains in the sensitive block", semiglobal)
+
     def test_implemented_handoff_and_timeout_are_part_of_scope(self):
         proof = _read("w3d-semiglobal-stability.tex-part")
         startup = _read("w3d-init.tex-part")

--- a/tests/validation/test_ou_semiglobal_stability.py
+++ b/tests/validation/test_ou_semiglobal_stability.py
@@ -77,6 +77,8 @@ class OUIIISemiglobalStabilityContractTests(unittest.TestCase):
             self.assertIn(marker, block)
 
         self.assertIn("dimensionless", block)
+        self.assertIn("post-prediction, pre-correction", block)
+        self.assertIn("uniform bounds on both", block)
         self.assertIn("no direct dependence on", block)
         self.assertIn("does \\emph{not} certify arbitrarily large", block)
         self.assertIn("Nor does it remove $S$ from", block)


### PR DESCRIPTION
Phase 1 of the semiglobal handoff-certification work.

This PR is based on current `main` (`e9bfbb2691465844102a139d9f744ffa2baabe59`) and changes the manuscript/proof only; production filter code is unchanged.

Key result:
- introduce a fixed dimensionless scaling of the 21-state error;
- prove that the nonlinear remainder depends directly on the 15-state sensitive block `[δθ, δb_g, δS, δa_w, δb_a]` and not directly on the 6-state kinematic block `[δv, δp]`;
- derive a block-local ISS entrance condition with a finite cross-transient gain `M_{ξℓ}` from initial `v,p` error into the sensitive tube;
- retain `S` in the local block because the `S=0` pseudo-update can couple into attitude through Kalman cross-covariance and the quaternion reset;
- replace the old unscaled 21-state Euclidean handoff ball in the semiglobal theorem with the dimensionless block condition, including the declared bounded Live disturbance margin;
- update startup prose and add a semantic publication contract for the new proof structure.

The result deliberately does **not** claim arbitrary `v,p` capture. It removes the requirement that `v,p` themselves lie inside the same nonlinear local radius; their induced homogeneous transient is still bounded by `M_{ξℓ}`. Numerical certification of the scales/gains/radius is intentionally deferred to the next phase.