### PR TITLE
Prove finite Live capture before local ISS handoff

### DIFF
--- a/doc/kalman_ou_iii/w3d-finite-live-capture.tex-part
+++ b/doc/kalman_ou_iii/w3d-finite-live-capture.tex-part
@@ -1,0 +1,237 @@
+\section{Finite Certified Capture into the Live ISS Tube}
+\label{sec:finite-live-capture}
+
+The local ISS result of Sec.~\ref{sec:iss-block-basin} is an invariance theorem,
+not a startup theorem.  Requiring the first Live sample to lie inside its final
+small nonlinear tube is unnecessarily strong and does not match the deployed
+transient: after the linear block and regularizer are enabled, the estimator may
+ring before covariance coupling and repeated vector and $S=0$ corrections settle
+the error.  The appropriate statement is therefore finite \emph{capture}: the
+handoff must lie in a larger certified region from which the full implemented
+Live recursion reaches the smaller invariant ISS region after a finite lifted
+horizon.  Individual samples, and even short prefixes, need not contract.
+
+\subsection{Riccati metric and exact lifted map}
+
+Let $\vct e_k\in\mathbb R^{21}$ denote the local error at the same normal-Live
+phase used in Sec.~\ref{sec:iss-block-basin}, and let $\mat P_k\succ0$ be the
+corresponding covariance produced by the implemented filter.  With
+$\mat P_k=\mat L_k\mat L_k^\top$, define
+\begin{equation}
+ \|\vct e\|_k:=
+ \left(\vct e^\top\mat P_k^{-1}\vct e\right)^{1/2}
+ =\|\mat L_k^{-1}\vct e\|_2 .
+ \label{eq:capture-riccati-norm}
+\end{equation}
+For a lift of $m\ge1$ samples, write the exact nonlinear error map of the
+implemented recursion as
+\begin{equation}
+ \vct e_{k+m}
+ =\mat\Psi_{k,m}\vct e_k
+  +\vct\varphi_{k,m}(\vct e_k)
+  +\vct\Delta_{k,m}(\vct e_k,\vct d_{k:k+m-1}),
+ \label{eq:capture-lifted-map}
+\end{equation}
+where $\mat\Psi_{k,m}$ is the homogeneous linearized transition,
+$\vct\varphi_{k,m}(0)=0$ and
+$D\vct\varphi_{k,m}(0)=0$, and $\vct\Delta_{k,m}$ collects bounded model and
+measurement disturbances over the lift.  Equation~\eqref{eq:capture-lifted-map}
+uses the actual execution order and the full Kalman correction.  In particular,
+the $S=0$ update retains its attitude and bias rows through cross-covariance;
+no Schmidt, block-only, or gain-truncated approximation is introduced for the
+proof.
+
+Let $\mathcal C_{\rm cap}$ be a compact, principal-chart-safe Live domain and
+let $R_C$ satisfy
+\begin{equation}
+ \{\vct e:\|\vct e\|_k\le R_C\}\subset\mathcal C_{\rm cap}.
+ \label{eq:capture-outer-domain}
+\end{equation}
+The capture certificate consists of uniform bounds over this domain, the
+admissible predictable OU/$R_S$ schedule, and the accepted-update patterns.
+First, the lifted homogeneous map contracts in the Riccati metric,
+\begin{equation}
+ \boxed{
+ \left\|\mat L_{k+m}^{-1}\mat\Psi_{k,m}\mat L_k\right\|_2
+ \le\chi_C<1 .}
+ \label{eq:capture-linear-contraction}
+\end{equation}
+Second, the lifted nonlinear and disturbance terms obey
+\begin{align}
+ \left\|\mat L_{k+m}^{-1}
+ \vct\varphi_{k,m}(\vct e)\right\|_2
+ &\le c_C\|\vct e\|_k^2,
+ \label{eq:capture-nonlinear-bound}\\
+ \left\|\mat L_{k+m}^{-1}
+ \vct\Delta_{k,m}(\vct e,\vct d)\right\|_2
+ &\le g_C\overline d_L,
+ \label{eq:capture-disturbance-bound}
+\end{align}
+for $\|\vct d\|_\infty\le\overline d_L$.  Finally, every prefix
+$j=1,\ldots,m-1$ is verified to remain inside the same chart and measurement
+geometry.  A finite prefix amplification larger than one is permitted.  Thus
+Eq.~\eqref{eq:capture-linear-contraction} is deliberately a lifted condition,
+not a requirement that the first or every Live correction decrease the error.
+
+Taking the norm of Eq.~\eqref{eq:capture-lifted-map} gives the scalar comparison
+\begin{equation}
+ r_{n+1}\le\chi_C r_n+c_Cr_n^2+g_C\overline d_L,
+ \qquad r_n:=\|\vct e_{k+nm}\|_{k+nm}.
+ \label{eq:capture-scalar-recursion}
+\end{equation}
+Define
+\begin{equation}
+ \Delta_C:=(1-\chi_C)^2-4c_Cg_C\overline d_L
+ \label{eq:capture-discriminant}
+\end{equation}
+and, when $\Delta_C>0$,
+\begin{equation}
+ \boxed{
+ R_\pm=
+ \frac{(1-\chi_C)\pm\sqrt{\Delta_C}}{2c_C}.}
+ \label{eq:capture-roots}
+\end{equation}
+
+\begin{theorem}[Finite certified Live capture]
+\label{thm:finite-live-capture}
+Assume Eqs.~\eqref{eq:capture-linear-contraction}--
+\eqref{eq:capture-disturbance-bound} and the certified prefix bounds hold on
+$\mathcal C_{\rm cap}$, with $\Delta_C>0$.  Choose an inner radius $R_B$ and an
+outer capture radius $R_C$ such that
+\begin{equation}
+ \boxed{R_-<R_B<R_C<R_+.}
+ \label{eq:capture-radius-order}
+\end{equation}
+Assume additionally that the Riccati ball
+$\mathcal B_B(k):=\{\vct e:\|\vct e\|_k\le R_B\}$ is contained in the
+block-local ISS entrance set of Theorem~\ref{thm:iss-block-local}.  Then every
+Live trajectory beginning with $\|\vct e_H\|_H\le R_C$ enters
+$\mathcal B_B$ after finitely many lifted intervals and remains in the
+block-local ISS region thereafter.
+
+More precisely, define
+\begin{equation}
+ q_C(r):=(1-\chi_C)r-c_Cr^2-g_C\overline d_L
+ \label{eq:capture-decrease-function}
+\end{equation}
+and
+\begin{equation}
+ \mu_C:=\min\{q_C(R_B),q_C(R_C)\}>0 .
+ \label{eq:capture-mu}
+\end{equation}
+Then capture occurs after no more than
+\begin{equation}
+ \boxed{
+ N_C=\left\lceil\frac{R_C-R_B}{\mu_C}\right\rceil}
+ \label{eq:capture-count}
+\end{equation}
+lifted intervals, hence within
+\begin{equation}
+ T_C\le m h_{\max}N_C .
+ \label{eq:capture-time}
+\end{equation}
+\end{theorem}
+
+\begin{proof}
+Subtract Eq.~\eqref{eq:capture-scalar-recursion} from $r_n$ to obtain
+\begin{equation}
+ r_n-r_{n+1}\ge q_C(r_n).
+\end{equation}
+The function $q_C$ is a concave quadratic with roots $R_-$ and $R_+$, so it is
+strictly positive on $(R_-,R_+)$.  Before the first entrance into
+$[0,R_B]$, Eq.~\eqref{eq:capture-radius-order} gives
+$R_B\le r_n\le R_C$.  Concavity implies that the minimum of $q_C$ on this
+closed interval occurs at an endpoint, giving
+$r_{n+1}\le r_n-\mu_C$.  Therefore at most
+$\lceil(R_C-R_B)/\mu_C\rceil$ lifted intervals can elapse without entering
+$[0,R_B]$.
+
+For invariance after entrance, let
+$f_C(r)=\chi_Cr+c_Cr^2+g_C\overline d_L$.  This function is increasing for
+$r\ge0$, and $q_C(R_B)>0$ implies
+$f_C(R_B)<R_B$.  Hence $r_n\le R_B$ gives
+$r_{n+1}\le f_C(r_n)\le f_C(R_B)<R_B$.  The prefix certificate keeps all
+intermediate samples inside the chart-safe domain.  By the assumed set
+inclusion, Theorem~\ref{thm:iss-block-local} applies after capture.
+\end{proof}
+
+Inside $\mathcal B_B$, the quadratic term satisfies
+$c_Cr_n^2\le c_CR_Br_n$, and therefore
+\begin{equation}
+ r_{n+1}\le\lambda_B r_n+g_C\overline d_L,
+ \qquad
+ \lambda_B:=\chi_C+c_CR_B<1 .
+ \label{eq:capture-post-bound}
+\end{equation}
+Thus the captured trajectory has the explicit practical exponential bound
+\begin{equation}
+ \boxed{
+ r_{N_C+j}\le
+ \lambda_B^j r_{N_C}
+ +\frac{g_C}{1-\lambda_B}\overline d_L .}
+ \label{eq:capture-practical-iss}
+\end{equation}
+For zero Live disturbance, $R_-=0$ and the post-capture error converges
+exponentially to zero.
+
+\subsection{Operational capture-certificate contract}
+\label{sec:capture-certificate-contract}
+
+A startup certificate must demonstrate a materially larger capture region than
+the inner ISS-entry region; otherwise it merely renames the local-basin test.
+Accordingly define the capture-width ratio
+\begin{equation}
+ \boxed{\Gamma_{\rm cap}:=\frac{R_C}{R_B}.}
+ \label{eq:capture-width-ratio}
+\end{equation}
+The verification declares a minimum separation
+$\Gamma_{\rm req}>1$ \emph{before} evaluating the certificate and must show
+\begin{equation}
+ \boxed{\Gamma_{\rm cap}\ge\Gamma_{\rm req}.}
+ \label{eq:capture-width-requirement}
+\end{equation}
+For the operational startup claim in this work we set the predeclared target
+$\Gamma_{\rm req}=5$.  This factor is not a stability constant and is not used
+to manufacture contraction; it is a reporting requirement that prevents a
+barely enlarged local tube from being presented as a useful capture result.
+If verified arithmetic does not meet it, the paper retains the local theorem
+but does not claim operational startup capture.
+
+The numerical capture certificate must start at the covariance and estimator
+mode produced by the actual \texttt{goLive()} handoff, including the staged OU
+parameters, covariance synchronization, enabled linear block, full $S=0$ gain,
+and the initially held accelerometer-bias update.  It must not insert the
+\SI{120}{s} equilibrium covariance warm-up used by the separate deployed-point
+diagnostic.  The certificate reports at least
+\begin{equation}
+ \boxed{
+ \{R_H^{\max},R_B,R_C,R_-,R_+,\Gamma_{\rm cap},
+   \chi_C,c_C,g_C,\mu_C,N_C,T_C,B_{\rm pre}\},}
+ \label{eq:capture-certificate-outputs}
+\end{equation}
+where $R_H^{\max}$ is the worst Riccati norm of the declared handoff set and
+$B_{\rm pre}$ is the worst verified prefix amplification.  The operational
+pass conditions are
+\begin{equation}
+ \boxed{
+ R_H^{\max}<R_C,
+ \quad R_-<R_B<R_C<R_+,
+ \quad\Gamma_{\rm cap}\ge5,
+ \quad N_C<\infty,}
+ \label{eq:capture-certificate-pass}
+\end{equation}
+together with the chart/measurement prefix conditions and the inclusion of
+$\mathcal B_B$ in the block-local ISS entrance set.
+
+This certificate is intentionally wider than the first-measurement or
+one-step local condition.  It allows $B_{\rm pre}>1$: the post-handoff estimate
+may oscillate or temporarily grow while remaining inside
+$\mathcal C_{\rm cap}$.  What is certified is finite entry into the inner ISS
+tube, not monotone decay from the first Live sample.
+
+The very broad interval certificate of Sec.~\ref{sec:iss-computer-assisted-certificate}
+serves a different purpose.  Its extremely conservative positive radius proves
+existence of a local nonlinear neighborhood over a large source-parameter box;
+it is not used as $R_C$, $R_B$, or the startup handoff test here.  Operational
+capture is established only by the regional certificate above, evaluated from
+the actual handoff family.

