### PR TITLE
Experiment (negative result): Schmidt-style restricted gain for the S=0 pseudo-measurement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ vertical_accel_drift_*.csv
 tests/*/*-sim
 tests/*/*-test
 tests/freq/freq-track
+tests/kalman_ou_iii/live_basin_diagnostic
 tests/pii_observer/pii_observer-adaptive
 tests/wave_sim/wave-convention-check
 

--- a/doc/kalman_ou_iii/w3d-post-results-investigations.tex-part
+++ b/doc/kalman_ou_iii/w3d-post-results-investigations.tex-part
@@ -14,3 +14,4 @@ adaptation law.
 \input{w3d-adaptation-coefficient-investigation.tex-part}
 \input{w3d-full-state-h2.tex-part}
 \input{w3d-full-state-h2-scaling.tex-part}
+\input{w3d-restricted-s-gain-ablation.tex-part}

--- a/doc/kalman_ou_iii/w3d-restricted-s-gain-ablation.tex-part
+++ b/doc/kalman_ou_iii/w3d-restricted-s-gain-ablation.tex-part
@@ -1,0 +1,120 @@
+\subsection{Restricted-Gain Ablation of the Integral Pseudo-Measurement}
+\label{sec:restricted-s-gain-ablation}
+
+Section~\ref{sec:iss-block-basin} keeps $S$ inside the sensitive block
+$\vct z_\xi$ precisely because the Kalman gain of the linear $S=0$
+pseudo-measurement \eqref{eq:zero-pseudo} acquires attitude rows through the
+cross-covariance,
+\begin{equation}
+\mat E_\theta\mat K_S
+=\mat P_{\theta S}\left(\mat P_{SS}+\mat R_S\right)^{-1},
+\label{eq:restricted-s-gain-rows}
+\end{equation}
+so that an integral-channel residual produces an $SO(3)$ injection with a
+quadratic reset remainder.  That injection is priced by $a_S$ in
+\eqref{eq:iss-cert-angle-gains} and therefore enters both $c_\xi$
+\eqref{eq:iss-cert-cxi} and the certified radius $r_\xi$
+\eqref{eq:iss-cert-rxi}.  It is natural to ask whether the certificate can be
+improved simply by removing that path.
+
+\paragraph{The restricted update}
+The ablation applies a Schmidt-style restricted gain to the $S$ update alone,
+\begin{equation}
+\widetilde{\mat K}_S:=\left(\Id-\mat E_\theta^\top\mat E_\theta\right)\mat K_S,
+\qquad\text{so}\qquad
+\mat E_\theta\widetilde{\mat K}_S=0
+\label{eq:restricted-s-gain}
+\end{equation}
+exactly, whence $a_S=0$.  The restriction is applied to the gain only, never to
+$\mat P\mat H_S^\top$: freezing the mean correction is not the same as deleting
+the covariance, and asserting $\mat P_{\theta S}=0$ would be a different and
+false claim.  Consequently the optimal-gain shortcut is no longer available and
+the covariance must use the general-gain Joseph form
+\begin{equation}
+\mat P^{+}
+=\left(\Id-\widetilde{\mat K}_S\mat H_S\right)\mat P
+ \left(\Id-\widetilde{\mat K}_S\mat H_S\right)^{\top}
++\widetilde{\mat K}_S\mat R_S\widetilde{\mat K}_S^{\top},
+\label{eq:restricted-s-joseph}
+\end{equation}
+which remains symmetric and positive semidefinite for \emph{any} gain, optimal
+or not.  Everything else --- prediction, the OU model, the adaptation law,
+tuning, cadence, the accelerometer and magnetometer updates, state ordering,
+initialization, and quaternion conventions --- is unchanged.
+
+\paragraph{Outcome}
+The ablation fails, and it fails in both the certificate and the error metrics.
+Table~\ref{tab:restricted-s-gain} reports the certificate diagnostic over the
+eight reference records.  The intended gain is realized --- $\|\mat E_\theta
+\mat K_S\|_2$ is identically zero on every record --- but every quantity that
+matters degrades.  The attitude scale $\sigma_\theta$ inflates by a factor of
+$4.7$--$5.2$, the accelerometer gain's attitude rows
+$\|\mat E_\theta\mat K_a\|_2$ inflate by two to three orders of magnitude, and
+the effective nonlinear coefficient $c_{\rm eff}$ degrades from $29.3$ to
+$2.12\times10^{4}$, a factor of $726$.  The certified radius $r_\xi$ contracts
+from $88.0$ to $14.7$ and the Live-entrance budget collapses by the same
+$714\times$.
+
+\begin{table}[t]
+  \centering
+  \caption{Restricted-gain ablation, worst value over the eight reference
+  records.  ``Deployed'' is the unrestricted gain; ``Restricted'' imposes
+  \eqref{eq:restricted-s-gain}.}
+  \label{tab:restricted-s-gain}
+  \footnotesize
+  \setlength{\tabcolsep}{4pt}
+  \begin{tabular}{@{}lrr@{}}
+    \toprule
+    Quantity & Deployed & Restricted \\
+    \midrule
+    $\|\mat E_\theta\mat K_S\|_2$      & $2.66\times10^{-4}$ & $0$ \\
+    $\|\mat E_\theta\mat K_a\|_2$      & $1.37\times10^{-4}$ & $1.68\times10^{-2}$ \\
+    $\sigma_\theta$                    & $1.11\times10^{-2}$ & $5.27\times10^{-2}$ \\
+    $\Gamma_\theta$                    & $1.35\times10^{7}$  & $4.37\times10^{7}$ \\
+    $c_{\rm eff}$                      & $29.3$              & $2.12\times10^{4}$ \\
+    $r_\xi$                            & $88.0$              & $14.7$ \\
+    Live budget                        & $8.39\times10^{-3}$ & $1.17\times10^{-5}$ \\
+    \bottomrule
+  \end{tabular}
+\end{table}
+
+\paragraph{Why the trade is unfavourable}
+The premise of the ablation is that the $S\!\to\!\theta$ path is a parasitic
+nonlinearity.  It is not.  A tilt error rotates the gravity vector into the
+horizontal channels, producing a persistent spurious specific-force component
+that integrates into $\vct v$, then $\vct p$, then $S$; the integral state is
+therefore a very-long-baseline observer of tilt, and $\mat P_{\theta S}$ is the
+channel through which that observation reaches attitude.  Equation
+\eqref{eq:restricted-s-gain} discards it.
+
+The work does not disappear when the channel is closed --- it migrates.  With
+the slow tilt information withheld, the attitude covariance is no longer
+reduced by the $S$ update, $\sigma_\theta$ inflates, and the accelerometer
+update must carry the entire tilt correction on its own.  Because
+$a_a=\|\mat E_\theta\mat K_a\|_2(f_1s_\theta+s_{aw}+s_{ba})$ is driven by both
+factors, and both grow, $c_{\rm grp}$ grows far more than the deleted $a_S$
+term ever contributed.  The numbers make the asymmetry concrete: at the calmest
+record the deleted term was $\|\mat E_\theta\mat K_S\|_2=2.62\times10^{-4}$
+while the inflated one went from $6.66\times10^{-6}$ to $6.02\times10^{-3}$.
+Deleting a term worth $2.6\times10^{-4}$ cost three orders of magnitude on a
+term that had been negligible.
+
+\paragraph{Empirical confirmation}
+The estimator degrades accordingly.  With tuning held fixed --- the applied
+$\tau$, $\sigma_{aw}$, and $R_S$ are bit-identical on all eight records, so the
+adaptation law is not confounding the comparison --- every quality gate that
+passes under the deployed gain fails under the restricted gain.  Three-dimensional
+displacement RMS worsens by \pct{161}--\pct{539} on seven records, gyro-bias
+error by \pct{93}--\pct{850}, and pitch RMS by up to \pct{972}.  On the
+roughest PM record the filter effectively loses lock, reaching \SI{100.7}{m}
+3-D RMS and \SI{76.4}{\degree} yaw RMS.
+
+\paragraph{Conclusion}
+The attitude rows of $\mat K_S$ are load-bearing rather than parasitic, and the
+certificate cannot be improved by deleting them.  This strengthens rather than
+weakens the argument of Section~\ref{sec:iss-block-basin}: $S$ belongs in the
+sensitive block not merely as a conservative bookkeeping choice, but because the
+coupling it carries is doing estimation work.  A tighter certificate must come
+from bounding that coupling more sharply, not from severing it.  The restricted
+gain is documented here as a negative result and is not part of the deployed
+estimator.

