### PR TITLE
Gate full OU evidence replays on a broad content fingerprint

### DIFF
--- a/.github/workflows/ou-full-evidence-branch.yml
+++ b/.github/workflows/ou-full-evidence-branch.yml
@@ -1,0 +1,24 @@
+name: ou-full-evidence-branch
+
+on:
+  push:
+    branches-ignore:
+      - main
+
+# Branch pushes get the same full evidence gate as main. The reusable workflow
+# decides from the conservative replay-input/results fingerprints whether the
+# expensive ~1,150 simulator replays are actually necessary.
+concurrency:
+  group: ou-full-evidence-branch-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  evidence:
+    permissions:
+      contents: write
+    uses: ./.github/workflows/ou-validation.yml
+    with:
+      validation_mode: full

--- a/.github/workflows/ou-validation.yml
+++ b/.github/workflows/ou-validation.yml
@@ -171,6 +171,18 @@ jobs:
             --pattern sim-data-files.zip \
             --clobber
 
+      # Every full-study job below consumes this exact archive, rather than
+      # independently redownloading a release asset that could theoretically be
+      # replaced between jobs. The ZIP bytes used to compute the replay hash
+      # are therefore the same ZIP bytes used by every simulator replay.
+      - name: Preserve fingerprinted simulation archive
+        uses: actions/upload-artifact@v6
+        with:
+          name: ou-fingerprinted-simulation-data
+          path: sim-data-files.zip
+          if-no-files-found: error
+          retention-days: 1
+
       - name: Decide whether the full study is stale
         id: decide
         shell: bash
@@ -272,14 +284,14 @@ jobs:
           echo "apt-get did not succeed after 3 attempts"
           exit 1
 
-      - name: Download versioned simulation data
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Reuse fingerprinted simulation data
+        uses: actions/download-artifact@v8
+        with:
+          name: ou-fingerprinted-simulation-data
+          path: .
+
+      - name: Unpack fingerprinted simulation data
         run: |
-          gh release download v1.1.3 \
-            --repo bareboat-necessities/oceanography-waves-lib \
-            --pattern sim-data-files.zip \
-            --clobber
           mkdir -p plots/kalman_ou_ii
           unzip -o sim-data-files.zip -d plots/kalman_ou_ii >/dev/null
 
@@ -364,17 +376,18 @@ jobs:
           done
           echo "apt-get did not succeed after 3 attempts"
           exit 1
+
+      - name: Reuse fingerprinted simulation data
+        uses: actions/download-artifact@v8
+        with:
+          name: ou-fingerprinted-simulation-data
+          path: .
+
       # The combine step re-derives the calibrated tuning points and the
-      # transition diagnostic, which are simulator work, so it needs the same
-      # records and toolchain the shards had.
-      - name: Download versioned simulation data
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # transition diagnostic, which are simulator work, so it unpacks the
+      # same archive that the replay fingerprint and shards used.
+      - name: Unpack fingerprinted simulation data
         run: |
-          gh release download v1.1.3 \
-            --repo bareboat-necessities/oceanography-waves-lib \
-            --pattern sim-data-files.zip \
-            --clobber
           mkdir -p plots/kalman_ou_ii
           unzip -o sim-data-files.zip -d plots/kalman_ou_ii >/dev/null
 
@@ -470,17 +483,18 @@ jobs:
           done
           echo "apt-get did not succeed after 3 attempts"
           exit 1
+
+      - name: Reuse fingerprinted simulation data
+        uses: actions/download-artifact@v8
+        with:
+          name: ou-fingerprinted-simulation-data
+          path: .
+
       # The consistency step hashes every non-code source the manifest names,
       # and those include the simulation records. Without them the check errors
       # out on a missing file instead of reporting whether the numbers moved.
-      - name: Download versioned simulation data
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Unpack fingerprinted simulation data
         run: |
-          gh release download v1.1.3 \
-            --repo bareboat-necessities/oceanography-waves-lib \
-            --pattern sim-data-files.zip \
-            --clobber
           mkdir -p plots/kalman_ou_ii
           unzip -o sim-data-files.zip -d plots/kalman_ou_ii >/dev/null
 
@@ -524,14 +538,23 @@ jobs:
           mirror ou_robustness/ou_robustness_stress.svg \
                  ou_robustness_stress.svg
 
+      # Run every sync/contract step first. Only then hash reports/results, so
+      # the recorded results fingerprint describes the exact tree that will be
+      # committed rather than a pre-validation intermediate tree.
+      - name: Check the manuscript against the regenerated evidence
+        run: make -C tests/validation test
+
       - name: Record replay and results fingerprints
         run: |
           python3 tools/ou_replay_fingerprint.py \
             --simulation-zip sim-data-files.zip \
             --write reports/ou_evidence_fingerprint.json
 
-      - name: Check the manuscript against the regenerated evidence
-        run: make -C tests/validation test
+      - name: Verify final evidence fingerprints
+        run: |
+          python3 tools/ou_replay_fingerprint.py \
+            --simulation-zip sim-data-files.zip \
+            --check reports/ou_evidence_fingerprint.json
 
       - name: Commit the regenerated evidence
         run: |

--- a/.github/workflows/ou-validation.yml
+++ b/.github/workflows/ou-validation.yml
@@ -18,9 +18,8 @@ on:
       - "tools/ou_replay_fingerprint.py"
       - "tools/ou_publication_sync.py"
       - "plots/kalman_ou_iii/baseline-comparison.py"
-      - "reports/results/ou_validation/**"
-      - "reports/results/ou_robustness/**"
-      - "reports/results/ou_replay_fingerprint.json"
+      - "reports/results/**"
+      - "reports/ou_evidence_fingerprint.json"
       - "docs/ou-validation.md"
       - "docs/ou-robustness.md"
       - "doc/kalman_ou_iii/**"
@@ -37,8 +36,8 @@ on:
           - smoke
           - full
   # Called by the build workflow in full mode. A full call first compares the
-  # broad replay fingerprint; the expensive study runs only when executable,
-  # build/workflow content or the simulation-data ZIP changed.
+  # conservative replay-input and complete results-tree fingerprints; the
+  # expensive study runs only when either one changed.
   workflow_call:
     inputs:
       validation_mode:
@@ -149,11 +148,10 @@ jobs:
           if-no-files-found: warn
 
   # A full build is keyed by scientific inputs rather than the enclosing Git
-  # SHA. The fingerprint is deliberately broader than the actual simulator
-  # dependency closure: all tracked C/C++ source/headers, Python, shell, YAML,
-  # make files and Git-executable files are hashed, together with the exact
-  # simulation-data ZIP. False-positive replays are acceptable; false-negative
-  # reuse of stale evidence is not.
+  # SHA. The replay fingerprint is deliberately broader than the actual
+  # simulator dependency closure, and a second fingerprint covers every file
+  # under reports/results. False-positive replays are acceptable;
+  # false-negative reuse of stale evidence is not.
   fingerprint:
     if: inputs.validation_mode == 'full'
     runs-on: ubuntu-24.04
@@ -178,15 +176,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          marker=reports/results/ou_replay_fingerprint.json
+          marker=reports/ou_evidence_fingerprint.json
           if python3 tools/ou_replay_fingerprint.py \
               --simulation-zip sim-data-files.zip \
               --check "$marker"; then
             echo "replay_required=false" >> "$GITHUB_OUTPUT"
-            echo "Broad executable/data fingerprint is unchanged; reusing the full replay rows."
+            echo "Replay inputs and complete results tree are unchanged; reusing the full replay rows."
           else
             echo "replay_required=true" >> "$GITHUB_OUTPUT"
-            echo "Broad executable/data fingerprint changed; the full study must be regenerated."
+            echo "Replay inputs or results tree changed; the full study must be regenerated."
           fi
 
       - name: Install evidence-check dependencies