--- a/doc/kalman_ou_iii/w3d-init.tex-part
+++ b/doc/kalman_ou_iii/w3d-init.tex-part
@@ -8,6 +8,10 @@ Mahony observer of Sec.~\ref{sec:vertical-proxy} runs from the first sample
 while the MEKF remains untouched; wave-period and acceleration-variance
 estimators converge in parallel.  Once attitude, magnetic reference, and tuner
 quality are adequate, the proxy solution initializes the MEKF in Live mode.
+The resulting state is not required to lie immediately inside the final local
+ISS tube.  Instead, Sec.~\ref{sec:finite-live-capture} certifies a larger
+post-handoff capture region from which the full Live recursion reaches that tube
+in finite time.
 
 \subsection{Tilt and operating-point bootstrap}
 
@@ -31,8 +35,8 @@ branch---predicted and measured gravity directions with positive inner
 product---and gyro magnitude below \SI{30}{\degree\per\second}; (ii) a
 magnetic gauge when a magnetometer is present; and (iii) tuner readiness.  A
 minimum \SI{8}{s} startup prevents a quiet initial interval from passing
-prematurely.  A \SI{150}{s} timeout bounds
-startup duration without interrupting active magnetic-reference acquisition.
+prematurely.  A \SI{150}{s} timeout bounds startup duration without
+interrupting active magnetic-reference acquisition.
 
 At handoff, the proxy attitude seeds the MEKF once.  With magnetic north
 established, attitude covariance uses
@@ -41,30 +45,42 @@ established, attitude covariance uses
 \sigma_{\mathrm{yaw}}=\SI{0.087}{rad};
 \]
 without a magnetic gauge, $\sigma_{\mathrm{yaw}}=\pi/2$.  The linear
-$[v,p,S,a_w]$ block, nominal accelerometer covariance, current OU parameters,
-and integral regularizer are enabled together.  Accelerometer-bias learning is
-held until the magnetic refinement below because bias and small tilt error are
-weakly separable in waves and the residual bias correlation time is long.
+$[v,p,S,a_w]$ block, current OU parameters, and integral regularizer are enabled
+together.  Accelerometer-bias learning remains gated until the magnetic
+refinement logic releases it because bias and small tilt error are weakly
+separable in waves and the residual bias correlation time is long.
 
-The handoff is the basin-entry map analyzed in
+The handoff is the entry map analyzed in
 Sec.~\ref{sec:semiglobal-handoff}.  The gravity residual is a sine of the
 alignment angle, so it does not by itself distinguish the aligned and antipodal
 branches; the gate therefore also tests the sign of the inner product of the
-same two directions, and an accepted handoff satisfies the aligned-branch
-condition Eq.~\eqref{eq:semiglobal-aligned-branch} of the semiglobal theorem.
-The \SI{150}{s} timeout is held to that same test, so a forced handoff is
-delayed rather than accepted on the antipodal branch; it does not test the
-residual magnitude, so it certifies the branch and not the tilt bound.  The
-Phase-1 basin refinement separates the dimensionless nonlinear-sensitive block
-$[\delta\theta,\delta b_g,\delta S,\delta a_w,\delta b_a]$ from the kinematic
-$[\delta v,\delta p]$ block.  When the accepted proxy/magnetic bounds, the two
-handoff-block bounds, and the declared bounded Live disturbance satisfy
-Eq.~\eqref{eq:semiglobal-basin-entry}, the handoff enters the invariant
-sensitive tube of the block-local ISS theorem,
-Theorem~\ref{thm:iss-block-local}, and
-Theorem~\ref{thm:semiglobal-proxy-live} applies.  A timeout-forced handoff that
-does not independently satisfy Eq.~\eqref{eq:semiglobal-basin-entry} remains
-outside the semiglobal result.
+same two directions, and an accepted handoff satisfies
+Eq.~\eqref{eq:semiglobal-aligned-branch}.  The \SI{150}{s} timeout is held to
+that same sign test, so a forced handoff is delayed rather than accepted on the
+antipodal branch.
+
+The stability interface is deliberately wider than the final local basin.  The
+accepted proxy/magnetic attitude bound and independent finite physical bounds
+on the remaining MEKF errors define the structured handoff set $\mathcal H$ of
+Sec.~\ref{sec:semiglobal-handoff}.  The normal startup claim requires only
+\begin{equation}
+ R_H^{\max}<R_C,
+\end{equation}
+that is, the actual post-\texttt{goLive()} Riccati radius lies inside the outer
+capture region.  It is not required to satisfy the block-local invariant-tube
+condition on the first Live measurement.  Theorem~\ref{thm:finite-live-capture}
+then permits bounded prefix amplification---including the observed oscillatory
+post-handoff settling---and proves finite entry into the inner radius $R_B$,
+which is contained in the entrance set of Theorem~\ref{thm:iss-block-local}.
+The operational certificate additionally requires the predeclared separation
+$R_C/R_B\ge5$ so that the startup region is materially wider than the local ISS
+entry region rather than a nominally enlarged copy of it.
+
+A timeout-forced handoff does not test the 0.075 residual magnitude and therefore
+does not inherit the normal tilt bound.  It belongs to the composite stability
+result only when an independent timeout-state envelope yields
+$R_{H,T}^{\max}<R_C$; the branch test alone is not interpreted as a capture
+certificate.
 
 \subsection{Two-stage magnetic reference}
 \label{sec:mag-two-stage}
@@ -83,17 +99,18 @@ from the already-live MEKF.
 
 Acceptance of the refined reference replaces the world magnetic reference,
 re-gauges yaw once, and releases accelerometer-bias learning.  This event occurs
-before the \SI{900}{s} scoring window but remains a discrete reconfiguration
-outside the uninterrupted Live interval.  It is covered by the semiglobal
-argument only when its post-map state is independently verified to re-enter
-Eq.~\eqref{eq:semiglobal-basin-entry}; otherwise it defines a new Live-interval
-boundary.  The reported timing is an evaluated engineering tradeoff rather
-than a universal startup schedule.
+before the \SI{900}{s} scoring window but remains a discrete reconfiguration.
+It is covered by the same stability architecture whenever the post-map state is
+independently verified to re-enter $\mathcal C_{\rm cap}$; the finite-capture
+theorem may then be restarted.  Direct re-entry into the smaller invariant ISS
+tube is not required.  The reported timing is an evaluated engineering tradeoff
+rather than a universal startup schedule.
 
 \subsection{Live re-lock boundary}
 
 A sustained tilt inconsistency above $70^\circ$ for \SI{0.35}{s} can trigger a
 tilt-only re-lock that preserves yaw; a \SI{3}{s} cooldown limits repeated
-resets.  This safety reconfiguration is testable in implementation but, like
-magnetic re-gauging, is a separate hard map.  The stability result resumes after
-it only if the reset state satisfies the same Live-basin-entry condition.
+resets.  This safety reconfiguration is a separate hard map.  The stability
+argument resumes after it when the reset state is independently verified to lie
+inside $\mathcal C_{\rm cap}$, after which Theorem~\ref{thm:finite-live-capture}
+again supplies finite entry to the inner ISS region.

--- a/doc/kalman_ou_iii/w3d-live-basin-certificate.tex-part
+++ b/doc/kalman_ou_iii/w3d-live-basin-certificate.tex-part
@@ -1,16 +1,13 @@
-\subsection{Constructive Phase-2 Live-Basin Certificate}
+\subsection{Constructive Local-ISS Certificate}
 \label{sec:iss-live-certificate}
 
-The preceding block-local theorem is uniform but existential: the constants
+The block-local theorem is uniform but existential: the constants
 $M_{\xi\xi}$, $M_{\xi\ell}$, $M_\xi$, $\rho$, $c_\xi$, and $r_\xi$ are not
-numerical objects that the implementation can inspect.  This subsection turns
-that statement into a constructive certificate without replacing a proof by a
-finite grid.  The certificate has two parts.  First, a finite-horizon norm test
-on the \emph{actual} closed-loop linearized transition supplies explicit UES
-constants.  Second, closed-form rotation inequalities and bounded Kalman gains
-supply an explicit quadratic-remainder constant.  The reference-sea replay at
-the end of the subsection is used only to report margin for the deployed
-operating points; it is not used to establish uniform stability.
+numerical objects that the implementation can inspect.  This subsection makes
+that local result constructive.  Its role is deliberately narrower than the
+regional startup certificate of Sec.~\ref{sec:capture-certificate-contract}:
+it certifies strict local contraction and an inner invariant neighborhood.  It
+is not used to require the first Live sample to satisfy the resulting radius.
 
 \subsubsection{Fixed dimensionless coordinates}
 
@@ -29,241 +26,177 @@ s_{ba}&=0.5\ {\rm m/s^2}.&&
 \end{aligned}}
 \label{eq:iss-cert-scales}
 \end{equation}
-These are design anchors rather than optimized matrix-balancing weights.
-Specifically, $s_\theta$ is the magnetically gauged Live yaw standard deviation,
-$s_{bg}$ is the square root of the constructor gyro-bias variance, $s_v,s_p,s_S$
-are the constructor linear-state standard deviations, $s_{aw}$ is the deployed
-stationary-acceleration safety ceiling, and $s_{ba}$ is the hard residual
-accelerometer-bias projection radius.  Fixing them a priori prevents a posteriori
-rescaling from manufacturing a favorable contraction norm.
+These are design anchors rather than optimized balancing weights.  Let
+$\mat D$ be the corresponding full $21\times21$ diagonal scaling, so that
+$\vct z=\mat D\vct e$.
 
-Let $\mat D$ be the corresponding full $21\times21$ diagonal scaling, so that
-$\vct z=\mat D\vct e$.  In the remainder of this subsection all matrix norms are
-induced Euclidean norms in these fixed coordinates.
+\subsubsection{Finite-horizon homogeneous contraction}
 
-\subsubsection{Exact finite-horizon contraction certificate}
-
-At a normal Live sample, every matrix needed by the homogeneous linearized error
-map is already available to the filter: the exact prediction transition,
-accepted measurement Jacobians, Kalman gains, and the MEKF reset Jacobian.  If
-$u$ indexes the accepted corrections in their executed order, define
+At a normal Live sample, every matrix needed by the homogeneous linearized
+error map is available from the estimator.  If $u$ indexes accepted corrections
+in executed order, define
 \begin{equation}