--- a/src/kalman_ou_iii/Kalman3D_Wave_OU_III.h
+++ b/src/kalman_ou_iii/Kalman3D_Wave_OU_III.h
@@ -959,6 +959,22 @@ class Kalman3D_Wave_OU_III {
         }
     }
 
+    /*
+      Schmidt-style restriction: the attitude error state receives no
+      correction from this measurement.
+
+      Applied to the gain only, never to P C^T.  The two are different objects
+      and only the gain is being restricted: the Joseph update still needs the
+      true cross covariance to propagate the effect of the correction that the
+      other states did receive.  Zeroing P C^T as well would additionally
+      assert that the attitude is uncorrelated with the measured state, which
+      is a different (and false) claim -- freezing the mean correction is not
+      the same as deleting the covariance.
+    */
+    EIGEN_STRONG_INLINE void freeze_attitude_rows_(MatrixNX3& M) const {
+        M.template block<3,3>(0, 0).setZero();
+    }
+
     // Steady wind heel model (roll about BODY X)
     // wind_heel_rad_ : current steady heel in radians (hull frame)
     // Internally we work in a virtual "un-heeled" body frame B'
@@ -2400,10 +2416,39 @@ void Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::applyIntegralZero
         if (!acc_bias_updates_enabled_) freeze_acc_bias_rows_(K);
     }
 
+    /*
+      Restricted (Schmidt-style) gain: E_theta K_S = 0 exactly.
+
+      S=0 is a translational regularizer -- it asserts that the running
+      integral of displacement has zero mean, and it observes S and nothing
+      else.  The ordinary gain nevertheless corrects attitude through the
+      cross covariance,
+          K_{theta S} = P_{theta S} (P_SS + R_S)^{-1},
+      and that indirect path is not free: it makes an integral-channel
+      residual drive an SO(3) injection, which is the dominant nonlinear term
+      in the Live-basin certificate.  Direct attitude observation is the
+      accelerometer's and magnetometer's job and neither is touched here.
+
+      This is a deliberate restricted-gain estimator, not the unconstrained
+      minimum-covariance Kalman update for this measurement.  The covariance
+      update below is therefore the general-gain Joseph form, which
+      joseph_update3_() already implements: it forms
+          P - K C P - (K C P)^T + K (C P C^T + R) K^T,
+      which is exactly (I-KC)P(I-KC)^T + K R K^T for *any* K.  The optimal-gain
+      shortcut P <- (I-KC)P would be wrong once K is no longer optimal.
+    */
+    freeze_attitude_rows_(K);
+
     xext.noalias() += K * r;            // State update
     joseph_update3_(K, S_mat, PCt);     // Covariance update
 
-    // Apply quaternion correction (attitude may get nudged via cross-covariances)
+    // No attitude injection can come from this measurement: the error state's
+    // attitude block is untouched above, so it is still the zero left behind
+    // by the previous update's reset.  The call is kept rather than skipped so
+    // the reset path stays uniform across measurements -- with dtheta = 0 the
+    // quaternion composition is the identity and apply_left_error_reset()
+    // early-returns, so this is an exact no-op on both qref and Pext, while
+    // the accelerometer-bias projection still runs as it does elsewhere.
     applyQuaternionCorrectionFromErrorState();
 }
 

--- a/tests/kalman_ou_iii/Makefile
+++ b/tests/kalman_ou_iii/Makefile
@@ -21,7 +21,7 @@ LDFLAGS  =
 # Tell make to look for source files in src/util
 VPATH = $(REPO_ROOT)/src/util
 
-TARGETS = kalman_ou_iii-sim kalman_ou_common-test aw_covariance_policy-test acc_bias_ou-test channel_freeze-test wave_period-test mag_hard_iron-test continuous_mag_hard_iron-test tuner_coupling-test tuner_schedule-test wave_band_sigma-test iss_contract-test live_basin_diagnostic rs_law-test startup_init-test
+TARGETS = kalman_ou_iii-sim kalman_ou_common-test aw_covariance_policy-test acc_bias_ou-test channel_freeze-test wave_period-test mag_hard_iron-test continuous_mag_hard_iron-test tuner_coupling-test tuner_schedule-test wave_band_sigma-test iss_contract-test live_basin_diagnostic schmidt_s_pseudo-test rs_law-test startup_init-test
 
 all: build test
 
@@ -75,6 +75,9 @@ iss_contract-test: iss_contract-test.o
 	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
 
 live_basin_diagnostic: live_basin_diagnostic.o
+	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
+
+schmidt_s_pseudo-test: schmidt_s_pseudo-test.o
 	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
 
 rs_law-test: rs_law-test.o

--- a/tests/kalman_ou_iii/run_tests.sh
+++ b/tests/kalman_ou_iii/run_tests.sh
@@ -13,6 +13,7 @@
 ./wave_band_sigma-test
 ./iss_contract-test
 ./live_basin_diagnostic
+./schmidt_s_pseudo-test
 python3 ../../tools/ou_live_basin_interval_proof.py --repo-root ../..
 ./rs_law-test
 ./startup_init-test