@@ -225,7 +223,8 @@ jobs:
 
   # Evidence regeneration is sharded: the full validation study is roughly
   # 840 twenty-minute simulator replays and robustness another ~310. It runs
-  # only when the broad replay fingerprint says the committed rows are stale.
+  # only when the conservative evidence fingerprints say the committed rows
+  # are stale.
   regenerate:
     needs: fingerprint
     if: inputs.validation_mode == 'full' && needs.fingerprint.outputs.replay_required == 'true'
@@ -525,11 +524,11 @@ jobs:
           mirror ou_robustness/ou_robustness_stress.svg \
                  ou_robustness_stress.svg
 
-      - name: Record replay fingerprint
+      - name: Record replay and results fingerprints
         run: |
           python3 tools/ou_replay_fingerprint.py \
             --simulation-zip sim-data-files.zip \
-            --write reports/results/ou_replay_fingerprint.json
+            --write reports/ou_evidence_fingerprint.json
 
       - name: Check the manuscript against the regenerated evidence
         run: make -C tests/validation test
@@ -540,10 +539,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add reports/results/ou_validation reports/results/ou_robustness \
-                  reports/results/ou_replay_fingerprint.json \
+                  reports/ou_evidence_fingerprint.json \
                   doc/kalman_ou_iii
           if git diff --cached --quiet; then
-            echo "Regenerated bundle and replay fingerprint are identical to the committed ones."
+            echo "Regenerated bundles and both evidence fingerprints are identical to the committed ones."
             exit 0
           fi
           git commit \
@@ -557,13 +556,13 @@ jobs:
             git push origin HEAD:refs/heads/${{ github.ref_name }} && exit 0
             sleep $((2 ** attempt))
             git pull --rebase origin refs/heads/${{ github.ref_name }}
-            # A newer branch tip may change any executable/build/workflow file,
-            # even one outside the simulator dependency closure. Refuse to put
-            # the old rows on it unless the broad content fingerprint still
-            # matches, then run the detailed evidence contract as well.
+            # A newer branch tip may change executable/build/workflow content
+            # or the results tree. Refuse to put old rows on it unless both
+            # conservative fingerprints still match, then run the detailed
+            # evidence contract as well.
             python3 tools/ou_replay_fingerprint.py \
               --simulation-zip sim-data-files.zip \
-              --check reports/results/ou_replay_fingerprint.json
+              --check reports/ou_evidence_fingerprint.json
             make -C tests/validation test
           done
           exit 1

--- a/.github/workflows/ou-validation.yml
+++ b/.github/workflows/ou-validation.yml
@@ -15,10 +15,12 @@ on:
       - "tests/validation/**"
       - "tools/ou_validation.py"
       - "tools/ou_robustness.py"
+      - "tools/ou_replay_fingerprint.py"
       - "tools/ou_publication_sync.py"
       - "plots/kalman_ou_iii/baseline-comparison.py"
       - "reports/results/ou_validation/**"
       - "reports/results/ou_robustness/**"
+      - "reports/results/ou_replay_fingerprint.json"
       - "docs/ou-validation.md"
       - "docs/ou-robustness.md"
       - "doc/kalman_ou_iii/**"
@@ -34,9 +36,9 @@ on:
         options:
           - smoke
           - full
-  # Called by the build workflow so a main build regenerates the evidence
-  # before the article is typeset. The caller's ref is what the commit job
-  # pushes to, and the caller has to grant contents: write for it.
+  # Called by the build workflow in full mode. A full call first compares the
+  # broad replay fingerprint; the expensive study runs only when executable,
+  # build/workflow content or the simulation-data ZIP changed.
   workflow_call:
     inputs:
       validation_mode:
@@ -146,18 +148,87 @@ jobs:
             reports/results/ou_robustness/**
           if-no-files-found: warn
 
-  # Evidence regeneration. Dispatch-only, and sharded: the full validation
-  # study is roughly 840 twenty-minute simulator replays and the robustness
-  # study another 310, and a single four-core runner gets through those at
-  # about the rate that made this a multi-hour job.
-  #
-  # Every replay is fixed by its seed triplet, so the seed repetitions split
-  # across runners with no coordination. Each shard writes its rows to a file;
-  # the combine job merges them and produces the bundle a single process would
-  # have produced, byte for byte. Sharding by study as well as by seed keeps a
-  # failure in one bundle from throwing away the other's hours.
-  regenerate:
+  # A full build is keyed by scientific inputs rather than the enclosing Git
+  # SHA. The fingerprint is deliberately broader than the actual simulator
+  # dependency closure: all tracked C/C++ source/headers, Python, shell, YAML,
+  # make files and Git-executable files are hashed, together with the exact
+  # simulation-data ZIP. False-positive replays are acceptable; false-negative
+  # reuse of stale evidence is not.
+  fingerprint:
     if: inputs.validation_mode == 'full'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    outputs:
+      replay_required: ${{ steps.decide.outputs.replay_required }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download versioned simulation data
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download v1.1.3 \
+            --repo bareboat-necessities/oceanography-waves-lib \
+            --pattern sim-data-files.zip \
+            --clobber
+
+      - name: Decide whether the full study is stale
+        id: decide
+        shell: bash
+        run: |
+          set -euo pipefail
+          marker=reports/results/ou_replay_fingerprint.json
+          if python3 tools/ou_replay_fingerprint.py \
+              --simulation-zip sim-data-files.zip \
+              --check "$marker"; then
+            echo "replay_required=false" >> "$GITHUB_OUTPUT"
+            echo "Broad executable/data fingerprint is unchanged; reusing the full replay rows."
+          else
+            echo "replay_required=true" >> "$GITHUB_OUTPUT"
+            echo "Broad executable/data fingerprint changed; the full study must be regenerated."
+          fi
+
+      - name: Install evidence-check dependencies
+        if: steps.decide.outputs.replay_required == 'false'
+        timeout-minutes: 27
+        run: |
+          set -uo pipefail
+          apt_get() {
+            sudo timeout 8m env DEBIAN_FRONTEND=noninteractive apt-get \
+              -o Acquire::Retries=2 \
+              -o Acquire::http::Timeout=15 \
+              -o Acquire::https::Timeout=15 \
+              -o Dpkg::Use-Pty=0 \
+              "$@"
+          }
+          install_deps() {
+            apt_get update && apt_get install -y --no-install-recommends \
+              g++ make libeigen3-dev \
+              python3-numpy python3-matplotlib
+          }
+          for attempt in 1 2 3; do
+            if install_deps; then
+              exit 0
+            fi
+            sudo dpkg --configure -a || true
+            sleep $((attempt * 15))
+          done
+          exit 1
+
+      - name: Verify reusable committed evidence
+        if: steps.decide.outputs.replay_required == 'false'
+        run: |
+          mkdir -p plots/kalman_ou_ii
+          unzip -o sim-data-files.zip -d plots/kalman_ou_ii >/dev/null
+          make -C tests/validation test
+
+  # Evidence regeneration is sharded: the full validation study is roughly
+  # 840 twenty-minute simulator replays and robustness another ~310. It runs
+  # only when the broad replay fingerprint says the committed rows are stale.
+  regenerate:
+    needs: fingerprint
+    if: inputs.validation_mode == 'full' && needs.fingerprint.outputs.replay_required == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 350
     strategy:
@@ -454,6 +525,12 @@ jobs:
           mirror ou_robustness/ou_robustness_stress.svg \
                  ou_robustness_stress.svg
 
+      - name: Record replay fingerprint
+        run: |
+          python3 tools/ou_replay_fingerprint.py \
+            --simulation-zip sim-data-files.zip \
+            --write reports/results/ou_replay_fingerprint.json
+
       - name: Check the manuscript against the regenerated evidence
         run: make -C tests/validation test
 
@@ -463,9 +540,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add reports/results/ou_validation reports/results/ou_robustness \
+                  reports/results/ou_replay_fingerprint.json \
                   doc/kalman_ou_iii
           if git diff --cached --quiet; then
-            echo "Regenerated bundle is identical to the committed one."
+            echo "Regenerated bundle and replay fingerprint are identical to the committed ones."
             exit 0
           fi
           git commit \
@@ -479,9 +557,13 @@ jobs:
             git push origin HEAD:refs/heads/${{ github.ref_name }} && exit 0
             sleep $((2 ** attempt))
             git pull --rebase origin refs/heads/${{ github.ref_name }}
-            # A newer branch tip can change replay-producing source after this
-            # run generated its rows. Revalidate after every rebase before the
-            # next push so stale evidence can never be replayed onto new code.
+            # A newer branch tip may change any executable/build/workflow file,
+            # even one outside the simulator dependency closure. Refuse to put
+            # the old rows on it unless the broad content fingerprint still
+            # matches, then run the detailed evidence contract as well.
+            python3 tools/ou_replay_fingerprint.py \
+              --simulation-zip sim-data-files.zip \
+              --check reports/results/ou_replay_fingerprint.json
             make -C tests/validation test
           done
           exit 1

--- a/tests/OU_REPLAY_EVIDENCE_GATE.md
+++ b/tests/OU_REPLAY_EVIDENCE_GATE.md
@@ -2,37 +2,49 @@
 
 The OU validation/robustness evidence gate is intentionally conservative. Its purpose is to make a missed required replay much less likely, even at the cost of occasionally rerunning the full study when the change would not actually affect the numerical result.
 
-## What is fingerprinted
+## Replay-input fingerprint
 
-`tools/ou_replay_fingerprint.py` computes a content fingerprint from:
+`tools/ou_replay_fingerprint.py` computes a replay-input fingerprint from:
 
 - **every tracked file anywhere under `tests/`, regardless of filename, extension, or executable bit**;
 - tracked source, script, workflow, and build files elsewhere in the repository, using a deliberately broad set of executable/source/build extensions and standard build-system filenames;
 - every tracked file whose Git mode is executable, regardless of its name or extension; and
 - the SHA-256 of the exact `sim-data-files.zip` archive used by the study.
 
-The unconditional `tests/**` rule is important. Test and study configuration can be hidden in files such as `.txt`, `.csv`, `.json`, `.dat`, fixtures, reference data, or extensionless files. The gate therefore does not try to infer which test files are executable or reachable. A content change to any tracked file under `tests/` invalidates the replay fingerprint.
+The unconditional `tests/**` rule is important. Test and study configuration can be hidden in files such as `.txt`, `.csv`, `.json`, `.dat`, fixtures, reference data, or extensionless files. The gate therefore does not try to infer which test files are executable or reachable. A content change to any tracked file under `tests/` invalidates the replay-input fingerprint.
 
-This Markdown file is itself under `tests/`, so editing it also invalidates the fingerprint. That is an accepted false positive and is preferable to creating exceptions inside the directory that carries the study protocol and parameters.
+This Markdown file is itself under `tests/`, so editing it also invalidates the replay-input fingerprint. That is an accepted false positive and is preferable to creating exceptions inside the directory that carries the study protocol and parameters.
 
-## What is not used as the key
+## Results-tree fingerprint
+
+The same tool also computes a second SHA-256 fingerprint over **every file anywhere under `reports/results/`**, including each relative path and file content. Adding, deleting, renaming, or modifying any result file changes this fingerprint, regardless of filename or extension.
+
+This gives CI a direct indicator that the committed evidence tree changed independently of the executable/test inputs. A results-tree mismatch is treated conservatively as stale evidence and requires regeneration.
+
+The fingerprint record itself is stored at `reports/ou_evidence_fingerprint.json`, outside `reports/results/`. This is deliberate: it lets the results-tree fingerprint cover every file under `reports/results/` without a self-reference exception.
+
+The record contains both hashes:
+
+- `replay_fingerprint`: executable/test/workflow/build content plus the simulation ZIP;
+- `results_fingerprint`: the complete `reports/results/` tree.
+
+## Why the Git commit SHA is not the replay key
 
 The enclosing Git commit SHA is not the replay key. Generated evidence can be committed after a successful replay, producing a new commit SHA without changing the numerical computation. Keying directly on the commit SHA would therefore make the evidence commit invalidate itself.
 
-Generated evidence and ordinary prose outside `tests/` are not automatically included unless they otherwise match one of the broad source/build/workflow/executable rules.
+Generated evidence and ordinary prose outside `tests/` do not change the replay-input hash unless they otherwise match one of the broad source/build/workflow/executable rules. Changes under `reports/results/` do change the separate results-tree hash.
 
 ## CI behavior
 
 For a full OU publication/evidence run:
 
 1. CI checks out the target source and downloads the versioned simulation archive.
-2. It computes the current replay fingerprint.
-3. If the committed fingerprint record is missing or differs, CI runs the complete validation and robustness simulator studies, regenerates the evidence, and writes the new fingerprint alongside that evidence.
-4. If the fingerprint is unchanged, CI may reuse the committed full-study rows, but it still runs the validation/evidence contract tests.
-5. If a write retry rebases onto a newer branch tip, the fingerprint is checked again before regenerated evidence can be pushed.
+2. It computes the current replay-input fingerprint and complete results-tree fingerprint.
+3. If the committed fingerprint record is missing, or either fingerprint differs, CI runs the complete validation and robustness simulator studies, regenerates the evidence, and writes both new fingerprints.
+4. If both fingerprints are unchanged, CI may reuse the committed full-study rows, but it still runs the validation/evidence contract tests.
+5. After regeneration, the generated validation bundle, robustness bundle, mirrored manuscript inputs, and `reports/ou_evidence_fingerprint.json` are committed together.
+6. If a write retry rebases onto a newer branch tip, both fingerprints are checked again before regenerated evidence can be pushed.
 
 The policy is intentionally asymmetric:
 
-> An unnecessary full replay is acceptable. Reusing stale evidence after a potentially relevant repository or test-data change is not.
-
-The committed fingerprint record is `reports/results/ou_replay_fingerprint.json`.
+> An unnecessary full replay is acceptable. Reusing stale evidence after a potentially relevant repository, test-data, simulation-data, or results-tree change is not.

--- a/tests/OU_REPLAY_EVIDENCE_GATE.md
+++ b/tests/OU_REPLAY_EVIDENCE_GATE.md
@@ -1,0 +1,38 @@
+# OU full-study replay gate
+
+The OU validation/robustness evidence gate is intentionally conservative. Its purpose is to make a missed required replay much less likely, even at the cost of occasionally rerunning the full study when the change would not actually affect the numerical result.
+
+## What is fingerprinted
+
+`tools/ou_replay_fingerprint.py` computes a content fingerprint from:
+
+- **every tracked file anywhere under `tests/`, regardless of filename, extension, or executable bit**;
+- tracked source, script, workflow, and build files elsewhere in the repository, using a deliberately broad set of executable/source/build extensions and standard build-system filenames;
+- every tracked file whose Git mode is executable, regardless of its name or extension; and
+- the SHA-256 of the exact `sim-data-files.zip` archive used by the study.
+
+The unconditional `tests/**` rule is important. Test and study configuration can be hidden in files such as `.txt`, `.csv`, `.json`, `.dat`, fixtures, reference data, or extensionless files. The gate therefore does not try to infer which test files are executable or reachable. A content change to any tracked file under `tests/` invalidates the replay fingerprint.
+
+This Markdown file is itself under `tests/`, so editing it also invalidates the fingerprint. That is an accepted false positive and is preferable to creating exceptions inside the directory that carries the study protocol and parameters.
+
+## What is not used as the key
+
+The enclosing Git commit SHA is not the replay key. Generated evidence can be committed after a successful replay, producing a new commit SHA without changing the numerical computation. Keying directly on the commit SHA would therefore make the evidence commit invalidate itself.
+
+Generated evidence and ordinary prose outside `tests/` are not automatically included unless they otherwise match one of the broad source/build/workflow/executable rules.
+
+## CI behavior
+
+For a full OU publication/evidence run:
+
+1. CI checks out the target source and downloads the versioned simulation archive.
+2. It computes the current replay fingerprint.
+3. If the committed fingerprint record is missing or differs, CI runs the complete validation and robustness simulator studies, regenerates the evidence, and writes the new fingerprint alongside that evidence.
+4. If the fingerprint is unchanged, CI may reuse the committed full-study rows, but it still runs the validation/evidence contract tests.
+5. If a write retry rebases onto a newer branch tip, the fingerprint is checked again before regenerated evidence can be pushed.
+
+The policy is intentionally asymmetric:
+
+> An unnecessary full replay is acceptable. Reusing stale evidence after a potentially relevant repository or test-data change is not.
+
+The committed fingerprint record is `reports/results/ou_replay_fingerprint.json`.

--- a/tests/validation/Makefile
+++ b/tests/validation/Makefile
@@ -16,6 +16,7 @@ build:
 		test_ou_article_ablations.py \
 		test_ou_legacy_law_cleanup.py \
 		test_ou_evidence_contract.py \
+		test_ou_replay_fingerprint.py \
 		test_ou_semiglobal_stability.py \
 		test_ou_stability_phase_a.py \
 		test_ou_stability_phase_b.py \

--- a/tests/validation/Makefile
+++ b/tests/validation/Makefile
@@ -7,6 +7,7 @@ build:
 		../../tools/ou_roundtrip_transition.py \
 		../../tools/ou_evidence_provenance.py \
 		../../tools/ou_evidence_contract.py \
+		../../tools/ou_replay_fingerprint.py \
 		../../tools/ou_publication_sync.py \
 		../../tools/rotate_record_heading.py \
 		test_ou_validation.py \

--- a/tests/validation/test_ou_replay_fingerprint.py
+++ b/tests/validation/test_ou_replay_fingerprint.py
@@ -12,6 +12,19 @@ SPEC.loader.exec_module(fingerprint)
 
 
 class ReplayFingerprintClassificationTests(unittest.TestCase):
+    def test_every_file_under_tests_is_included_regardless_of_extension(self):
+        names = [
+            "tests/kalman_ou_iii/parameters.txt",
+            "tests/kalman_ou_iii/fixture.csv",
+            "tests/validation/config.json",
+            "tests/validation/reference.dat",
+            "tests/validation/README.md",
+            "tests/custom/no-extension",
+        ]
+        for name in names:
+            with self.subTest(name=name):
+                self.assertTrue(fingerprint.is_replay_source("100644", name))
+
     def test_expected_source_and_workflow_types_are_included(self):
         names = [
             "src/a.c",
@@ -69,7 +82,7 @@ class ReplayFingerprintClassificationTests(unittest.TestCase):
             fingerprint.is_replay_source("100755", "tools/no-recognized-extension")
         )
 
-    def test_generated_evidence_and_prose_do_not_self_invalidate(self):
+    def test_generated_evidence_and_prose_outside_tests_do_not_self_invalidate(self):
         names = [
             "reports/results/ou_validation/ou_validation.json",
             "reports/results/ou_robustness/ou_robustness_raw.csv",

--- a/tests/validation/test_ou_replay_fingerprint.py
+++ b/tests/validation/test_ou_replay_fingerprint.py
@@ -1,5 +1,6 @@
 import importlib.util
 from pathlib import Path
+import tempfile
 import unittest
 
 
@@ -82,16 +83,37 @@ class ReplayFingerprintClassificationTests(unittest.TestCase):
             fingerprint.is_replay_source("100755", "tools/no-recognized-extension")
         )
 
-    def test_generated_evidence_and_prose_outside_tests_do_not_self_invalidate(self):
+    def test_generated_evidence_and_prose_outside_tests_do_not_self_invalidate_replay(self):
         names = [
             "reports/results/ou_validation/ou_validation.json",
             "reports/results/ou_robustness/ou_robustness_raw.csv",
+            "reports/ou_evidence_fingerprint.json",
             "doc/kalman_ou_iii/w3d-ou-validation-results-generated.tex-part",
             "README.md",
         ]
         for name in names:
             with self.subTest(name=name):
                 self.assertFalse(fingerprint.is_replay_source("100644", name))
+
+    def test_results_fingerprint_covers_every_file_and_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "results"
+            nested = root / "nested"
+            nested.mkdir(parents=True)
+            (root / "a.json").write_text('{"value": 1}\n', encoding="utf-8")
+            (nested / "fixture.dat").write_bytes(b"abc")
+
+            first = fingerprint.compute_results_fingerprint(root)
+            self.assertEqual(first["file_count"], 2)
+
+            (nested / "fixture.dat").write_bytes(b"abcd")
+            second = fingerprint.compute_results_fingerprint(root)
+            self.assertNotEqual(first["fingerprint"], second["fingerprint"])
+
+            (nested / "new-extensionless-file").write_bytes(b"x")
+            third = fingerprint.compute_results_fingerprint(root)
+            self.assertNotEqual(second["fingerprint"], third["fingerprint"])
+            self.assertEqual(third["file_count"], 3)
 
 
 if __name__ == "__main__":

--- a/tests/validation/test_ou_replay_fingerprint.py
+++ b/tests/validation/test_ou_replay_fingerprint.py
@@ -52,20 +52,25 @@ class ReplayFingerprintClassificationTests(unittest.TestCase):
             "tools/a.js",
             "tools/a.ts",
             ".github/workflows/build.yml",
+            ".github/dependabot/config.json",
             "config/build.yaml",
             "cmake/toolchain.cmake",
             "rules/common.mk",
+            "rules/config.make",
         ]
         for name in names:
             with self.subTest(name=name):
                 self.assertTrue(fingerprint.is_replay_source("100644", name))
 
-    def test_expected_build_files_are_included(self):
+    def test_expected_build_files_and_variants_are_included(self):
         names = [
             "Makefile",
-            "tests/foo/Makefile",
+            "Makefile.local",
+            "Makefile.release",
             "CMakeLists.txt",
+            "CMakePresets.json",
             "Dockerfile",
+            "Dockerfile.ci",
             "meson.build",
             "meson_options.txt",
             "BUILD",
@@ -73,6 +78,11 @@ class ReplayFingerprintClassificationTests(unittest.TestCase):
             "WORKSPACE",
             "WORKSPACE.bazel",
             "MODULE.bazel",
+            "pyproject.toml",
+            "setup.cfg",
+            "platformio.ini",
+            "requirements.txt",
+            "requirements-ci.txt",
         ]
         for name in names:
             with self.subTest(name=name):

--- a/tests/validation/test_ou_replay_fingerprint.py
+++ b/tests/validation/test_ou_replay_fingerprint.py
@@ -1,0 +1,85 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "tools" / "ou_replay_fingerprint.py"
+SPEC = importlib.util.spec_from_file_location("ou_replay_fingerprint", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+fingerprint = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(fingerprint)
+
+
+class ReplayFingerprintClassificationTests(unittest.TestCase):
+    def test_expected_source_and_workflow_types_are_included(self):
+        names = [
+            "src/a.c",
+            "src/a.cc",
+            "src/a.cpp",
+            "src/a.cxx",
+            "src/a.h",
+            "src/a.hh",
+            "src/a.hpp",
+            "src/a.hxx",
+            "src/a.ino",
+            "src/a.S",
+            "src/a.asm",
+            "src/a.ipp",
+            "src/a.tpp",
+            "src/a.inc",
+            "tools/a.py",
+            "tools/a.sh",
+            "tools/a.bash",
+            "tools/a.zsh",
+            "tools/a.pl",
+            "tools/a.rb",
+            "tools/a.lua",
+            "tools/a.js",
+            "tools/a.ts",
+            ".github/workflows/build.yml",
+            "config/build.yaml",
+            "cmake/toolchain.cmake",
+            "rules/common.mk",
+        ]
+        for name in names:
+            with self.subTest(name=name):
+                self.assertTrue(fingerprint.is_replay_source("100644", name))
+
+    def test_expected_build_files_are_included(self):
+        names = [
+            "Makefile",
+            "tests/foo/Makefile",
+            "CMakeLists.txt",
+            "Dockerfile",
+            "meson.build",
+            "meson_options.txt",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+            "MODULE.bazel",
+        ]
+        for name in names:
+            with self.subTest(name=name):
+                self.assertTrue(fingerprint.is_replay_source("100644", name))
+
+    def test_git_executable_mode_is_always_included(self):
+        self.assertTrue(
+            fingerprint.is_replay_source("100755", "tools/no-recognized-extension")
+        )
+
+    def test_generated_evidence_and_prose_do_not_self_invalidate(self):
+        names = [
+            "reports/results/ou_validation/ou_validation.json",
+            "reports/results/ou_robustness/ou_robustness_raw.csv",
+            "doc/kalman_ou_iii/w3d-ou-validation-results-generated.tex-part",
+            "README.md",
+        ]
+        for name in names:
+            with self.subTest(name=name):
+                self.assertFalse(fingerprint.is_replay_source("100644", name))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/validation/test_workflow_contract.py
+++ b/tests/validation/test_workflow_contract.py
@@ -33,7 +33,7 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("tools/ou_publication_sync.py", stage)
         self.assertIn("reports/results/ou_validation", stage)
 
-    def test_full_replay_is_gated_by_broad_content_fingerprint(self):
+    def test_full_replay_is_gated_by_replay_and_results_fingerprints(self):
         workflow = WORKFLOW.read_text(encoding="utf-8")
         fingerprint = workflow.index("  fingerprint:")
         regenerate = workflow.index("  regenerate:")
@@ -42,9 +42,10 @@ class WorkflowContractTests(unittest.TestCase):
         gate = workflow[fingerprint:regenerate]
         self.assertIn("tools/ou_replay_fingerprint.py", gate)
         self.assertIn("sim-data-files.zip", gate)
-        self.assertIn("reports/results/ou_replay_fingerprint.json", gate)
+        self.assertIn("reports/ou_evidence_fingerprint.json", gate)
         self.assertIn("replay_required=false", gate)
         self.assertIn("replay_required=true", gate)
+        self.assertIn("complete results tree", gate)
         self.assertIn("make -C tests/validation test", gate)
 
         regen_header = workflow[regenerate:workflow.index("    runs-on:", regenerate)]
@@ -53,9 +54,9 @@ class WorkflowContractTests(unittest.TestCase):
             "needs.fingerprint.outputs.replay_required == 'true'", regen_header
         )
 
-    def test_regenerated_evidence_records_the_replay_fingerprint(self):
+    def test_regenerated_evidence_records_both_fingerprints(self):
         workflow = WORKFLOW.read_text(encoding="utf-8")
-        record = workflow.index("- name: Record replay fingerprint")
+        record = workflow.index("- name: Record replay and results fingerprints")
         check = workflow.index("- name: Check the manuscript against the regenerated evidence")
         commit = workflow.index("- name: Commit the regenerated evidence")
         self.assertLess(record, check)
@@ -63,10 +64,16 @@ class WorkflowContractTests(unittest.TestCase):
 
         stage = workflow[record:commit]
         self.assertIn("tools/ou_replay_fingerprint.py", stage)
-        self.assertIn("--write reports/results/ou_replay_fingerprint.json", stage)
+        self.assertIn("--write reports/ou_evidence_fingerprint.json", stage)
 
         commit_stage = workflow[commit:]
-        self.assertIn("reports/results/ou_replay_fingerprint.json", commit_stage)
+        self.assertIn("reports/ou_evidence_fingerprint.json", commit_stage)
+        self.assertIn("reports/results/ou_validation", commit_stage)
+        self.assertIn("reports/results/ou_robustness", commit_stage)
+
+    def test_results_tree_changes_are_in_workflow_trigger(self):
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn('- "reports/results/**"', workflow)
 
     def test_push_retry_revalidates_after_rebase(self):
         workflow = WORKFLOW.read_text(encoding="utf-8")

--- a/tests/validation/test_workflow_contract.py
+++ b/tests/validation/test_workflow_contract.py
@@ -33,6 +33,41 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("tools/ou_publication_sync.py", stage)
         self.assertIn("reports/results/ou_validation", stage)
 
+    def test_full_replay_is_gated_by_broad_content_fingerprint(self):
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        fingerprint = workflow.index("  fingerprint:")
+        regenerate = workflow.index("  regenerate:")
+        self.assertLess(fingerprint, regenerate)
+
+        gate = workflow[fingerprint:regenerate]
+        self.assertIn("tools/ou_replay_fingerprint.py", gate)
+        self.assertIn("sim-data-files.zip", gate)
+        self.assertIn("reports/results/ou_replay_fingerprint.json", gate)
+        self.assertIn("replay_required=false", gate)
+        self.assertIn("replay_required=true", gate)
+        self.assertIn("make -C tests/validation test", gate)
+
+        regen_header = workflow[regenerate:workflow.index("    runs-on:", regenerate)]
+        self.assertIn("needs: fingerprint", regen_header)
+        self.assertIn(
+            "needs.fingerprint.outputs.replay_required == 'true'", regen_header
+        )
+
+    def test_regenerated_evidence_records_the_replay_fingerprint(self):
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        record = workflow.index("- name: Record replay fingerprint")
+        check = workflow.index("- name: Check the manuscript against the regenerated evidence")
+        commit = workflow.index("- name: Commit the regenerated evidence")
+        self.assertLess(record, check)
+        self.assertLess(check, commit)
+
+        stage = workflow[record:commit]
+        self.assertIn("tools/ou_replay_fingerprint.py", stage)
+        self.assertIn("--write reports/results/ou_replay_fingerprint.json", stage)
+
+        commit_stage = workflow[commit:]
+        self.assertIn("reports/results/ou_replay_fingerprint.json", commit_stage)
+
     def test_push_retry_revalidates_after_rebase(self):
         workflow = WORKFLOW.read_text(encoding="utf-8")
         start = workflow.index("for attempt in 1 2 3 4; do")
@@ -40,8 +75,10 @@ class WorkflowContractTests(unittest.TestCase):
         loop = workflow[start:end]
 
         rebase = loop.index("git pull --rebase")
+        fingerprint = loop.index("tools/ou_replay_fingerprint.py")
         validate = loop.index("make -C tests/validation test")
-        self.assertLess(rebase, validate)
+        self.assertLess(rebase, fingerprint)
+        self.assertLess(fingerprint, validate)
 
     def test_failure_message_cannot_run_after_a_push(self):
         workflow = WORKFLOW.read_text(encoding="utf-8")

--- a/tests/validation/test_workflow_contract.py
+++ b/tests/validation/test_workflow_contract.py
@@ -54,17 +54,32 @@ class WorkflowContractTests(unittest.TestCase):
             "needs.fingerprint.outputs.replay_required == 'true'", regen_header
         )
 
-    def test_regenerated_evidence_records_both_fingerprints(self):
+    def test_every_full_replay_uses_the_fingerprinted_zip_bytes(self):
         workflow = WORKFLOW.read_text(encoding="utf-8")
-        record = workflow.index("- name: Record replay and results fingerprints")
+        full = workflow[workflow.index("  fingerprint:"):]
+        self.assertIn("- name: Preserve fingerprinted simulation archive", full)
+        self.assertIn("name: ou-fingerprinted-simulation-data", full)
+        self.assertGreaterEqual(
+            full.count("name: ou-fingerprinted-simulation-data"),
+            4,
+        )
+        regenerate = full[full.index("  regenerate:"):]
+        self.assertNotIn("gh release download v1.1.3", regenerate)
+
+    def test_regenerated_evidence_hashes_the_final_validated_tree(self):
+        workflow = WORKFLOW.read_text(encoding="utf-8")
         check = workflow.index("- name: Check the manuscript against the regenerated evidence")
+        record = workflow.index("- name: Record replay and results fingerprints")
+        verify = workflow.index("- name: Verify final evidence fingerprints")
         commit = workflow.index("- name: Commit the regenerated evidence")
-        self.assertLess(record, check)
-        self.assertLess(check, commit)
+        self.assertLess(check, record)
+        self.assertLess(record, verify)
+        self.assertLess(verify, commit)
 
         stage = workflow[record:commit]
         self.assertIn("tools/ou_replay_fingerprint.py", stage)
         self.assertIn("--write reports/ou_evidence_fingerprint.json", stage)
+        self.assertIn("--check reports/ou_evidence_fingerprint.json", stage)
 
         commit_stage = workflow[commit:]
         self.assertIn("reports/ou_evidence_fingerprint.json", commit_stage)

--- a/tools/ou_replay_fingerprint.py
+++ b/tools/ou_replay_fingerprint.py
@@ -1,33 +1,33 @@
 #!/usr/bin/env python3
-"""Content fingerprint for deciding whether OU simulator evidence must be replayed.
+"""Content fingerprints for deciding whether OU evidence must be replayed.
 
-The gate is deliberately conservative. It hashes every tracked file under
+The replay gate is deliberately conservative. It hashes every tracked file under
 ``tests/`` regardless of extension, every tracked source/script or build/workflow
 file elsewhere, every tracked file whose Git mode is executable, and the exact
 downloaded simulation-data ZIP.
 
+A second fingerprint hashes every file under ``reports/results/``. The record
+that stores the two fingerprints lives outside that tree, so the results digest
+has no self-reference exception.
+
 This is intentionally broader than the simulator dependency closure. False
 positive full replays are acceptable; reusing evidence after a potentially
-replay-affecting repository change is not.
-
-The fingerprint is independent of the enclosing Git commit SHA and of generated
-evidence. A documentation/evidence-only commit outside ``tests/`` therefore does
-not invalidate a scientifically identical replay. Files under ``tests/`` are
-always included because test configuration and study parameters may use
-arbitrary file extensions.
+replay-affecting repository or evidence-tree change is not.
 """
 from __future__ import annotations
 
 import argparse
 import hashlib
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
 from typing import Iterable
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-SCHEMA_VERSION = 1
+RESULTS_ROOT = REPO_ROOT / "reports" / "results"
+SCHEMA_VERSION = 2
 ALGORITHM = "sha256-framed-v1"
 
 # Deliberately broad. Do not replace this with include/reachability analysis:
@@ -114,6 +114,51 @@ def _frame(digest, *parts: bytes) -> None:
         digest.update(part)
 
 
+def compute_results_fingerprint(results_root: Path = RESULTS_ROOT) -> dict[str, object]:
+    """Hash every regular file/symlink below reports/results, including names."""
+    results_root = results_root.resolve()
+    if not results_root.is_dir():
+        raise FileNotFoundError(results_root)
+
+    digest = hashlib.sha256()
+    _frame(digest, b"ocean-imu-ou-results-fingerprint", str(SCHEMA_VERSION).encode())
+
+    files: list[dict[str, object]] = []
+    for path in sorted(results_root.rglob("*"), key=lambda item: item.as_posix()):
+        if path.is_symlink():
+            target = os.readlink(path)
+            content_sha = hashlib.sha256(target.encode("utf-8")).hexdigest()
+            kind = "symlink"
+        elif path.is_file():
+            content_sha = sha256_file(path)
+            kind = "file"
+        else:
+            continue
+
+        try:
+            relative_path = path.relative_to(REPO_ROOT).as_posix()
+        except ValueError:
+            relative_path = path.relative_to(results_root).as_posix()
+
+        files.append(
+            {"path": relative_path, "kind": kind, "sha256": content_sha}
+        )
+        _frame(
+            digest,
+            b"results-entry",
+            kind.encode("ascii"),
+            relative_path.encode("utf-8", errors="surrogateescape"),
+            bytes.fromhex(content_sha),
+        )
+
+    return {
+        "root": "reports/results" if results_root == RESULTS_ROOT.resolve() else str(results_root),
+        "fingerprint": digest.hexdigest(),
+        "file_count": len(files),
+        "files": files,
+    }
+
+
 def compute_fingerprint(simulation_zip: Path) -> dict[str, object]:
     simulation_zip = simulation_zip.resolve()
     if not simulation_zip.is_file():
@@ -139,17 +184,21 @@ def compute_fingerprint(simulation_zip: Path) -> dict[str, object]:
 
     zip_sha = sha256_file(simulation_zip)
     _frame(digest, b"simulation-data-zip", bytes.fromhex(zip_sha))
+    results = compute_results_fingerprint()
 
     return {
         "schema_version": SCHEMA_VERSION,
         "algorithm": ALGORITHM,
-        "fingerprint": digest.hexdigest(),
+        "replay_fingerprint": digest.hexdigest(),
         "simulation_data": {
             "file": simulation_zip.name,
             "sha256": zip_sha,
         },
         "tracked_replay_file_count": len(files),
         "tracked_replay_files": files,
+        "results_fingerprint": results["fingerprint"],
+        "results_file_count": results["file_count"],
+        "results_files": results["files"],
     }
 
 
@@ -159,8 +208,9 @@ def _comparison_view(record: dict[str, object]) -> tuple[object, ...]:
     return (
         record.get("schema_version"),
         record.get("algorithm"),
-        record.get("fingerprint"),
+        record.get("replay_fingerprint"),
         simulation_sha,
+        record.get("results_fingerprint"),
     )
 
 
@@ -171,24 +221,31 @@ def write_record(path: Path, record: dict[str, object]) -> None:
 
 def check_record(path: Path, current: dict[str, object]) -> bool:
     if not path.is_file():
-        print(f"replay fingerprint missing: {path}", file=sys.stderr)
+        print(f"OU evidence fingerprint missing: {path}", file=sys.stderr)
         return False
     try:
         recorded = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
-        print(f"cannot read replay fingerprint {path}: {exc}", file=sys.stderr)
+        print(f"cannot read OU evidence fingerprint {path}: {exc}", file=sys.stderr)
         return False
     if not isinstance(recorded, dict):
-        print(f"replay fingerprint is not a JSON object: {path}", file=sys.stderr)
+        print(f"OU evidence fingerprint is not a JSON object: {path}", file=sys.stderr)
         return False
     if _comparison_view(recorded) != _comparison_view(current):
         print(
-            "OU replay fingerprint changed: "
-            f"recorded={recorded.get('fingerprint')} current={current.get('fingerprint')}",
+            "OU replay/results fingerprint changed: "
+            f"replay recorded={recorded.get('replay_fingerprint')} "
+            f"current={current.get('replay_fingerprint')}; "
+            f"results recorded={recorded.get('results_fingerprint')} "
+            f"current={current.get('results_fingerprint')}",
             file=sys.stderr,
         )
         return False
-    print(f"OU replay fingerprint unchanged: {current['fingerprint']}")
+    print(
+        "OU replay/results fingerprints unchanged: "
+        f"replay={current['replay_fingerprint']} "
+        f"results={current['results_fingerprint']}"
+    )
     return True
 
 
@@ -211,7 +268,11 @@ def main(argv: Iterable[str] | None = None) -> int:
     current = compute_fingerprint(args.simulation_zip)
     if args.write is not None:
         write_record(args.write, current)
-        print(f"wrote OU replay fingerprint {current['fingerprint']} to {args.write}")
+        print(
+            "wrote OU evidence fingerprints "
+            f"replay={current['replay_fingerprint']} "
+            f"results={current['results_fingerprint']} to {args.write}"
+        )
         return 0
     if args.check is not None:
         return 0 if check_record(args.check, current) else 1

--- a/tools/ou_replay_fingerprint.py
+++ b/tools/ou_replay_fingerprint.py
@@ -1,22 +1,23 @@
 #!/usr/bin/env python3
 """Content fingerprint for deciding whether OU simulator evidence must be replayed.
 
-The gate is deliberately conservative.  It hashes every tracked C/C++ source or
-header, Python or shell script, YAML workflow/configuration file, make fragment,
-Makefile/CMakeLists/Dockerfile, and every tracked file whose Git mode is
-executable.  It also hashes the exact downloaded simulation-data ZIP.
+The gate is deliberately conservative. It hashes every tracked source/script,
+build/workflow file, and every tracked file whose Git mode is executable. It
+also hashes the exact downloaded simulation-data ZIP.
 
-The fingerprint is intentionally independent of the enclosing Git commit SHA and
-of generated evidence.  A documentation/evidence-only commit therefore does not
-invalidate a scientifically identical replay, while any change to executable or
-build/workflow content does.
+This is intentionally broader than the simulator dependency closure. False
+positive full replays are acceptable; reusing evidence after a potentially
+replay-affecting repository change is not.
+
+The fingerprint is independent of the enclosing Git commit SHA and of generated
+evidence. A documentation/evidence-only commit therefore does not invalidate a
+scientifically identical replay.
 """
 from __future__ import annotations
 
 import argparse
 import hashlib
 import json
-import os
 import subprocess
 import sys
 from pathlib import Path
@@ -26,22 +27,32 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 SCHEMA_VERSION = 1
 ALGORITHM = "sha256-framed-v1"
 
+# Deliberately broad. Do not replace this with include/reachability analysis:
+# the replay gate is designed to fail toward unnecessary recomputation rather
+# than toward accidental reuse of stale evidence.
 SOURCE_SUFFIXES = {
-    ".c",
-    ".cc",
-    ".cpp",
-    ".cxx",
-    ".h",
-    ".hh",
-    ".hpp",
-    ".hxx",
-    ".py",
-    ".sh",
-    ".yml",
-    ".yaml",
-    ".mk",
+    # C/C++/Objective-C/Arduino/assembly and source fragments.
+    ".c", ".cc", ".cpp", ".cxx", ".h", ".hh", ".hpp", ".hxx",
+    ".m", ".mm", ".ino", ".s", ".asm", ".ipp", ".tpp", ".inc",
+    # Scripts and executable-language sources.
+    ".py", ".sh", ".bash", ".zsh", ".fish", ".pl", ".rb", ".lua",
+    ".js", ".mjs", ".cjs", ".ts", ".mts", ".cts", ".java", ".kt",
+    ".kts", ".rs", ".go", ".swift",
+    # Workflow/build configuration that can change how executable code runs.
+    ".yml", ".yaml", ".mk", ".cmake", ".ac", ".am",
 }
-SOURCE_BASENAMES = {"Makefile", "CMakeLists.txt", "Dockerfile"}
+SOURCE_BASENAMES = {
+    "Makefile",
+    "CMakeLists.txt",
+    "Dockerfile",
+    "meson.build",
+    "meson_options.txt",
+    "BUILD",
+    "BUILD.bazel",
+    "WORKSPACE",
+    "WORKSPACE.bazel",
+    "MODULE.bazel",
+}
 
 
 def sha256_file(path: Path) -> str:
@@ -93,7 +104,7 @@ def replay_source_entries() -> list[tuple[str, str]]:
     )
 
 
-def _frame(digest: "hashlib._Hash", *parts: bytes) -> None:
+def _frame(digest, *parts: bytes) -> None:
     for part in parts:
         digest.update(len(part).to_bytes(8, "big"))
         digest.update(part)

--- a/tools/ou_replay_fingerprint.py
+++ b/tools/ou_replay_fingerprint.py
@@ -42,11 +42,13 @@ SOURCE_SUFFIXES = {
     ".js", ".mjs", ".cjs", ".ts", ".mts", ".cts", ".java", ".kt",
     ".kts", ".rs", ".go", ".swift",
     # Workflow/build configuration that can change how executable code runs.
-    ".yml", ".yaml", ".mk", ".cmake", ".ac", ".am",
+    ".yml", ".yaml", ".mk", ".make", ".cmake", ".ninja", ".ac", ".am",
 }
 SOURCE_BASENAMES = {
     "Makefile",
     "CMakeLists.txt",
+    "CMakePresets.json",
+    "CMakeUserPresets.json",
     "Dockerfile",
     "meson.build",
     "meson_options.txt",
@@ -55,6 +57,24 @@ SOURCE_BASENAMES = {
     "WORKSPACE",
     "WORKSPACE.bazel",
     "MODULE.bazel",
+    "pyproject.toml",
+    "setup.cfg",
+    "tox.ini",
+    "platformio.ini",
+    "Pipfile",
+    "Pipfile.lock",
+    "poetry.lock",
+    "package.json",
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "Cargo.toml",
+    "Cargo.lock",
+    "go.mod",
+    "go.sum",
+    "build.gradle",
+    "settings.gradle",
+    "gradle.properties",
 }
 
 
@@ -91,12 +111,23 @@ def _git_ls_files() -> list[tuple[str, str]]:
     return entries
 
 
+def _is_build_filename(name: str) -> bool:
+    lower = name.lower()
+    return (
+        name in SOURCE_BASENAMES
+        or name.startswith("Makefile")
+        or name.startswith("Dockerfile")
+        or (lower.startswith("requirements") and lower.endswith(".txt"))
+    )
+
+
 def is_replay_source(mode: str, relative_path: str) -> bool:
     path = Path(relative_path)
     return (
         relative_path.startswith("tests/")
+        or relative_path.startswith(".github/")
         or path.suffix.lower() in SOURCE_SUFFIXES
-        or path.name in SOURCE_BASENAMES
+        or _is_build_filename(path.name)
         or mode == "100755"
     )
 

--- a/tools/ou_replay_fingerprint.py
+++ b/tools/ou_replay_fingerprint.py
@@ -1,17 +1,20 @@
 #!/usr/bin/env python3
 """Content fingerprint for deciding whether OU simulator evidence must be replayed.
 
-The gate is deliberately conservative. It hashes every tracked source/script,
-build/workflow file, and every tracked file whose Git mode is executable. It
-also hashes the exact downloaded simulation-data ZIP.
+The gate is deliberately conservative. It hashes every tracked file under
+``tests/`` regardless of extension, every tracked source/script or build/workflow
+file elsewhere, every tracked file whose Git mode is executable, and the exact
+downloaded simulation-data ZIP.
 
 This is intentionally broader than the simulator dependency closure. False
 positive full replays are acceptable; reusing evidence after a potentially
 replay-affecting repository change is not.
 
 The fingerprint is independent of the enclosing Git commit SHA and of generated
-evidence. A documentation/evidence-only commit therefore does not invalidate a
-scientifically identical replay.
+evidence. A documentation/evidence-only commit outside ``tests/`` therefore does
+not invalidate a scientifically identical replay. Files under ``tests/`` are
+always included because test configuration and study parameters may use
+arbitrary file extensions.
 """
 from __future__ import annotations
 
@@ -91,7 +94,8 @@ def _git_ls_files() -> list[tuple[str, str]]:
 def is_replay_source(mode: str, relative_path: str) -> bool:
     path = Path(relative_path)
     return (
-        path.suffix.lower() in SOURCE_SUFFIXES
+        relative_path.startswith("tests/")
+        or path.suffix.lower() in SOURCE_SUFFIXES
         or path.name in SOURCE_BASENAMES
         or mode == "100755"
     )

--- a/tools/ou_replay_fingerprint.py
+++ b/tools/ou_replay_fingerprint.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Content fingerprint for deciding whether OU simulator evidence must be replayed.
+
+The gate is deliberately conservative.  It hashes every tracked C/C++ source or
+header, Python or shell script, YAML workflow/configuration file, make fragment,
+Makefile/CMakeLists/Dockerfile, and every tracked file whose Git mode is
+executable.  It also hashes the exact downloaded simulation-data ZIP.
+
+The fingerprint is intentionally independent of the enclosing Git commit SHA and
+of generated evidence.  A documentation/evidence-only commit therefore does not
+invalidate a scientifically identical replay, while any change to executable or
+build/workflow content does.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_VERSION = 1
+ALGORITHM = "sha256-framed-v1"
+
+SOURCE_SUFFIXES = {
+    ".c",
+    ".cc",
+    ".cpp",
+    ".cxx",
+    ".h",
+    ".hh",
+    ".hpp",
+    ".hxx",
+    ".py",
+    ".sh",
+    ".yml",
+    ".yaml",
+    ".mk",
+}
+SOURCE_BASENAMES = {"Makefile", "CMakeLists.txt", "Dockerfile"}
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _git_ls_files() -> list[tuple[str, str]]:
+    completed = subprocess.run(
+        ("git", "ls-files", "-s", "-z"),
+        cwd=REPO_ROOT,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            "git ls-files failed: "
+            + completed.stderr.decode("utf-8", errors="replace").strip()
+        )
+
+    entries: list[tuple[str, str]] = []
+    for raw in completed.stdout.split(b"\0"):
+        if not raw:
+            continue
+        meta, path_bytes = raw.split(b"\t", 1)
+        mode = meta.split(b" ", 1)[0].decode("ascii")
+        path = path_bytes.decode("utf-8", errors="surrogateescape")
+        entries.append((mode, path))
+    return entries
+
+
+def is_replay_source(mode: str, relative_path: str) -> bool:
+    path = Path(relative_path)
+    return (
+        path.suffix.lower() in SOURCE_SUFFIXES
+        or path.name in SOURCE_BASENAMES
+        or mode == "100755"
+    )
+
+
+def replay_source_entries() -> list[tuple[str, str]]:
+    return sorted(
+        (entry for entry in _git_ls_files() if is_replay_source(*entry)),
+        key=lambda item: item[1],
+    )
+
+
+def _frame(digest: "hashlib._Hash", *parts: bytes) -> None:
+    for part in parts:
+        digest.update(len(part).to_bytes(8, "big"))
+        digest.update(part)
+
+
+def compute_fingerprint(simulation_zip: Path) -> dict[str, object]:
+    simulation_zip = simulation_zip.resolve()
+    if not simulation_zip.is_file():
+        raise FileNotFoundError(simulation_zip)
+
+    digest = hashlib.sha256()
+    _frame(digest, b"ocean-imu-ou-replay-fingerprint", str(SCHEMA_VERSION).encode())
+
+    files: list[dict[str, object]] = []
+    for mode, relative_path in replay_source_entries():
+        path = REPO_ROOT / relative_path
+        if not path.is_file():
+            raise FileNotFoundError(path)
+        file_sha = sha256_file(path)
+        files.append({"path": relative_path, "mode": mode, "sha256": file_sha})
+        _frame(
+            digest,
+            b"repo-file",
+            mode.encode("ascii"),
+            relative_path.encode("utf-8", errors="surrogateescape"),
+            bytes.fromhex(file_sha),
+        )
+
+    zip_sha = sha256_file(simulation_zip)
+    _frame(digest, b"simulation-data-zip", bytes.fromhex(zip_sha))
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "algorithm": ALGORITHM,
+        "fingerprint": digest.hexdigest(),
+        "simulation_data": {
+            "file": simulation_zip.name,
+            "sha256": zip_sha,
+        },
+        "tracked_replay_file_count": len(files),
+        "tracked_replay_files": files,
+    }
+
+
+def _comparison_view(record: dict[str, object]) -> tuple[object, ...]:
+    simulation = record.get("simulation_data")
+    simulation_sha = simulation.get("sha256") if isinstance(simulation, dict) else None
+    return (
+        record.get("schema_version"),
+        record.get("algorithm"),
+        record.get("fingerprint"),
+        simulation_sha,
+    )
+
+
+def write_record(path: Path, record: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def check_record(path: Path, current: dict[str, object]) -> bool:
+    if not path.is_file():
+        print(f"replay fingerprint missing: {path}", file=sys.stderr)
+        return False
+    try:
+        recorded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"cannot read replay fingerprint {path}: {exc}", file=sys.stderr)
+        return False
+    if not isinstance(recorded, dict):
+        print(f"replay fingerprint is not a JSON object: {path}", file=sys.stderr)
+        return False
+    if _comparison_view(recorded) != _comparison_view(current):
+        print(
+            "OU replay fingerprint changed: "
+            f"recorded={recorded.get('fingerprint')} current={current.get('fingerprint')}",
+            file=sys.stderr,
+        )
+        return False
+    print(f"OU replay fingerprint unchanged: {current['fingerprint']}")
+    return True
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--simulation-zip",
+        type=Path,
+        required=True,
+        help="exact sim-data-files.zip used by the studies",
+    )
+    action = parser.add_mutually_exclusive_group()
+    action.add_argument("--write", type=Path, help="write the current fingerprint JSON")
+    action.add_argument("--check", type=Path, help="return 0 only when this record matches")
+    return parser.parse_args(argv)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(argv)
+    current = compute_fingerprint(args.simulation_zip)
+    if args.write is not None:
+        write_record(args.write, current)
+        print(f"wrote OU replay fingerprint {current['fingerprint']} to {args.write}")
+        return 0
+    if args.check is not None:
+        return 0 if check_record(args.check, current) else 1
+    json.dump(current, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a deliberately conservative replay-input fingerprint over every tracked file under `tests/**`, broad executable/source/build/workflow inputs elsewhere, every Git-executable file, and the SHA-256 of `sim-data-files.zip`
- add a second fingerprint over **every file under `reports/results/**`**, including path and content
- store both hashes in `reports/ou_evidence_fingerprint.json`, outside the results tree so the results hash has no self-reference exception
- on full publication builds, run the ~840 validation + ~310 robustness simulator replays whenever either the replay-input hash or complete results-tree hash differs
- when both hashes are unchanged, reuse committed full replay rows but still run the validation/evidence contract
- after a full replay, commit the regenerated validation/robustness evidence, mirrored OU-III manuscript inputs, and both fingerprints together
- after any push retry/rebase, re-check both hashes before stale rows can be pushed onto newer executable code or a changed results tree

## Conservative policy
False-positive full replays are acceptable; missing a required replay is not. The classifier therefore includes `Makefile*`, `Dockerfile*`, `.make`, `.mk`, CMake/meson/Bazel/dependency manifests, all `.github/**`, and every file under `tests/**` regardless of extension.

The enclosing Git SHA is intentionally not the replay key: committing regenerated evidence changes the Git SHA without changing the executable/test/data inputs. The content hashes remain stable across that evidence-only commit.