-\mat J_{u,k}=\mat G_{{\rm reset},u,k}
-              (\mat I-\mat K_{u,k}\mat C_{u,k})
+ \mat J_{u,k}=\mat G_{{\rm reset},u,k}
+               (\mat I-\mat K_{u,k}\mat C_{u,k}),
 \end{equation}
-and let $\mat\Phi_k$ denote the prediction transition.  Their product in the
-actual execution order gives the one-sample homogeneous transition
-$\mat A_k^{\rm cl}$.  Hence
+and let $\mat\Phi_k$ denote the exact prediction transition.  Their ordered
+product gives $\mat A_k^{\rm cl}$ and therefore
 \begin{equation}
-\widetilde{\mat A}_k
-=\mat D\mat A_k^{\rm cl}\mat D^{-1}
-\label{eq:iss-cert-one-step}
+ \widetilde{\mat A}_k
+ =\mat D\mat A_k^{\rm cl}\mat D^{-1}.
+ \label{eq:iss-cert-one-step}
 \end{equation}
-is reconstructible from estimator quantities; no truth state or simulated
-trajectory is required to evaluate it.
-
 For an integer horizon $H\ge1$, define
 \begin{align}
-\chi_H
-&:=\sup_k\left\|
- \widetilde\Psi(k+H,k)\right\|_2,
-\label{eq:iss-cert-chi}\\
-B_H
-&:=\sup_k\max_{0\le r<H}\left\|
- \widetilde\Psi(k+r,k)\right\|_2 .
-\label{eq:iss-cert-prefix}
+ \chi_H&:=\sup_k\|\widetilde\Psi(k+H,k)\|_2,
+ \label{eq:iss-cert-chi}\\
+ B_H&:=\sup_k\max_{0\le r<H}
+ \|\widetilde\Psi(k+r,k)\|_2 .
+ \label{eq:iss-cert-prefix}
 \end{align}
-These are conditions on the realized Live interval, not values inferred from a
-parameter grid.
 
 \begin{theorem}[Constructive finite-horizon UES certificate]
 \label{thm:iss-cert-finite-horizon}
-Suppose an uninterrupted Live interval satisfies, for one fixed $H$,
+Suppose an uninterrupted Live interval satisfies
 \begin{equation}
-\chi_H\le\bar\chi<1,
-\qquad
-B_H\le\bar B<\infty .
-\label{eq:iss-cert-contract}
+ \chi_H\le\bar\chi<1,
+ \qquad B_H\le\bar B<\infty .
+ \label{eq:iss-cert-contract}
 \end{equation}
-Then its scaled homogeneous transition is UES with the explicit constants
+Then its scaled homogeneous transition is UES with
 \begin{equation}
-\boxed{
-\rho_H=\bar\chi^{1/H},
-\qquad
-M_H=\bar B\,\rho_H^{-(H-1)},}
-\label{eq:iss-cert-M-rho}
+ \boxed{
+ \rho_H=\bar\chi^{1/H},
+ \qquad
+ M_H=\bar B\,\rho_H^{-(H-1)}.}
+ \label{eq:iss-cert-M-rho}
 \end{equation}
-that is,
+In particular,
 \begin{equation}
-\|\widetilde\Psi(k,j)\|_2
-\le M_H\rho_H^{k-j},\qquad k\ge j.
-\label{eq:iss-cert-ues}
+ \|\widetilde\Psi(k,j)\|_2
+ \le M_H\rho_H^{k-j},\qquad k\ge j,
+ \label{eq:iss-cert-ues}
 \end{equation}
-Consequently the projected constants in
+and the projected constants in
 Eq.~\eqref{eq:iss-block-projected-gains} may conservatively be chosen as
 \begin{equation}
-M_{\xi\xi}=M_{\xi\ell}=M_\xi=M_H.
-\label{eq:iss-cert-projected-M}
+ M_{\xi\xi}=M_{\xi\ell}=M_\xi=M_H.
+ \label{eq:iss-cert-projected-M}
 \end{equation}
 \end{theorem}
 
 \begin{proof}
-Write $k-j=qH+r$ with $0\le r<H$.  Split the transition into $q$ consecutive
-$H$-sample products and one remainder product.  Submultiplicativity and
-Eq.~\eqref{eq:iss-cert-contract} give
+Write $k-j=qH+r$ with $0\le r<H$.  Splitting the transition into $q$
+consecutive $H$-sample products and one prefix gives
 \begin{equation}
-\|\widetilde\Psi(k,j)\|_2
-\le \bar B\,\bar\chi^q
-=\bar B\rho_H^{qH}
-\le\bar B\rho_H^{-(H-1)}\rho_H^{k-j},
+ \|\widetilde\Psi(k,j)\|_2
+ \le\bar B\bar\chi^q
+ \le\bar B\rho_H^{-(H-1)}\rho_H^{k-j}.
 \end{equation}
-which is Eq.~\eqref{eq:iss-cert-ues}.  Projection by coordinate selectors has
-unit norm, yielding Eq.~\eqref{eq:iss-cert-projected-M}.
+Coordinate projections have unit norm, giving
+Eq.~\eqref{eq:iss-cert-projected-M}.
 \end{proof}
 
-This theorem is intentionally stronger than checking eight sea states: if the
-matrix inequalities are enforced or verified for an interval, the UES
-constants follow algebraically for that interval.  Conversely, a replay that
-happens to satisfy the inequalities is evidence that the chosen thresholds are
-practical, not a proof that an unexamined trajectory will do so.
+The same lifted structure is used by the wider capture theorem, but with a
+Riccati metric and a regional nonlinear remainder rather than the broad-box
+Euclidean constants above.  In both cases finite prefix amplification is
+allowed; only the lifted map is required to contract.
 
-\subsubsection{Constructive nonlinear remainder}
+\subsubsection{Constructive local nonlinear remainder}
 \label{sec:iss-cert-remainder}
 
-For the quantitative certificate we first state the default zero-lever-arm
-configuration.  A nonzero IMU lever arm adds a known quadratic centripetal term
-in gyro-bias error and can be appended to the bound; it is not silently covered
-by the numerical constants below.  Hard heel retargeting, magnetic re-gauging,
-and tilt re-lock remain interval boundaries as in the preceding theorems.
-
-For any skew-symmetric $\mat X$, orthogonality of $e^{s\mat X}$ and the integral
-Taylor remainder give
+For the default zero-lever-arm configuration, the rotation remainder satisfies
 \begin{equation}
-\boxed{
-\|e^{\mat X}-\mat I-\mat X\|_2
-\le\frac12\|\mat X\|_2^2 .}
-\label{eq:iss-cert-exp-remainder}
+ \|e^{\mat X}-\mat I-\mat X\|_2
+ \le\frac12\|\mat X\|_2^2
+ \label{eq:iss-cert-exp-remainder}
 \end{equation}
-Indeed,
-$e^{\mat X}-\mat I-\mat X=
-\int_0^1(1-s)e^{s\mat X}\mat X^2ds$.
-Therefore, after subtracting the first-order MEKF Jacobians, the accelerometer
-and magnetometer residual remainders satisfy
+for skew-symmetric $\mat X$.  Hence, after subtracting the first-order MEKF
+Jacobians,
 \begin{align}
-\|\vct\eta_a\|
-&\le\frac12 f_1\|\delta\vct\theta\|^2
+ \|\vct\eta_a\|
+ &\le\frac12 f_1\|\delta\vct\theta\|^2
  +\|\delta\vct\theta\|\,\|\delta\vct a_w\|,
-\label{eq:iss-cert-acc-rem}\\
-\|\vct\eta_m\|
-&\le\frac12 m_1\|\delta\vct\theta\|^2,
-\label{eq:iss-cert-mag-rem}
+ \label{eq:iss-cert-acc-rem}\\
+ \|\vct\eta_m\|
+ &\le\frac12m_1\|\delta\vct\theta\|^2.
+ \label{eq:iss-cert-mag-rem}
 \end{align}
-where $f_1,m_1$ are the accepted-vector magnitude bounds already required by
-Eqs.~\eqref{eq:iss-vector-magnitude-bounds}.  The $S=0$ residual is exactly
-linear and contributes no measurement-model remainder.
+The $S=0$ measurement residual itself is exactly linear, but its Kalman gain is
+not block truncated: attitude rows generated by cross-covariance remain part of
+the quaternion correction and therefore of the group-reset remainder.
 
-Let $\mat E_\xi$ select the sensitive scaled coordinates and define the
-realized gain envelopes
+Let $\mat E_\xi$ select the sensitive scaled coordinates and define
 \begin{equation}
-\kappa_a=\sup_k\|\mat E_\xi\mat D\mat K_{a,k}\|_2,
-\qquad
-\kappa_m=\sup_k\|\mat E_\xi\mat D\mat K_{m,k}\|_2 .
-\label{eq:iss-cert-gain-envelopes}
+ \kappa_a=\sup_k\|\mat E_\xi\mat D\mat K_{a,k}\|_2,
+ \qquad
+ \kappa_m=\sup_k\|\mat E_\xi\mat D\mat K_{m,k}\|_2 .
+ \label{eq:iss-cert-gain-envelopes}
 \end{equation}
-Then the nonlinear measurement contribution is bounded by
+Then one measurement-model contribution is
 \begin{equation}
-c_{\rm meas}
-=\kappa_a\left(\frac12 f_1s_\theta^2+s_\theta s_{aw}\right)
+ c_{\rm meas}
+ =\kappa_a\left(\frac12f_1s_\theta^2+s_\theta s_{aw}\right)
  +\kappa_m\frac12m_1s_\theta^2 .
-\label{eq:iss-cert-cmeas}
+ \label{eq:iss-cert-cmeas}
 \end{equation}
-These gain norms are estimator quantities and can be checked directly on the
-same certified interval as Eq.~\eqref{eq:iss-cert-contract}.
-
-The remaining group nonlinearity is quaternion composition during prediction
-and reset.  For $\|\vct x\|<\pi$, the inverse left Jacobian of $\SO(3)$ is
-\begin{equation}
-\mat J_l^{-1}(\vct x)
-=\mat I-\frac12[\vct x]_\times
- +A(\|\vct x\|)[\vct x]_\times^2,
-\end{equation}
-where
-\begin{equation}
-A(q)=\frac1{q^2}-\frac{1+\cos q}{2q\sin q}.
-\end{equation}
-Hence, on $0\le q\le\theta_c<\pi$,
-\begin{equation}
-\|\mat J_l^{-1}(\vct x)-\mat I\|_2
-\le j_c\|\vct x\|,
-\qquad
-j_c:=\frac12+A(\theta_c)\theta_c .
-\label{eq:iss-cert-jinv}
-\end{equation}
-If one exact group composition applies a correction whose angle is bounded by
-$a_g\|\vct z_\xi\|$, while
-$\|\delta\vct\theta\|\le s_\theta\|\vct z_\xi\|$ and
-$(s_\theta+a_g)r\le\theta_c$, integration of the logarithm along the correction
-path gives the normalized quadratic bound
-\begin{equation}
-c_g
-=\frac{j_c}{s_\theta}(s_\theta+a_g)a_g .
-\label{eq:iss-cert-group-rem}
-\end{equation}
-For prediction one may take $a_g=h_{\max}s_{bg}$.  For an accepted correction
-$u\in\{a,m,S\}$, a conservative $a_g$ is obtained from the attitude rows of its
-Kalman gain and the first-order residual bound,
+For the group composition, if one correction angle is bounded by
+$a_g\|\vct z_\xi\|$, a local quadratic constant may be obtained from the
+inverse left Jacobian of $\SO(3)$.  In particular, the accepted correction
+angle bounds retain the full gains,
 \begin{align}