--- a/tests/kalman_ou_iii/schmidt_s_pseudo-test.cpp
+++ b/tests/kalman_ou_iii/schmidt_s_pseudo-test.cpp
@@ -1,0 +1,361 @@
+// Contract for the restricted (Schmidt-style) S=0 pseudo-measurement update.
+//
+// The S=0 pseudo-measurement is a translational regularizer: it asserts that
+// the running integral of displacement has zero mean, and it observes S and
+// nothing else.  The ordinary Kalman gain nevertheless corrects attitude
+// through the cross covariance,
+//
+//     K_{theta S} = P_{theta S} (P_SS + R_S)^{-1},
+//
+// which makes an integral-channel residual drive an SO(3) injection.  The
+// deployed update now freezes the attitude error state for this measurement,
+// so E_theta K_S = 0 exactly, and uses the general-gain Joseph covariance
+// update because the gain is no longer the minimum-covariance one.
+//
+// These tests pin that behaviour, and -- just as importantly -- pin that the
+// path being removed was really there, that every other S-gain row still
+// works, and that the accelerometer and magnetometer updates are untouched.
+#define EIGEN_NON_ARDUINO
+
+#include <cmath>
+#include <iostream>
+#include <string>
+
+#include <Eigen/Dense>
+#include <Eigen/Eigenvalues>
+#include <Eigen/Geometry>
+
+#define private public
+#include "kalman_ou_iii/Kalman3D_Wave_OU_III.h"
+#undef private
+
+namespace {
+
+using Core = Kalman3D_Wave_OU_III<double, true, true>;
+using Vec3 = Eigen::Vector3d;
+using Mat3 = Eigen::Matrix3d;
+using Mat21 = Eigen::Matrix<double, 21, 21>;
+using Mat21x3 = Eigen::Matrix<double, 21, 3>;
+
+constexpr int OFF_TH = 0;
+constexpr int OFF_BG = 3;
+constexpr int OFF_V  = 6;
+constexpr int OFF_P  = 9;
+constexpr int OFF_S  = 12;
+constexpr int OFF_AW = 15;
+constexpr int OFF_BA = 18;
+
+int failures = 0;
+
+void check(bool ok, const std::string& what) {
+    if (!ok) {
+        std::cerr << "FAIL: " << what << "\n";
+        ++failures;
+    }
+}
+
+void checkClose(double a, double b, double tol, const std::string& what) {
+    if (!(std::fabs(a - b) <= tol)) {
+        std::cerr << "FAIL: " << what << " (" << a << " vs " << b
+                  << ", tol " << tol << ")\n";
+        ++failures;
+    }
+}
+
+Core makeFilter() {
+    Core f(Vec3::Constant(0.0294), Vec3::Constant(0.000157), Vec3::Constant(0.36));
+    f.set_mag_world_ref(Vec3(20.5, 0.0, 44.0));
+    f.initialize_from_attitude(Eigen::Quaterniond::Identity(), 0.035, 0.087);
+    f.set_linear_block_enabled(true);
+    f.set_acc_bias_updates_enabled(true);
+    return f;
+}
+
+// A covariance with deliberately large attitude-S coupling, plus coupling from
+// every other block to S so the "other rows still act" test has something to
+// measure.  Built as M M^T + eps I so it is symmetric positive definite by
+// construction rather than by hope.
+Mat21 coupledCovariance() {
+    Mat21 M = Mat21::Zero();
+    for (int i = 0; i < 21; ++i) M(i, i) = 0.35;
+    // theta <-> S, deliberately strong.
+    for (int i = 0; i < 3; ++i) {
+        M(OFF_TH + i, OFF_S + i) = 0.9;
+        M(OFF_S + i, OFF_TH + i) = 0.9;
+    }
+    // Every other block also couples to S.
+    for (int i = 0; i < 3; ++i) {
+        M(OFF_BG + i, OFF_S + i) = 0.20;
+        M(OFF_V  + i, OFF_S + i) = 0.55;
+        M(OFF_P  + i, OFF_S + i) = 0.60;
+        M(OFF_AW + i, OFF_S + i) = 0.45;
+        M(OFF_BA + i, OFF_S + i) = 0.30;
+    }
+    Mat21 P = M * M.transpose();
+    P += Mat21::Identity() * 1e-3;
+    return 0.5 * (P + P.transpose());
+}
+
+// The gain the filter would have used before the restriction.
+Mat21x3 unconstrainedGain(const Mat21& P, const Mat3& R_S) {
+    const Mat3 S = P.block<3,3>(OFF_S, OFF_S) + R_S;
+    const Mat21x3 PCt = P.block<21,3>(0, OFF_S);
+    return PCt * S.inverse();
+}
+
+double minEigenvalue(const Mat21& P) {
+    Eigen::SelfAdjointEigenSolver<Mat21> es(P, Eigen::EigenvaluesOnly);
+    return es.eigenvalues()(0);
+}
+
+// ---------------------------------------------------------------- 1 + 2 ----
+void testAttitudeIsFrozenAndThePathWasReal() {
+    Core f = makeFilter();
+    f.Pext = coupledCovariance();
+    // Nonzero innovation: the update targets S = 0, so any nonzero S gives one.
+    f.xext.segment<3>(OFF_S) = Vec3(1.3, -0.7, 0.45);
+
+    const Mat21 P_before = f.Pext;
+    const Vec3 dtheta_before = f.xext.segment<3>(OFF_TH);
+    const Eigen::Quaterniond q_before = f.quaternion_boat();
+
+    // 2. The unconstrained gain really would have moved attitude, so the
+    //    regression below is exercising the path we intend to remove.
+    const Mat21x3 K_full = unconstrainedGain(P_before, f.R_S);
+    const double Ktheta_norm = K_full.block<3,3>(OFF_TH, 0).norm();
+    check(Ktheta_norm > 1e-3,
+          "the unconstrained S gain has no attitude rows to remove; the test "
+          "setup does not exercise the path");
+    const Vec3 dtheta_would_have_been =
+        K_full.block<3,3>(OFF_TH, 0) * (-f.xext.segment<3>(OFF_S));
+    check(dtheta_would_have_been.norm() > 1e-3,
+          "the unconstrained gain would not have corrected attitude here");
+
+    f.applyIntegralZeroPseudoMeas();
+
+    // 1. Attitude is frozen, in the error state and in the nominal quaternion.
+    const Vec3 dtheta_after = f.xext.segment<3>(OFF_TH);
+    checkClose((dtheta_after - dtheta_before).norm(), 0.0, 0.0,
+               "the restricted S update moved the attitude error state");
+    const Eigen::Quaterniond q_after = f.quaternion_boat();
+    Eigen::Quaterniond dq = q_before.conjugate() * q_after;
+    dq.normalize();
+    checkClose(std::fabs(dq.w()), 1.0, 1e-15,
+               "the restricted S update rotated the nominal quaternion");
+
+    std::cout << "SCHMIDT_S removed_attitude_gain_norm=" << Ktheta_norm
+              << " would_have_injected_rad=" << dtheta_would_have_been.norm()
+              << "\n";
+}
+
+// -------------------------------------------------------------------- 3 ----
+void testOtherRowsStillAct() {
+    Core f = makeFilter();
+    f.Pext = coupledCovariance();
+    const Vec3 S0(1.3, -0.7, 0.45);
+    f.xext.segment<3>(OFF_S) = S0;
+
+    const Mat21 P_before = f.Pext;
+    const Mat21x3 K_full = unconstrainedGain(P_before, f.R_S);
+    const Vec3 r = -S0;
+
+    Eigen::Matrix<double, 21, 1> x_before = f.xext;
+    f.applyIntegralZeroPseudoMeas();
+
+    struct Block { const char* name; int off; };
+    const Block blocks[] = {
+        {"S",   OFF_S},  {"p", OFF_P},  {"v", OFF_V},
+        {"a_w", OFF_AW}, {"b_g", OFF_BG}, {"b_a", OFF_BA},
+    };
+    for (const Block& b : blocks) {
+        const Vec3 expected = K_full.block<3,3>(b.off, 0) * r;
+        const Vec3 actual =
+            f.xext.segment<3>(b.off) - x_before.segment<3>(b.off);
+        check(expected.norm() > 1e-6,
+              std::string("test setup gives no ") + b.name + " correction");
+        checkClose((actual - expected).norm(), 0.0, 1e-12,
+                   std::string("the ") + b.name +
+                       " row of the S gain no longer acts as the ordinary gain");
+    }
+}
+
+// -------------------------------------------------------------------- 4 ----
+void testJosephCovarianceMatchesTheRestrictedGain() {
+    Core f = makeFilter();
+    f.Pext = coupledCovariance();
+    f.xext.segment<3>(OFF_S) = Vec3(0.8, 0.2, -1.1);
+
+    const Mat21 P_before = f.Pext;
+    Mat21x3 K = unconstrainedGain(P_before, f.R_S);
+    K.block<3,3>(OFF_TH, 0).setZero();          // the restriction under test
+
+    Eigen::Matrix<double, 3, 21> H = Eigen::Matrix<double, 3, 21>::Zero();
+    H.block<3,3>(0, OFF_S) = Mat3::Identity();
+
+    const Mat21 IKH = Mat21::Identity() - K * H;
+    const Mat21 expected =
+        IKH * P_before * IKH.transpose() + K * f.R_S * K.transpose();
+
+    f.applyIntegralZeroPseudoMeas();
+
+    // The reset is an exact no-op at dtheta = 0, so the filter covariance must
+    // be the general-gain Joseph form and nothing else.
+    const double err = (f.Pext - expected).cwiseAbs().maxCoeff();
+    checkClose(err, 0.0, 1e-10,
+               "the covariance is not (I-KH)P(I-KH)^T + K R K^T for the "
+               "restricted gain");
+
+    // And it is emphatically not the optimal-gain shortcut, which would be
+    // wrong for a restricted gain.
+    const Mat21 optimal_shortcut = IKH * P_before;
+    const double shortcut_gap =
+        (optimal_shortcut - expected).cwiseAbs().maxCoeff();
+    check(shortcut_gap > 1e-9,
+          "the two covariance forms coincide here, so this test cannot tell "
+          "them apart");
+
+    std::cout << "SCHMIDT_S joseph_max_abs_err=" << err
+              << " optimal_shortcut_gap=" << shortcut_gap << "\n";
+}
+
+// ----------------------------------------------------------------- 5 + 6 ----
+void testSymmetryAndPositiveSemidefiniteness() {
+    Core f = makeFilter();
+    f.Pext = coupledCovariance();
+
+    double worst_asym = 0.0;
+    double worst_min_eig = std::numeric_limits<double>::infinity();
+    for (int i = 0; i < 200; ++i) {
+        f.xext.segment<3>(OFF_S) =
+            Vec3(0.9 * std::cos(0.3 * i), 0.6 * std::sin(0.2 * i), 0.4);
+        f.applyIntegralZeroPseudoMeas();
+        worst_asym = std::max(worst_asym,
+                              (f.Pext - f.Pext.transpose()).cwiseAbs().maxCoeff());
+        worst_min_eig = std::min(worst_min_eig, minEigenvalue(f.Pext));
+    }
+    checkClose(worst_asym, 0.0, 1e-12,
+               "repeated restricted S updates broke covariance symmetry");
+    check(worst_min_eig > -1e-12,
+          "repeated restricted S updates drove the covariance indefinite");
+
+    std::cout << "SCHMIDT_S repeated_updates_worst_asymmetry=" << worst_asym
+              << " worst_min_eigenvalue=" << worst_min_eig << "\n";
+}
+
+// -------------------------------------------------------------------- 7 ----
+void testAccelAndMagStillCorrectAttitude() {
+    // Both keep the ordinary full gain, so both must still move attitude when
+    // given a residual that says the attitude is wrong.
+    {
+        Core f = makeFilter();
+        const Eigen::Quaterniond q_before = f.quaternion_boat();
+        // A specific force tilted away from the filter's idea of down.
+        f.measurement_update_acc_only(Vec3(1.5, -0.9, -9.6), 35.0);
+        Eigen::Quaterniond dq = q_before.conjugate() * f.quaternion_boat();
+        dq.normalize();
+        check(std::fabs(dq.w()) < 1.0 - 1e-12,
+              "the accelerometer update no longer corrects attitude");
+    }
+    {
+        Core f = makeFilter();
+        const Eigen::Quaterniond q_before = f.quaternion_boat();
+        // A field rotated about down, which is a pure heading residual.
+        const double c = std::cos(0.25), s = std::sin(0.25);
+        f.measurement_update_mag_only(Vec3(20.5 * c, -20.5 * s, 44.0));
+        Eigen::Quaterniond dq = q_before.conjugate() * f.quaternion_boat();
+        dq.normalize();
+        check(std::fabs(dq.w()) < 1.0 - 1e-12,
+              "the magnetometer update no longer corrects attitude");
+    }
+}
+
+// -------------------------------------------------------------------- 8 ----
+void testPredictionStillCouplesStates() {
+    // The freeze applies to the S correction only.  Prediction must still let
+    // attitude evolve, and must still rebuild the theta-S coupling the update
+    // did not delete.
+    Core f = makeFilter();
+    f.Pext = coupledCovariance();
+    const Eigen::Quaterniond q0 = f.quaternion_boat();
+
+    f.xext.segment<3>(OFF_S) = Vec3(1.0, -0.5, 0.3);
+    f.applyIntegralZeroPseudoMeas();
+
+    const double coupling_after_update =
+        f.Pext.block<3,3>(OFF_TH, OFF_S).norm();
+    check(coupling_after_update > 0.0,
+          "the restricted update zeroed P_theta_S; freezing the mean "
+          "correction must not delete the covariance");
+
+    for (int i = 0; i < 50; ++i) {
+        f.time_update(Vec3(0.05, -0.02, 0.01), 0.005);
+    }
+    Eigen::Quaterniond dq = q0.conjugate() * f.quaternion_boat();
+    dq.normalize();
+    check(std::fabs(dq.w()) < 1.0 - 1e-9,
+          "attitude no longer evolves through prediction");
+
+    std::cout << "SCHMIDT_S P_theta_S_after_restricted_update="
+              << coupling_after_update << "\n";
+}
+
+// Cross-covariance behaviour the PR has to report on.
+void reportCrossCovariances() {
+    auto run = [](bool restricted) {
+        Core f = makeFilter();
+        f.Pext = coupledCovariance();
+        for (int i = 0; i < 200; ++i) {
+            f.xext.segment<3>(OFF_S) =
+                Vec3(0.9 * std::cos(0.3 * i), 0.6 * std::sin(0.2 * i), 0.4);
+            if (restricted) {
+                f.applyIntegralZeroPseudoMeas();
+            } else {
+                // Reproduce the pre-change update: ordinary gain, same Joseph
+                // form, same reset path.
+                const Mat3 S = f.Pext.block<3,3>(OFF_S, OFF_S) + f.R_S;
+                const Mat21x3 PCt = f.Pext.block<21,3>(0, OFF_S);
+                const Mat21x3 K = PCt * S.inverse();
+                const Vec3 r = -f.xext.segment<3>(OFF_S);
+                f.xext.noalias() += K * r;
+                f.joseph_update3_(K, S, PCt);
+                f.applyQuaternionCorrectionFromErrorState();
+            }
+        }
+        return f.Pext;
+    };
+    const Mat21 P_old = run(false);
+    const Mat21 P_new = run(true);
+    auto blk = [](const Mat21& P, int a, int b) {
+        return P.block<3,3>(a, b).norm();
+    };
+    std::cout << "SCHMIDT_S_XCOV block,unrestricted,restricted\n"
+              << "SCHMIDT_S_XCOV P_theta_S," << blk(P_old, OFF_TH, OFF_S)
+              << "," << blk(P_new, OFF_TH, OFF_S) << "\n"
+              << "SCHMIDT_S_XCOV P_theta_aw," << blk(P_old, OFF_TH, OFF_AW)
+              << "," << blk(P_new, OFF_TH, OFF_AW) << "\n"
+              << "SCHMIDT_S_XCOV P_theta_p," << blk(P_old, OFF_TH, OFF_P)
+              << "," << blk(P_new, OFF_TH, OFF_P) << "\n"
+              << "SCHMIDT_S_XCOV P_aw_S," << blk(P_old, OFF_AW, OFF_S)
+              << "," << blk(P_new, OFF_AW, OFF_S) << "\n"
+              << "SCHMIDT_S_XCOV P_theta_theta," << blk(P_old, OFF_TH, OFF_TH)
+              << "," << blk(P_new, OFF_TH, OFF_TH) << "\n";
+}
+
+}  // namespace
+
+int main() {
+    testAttitudeIsFrozenAndThePathWasReal();
+    testOtherRowsStillAct();
+    testJosephCovarianceMatchesTheRestrictedGain();
+    testSymmetryAndPositiveSemidefiniteness();
+    testAccelAndMagStillCorrectAttitude();
+    testPredictionStillCouplesStates();
+    reportCrossCovariances();
+
+    if (failures) {
+        std::cerr << failures << " restricted-S contract(s) failed\n";
+        return 1;
+    }
+    std::cout << "SCHMIDT_S_PSEUDO all contracts hold\n";
+    return 0;
+}