-a_a&=\|\mat E_\theta\mat K_a\|_2
+ a_a&=\|\mat E_\theta\mat K_a\|_2
        (f_1s_\theta+s_{aw}+s_{ba}),\\
-a_m&=\|\mat E_\theta\mat K_m\|_2m_1s_\theta,\\
-a_S&=\|\mat E_\theta\mat K_S\|_2s_S .
-\label{eq:iss-cert-angle-gains}
+ a_m&=\|\mat E_\theta\mat K_m\|_2m_1s_\theta,\\
+ a_S&=\|\mat E_\theta\mat K_S\|_2s_S .
+ \label{eq:iss-cert-angle-gains}
 \end{align}
-Taking suprema over the certified interval and summing the group operations in
-one sample yields $c_{\rm grp}=\sum_g c_g$.  Thus an explicit one-step choice
-for Lemma~\ref{lem:iss-block-remainder} is
+Taking interval suprema and summing the group operations yields
 \begin{equation}
-\boxed{c_\xi=c_{\rm meas}+c_{\rm grp},}
-\label{eq:iss-cert-cxi}
+ \boxed{c_\xi=c_{\rm meas}+c_{\rm grp},}
+ \label{eq:iss-cert-cxi}
 \end{equation}
-valid for every
+valid on a chart-safe radius
 \begin{equation}
-0<r\le r_\xi:=
-\min_g\frac{\theta_c}{s_\theta+a_g}.
-\label{eq:iss-cert-rxi}
+ 0<r\le r_\xi:=
+ \min_g\frac{\theta_c}{s_\theta+a_g}.
+ \label{eq:iss-cert-rxi}
 \end{equation}
-The bounds are deliberately conservative: they price every gain and rotation at
-its interval supremum rather than relying on cancellation.
+The exact expression for $c_{\rm grp}$ and its verified bounds are carried by
+the computer-assisted closure of
+Sec.~\ref{sec:iss-computer-assisted-certificate}.
 
 Combining Eqs.~\eqref{eq:iss-cert-M-rho} and
-\eqref{eq:iss-cert-cxi} makes the Phase-1 small-gain quantity numerical,
+\eqref{eq:iss-cert-cxi} gives
 \begin{equation}
-\boxed{
-\nu_{\rm cert}(r)
-=\frac{M_Hc_\xi r}{1-\rho_H}.}
-\label{eq:iss-cert-nu}
+ \boxed{
+ \nu_{\rm cert}(r)
+ =\frac{M_Hc_\xi r}{1-\rho_H}}
+ \label{eq:iss-cert-nu}
 \end{equation}
-A constructive admissible radius is therefore
+and the sufficient local radius
 \begin{equation}
-\boxed{
-r_{\rm cert}
-<\min\left\{r_\xi,
-\frac{1-\rho_H}{M_Hc_\xi}\right\}.}
-\label{eq:iss-cert-radius}
+ \boxed{
+ r_{\rm cert}<
+ \min\left\{r_\xi,
+ \frac{1-\rho_H}{M_Hc_\xi}\right\}.}
+ \label{eq:iss-cert-radius}
 \end{equation}
-Substitution of $r=r_{\rm cert}$ in
-Eq.~\eqref{eq:semiglobal-basin-entry} produces a numerical handoff test rather
-than the existential radius used in Phase 1.
+This radius is a constructive inner invariant-neighborhood certificate.  The
+very broad interval arithmetic used below makes it intentionally conservative;
+it is not substituted for $R_C$ and is not a requirement on the first Live
+measurement.  Startup is instead certified by
+Eqs.~\eqref{eq:capture-certificate-pass} and
+\eqref{eq:semiglobal-capture-entry}.
 
-\subsubsection{Deployed-point margin diagnostic}
+\subsubsection{Deployed-point contraction diagnostic}
 \label{sec:iss-cert-diagnostic}
 
 The host-side program \texttt{live\_basin\_diagnostic.cpp} reconstructs
-Eq.~\eqref{eq:iss-cert-one-step} from the filter's own prediction matrices and
-Kalman gains at the eight committed SpectralMSE reference operating points.  It
-uses a \SI{30}{s} horizon after covariance warm-up and reports
-$\chi_H$, the prefix norm $B_H$, the sensitive/kinematic projected norms, and
-the implied $M_H,\rho_H$.  The diagnostic is a regression witness for the
-practicality of the certificate.  It is \emph{not} substituted for the uniform
-conditions of Theorem~\ref{thm:iss-cert-finite-horizon}; an operating trajectory
-must satisfy its own matrix and gain envelopes to be called certified.
+Eq.~\eqref{eq:iss-cert-one-step} from the filter's prediction matrices and
+Kalman gains at the eight committed reference operating points.  It uses a
+\SI{30}{s} horizon after covariance warm-up and reports Euclidean and
+Riccati-metric contraction diagnostics.  This replay is useful evidence that
+the deployed steady-Live points contract, but it is not the operational
+startup certificate because the warm-up removes exactly the covariance
+transient that Sec.~\ref{sec:finite-live-capture} is designed to cover.

--- a/doc/kalman_ou_iii/w3d-semiglobal-stability.tex-part
+++ b/doc/kalman_ou_iii/w3d-semiglobal-stability.tex-part
@@ -1,29 +1,31 @@
 \input{w3d-block-local-iss.tex-part}
+\input{w3d-finite-live-capture.tex-part}
 
-\section{Almost-Global Startup Capture and Semiglobal Practical Extension}
+\section{Almost-Global Proxy Entry to the Live Capture Region}
 \label{sec:semiglobal-stability}
 
-The Live-state result of Sec.~\ref{app:iss-stability} is necessarily local in
-MEKF coordinates: the attitude error is represented by a three-vector chart and
-the nonlinear remainder is absorbed only inside an invariant neighborhood.
-Theorem~\ref{thm:iss-21-local} gives a convenient sufficient 21-state ball,
-while Theorem~\ref{thm:iss-block-local} sharpens that ball using the exact
-measurement and reset structure.  The deployed estimator nevertheless does not
-ask the MEKF itself to recover from an arbitrary startup attitude.  Before
-handoff, the MEKF is untouched and a measurement-only Mahony observer supplies
-tilt while the magnetic-reference logic establishes the yaw gauge.  This
-section uses that architecture to extend the result from a local Live theorem
-to an almost-global, semiglobal practical proxy-to-Live statement.
-``Semiglobal'' means uniformity on any prescribed compact startup set contained
-in the desired proxy domain of attraction; it does not claim semiglobal
-convergence of an already-running MEKF from arbitrary 21-state errors.
+The preceding results separate two questions that should not be conflated.
+Theorem~\ref{thm:iss-block-local} gives an invariant local Live tube, whereas
+Theorem~\ref{thm:finite-live-capture} gives a larger regional set from which the
+full coupled OU--III recursion reaches that tube in finite time.  Startup
+therefore does not have to place the first MEKF sample directly inside the
+local ISS basin.  Its only task is to place the initialized filter inside the
+outer capture region $\mathcal C_{\rm cap}$.  This ordering matches the deployed
+behavior: the measurement-only Mahony proxy supplies a bounded attitude seed,
+then the newly enabled Live filter is allowed a bounded oscillatory transient
+before entering its invariant neighborhood.
+
+``Semiglobal'' below means uniformity on any prescribed compact startup set
+contained in the desired proxy domain of attraction.  It does not claim
+semiglobal convergence of an already-running MEKF from arbitrary 21-state
+errors, and it does not turn the local MEKF chart into a global coordinate
+system.
 
 \subsection{Compatibility with the deployed physical-MSE schedule}
 \label{sec:semiglobal-mse-schedule}
 
-The stability argument does not require a particular monomial relationship
-between the scheduled OU and pseudo-measurement parameters.  It requires only
-the predictable, positive compact bounds of
+The capture and ISS arguments do not require a particular monomial adaptation
+law.  They require the predictable positive compact bounds of
 Eqs.~\eqref{eq:iss-step-tau-bounds}--\eqref{eq:iss-tuning-bounds}.  For the
 deployed SpectralMSE regularizer, the physical-MSE calculation gives
 \begin{equation}
@@ -31,390 +33,293 @@ deployed SpectralMSE regularizer, the physical-MSE calculation gives
  =C_J q_{\rm eff}^{1/14}\,
  \widehat\sigma_{a,B}^{\,6/7}\,
  \tau_\star^{24/7}T_S^{-1/2},
-\label{eq:semiglobal-mse-schedule}
+ \label{eq:semiglobal-mse-schedule}
 \end{equation}
-which is Eq.~\eqref{eq:adapt-mse-applied-form}.  Away from the cadence clamps,
-$T_S=c_T\tau$ and therefore
+and, away from the cadence clamps where $T_S=c_T\tau$,
 \begin{equation}
  r_{S,\star}\propto
  q_{\rm eff}^{1/14}\widehat\sigma_{a,B}^{\,6/7}
  \tau^{41/14}.
-\label{eq:semiglobal-mse-powers}
+ \label{eq:semiglobal-mse-powers}
 \end{equation}
-The exponents $6/7$ and $41/14$ are the theoretical physical-MSE exponents;
-no $\sigma\tau^3$ adaptation relation is used in this proof.
+No $\sigma\tau^3$ adaptation relation is used in this proof.  Positive finite
+bounds on $q_{\rm eff}$, $\widehat\sigma_{a,B}$, $T_S$, and $\tau$, together
+with the implementation clamps and convex exponential smoothing, keep the
+applied $(\tau,\sigma_{aw},r_S)$ schedule in a compact set.  The schedule is
+therefore part of the regional parameter family over which the capture
+constants $\chi_C,c_C,g_C$ are verified; it does not alter the logical form of
+the proof.
 
-To see why adaptation remains admissible, first suppose the unclipped inputs of
-Eq.~\eqref{eq:semiglobal-mse-schedule} lie in positive compact intervals,
-\begin{equation}
-0<\underline q\le q_{\rm eff}\le\overline q,
-\quad
-0<\underline\sigma_B\le\widehat\sigma_{a,B}\le\overline\sigma_B,
-\quad
-0<\underline T_S\le T_S\le\overline T_S.
-\end{equation}
-Together with Eq.~\eqref{eq:iss-step-tau-bounds}, monotonicity gives
-\begin{align}
-\underline r_{S,\rm MSE}
-&=C_J\underline q^{1/14}\underline\sigma_B^{6/7}
-  \underline\tau^{24/7}\overline T_S^{-1/2},\\
-\overline r_{S,\rm MSE}
-&=C_J\overline q^{1/14}\overline\sigma_B^{6/7}
-  \overline\tau^{24/7}\underline T_S^{-1/2}.
-\end{align}
-Thus $0<\underline r_{S,\rm MSE}\le r_{S,\star}
-\le\overline r_{S,\rm MSE}<\infty$.  The implementation further clips the
-regularizer to a strictly positive finite interval and applies only positive
-bounded cadence normalization.  Consequently the same conclusion holds even
-when a near-still analytical target approaches zero.  Exponential smoothing is
-a convex update between the previous applied value and the bounded target, so
-it preserves the enclosure.  Hence the SpectralMSE law changes the numerical
-compact set over which Theorem~\ref{thm:iss-21-ues} is uniform, not the
-structure of its proof.
-
-\subsection{Reduced proxy attitude error}
+\subsection{Reduced Mahony proxy dynamics}
 \label{sec:semiglobal-proxy}
 
 Let $\vct d\in\mathbb S^2$ denote the true body-frame direction of world down
-and let $\widehat{\vct d}_P\in\mathbb S^2$ be the direction predicted by the
-startup proxy.  Only tilt is observable from this channel, so define
+and $\widehat{\vct d}_P\in\mathbb S^2$ the direction predicted by the startup
+proxy.  Only tilt is observable from this channel, so define
 \begin{equation}
-\theta_P=\cos^{-1}(\widehat{\vct d}_P^{\top}\vct d),
-\qquad 0\le\theta_P\le\pi,
-\label{eq:semiglobal-tilt-error}
+ \theta_P=\cos^{-1}(\widehat{\vct d}_P^\top\vct d),
+ \qquad 0\le\theta_P\le\pi,
+ \label{eq:semiglobal-tilt-error}
 \end{equation}
 and let $\widetilde{\vct\beta}_{\perp}$ be the component of proxy gyro-bias
 error perpendicular to $\vct d$.  Rotation about $\vct d$ and the corresponding
-parallel bias component are gauge variables for the gravity-only proxy and are
-not included in the reduced error
+parallel bias component are gauge variables for the gravity-only proxy.  The
+reduced state is therefore
 \begin{equation}
-\vct z_P=(\widehat{\vct d}_P,\widetilde{\vct\beta}_{\perp}).
+ \vct z_P=(\widehat{\vct d}_P,\widetilde{\vct\beta}_{\perp}),
 \end{equation}
-The desired reduced set is
+with desired set
 \begin{equation}
-\mathcal A_P=\{\widehat{\vct d}_P=\vct d,
-               \widetilde{\vct\beta}_{\perp}=0\}.
+ \mathcal A_P=\{\widehat{\vct d}_P=\vct d,
+                 \widetilde{\vct\beta}_{\perp}=0\}.
 \end{equation}
 The smooth single-vector correction also has the undesired antipodal critical
-set $\mathcal U_P$ associated with
-$\widehat{\vct d}_P=-\vct d$.  With integral bias estimation, the set that must
-be excluded from the desired domain is rigorously the stable set of those
-undesired critical points, not merely the critical points themselves.  Denote
-that measure-zero set by
+set $\mathcal U_P$.  With integral bias estimation, the excluded set is the
+stable set of those undesired equilibria,
 \begin{equation}
-\mathcal N_P:=W^s(\mathcal U_P),
-\qquad
-\mathcal D_P:=\bigl(\mathbb S^2\times\mathbb R^2\bigr)\setminus\mathcal N_P.
-\label{eq:semiglobal-proxy-domain}
+ \boxed{
+ \mathcal N_P:=W^s(\mathcal U_P),\qquad
+ \mathcal D_P:=
+ (\mathbb S^2\times\mathbb R^2)\setminus\mathcal N_P .}
+ \label{eq:semiglobal-proxy-domain}
 \end{equation}
+For the disturbance-free reduced dynamics induced by
+Eq.~\eqref{eq:proxy-mahony}, the Mahony construction gives almost-global
+asymptotic convergence to $\mathcal A_P$; the complement of
+$\mathcal D_P$ has measure zero \cite{Mahony2008NonlinearComplementary}.
 
-In the disturbance-free case, the reduced dynamics induced by
-Eq.~\eqref{eq:proxy-mahony} are the standard nonlinear complementary-filter
-dynamics on the observable gravity quotient.  The Mahony construction gives
-almost-global asymptotic convergence to $\mathcal A_P$; equivalently,
-$\mathcal D_P$ is the desired domain of attraction and its complement is the
-measure-zero stable set of the undesired attitude equilibria
-\cite{Mahony2008NonlinearComplementary}.
+Fix any compact
+\begin{equation}
+ \mathcal K_{\epsilon,B_\beta}\subset\mathcal D_P,
+ \qquad
+ \operatorname{dist}(\mathcal K_{\epsilon,B_\beta},\mathcal N_P)
+ \ge\epsilon>0,
+ \qquad
+ \|\widetilde{\vct\beta}_{\perp}\|\le B_\beta.
+ \label{eq:semiglobal-proxy-compact}
+\end{equation}
+A converse Lyapunov theorem on a compact forward neighborhood gives a smooth
+$V_\epsilon$ and class-$\mathcal K$ functions with
+\begin{equation}
+ \alpha_{1,\epsilon}(|\vct z_P|_{\mathcal A_P})
+ \le V_\epsilon
+ \le\alpha_{2,\epsilon}(|\vct z_P|_{\mathcal A_P}),
+ \qquad
+ \dot V_\epsilon
+ \le-\alpha_{3,\epsilon}(|\vct z_P|_{\mathcal A_P})
+ \label{eq:semiglobal-proxy-converse}
+\end{equation}
+\cite{Khalil2002_NonlinearSystems}.  Let $\vct u_P$ collect bounded wave-induced
+specific-force perturbation in the normalized direction, gyro noise, slow
+bias/model mismatch, and the finite-step defect.  Assume
+\begin{equation}
+ 0<f_{P,0}\le\|\vct f_b(t)\|\le f_{P,1}<\infty
+ \label{eq:semiglobal-proxy-force-bound}
+\end{equation}
+so accelerometer normalization remains smooth on the prescribed compact set.
+Smoothness then gives a finite $L_\epsilon$ such that
+\begin{equation}
+ \dot V_\epsilon
+ \le-\alpha_{3,\epsilon}(|\vct z_P|_{\mathcal A_P})
+ +L_\epsilon\|\vct u_P\|.
+\end{equation}
+Standard comparison yields
+\begin{equation}
+ \boxed{
+ |\vct z_P(t)|_{\mathcal A_P}
+ \le
+ \beta_\epsilon(|\vct z_P(0)|_{\mathcal A_P},t)
+ +\gamma_\epsilon(\|\vct u_P\|_\infty).}
+ \label{eq:semiglobal-proxy-iss}
+\end{equation}
+Thus the proxy is semiglobally practically ISS on every compact subset of
+$\mathcal D_P$, with constants that need not remain uniform as the initial set
+approaches $\mathcal N_P$.
 
-Fix any compact startup set
-\begin{equation}
-\mathcal K_{\epsilon,B_\beta}\subset\mathcal D_P,
-\qquad
-\operatorname{dist}(\mathcal K_{\epsilon,B_\beta},\mathcal N_P)\ge\epsilon>0,
-\qquad
-\|\widetilde{\vct\beta}_{\perp}\|\le B_\beta<\infty.
-\label{eq:semiglobal-proxy-compact}
-\end{equation}
-Because this compact set lies strictly inside the domain of attraction, a
-converse Lyapunov theorem supplies, on a compact forward neighborhood, a smooth
-function $V_\epsilon$ and class-$\mathcal K$ functions
-$\alpha_{1,\epsilon}$, $\alpha_{2,\epsilon}$, and
-$\alpha_{3,\epsilon}$ such that \cite{Khalil2002_NonlinearSystems}
-\begin{equation}
-\alpha_{1,\epsilon}(|\vct z_P|_{\mathcal A_P})
-\le V_\epsilon
-\le\alpha_{2,\epsilon}(|\vct z_P|_{\mathcal A_P}),
-\qquad
-\dot V_\epsilon
-\le-\alpha_{3,\epsilon}(|\vct z_P|_{\mathcal A_P}).
-\label{eq:semiglobal-proxy-converse}
-\end{equation}
-Here $|\cdot|_{\mathcal A_P}$ denotes distance to the desired reduced set.
-
-Let $\vct u_P$ collect bounded perturbations of the proxy vector field:
-wave-induced non-gravitational specific force in the normalized direction,
-gyro noise, slow bias/model mismatch, and the finite-step implementation
-defect.  Assume on the startup family that
-\begin{equation}
-0<f_{P,0}\le\|\vct f_b(t)\|\le f_{P,1}<\infty,
-\label{eq:semiglobal-proxy-force-bound}
-\end{equation}
-so normalization of the accelerometer vector is smooth and Lipschitz on the
-relevant compact set.  For the sampled implementation, take the step bound in
-Eq.~\eqref{eq:iss-step-tau-bounds} sufficiently small on that set that the
-consistent Mahony discretization error is included in $\vct u_P$.  Smoothness
-then gives a finite $L_\epsilon$ with
-\begin{equation}
-\dot V_\epsilon
-\le-\alpha_{3,\epsilon}(|\vct z_P|_{\mathcal A_P})
-   +L_\epsilon\|\vct u_P\|.
-\label{eq:semiglobal-proxy-perturbed}
-\end{equation}
-Standard comparison then yields class-$\mathcal{KL}$ and class-$\mathcal K$
-functions $\beta_\epsilon$ and $\gamma_\epsilon$ such that, for sufficiently
-small bounded perturbations that keep the trajectory in that compact
-neighborhood,
-\begin{equation}
-|\vct z_P(t)|_{\mathcal A_P}
-\le
-\beta_\epsilon(|\vct z_P(0)|_{\mathcal A_P},t)
-+\gamma_\epsilon(\|\vct u_P\|_\infty).
-\label{eq:semiglobal-proxy-iss}
-\end{equation}
-This is the semiglobal practical-ISS property of the startup tilt observer:
-the bound is uniform on every prescribed compact subset of $\mathcal D_P$, but
-its constants need not remain uniform as that set approaches
-$\mathcal N_P$.
-
-\subsection{Quality gate as a block-structured basin-entry map}
+\subsection{Quality gate as an entry map to the capture region}
 \label{sec:semiglobal-handoff}
 
-The proxy is not required to converge asymptotically before handoff.  It need
-only enter the basin in which the Live MEKF theorem applies.  The implementation
-forms a sine residual from the predicted and low-pass measured rest-specific-
-force directions.  Write
+The proxy is not required to converge to the final Live ISS tube.  It need only
+make the subsequent MEKF handoff belong to the larger set certified by
+Theorem~\ref{thm:finite-live-capture}.  The implemented gravity gate uses
 \begin{equation}
-\widehat{\vct s}_P=-\widehat{\vct d}_P,
-\qquad
-\widehat{\vct s}_{\rm meas}
-=\frac{\vct f_{\rm LP}}{\|\vct f_{\rm LP}\|}.
+ \widehat{\vct s}_P=-\widehat{\vct d}_P,
+ \qquad
+ \widehat{\vct s}_{\rm meas}
+ =\frac{\vct f_{\rm LP}}{\|\vct f_{\rm LP}\|},
 \end{equation}
-The residual part of the gate requires
+and requires
 \begin{equation}
-\|\widehat{\vct s}_P\times\widehat{\vct s}_{\rm meas}\|\le0.075.
-\label{eq:semiglobal-sine-gate}
+ \|\widehat{\vct s}_P\times\widehat{\vct s}_{\rm meas}\|
+ \le0.075.
+ \label{eq:semiglobal-sine-gate}
 \end{equation}