### PR DESCRIPTION
**Negative result. This PR is an experiment, and it should not be merged.**

The restricted gain is implemented exactly as specified and does exactly what it was asked to do — and both the stability certificate and every error metric get substantially worse. The `S → attitude` gain path turns out to be load-bearing rather than parasitic.

---

## 1. Exact mathematical change

The `S = 0` pseudo-measurement is a translational/integral regularizer: it asserts that the running integral of displacement has zero mean, and it observes `S` and nothing else. Its ordinary Kalman gain nevertheless corrects attitude through the cross covariance,

```
E_θ K_S = P_θS (P_SS + R_S)^{-1}
```

so an integral-channel residual drives an SO(3) injection with a quadratic reset remainder.

The change applies a Schmidt-style restricted gain to the `S` update alone:

```
K̃_S := (I − E_θᵀ E_θ) K_S       so that     E_θ K̃_S = 0  exactly
```

**The restriction is applied to the gain only, never to `P Hᵀ`.** Freezing the mean correction is not the same as deleting the covariance; asserting `P_θS = 0` would be a different and false claim, and the Joseph update still needs the true cross covariance to propagate the effect of the correction the other states *did* receive.

Because `K̃_S` is no longer the minimum-variance gain, the optimal-gain shortcut is invalid and the covariance must use the general-gain Joseph form:

```
P⁺ = (I − K̃_S H_S) P (I − K̃_S H_S)ᵀ + K̃_S R_S K̃_Sᵀ
```

No new covariance path was added: `joseph_update3_()` already forms `P − KCP − (KCP)ᵀ + K(CPCᵀ + R)Kᵀ`, which is algebraically exactly the above for *any* `K`, optimal or not. This was verified numerically rather than assumed (§3, property 4).

Nothing else changes: prediction, the OU model, the adaptation law, tuning, cadence, the accelerometer and magnetometer updates, state ordering, initialization and quaternion conventions are untouched, and every other row of the `S` gain still acts as before.

**Choice of certificate instrument: option (b).** The commits here are based on current `main` (`d324e8c`) and depend on nothing unmerged. PR #367's Phase-3 diagnostic was used *only as a measurement instrument*, compiled twice — once against `main`'s `src/`, once against this branch's `src/` — so the two PRs stay independent. Numbers labelled `c_eff`, `Γ_θ/Γ_a/Γ_m`, `α_max`, `r_ξ` and the entrance margin come from that unmerged instrument. `χ_V(30)`, prefix, `κ_E` and `M_E` are additionally reported from `main`'s own `live_basin_diagnostic`, which needs no unmerged code.

## 2. Files modified

| File | Change |
|---|---|
| `src/kalman_ou_iii/Kalman3D_Wave_OU_III.h` | `freeze_attitude_rows_()` helper; applied to `K` in `applyIntegralZeroPseudoMeas()` (+47/−0) |
| `tests/kalman_ou_iii/schmidt_s_pseudo-test.cpp` | **new**, 361 lines — all 8 required properties + cross-covariance report |
| `tests/kalman_ou_iii/Makefile` | build the new test |
| `tests/kalman_ou_iii/run_tests.sh` | run it in the normal CI path |
| `doc/kalman_ou_iii/w3d-restricted-s-gain-ablation.tex-part` | **new** — the ablation, its mechanism, and the negative outcome |
| `doc/kalman_ou_iii/w3d-post-results-investigations.tex-part` | wire the new part into the ablations section |
| `.gitignore` | ignore a build artifact |