-Because a sine residual is identical at angles $\alpha$ and $\pi-\alpha$,
-Eq.~\eqref{eq:semiglobal-sine-gate} by itself is not a branch certificate: it
-scores an attitude and its antipode alike.  An accepted handoff is therefore
-required to lie on the aligned branch as well,
+A sine residual alone is identical at angles $\alpha$ and $\pi-\alpha$.
+Therefore every accepted handoff also tests the sign of the inner product,
 \begin{equation}
-\widehat{\vct s}_P^{\top}\widehat{\vct s}_{\rm meas}>0,
-\label{eq:semiglobal-aligned-branch}
+ \boxed{
+ \widehat{\vct s}_P^\top\widehat{\vct s}_{\rm meas}>0,}
+ \label{eq:semiglobal-aligned-branch}
 \end{equation}
-which is the sign of the inner product of the same two directions and is
-evaluated with Eq.~\eqref{eq:semiglobal-sine-gate} on every sample of the
-accepted hold and on the sample that seeds the filter.
-On that branch the angle between the two directions is at most
-$\sin^{-1}(0.075)$.  Let $\eta_g$ bound the angular difference between
-$\widehat{\vct s}_{\rm meas}$ and the true rest-specific-force direction
-$-\vct d$ during the accepted hold.  Then the spherical triangle inequality
-gives the conservative true-tilt bound
+selecting the aligned rather than antipodal branch.  If $\eta_g$ bounds the
+angular difference between the low-pass measured direction and true rest
+specific force during the accepted hold, then
 \begin{equation}
-\theta_{H,\rm tilt}
-\le\sin^{-1}(0.075)+\eta_g.
-\label{eq:semiglobal-handoff-tilt}
+ \theta_{H,\rm tilt}
+ \le\sin^{-1}(0.075)+\eta_g.
+ \label{eq:semiglobal-handoff-tilt}
 \end{equation}
-Thus the proof does not infer a small tilt merely from a small sine residual;
-it also requires the physically correct alignment branch.
+If an accepted magnetic or equivalent heading gauge has error at most $\eta_m$,
+then the geodesic triangle inequality gives
+\begin{equation}
+ \boxed{
+ \|\delta\vct\theta_H\|
+ \le\overline\theta_H
+ :=\sin^{-1}(0.075)+\eta_g+\eta_m<\pi.}
+ \label{eq:semiglobal-handoff-attitude}
+\end{equation}
 
-Let $\eta_m$ be a bound on the heading error supplied by an accepted magnetic
-gauge.  For example, if the true horizontal magnetic component has magnitude
-at least $B_{h,0}>0$ and the learned horizontal reference error is at most
-$\delta B_h<B_{h,0}$, then one may take
-$\eta_m=\sin^{-1}(\delta B_h/B_{h,0})$.  By the geodesic triangle inequality,
-\begin{equation}
-d_{\SO(3)}(\widetilde{\mat R}_H,\mat I)
-\le\overline\theta_H
-:=\sin^{-1}(0.075)+\eta_g+\eta_m.
-\label{eq:semiglobal-handoff-attitude}
-\end{equation}
-Thus, provided $\overline\theta_H<\pi$, the principal MEKF attitude-error
-coordinate exists at handoff and satisfies
-$\|\delta\vct\theta_H\|\le\overline\theta_H$.
-
-For the remaining sensitive coordinates, suppose the physical startup family
-provides finite bounds
-\begin{equation}
-\|\delta\vct b_{g,H}\|\le B_{g,H},\quad
-\|\delta\vct S_H\|\le B_{S,H},\quad
-\|\delta\vct a_{w,H}\|\le B_{aw,H},\quad
-\|\delta\vct b_{a,H}\|\le B_{a,H},
-\label{eq:semiglobal-handoff-sensitive-bounds}
-\end{equation}
-and let
-\begin{equation}
-\|\delta\vct v_H\|\le B_{v,H},\qquad
-\|\delta\vct p_H\|\le B_{p,H}
-\label{eq:semiglobal-handoff-kinematic-bounds}
-\end{equation}
-bound the kinematic-only coordinates.  With the fixed scales of
-Eqs.~\eqref{eq:iss-block-xi}--\eqref{eq:iss-block-ell}, define the dimensionless
-handoff bounds
+The proxy does not estimate every MEKF state and therefore must not be credited
+with shrinking them.  Let the physical startup family provide finite bounds
 \begin{align}
-B_{\xi,H}
-&:=\left[
- \left(\frac{\overline\theta_H}{s_\theta}\right)^2
- +\left(\frac{B_{g,H}}{s_{bg}}\right)^2
- +\left(\frac{B_{S,H}}{s_S}\right)^2
- +\left(\frac{B_{aw,H}}{s_{aw}}\right)^2
- +\left(\frac{B_{a,H}}{s_{ba}}\right)^2
- \right]^{1/2},\\
-B_{\ell,H}
-&:=\left[
- \left(\frac{B_{v,H}}{s_v}\right)^2
- +\left(\frac{B_{p,H}}{s_p}\right)^2
- \right]^{1/2}.
-\label{eq:semiglobal-handoff-block-bounds}
+ \|\delta\vct b_{g,H}\|&\le B_{g,H},&
+ \|\delta\vct S_H\|&\le B_{S,H},\\
+ \|\delta\vct a_{w,H}\|&\le B_{aw,H},&
+ \|\delta\vct b_{a,H}\|&\le B_{a,H},
+ \label{eq:semiglobal-handoff-sensitive-bounds}
 \end{align}
-Then $\|\vct z_{\xi,H}\|\le B_{\xi,H}$ and
-$\|\vct z_{\ell,H}\|\le B_{\ell,H}$.
-
-Let $\overline d_L$ bound the deterministic Live disturbance on the certified
-interval.  Choose the sensitive-tube radius $r$ and small-gain margin $\nu$ of
-Theorem~\ref{thm:iss-block-local}.  A sufficient block-structured basin-entry
-condition is
+and
 \begin{equation}
-\boxed{
-r_H^{\rm blk}:=
-M_{\xi\xi}B_{\xi,H}
-+M_{\xi\ell}B_{\ell,H}
-+\frac{M_\xi\overline G_z}{1-\rho}\,\overline d_L
-<(1-\nu)r .}
-\label{eq:semiglobal-basin-entry}
+ \|\delta\vct v_H\|\le B_{v,H},
+ \qquad
+ \|\delta\vct p_H\|\le B_{p,H}.
+ \label{eq:semiglobal-handoff-kinematic-bounds}
 \end{equation}
-This replaces the earlier unscaled 21-state Euclidean-ball condition.  It does
-not require $v$ and $p$ themselves to lie inside the same local radius as the
-nonlinear coordinates; only their induced homogeneous transient into the
-sensitive block is charged through $M_{\xi\ell}$.  The result is not a claim of
-arbitrarily large translational capture: $M_{\xi\ell}$ is generally nonzero,
-and $S$ remains in the sensitive block because its pseudo-measurement can
-produce an attitude correction through Kalman cross-covariance.  This is the
-block separation supported by the deployed architecture without changing the
-filter.
+For compatibility with the block-local notation define
+\begin{align}
+ B_{\xi,H}
+ &:={\left[
+ (\overline\theta_H/s_\theta)^2
+ +(B_{g,H}/s_{bg})^2
+ +(B_{S,H}/s_S)^2
+ +(B_{aw,H}/s_{aw})^2
+ +(B_{a,H}/s_{ba})^2\right]^{1/2}},\\
+ B_{\ell,H}
+ &:={\left[
+ (B_{v,H}/s_v)^2+(B_{p,H}/s_p)^2\right]^{1/2}}.
+ \label{eq:semiglobal-handoff-block-bounds}
+\end{align}
+These are physical handoff bounds, not a claim that the handoff already
+satisfies Theorem~\ref{thm:iss-block-local}.
 
-\begin{theorem}[Almost-global/semiglobal practical proxy-to-Live ISS]
+Let $\Pi_H$ denote the compact set of staged handoff tuning/covariance modes and
+let $\mathcal H$ be the structured physical-error set defined by
+Eqs.~\eqref{eq:semiglobal-handoff-attitude}--
+\eqref{eq:semiglobal-handoff-kinematic-bounds}.  Using the covariance
+$\mat P_H(\pi)$ produced by the actual \texttt{goLive()} map, define
+\begin{equation}
+ \boxed{
+ R_H^{\max}:=
+ \sup_{\pi\in\Pi_H}\sup_{\vct e\in\mathcal H}
+ \left(\vct e^\top\mat P_H(\pi)^{-1}\vct e\right)^{1/2}.}
+ \label{eq:semiglobal-handoff-metric-radius}
+\end{equation}
+The proxy-to-Live interface condition is now
+\begin{equation}
+ \boxed{R_H^{\max}<R_C,}
+ \label{eq:semiglobal-capture-entry}
+\end{equation}
+where $R_C$ is the \emph{outer} regional radius in
+Theorem~\ref{thm:finite-live-capture}.  Equation~\eqref{eq:semiglobal-capture-entry}
+replaces the earlier requirement that the first Live sample already satisfy the
+block-local invariant-tube inequality.  In particular, the capture certificate
+requires the declared separation $R_C/R_B\ge5$ before an operational startup
+claim is made.
+
+\begin{theorem}[Almost-global/semiglobal proxy-to-Live capture and practical ISS]
 \label{thm:semiglobal-proxy-live}
-Fix a compact $\mathcal K_{\epsilon,B_\beta}\subset\mathcal D_P$ as in
-Eq.~\eqref{eq:semiglobal-proxy-compact} and a compact family of physical startup
-conditions satisfying Eqs.~\eqref{eq:semiglobal-proxy-force-bound},
+Fix $\mathcal K_{\epsilon,B_\beta}$ as in
+Eq.~\eqref{eq:semiglobal-proxy-compact} and a compact physical startup family
+satisfying Eqs.~\eqref{eq:semiglobal-proxy-force-bound},
 \eqref{eq:semiglobal-handoff-sensitive-bounds}, and
 \eqref{eq:semiglobal-handoff-kinematic-bounds}.  Assume:
-(i) the reduced proxy initial error belongs to
-$\mathcal K_{\epsilon,B_\beta}$;
-(ii) the bounded proxy perturbation and sample step are small enough for
-Eq.~\eqref{eq:semiglobal-proxy-iss} to reach an accepted gravity interval;
-(iii) the accepted gravity interval satisfies the aligned-branch condition
-\eqref{eq:semiglobal-aligned-branch};
-(iv) the auxiliary handoff channels---tuner readiness and, when required by the
-Live observability hypothesis, a noncollinear magnetic or equivalent vector
-reference---become ready within a finite time uniform over the chosen startup
-family, with heading error bounded as in
-Eq.~\eqref{eq:semiglobal-handoff-attitude};
-(v) the block basin-entry inequality \eqref{eq:semiglobal-basin-entry} holds for
-a declared Live disturbance bound $\overline d_L$; and
-(vi) after handoff, the hypotheses of Theorems~\ref{thm:iss-21-ues} and
-\ref{thm:iss-block-local} hold, including the bounded predictable SpectralMSE
-schedule and no hard reset on the analyzed Live interval.  Then there is a
-finite handoff index $k_H$, uniform over the chosen compact startup family, and
-constants $C_z\ge1$, $0<\lambda_z<1$, and $\Gamma_z<\infty$ such that for every
-$k\ge k_H$,
+(i) the proxy initial error belongs to $\mathcal K_{\epsilon,B_\beta}$;
+(ii) its bounded perturbation is small enough for
+Eq.~\eqref{eq:semiglobal-proxy-iss} to reach a quality-gated gravity interval;
+(iii) the accepted interval satisfies
+Eq.~\eqref{eq:semiglobal-aligned-branch};
+(iv) tuner readiness and, when required for full Live observability, a
+noncollinear magnetic or equivalent reference become available in finite time
+uniformly over the startup family;
+(v) the resulting handoff family satisfies
+Eq.~\eqref{eq:semiglobal-capture-entry}; and
+(vi) the regional certificate of Theorem~\ref{thm:finite-live-capture}, including
+its predictable schedule and no-hard-reset assumptions, holds through the
+capture interval.  Then there is a finite uniform handoff index $k_H$ and a
+finite capture index $k_C$ satisfying
 \begin{equation}
-\boxed{
-\|\vct z_k\|
-\le C_z\lambda_z^{k-k_H}
- \bigl(B_{\xi,H}+B_{\ell,H}\bigr)
- +\Gamma_z\sup_{k_H\le i<k}\|\vct d_i\| .}
-\label{eq:semiglobal-live-bound}
+ \boxed{
+ k_C-k_H\le
+ m\left\lceil\frac{R_C-R_B}{\mu_C}\right\rceil .}
+ \label{eq:semiglobal-capture-count}
 \end{equation}
-For zero Live disturbance and exact accepted references, the post-handoff error
-converges to zero.  For bounded deterministic disturbance,
+For every $k\ge k_C$, Theorem~\ref{thm:iss-block-local} applies and there are
+$C_z\ge1$, $0<\lambda_z<1$, and $\Gamma_z<\infty$ such that
 \begin{equation}
-\limsup_{k\to\infty}\|\vct z_k\|
-\le\Gamma_z\|\vct d\|_\infty.
-\label{eq:semiglobal-ultimate-bound}
+ \boxed{
+ \|\vct z_k\|
+ \le C_z\lambda_z^{k-k_C}\|\vct z_{k_C}\|
+ +\Gamma_z\sup_{k_C\le i<k}\|\vct d_i\|.}
+ \label{eq:semiglobal-live-bound}
 \end{equation}
-Because every compact subset of the almost-global domain $\mathcal D_P$ is
-admissible, the startup attraction property is semiglobal on that domain; since
-its complement $\mathcal N_P$ has measure zero, the attitude-capture statement
-is almost global.  Bounded inputs enlarge the target to the practical
-neighborhood in Eq.~\eqref{eq:semiglobal-ultimate-bound}.
+Thus zero Live disturbance gives convergence to zero after finite capture,
+while bounded disturbance gives the usual practical ultimate neighborhood.
 \end{theorem}
 
 \begin{proof}
-Equation~\eqref{eq:semiglobal-proxy-iss} implies uniform convergence, up to the
-input-dependent practical radius, on the compact set
-$\mathcal K_{\epsilon,B_\beta}$.  Under assumption (ii), choose a finite time
-$T_P$ for which the right-hand side of
-Eq.~\eqref{eq:semiglobal-proxy-iss} reaches the proxy accuracy required by an
-accepted gravity interval; compactness makes this choice uniform over the
-prescribed startup family.  Assumption (iii) selects the aligned branch of the
-sine gate---the condition the deployed gate tests rather than infers---so
-Eqs.~\eqref{eq:semiglobal-sine-gate} and
-\eqref{eq:semiglobal-handoff-tilt} provide a genuine small-tilt bound rather
-than its antipodal alternative.  Assumption (iv) supplies a finite uniform time
-$T_A$ for the remaining handoff channels and bounds yaw.  Hence an accepted
-handoff exists no later than a finite family-dependent bound formed from
-$T_P$ and $T_A$, subject to the timeout qualification below, and
-Eq.~\eqref{eq:semiglobal-handoff-attitude} bounds the complete attitude error at
-that handoff.  Equations~\eqref{eq:semiglobal-handoff-sensitive-bounds}--
-\eqref{eq:semiglobal-handoff-block-bounds} then give the two scaled handoff
-bounds.  Assumption (v) is exactly the invariant-tube entrance condition of
-Theorem~\ref{thm:iss-block-local}, so the handoff enters the sensitive Live tube
-even when the admissible $v,p$ block is larger than that tube.  Applying
-Eq.~\eqref{eq:iss-block-local-bound} from $j=k_H$ gives
-Eq.~\eqref{eq:semiglobal-live-bound}; taking the limit superior gives
-Eq.~\eqref{eq:semiglobal-ultimate-bound}.  Finally, the almost-global proxy
-result makes $\mathcal N_P$ measure zero, while the argument above is uniform
-on every compact subset of $\mathcal D_P$.  This gives the claimed
-almost-global/semiglobal qualification.
+Equation~\eqref{eq:semiglobal-proxy-iss} gives uniform practical convergence on
+the prescribed compact proxy set.  Under assumptions (ii)--(iv), compactness
+gives a finite uniform time at which the gravity, branch, tuner, and heading
+conditions required for a normal handoff are satisfied.  Equations
+\eqref{eq:semiglobal-handoff-attitude}--
+\eqref{eq:semiglobal-handoff-kinematic-bounds} then place the resulting MEKF
+initial condition in $\mathcal H$.  Assumption (v) maps this set into
+$\mathcal C_{\rm cap}$; it does \emph{not} assert entry into the final local ISS
+tube.
+
+Theorem~\ref{thm:finite-live-capture} now permits the full filter, including the
+coupled $S=0$ correction, to undergo its bounded transient and guarantees entry
+into $\mathcal B_B$ after at most Eq.~\eqref{eq:semiglobal-capture-count} samples.
+By construction $\mathcal B_B$ is contained in the entrance set of
+Theorem~\ref{thm:iss-block-local}, which gives
+Eq.~\eqref{eq:semiglobal-live-bound}.  Uniformity holds on the declared compact
+families.  Finally, $\mathcal N_P$ has measure zero, so the attitude-startup
+qualification is almost global while the complete proxy-to-Live statement is
+semiglobal on each prescribed compact physical startup family.
 \end{proof}
 
-\paragraph{Finite startup timeout}
+\paragraph{Finite startup timeout.}
 Almost-global convergence is not uniform as the undesired stable set is
-approached.  Therefore a fixed startup timeout cannot certify all compact sets
-approaching $\mathcal N_P$ simultaneously.  With the implemented \SI{150}{s}
-latest-handoff policy, Theorem~\ref{thm:semiglobal-proxy-live} applies to those
-compact sets and disturbance levels whose uniform quality-handoff time is less
-than the effective timeout, or whenever a timeout-triggered handoff
-independently satisfies Eqs.~\eqref{eq:semiglobal-aligned-branch} and
-\eqref{eq:semiglobal-basin-entry}.  The implementation withholds a
-timeout-forced handoff until Eq.~\eqref{eq:semiglobal-aligned-branch} holds, so
-the branch half of that qualification is enforced rather than assumed; because
-the antipodal set is not attracting for the accel-corrected proxy, this delays
-the forced handoff by a bounded interval rather than suppressing it.  The
-forced path does not test the residual magnitude, so it certifies the branch
-and not the tilt bound of Eq.~\eqref{eq:semiglobal-handoff-tilt}: a
-timeout-forced handoff that does not independently satisfy
-Eq.~\eqref{eq:semiglobal-basin-entry} is outside the theorem.
+approached, so a fixed \SI{150}{s} policy cannot certify all compact startup
+sets simultaneously.  The implementation withholds a timeout-forced handoff
+until Eq.~\eqref{eq:semiglobal-aligned-branch} holds, so the antipodal branch is
+delayed rather than accepted.  The timeout path does not require the 0.075
+residual and therefore does not inherit
+Eq.~\eqref{eq:semiglobal-handoff-tilt}.  It is covered by the composite theorem
+only when an independent timeout attitude bound defines a handoff set
+$\mathcal H_T$ whose actual post-\texttt{goLive()} metric radius also satisfies
+$R_{H,T}^{\max}<R_C$.  This is deliberately weaker than demanding direct entry
+into the final ISS tube, but it is not an unverified forced-start claim.
 
-\paragraph{Implementation note on the branch certificate}
-The implementation evaluates both halves of the gate: the cross-product norm
-for Eq.~\eqref{eq:semiglobal-sine-gate} and the sign of the inner product for
-Eq.~\eqref{eq:semiglobal-aligned-branch}.  In normal startup the Mahony proxy is
-seeded from the measured accelerometer direction, so the aligned branch is the
-intended operating branch; a sine-only residual is nevertheless not by itself a
-formal certificate of that fact, which is why the sign is tested rather than
-inferred from the seeding argument.  The test is a proof condition and not a
-tuning parameter, so it carries no configurable tolerance, and it holds on both
-acceptance paths---quality hold and forced timeout---for the startup gravity
-bootstrap and for the proxy-to-MEKF handoff alike.
-Equation~\eqref{eq:semiglobal-aligned-branch} remains stated as an assumption of
-Theorem~\ref{thm:semiglobal-proxy-live} because the theorem is a statement about
-accepted handoffs; for handoffs the deployed gate accepts, the gate discharges
-it.
+\paragraph{Later reconfiguration.}
+The refined magnetic re-gauging and the $70^\circ$ tilt re-lock are separate
+hard maps.  After either event, the stability argument may restart from the
+capture theorem whenever the post-map state is independently verified to lie
+inside $\mathcal C_{\rm cap}$.  It need not jump directly into
+$\mathcal B_B$.
 
-\paragraph{Later reconfiguration}
-The theorem certifies the first quality-gated proxy-to-MEKF handoff and each
-subsequent uninterrupted Live interval satisfying the standing assumptions.
-The second magnetic re-gauging and the $70^\circ$ tilt re-lock remain separate
-hard maps.  They are covered only if their post-map state is independently
-verified to satisfy Eq.~\eqref{eq:semiglobal-basin-entry}; otherwise they remain
-boundaries between certified Live intervals rather than part of the present
-proof.
-
-\paragraph{Stochastic qualification}
-As in Sec.~\ref{app:iss-stability}, the ISS statements above are deterministic
-bounded-input statements.  Gaussian process and measurement noise do not have
-an almost-sure finite infinite-horizon supremum; corresponding stochastic
-claims require mean-square or finite-horizon high-probability bounds.
+\paragraph{Stochastic qualification.}
+All ISS and capture statements above are deterministic bounded-input results.
+Gaussian process and measurement noise do not possess an almost-sure finite
+infinite-horizon supremum; stochastic versions require mean-square or
+finite-horizon high-probability bounds.

--- a/tests/validation/test_ou_semiglobal_stability.py
+++ b/tests/validation/test_ou_semiglobal_stability.py
@@ -1,4 +1,4 @@
-"""Semantic contract for the OU--III semiglobal stability extension."""
+"""Semantic contract for OU--III finite capture and proxy-to-Live stability."""
 
 import unittest
 from pathlib import Path
@@ -14,7 +14,6 @@ def _read(name: str) -> str:
 
 
 def _flat(text: str) -> str:
-    """Line breaks in the sources are wrapping, not content."""
     return " ".join(text.split())
 
 
@@ -22,8 +21,8 @@ def _source(relative: str) -> str:
     return (SRC / relative).read_text(encoding="utf-8")
 
 