The retained `applyQuaternionCorrectionFromErrorState()` call is an exact no-op here, not a leftover: with the attitude error block zeroed, `apply_left_error_reset` early-returns on `dtheta.squaredNorm() == 0`, leaving `qref` and `Pext` untouched while `project_acc_bias_()` still runs. Keeping it makes the path uniform across measurements.

## 3. Unit-test results

`tests/kalman_ou_iii/schmidt_s_pseudo-test` — **all 8 required properties pass**, in the normal CI path (no temporary workflow, no probe executable including another `.cpp`, no `ComputeThinU`/`ComputeThinV` on fixed-size Eigen). Clean under `-Wall -Wextra -Wshadow -Wconversion`: **0 warnings**.

| # | Property | Result |
|---|---|---|
| 1 | Attitude frozen: `δθ⁺ = δθ⁻`, nominal quaternion unchanged | PASS |
| 2 | The removed path was real: unconstrained `K_θS ≠ 0` | PASS — `‖removed rows‖ = 0.448404`, would have injected **0.3996 rad** |
| 3 | Other `S`-gain rows still active (`v`, `p`, `a_w`, `S`) | PASS |
| 4 | Joseph covariance matches independent construction | PASS — max abs err `5.55e-17`; optimal-gain shortcut would have been off by `0.24167` |
| 5 | Symmetry `‖P − Pᵀ‖` within tolerance | PASS — worst asymmetry `0` |
| 6 | PSD over repeated `S` updates | PASS — worst min eigenvalue `+0.00741168` |
| 7 | Accel/mag still use the full gain and still correct attitude | PASS |
| 8 | Prediction still couples states normally | PASS |

All 14 other OU-III unit tests pass unchanged (`kalman_ou_common`, `aw_covariance_policy`, `acc_bias_ou`, `channel_freeze`, `wave_period`, `mag_hard_iron`, `continuous_mag_hard_iron`, `tuner_coupling`, `tuner_schedule`, `wave_band_sigma`, `iss_contract`, `rs_law`, `startup_init`, `live_basin_diagnostic`), as do `tools/ou_live_basin_interval_proof.py` and the article-contract validation tests.

## 4. Complete eight-sea before/after regression table

Same inputs, same seeds, same window. **Every one of the eight gates flips PASS → FAIL.**

Tuning is bit-identical on all eight records — applied `τ`, `σ_aw` and `R_S` all change by `+0.00%` — so the adaptation law is provably not confounding this comparison. The `τ`/`σ`/`R_S` rows are shown once per sea to make that explicit.

| sea | metric | main | restricted | Δ% |
|---|---|---|---|---|
| **J0.27** | X / Y / Z RMS [m] | 0.0190853 / 0.0170048 / 0.0120594 | 0.0657693 / 0.0311699 / 0.0121667 | **+244.6 / +83.3 / +0.9** |
| | 3-D RMS [m] | 0.0282638 | 0.0737916 | **+161.1** |
| | Roll / Pitch / Yaw [°] | 0.226798 / 0.181191 / 0.630294 | 0.240577 / 0.307365 / 0.807971 | **+6.1 / +69.6 / +28.2** |
| | gyro-bias err [%] | 14.119 | 27.2587 | **+93.1** |
| | τ / σ_aw / R_S | 1.2914 / 0.374845 / 0.181606 | 1.2914 / 0.374845 / 0.181606 | +0.00 / +0.00 / +0.00 |
| | **gate** | **PASS** | **FAIL** | |
| **J1.50** | X / Y / Z RMS [m] | 0.11696 / 0.0956007 / 0.0633743 | 0.414461 / 0.161508 / 0.0655123 | **+254.4 / +68.9 / +3.4** |
| | 3-D RMS [m] | 0.163815 | 0.449616 | **+174.5** |
| | Roll / Pitch / Yaw [°] | 0.185542 / 0.136575 / 0.895876 | 0.235064 / 0.525291 / 1.61271 | **+26.7 / +284.6 / +80.0** |
| | gyro-bias err [%] | 12.0346 | 47.0721 | **+291.1** |
| | τ / σ_aw / R_S | 2.07116 / 0.84177 / 1.4552 | 2.07116 / 0.84177 / 1.4552 | +0.00 / +0.00 / +0.00 |
| | **gate** | **PASS** | **FAIL** | |
| **J4.00** | X / Y / Z RMS [m] | 0.338637 / 0.277496 / 0.161381 | 1.31882 / 0.551239 / 0.162653 | **+289.5 / +98.7 / +0.8** |
| | 3-D RMS [m] | 0.466608 | 1.43861 | **+208.3** |
| | Roll / Pitch / Yaw [°] | 0.314166 / 0.12829 / 0.470451 | 0.404612 / 0.72942 / 1.74142 | **+28.8 / +468.6 / +270.2** |
| | gyro-bias err [%] | 14.0796 | 57.8644 | **+311.0** |
| | τ / σ_aw / R_S | 3.67923 / 1.19103 / 10.5378 | 3.67923 / 1.19103 / 10.5378 | +0.00 / +0.00 / +0.00 |
| | **gate** | **PASS** | **FAIL** | |
| **J8.50** | X / Y / Z RMS [m] | 0.789098 / 0.689279 / 0.309972 | 3.92443 / 1.04807 / 0.338377 | **+397.3 / +52.1 / +9.2** |
| | 3-D RMS [m] | 1.09264 | 4.07604 | **+273.1** |
| | Roll / Pitch / Yaw [°] | 0.167566 / 0.113036 / 0.565632 | 0.284265 / 1.2117 / 3.05809 | **+69.6 / +972.0 / +440.7** |
| | gyro-bias err [%] | 14.0516 | 82.2366 | **+485.3** |
| | τ / σ_aw / R_S | 4.18664 / 1.53846 / 18.2458 | 4.18664 / 1.53846 / 18.2458 | +0.00 / +0.00 / +0.00 |
| | **gate** | **PASS** | **FAIL** | |
| **P0.27** | X / Y / Z RMS [m] | 0.0182029 / 0.016079 / 0.0119857 | 0.0629074 / 0.0318045 / 0.0121166 | **+245.6 / +97.8 / +1.1** |
| | 3-D RMS [m] | 0.0270839 | 0.071524 | **+164.1** |
| | Roll / Pitch / Yaw [°] | 0.218066 / 0.184888 / 0.690636 | 0.235953 / 0.30845 / 0.698845 | **+8.2 / +66.8 / +1.2** |
| | gyro-bias err [%] | 15.6765 | 30.0831 | **+91.9** |
| | τ / σ_aw / R_S | 1.15439 / 0.4273 / 0.150539 | 1.15439 / 0.4273 / 0.150539 | +0.00 / +0.00 / +0.00 |
| | **gate** | **PASS** | **FAIL** | |
| **P1.50** | X / Y / Z RMS [m] | 0.102237 / 0.0874132 / 0.0596769 | 0.404038 / 0.145926 / 0.0625482 | **+295.2 / +66.9 / +4.8** |
| | 3-D RMS [m] | 0.147156 | 0.434112 | **+195.0** |
| | Roll / Pitch / Yaw [°] | 0.210158 / 0.172708 / 0.576477 | 0.265944 / 0.555266 / 1.44972 | **+26.5 / +221.5 / +151.5** |
| | gyro-bias err [%] | 12.3824 | 52.1892 | **+321.5** |
| | τ / σ_aw / R_S | 1.99934 / 0.788736 / 1.26038 | 1.99934 / 0.788736 / 1.26038 | +0.00 / +0.00 / +0.00 |
| | **gate** | **PASS** | **FAIL** | |
| **P4.00** | X / Y / Z RMS [m] | 0.296372 / 0.25627 / 0.156977 | 2.57085 / 0.787896 / 0.204593 | **+767.4 / +207.5 / +30.3** |
| | 3-D RMS [m] | 0.422082 | 2.69665 | **+538.9** |
| | Roll / Pitch / Yaw [°] | 0.3495 / 0.19648 / 0.722359 | 0.6204 / 1.75758 / 4.32182 | **+77.5 / +794.5 / +498.3** |
| | gyro-bias err [%] | 14.7578 | 140.19 | **+849.9** |
| | τ / σ_aw / R_S | 3.55262 / 1.09333 / 8.34011 | 3.55262 / 1.09333 / 8.34011 | +0.00 / +0.00 / +0.00 |
| | **gate** | **PASS** | **FAIL** | |
| **P8.50** | X / Y / Z RMS [m] | 0.670582 / 0.607332 / 0.319057 | 56.7914 / 82.3255 / 11.3656 | **+8369 / +13455 / +3462** |
| | 3-D RMS [m] | 0.959338 | **100.657** | **+10392** |
| | Roll / Pitch / Yaw [°] | 0.161914 / 0.112945 / 0.313551 | 12.6722 / 15.0435 / **76.3677** | **+7727 / +13219 / +24256** |
| | gyro-bias err [%] | 13.6543 | 3026.65 | **+22066** |
| | τ / σ_aw / R_S | 4.26964 / 1.4696 / 17.7645 | 4.26964 / 1.4696 / 17.7645 | +0.00 / +0.00 / +0.00 |
| | **gate** | **PASS** | **FAIL** | |

On PM `Hs = 8.50` the filter effectively loses lock: 100.7 m 3-D RMS and 76.4° yaw RMS. The dominant failing gate on all eight records is `gyro_bias_3d_percent_exceeded`, with Z-RMS, 3-D-RMS and pitch gates also failing on most.

To obtain all eight records rather than stopping at the first failure I used the simulator's existing `W3D_COLLECT_ALL_GATES` env var, which is already in `main` for exactly this purpose. **No limit, threshold or tuning constant was modified.**

## 5. Stability-certificate before/after table

Worst value over the eight reference records.

**Phase-3 instrument** (from #367, compiled against each `src/`):

| Quantity | main | restricted | factor |
|---|---|---|---|
| one-sample metric monotonicity `α_max` | 1 | 1 | unchanged (≤ 1 holds) |
| `M_H` | 1.02003 | 1.01078 | 0.99× |
| `Γ_θ` | 1.354e7 | 4.373e7 | **3.23×** |
| `Γ_a` | 1999.1 | 13806.7 | **6.91×** |
| `Γ_m` | 393.12 | 584.50 | **1.49×** |
| **`c_eff`** | **29.283** | **21247.1** | **725.6×** |
| `r_ξ` | 88.032 | 14.651 | **0.166×** |
| `r_cert` | 0.034150 | 4.7065e-5 | **0.00138×** |
| **Live-entrance budget** | **8.3873e-3** | **1.1744e-5** | **0.00140×** |
| scalar ℓ1 gain | 344943 | 3324571 | **9.64×** |
| `Γ_θ` attitude-tail share | 1.77e-4 | 0.616 | **3480×** |

**Phase-2 instrument** (`main`'s own `live_basin_diagnostic`, no unmerged code):

| Quantity | main | restricted |
|---|---|---|
| horizon contraction `χ_V(30)` | 0.944298 | **0.995853** |
| `χ_E(30)` | 6.02997 | 6.96342 |
| prefix `E(30)` | 12.0497 | **51.8083** |
| `ρ_V` second | 0.998091 | 0.999861 |
| `p_z` max | 0.0064582 | **0.872750** |
| `κ_E` | 566.91 | **6590.31** |
| implied `M_E` | 600.35 | **6617.75** |
| reference metric contract | 1 (holds) | 1 (holds) |

`α_max = 1` on both sides: one-sample metric monotonicity is a Joseph-identity consequence and is unaffected, as expected. Everything that is *not* forced by an identity degrades.

### `c_eff` decomposition — the point of the experiment

`c_eff = Γ_θ·c_θ + Γ_a·c_acc + Γ_m·c_mag` with `c_θ = j_c·σ_θ·A_g`, and `A_g` collecting the attitude-row gains of every accepted correction:

```
A_g = ‖E_θK_a‖(f₁σ_θ + σ_aw + σ_ba) + ‖E_θK_m‖m₁σ_θ + ‖E_θK_S‖σ_S + Δt·σ_bg
```

| sea | `c_eff` | `Γ_θ·c_θ` | `Γ_a·c_acc` | `Γ_m·c_mag` | **S share of `A_g`** | accel share of `A_g` | `Γ_a·σ_θ·σ_aw` |
|---|---|---|---|---|---|---|---|
| J0.27 main | 0.6940 | 0.3898 | 0.2425 | 0.0616 | 38.1% | 2.60% | 0.1433 |
| J0.27 restr | 419.90 | 406.64 | 10.211 | 3.048 | **0%** | 96.7% | 4.567 |
| J1.50 main | 1.0670 | 0.7166 | 0.2784 | 0.0719 | 65.7% | 1.80% | 0.1649 |
| J1.50 restr | 4276.6 | 4143.2 | 120.16 | 13.274 | **0%** | 98.5% | 49.720 |
| J4.00 main | 12.525 | 10.864 | 1.2029 | 0.4578 | 81.7% | 6.31% | 0.5508 |
| J4.00 restr | 15118.9 | 15000.7 | 89.504 | 28.680 | **0%** | 99.1% | 34.838 |
| **J8.50 main** | **29.283** | **25.433** | 2.6802 | 1.1703 | **77.7%** | 10.5% | 1.0906 |
| **J8.50 restr** | **21247.1** | **21121.6** | 87.026 | 38.454 | **0%** | **99.1%** | 32.495 |
| P0.27 main | 0.6812 | 0.3758 | 0.2441 | 0.0613 | 36.1% | 2.38% | 0.1455 |
| P0.27 restr | 447.03 | 417.51 | 26.195 | 3.327 | **0%** | 96.5% | 11.665 |
| P1.50 main | 0.9879 | 0.6394 | 0.2777 | 0.0709 | 62.3% | 1.53% | 0.1645 |
| P1.50 restr | 4349.7 | 4248.4 | 86.805 | 14.476 | **0%** | 98.4% | 35.593 |
| P4.00 main | 7.0071 | 5.9943 | 0.7540 | 0.2588 | 83.2% | 4.02% | 0.3715 |
| P4.00 restr | 13325.2 | 12993.6 | 303.86 | 27.681 | **0%** | 99.0% | 118.27 |
| P8.50 main | 26.056 | 22.600 | 2.4264 | 1.0306 | 79.4% | 8.65% | 0.9881 |
| P8.50 restr | 20693.3 | 20568.6 | 85.260 | 39.453 | **0%** | 99.0% | 31.518 |

This reproduces #367's stated baseline exactly — at JONSWAP 8.5 m the S-sourced group term is **25.43 of `c_eff` = 29.28** against the "about 25 of 29.3" quoted in the task — which confirms the instrument is measuring the intended quantity.

**`E_θ K̃_S = 0` is confirmed explicitly**: the S share of `A_g` is identically `0%` on all eight records (`EthKS = 0` in every row of the diagnostic; it was `6.5e-5 … 2.7e-4` on main, matching #367).

**The requested term `Γ_a‖δθ‖‖δa_w‖`** is the last column: it grows 30–318×, e.g. `1.0906 → 32.495` at J8.50 and `0.3715 → 118.27` at P4.00.

**New dominant term:** still the SO(3) group-composition term `Γ_θ·j_c·σ_θ·A_g` — 99.4% of `c_eff` at J8.50 — but now sourced from the **accelerometer** channel (99.1% of `A_g`) rather than from `S`. The expected outcome stated in the task ("`c_eff` drops sharply at the rough seas … with the accelerometer residual term becoming dominant") is half-right: the accelerometer term does become dominant, but `c_eff` does not drop — it rises by 726×.

## 6. Covariance / cross-covariance findings

**No covariance block was zeroed.** Schmidt-filter mathematics does not require it here: the restriction is on the gain, and the general-gain Joseph form is valid for any gain, so there is no derivation that would force `P_θS = 0`. Measured after an otherwise identical update:

| block | unrestricted | restricted | Δ |
|---|---|---|---|
| `P_θS` | 0.0088234 | 0.00869707 | **−1.4% (retained, not deleted)** |
| `P_θa_w` | 0.526379 | 0.518842 | −1.4% |
| `P_θp` | 0.701838 | 0.691790 | −1.4% |
| `P_a_w S` | 0.00217427 | 0.00217427 | 0.0% (exactly unchanged) |
| `P_θθ` | 0.912341 | 1.61687 | **+77.2%** |

The signature is exactly what the restricted gain should produce. `P_a_w S` is untouched because neither of its indices is the frozen block. The cross terms involving `θ` shrink only marginally — they are still propagated by the Joseph form via the corrections the other states received. The diagonal `P_θθ` grows 77%, because the restricted update no longer reduces attitude variance at all. That inflation is the covariance-level shadow of the `σ_θ` growth (4.7–5.2×) that drives the certificate collapse in §5.

Over time this is not benign: `σ_θ` inflating is precisely why `‖E_θK_a‖` grows 120–904×, since the accelerometer update is left to do all the tilt correction.

## 7. Do all existing quality gates pass?

**No. All eight fail** (see §4). On `main`, all eight pass. Per instruction, nothing was tuned to recover the regression.

## 8. Does the Live-entry certificate now close?

**No — and it closes considerably less well than before.** It did not close on `main` either; this change moves it three further orders of magnitude away.

## 9. Remaining dominant term and miss factor

Dominant term: the SO(3) group-composition term `Γ_θ·j_c·σ_θ·A_g`, now sourced from the accelerometer attitude-gain rows (99.1% of `A_g`, 99.4% of `c_eff` at the worst record).

Miss factor against the entrance inequality (from the handoff budget, `lhs = 17.8183` for the deployed seed and `4.15774` for the coherent seed):

| seed | required `c_eff` | main | restricted | further degradation |
|---|---|---|---|---|
| deployed | ≤ 0.0140305 | misses by **2087×** | misses by **1.51e6×** | 726× worse |
| coherent | ≤ 0.0601288 | misses by **487×** | misses by **3.53e5×** | 726× worse |

## Interpretation

The premise was that the `S → θ` path is a parasitic nonlinearity worth deleting. It is not.

A tilt error rotates gravity into the horizontal channels, producing a persistent spurious specific-force component that integrates into `v`, then `p`, then `S`. The integral state is therefore a **very-long-baseline observer of tilt**, and `P_θS` is the channel through which that observation reaches attitude. The restricted gain discards it.

The work does not disappear when the channel is closed — it migrates. With the slow tilt information withheld, `σ_θ` inflates ~5×, and the accelerometer update must carry the entire tilt correction alone, so `‖E_θK_a‖` grows by two to three orders of magnitude. Since `a_a = ‖E_θK_a‖(f₁σ_θ + σ_aw + σ_ba)` is driven by *both* factors and both grow, `c_grp` grows far more than the deleted `a_S` term ever contributed. The asymmetry is stark: at the calmest record the deleted term was `2.62e-4`, while the term it inflated went from `6.66e-6` to `6.02e-3`. **Deleting a term worth `2.6e-4` cost three orders of magnitude on a term that had been negligible.**

It is worth noting that the a-priori reasoning was sound — on `main`, `‖E_θK_S‖` genuinely *was* the largest of the three attitude-gain norms at the calm seas and genuinely *did* dominate `c_eff` at the rough ones. It dominated precisely because it was doing the work.

This strengthens rather than weakens the existing argument for keeping `S` in the sensitive block `z_ξ`: the coupling is load-bearing, so a tighter certificate must come from **bounding** it more sharply, not from **severing** it.

## Recommendation

Do not merge. The experiment is documented in `w3d-restricted-s-gain-ablation.tex-part` and pinned by a permanent test, so the finding is preserved either way; if you would prefer the record without the estimator change, I can re-land the ablation section and the unit test on top of the deployed gain as a docs-and-tests-only PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_0169vpP25VYEoSC6e684Wo9v)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a restricted pseudo-measurement update that prevents direct attitude corrections while preserving covariance relationships and other state corrections.

- **Documentation**
  - Documented the restricted-gain ablation, including its diagnostic and estimation impacts, and recorded its exclusion from deployment.

- **Tests**
  - Added automated coverage for restricted updates, covariance stability, cross-covariance reporting, and continued sensor-based attitude correction.

- **Chores**
  - Integrated the new test into the standard test suite and excluded its generated executable from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->