-class OUIIISemiglobalStabilityContractTests(unittest.TestCase):
-    def test_main_article_wires_semiglobal_extension_after_live_iss(self):
+class OUIIIFiniteCaptureContractTests(unittest.TestCase):
+    def test_main_article_wires_composite_stability_after_live_iss(self):
         main = _read("kalman_ou-w3d.tex")
         local = r"\input{w3d-iss-stability.tex-part}"
         semiglobal = r"\input{w3d-semiglobal-stability.tex-part}"
@@ -31,6 +30,63 @@ class OUIIISemiglobalStabilityContractTests(unittest.TestCase):
         self.assertIn(semiglobal, main)
         self.assertLess(main.index(local), main.index(semiglobal))
         self.assertLess(main.index(semiglobal), main.index(evidence))
+
+    def test_capture_is_inserted_before_mahony_composition(self):
+        proof = _read("w3d-semiglobal-stability.tex-part")
+        self.assertTrue(proof.startswith(r"\input{w3d-block-local-iss.tex-part}"))
+        self.assertIn(r"\input{w3d-finite-live-capture.tex-part}", proof)
+        self.assertLess(
+            proof.index(r"\input{w3d-finite-live-capture.tex-part}"),
+            proof.index(r"\section{Almost-Global Proxy Entry"),
+        )
+
+    def test_finite_capture_theorem_allows_oscillatory_prefix(self):
+        capture = _read("w3d-finite-live-capture.tex-part")
+        for marker in (
+            r"\label{thm:finite-live-capture}",
+            r"\label{eq:capture-linear-contraction}",
+            r"\label{eq:capture-nonlinear-bound}",
+            r"\label{eq:capture-disturbance-bound}",
+            r"\label{eq:capture-radius-order}",
+            r"\label{eq:capture-count}",
+            r"\label{eq:capture-practical-iss}",
+        ):
+            self.assertIn(marker, capture)
+        flat = _flat(capture)
+        self.assertIn("Individual samples, and even short prefixes, need not contract", flat)
+        self.assertIn("A finite prefix amplification larger than one is permitted", flat)
+        self.assertIn("full Kalman correction", flat)
+        self.assertIn("no Schmidt, block-only, or gain-truncated approximation", flat)
+
+    def test_operational_capture_region_is_materially_wider_than_iss_entry(self):
+        capture = _read("w3d-finite-live-capture.tex-part")
+        for marker in (
+            r"\Gamma_{\rm cap}:=\frac{R_C}{R_B}",
+            r"\Gamma_{\rm req}=5",
+            r"\Gamma_{\rm cap}\ge5",
+            r"R_H^{\max}<R_C",
+            r"\label{eq:capture-certificate-pass}",
+        ):
+            self.assertIn(marker, capture)
+        self.assertIn("materially larger capture region", _flat(capture))
+        self.assertIn("must not insert the \\SI{120}{s} equilibrium covariance warm-up", _flat(capture))
+
+    def test_proxy_targets_capture_region_not_local_basin(self):
+        proof = _read("w3d-semiglobal-stability.tex-part")
+        startup = _read("w3d-init.tex-part")
+        for marker in (
+            r"\label{eq:semiglobal-handoff-metric-radius}",
+            r"\label{eq:semiglobal-capture-entry}",
+            r"R_H^{\max}<R_C",
+            r"\ref{thm:finite-live-capture}",
+            r"\label{thm:semiglobal-proxy-live}",
+        ):
+            self.assertIn(marker, proof)
+        self.assertNotIn(r"\label{eq:semiglobal-basin-entry}", proof)
+        self.assertIn("does \\emph{not} assert entry into the final local ISS tube", proof)
+        self.assertIn(r"R_H^{\max}<R_C", startup)
+        self.assertIn(r"\ref{thm:finite-live-capture}", startup)
+        self.assertIn("not required to satisfy the block-local invariant-tube", _flat(startup))
 
     def test_extension_uses_spectral_mse_schedule_not_cubic_adaptation(self):
         proof = _read("w3d-semiglobal-stability.tex-part")
@@ -41,9 +97,9 @@ class OUIIISemiglobalStabilityContractTests(unittest.TestCase):
             r"\label{eq:semiglobal-mse-powers}",
         ):
             self.assertIn(marker, proof)
-        self.assertIn("no $\\sigma\\tau^3$ adaptation relation", proof)
+        self.assertIn("No $\\sigma\\tau^3$ adaptation relation", proof)
 
-    def test_extension_is_explicitly_almost_global_not_global_ekf(self):
+    def test_extension_is_almost_global_only_through_proxy(self):
         proof = _read("w3d-semiglobal-stability.tex-part")
         for marker in (
             r"\mathcal K_{\epsilon,B_\beta}",
@@ -51,20 +107,15 @@ class OUIIISemiglobalStabilityContractTests(unittest.TestCase):
             "antipodal",
             r"\cite{Mahony2008NonlinearComplementary}",
             r"\label{thm:semiglobal-proxy-live}",
-            r"\ref{thm:iss-21-local}",
-            r"\label{eq:semiglobal-basin-entry}",
         ):
             self.assertIn(marker, proof)
-        self.assertIn("does not claim semiglobal convergence", _flat(proof))
+        flat = _flat(proof)
+        self.assertIn("does not claim semiglobal convergence", flat)
+        self.assertIn("attitude-startup qualification is almost global", flat)
 
-    def test_phase1_uses_block_structured_dimensionless_live_basin(self):
+    def test_block_local_structure_is_retained_after_capture(self):
         block = _read("w3d-block-local-iss.tex-part")
-        semiglobal = _read("w3d-semiglobal-stability.tex-part")
-
-        self.assertTrue(
-            semiglobal.startswith(r"\input{w3d-block-local-iss.tex-part}"),
-            "block-local refinement must be inserted before Section XII",
-        )
+        proof = _read("w3d-semiglobal-stability.tex-part")
         for marker in (
             r"\label{lem:iss-block-remainder}",
             r"\label{thm:iss-block-local}",
@@ -75,46 +126,19 @@ class OUIIISemiglobalStabilityContractTests(unittest.TestCase):
             r"M_{\xi\ell}",
         ):
             self.assertIn(marker, block)
+        self.assertIn(r"B_{\xi,H}", proof)
+        self.assertIn(r"B_{\ell,H}", proof)
+        self.assertIn("Theorem~\\ref{thm:iss-block-local} applies", proof)
 
-        self.assertIn("dimensionless", block)
-        self.assertIn("post-prediction, pre-correction", block)
-        self.assertIn("uniform bounds on both", block)
-        self.assertIn("no direct dependence on", block)
-        self.assertIn("does \\emph{not} certify arbitrarily large", block)
-        self.assertIn("Nor does it remove $S$ from", block)
-
-        for marker in (
-            r"B_{\xi,H}",
-            r"B_{\ell,H}",
-            r"M_{\xi\ell}B_{\ell,H}",
-            r"\overline d_L",
-            r"\ref{thm:iss-block-local}",
-        ):
-            self.assertIn(marker, semiglobal)
-        self.assertIn("replaces the earlier unscaled 21-state Euclidean-ball condition", semiglobal)
-        self.assertIn("$S$ remains in the sensitive block", semiglobal)
-
-    def test_implemented_handoff_and_timeout_are_part_of_scope(self):
+    def test_handoff_and_timeout_keep_aligned_branch_gate(self):
         proof = _read("w3d-semiglobal-stability.tex-part")
         startup = _read("w3d-init.tex-part")
         self.assertIn("0.075", proof)
         self.assertIn(r"\SI{150}{s}", proof)
         self.assertIn(r"\label{eq:semiglobal-aligned-branch}", proof)
-        self.assertIn("sine-only residual is nevertheless not by itself", proof)
-        self.assertIn(r"\eqref{eq:semiglobal-aligned-branch}", startup)
-        self.assertIn(r"\eqref{eq:semiglobal-basin-entry}", startup)
-        self.assertIn(r"\ref{thm:semiglobal-proxy-live}", startup)
-
-    def test_aligned_branch_is_gated_and_not_merely_assumed(self):
-        """The sine residual is blind to a 180 deg flip, so the branch has to
-        be tested where the handoff is accepted -- including on the forced
-        timeout path, which never looks at the residual at all."""
-        proof = _flat(_read("w3d-semiglobal-stability.tex-part"))
-        startup = _flat(_read("w3d-init.tex-part"))
-
         self.assertIn("sign of the inner product", proof)
-        self.assertIn("sign of the inner product", startup)
         self.assertIn("withholds a timeout-forced handoff until", proof)
+        self.assertIn(r"\eqref{eq:semiglobal-aligned-branch}", startup)
         self.assertIn("delayed rather than accepted on the antipodal branch", startup)
 
         common = _source("kalman_common/SeaStateFusionFilterCommon.h")
@@ -128,12 +152,14 @@ class OUIIISemiglobalStabilityContractTests(unittest.TestCase):
         ):
             gate = _flat(_source(header))
             self.assertIn("seastate::common::gravityAlignedBranch", gate)
-            # The quality hold and the 150 s forced handoff are both branch-gated.
             self.assertIn(
-                "const bool tilt_trusted = mag_gravity_aligned_branch_ &&", gate)
+                "const bool tilt_trusted = mag_gravity_aligned_branch_ &&", gate
+            )
             self.assertIn(
                 "const bool ready_by_timeout = proxy_ready && (t_ >= timeout_sec) "
-                "&& mag_gravity_aligned_branch_;", gate)
+                "&& mag_gravity_aligned_branch_;",
+                gate,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Replace the previous requirement that the first Live MEKF sample already satisfy the narrow block-local ISS basin with a two-region stability argument that matches the deployed transient:

- define a wide Riccati-metric capture region `R_C` for the full coupled OU-III recursion;
- allow bounded prefix amplification / post-handoff oscillation and require contraction only over a lifted horizon;
- prove finite entry into an inner invariant radius `R_B` via a scalar quadratic comparison;
- retain the full `S=0` Kalman cross-covariance, including attitude rows (`K_S`); no Schmidt/block-only approximation;
- require an operational capture-width ratio `R_C / R_B >= 5` so startup coverage is materially wider than the local ISS-entry tube;
- start the future operational certificate at the actual `goLive()` covariance/mode, explicitly excluding the 120 s equilibrium warm-up used by the steady-Live diagnostic;
- compose the Mahony almost-global proxy result with the outer capture set (`R_H^max < R_C`) rather than directly with the local ISS basin;
- treat timeout handoff, magnetic re-gauging, and tilt re-lock as capture-region re-entry maps rather than requiring immediate local-basin entry;
- relabel the existing broad interval certificate as a conservative inner/local existence certificate, not a startup handoff test.

## Proof structure

`Mahony proxy -> structured handoff set H -> outer capture region C_cap -> finite lifted capture -> inner ISS region -> block-local practical ISS`

The capture theorem permits individual samples and short prefixes to grow; only the lifted map must contract, while prefix bounds keep the trajectory chart/geometry safe. This is intended to cover the observed oscillatory settling immediately after the filter goes Live.

## Scope

This PR changes the analytical manuscript and its semantic contract tests. It does not change the estimator gains, the full S pseudo-measurement update, or runtime behavior. The numerical regional capture constants (`R_H^max`, `R_C`, `R_B`, `chi_C`, `c_C`, `g_C`, `N_C`, etc.) are specified as a verified-arithmetic certificate contract; the manuscript does not fabricate values before that certificate is evaluated.