### PR TITLE
Finalize OU evidence publication closure after #380

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,11 +27,14 @@ jobs:
 
   build:
     needs: [ou-evidence]
-    # Off main ou-evidence is skipped, and on main it fails when the
-    # regenerated numbers no longer match the prose. Neither is a reason to
-    # stop typesetting -- by the time that check runs the bundle has already
-    # landed, and the run is red on its own without withholding the article.
-    if: ${{ !cancelled() }}
+    # Off main ou-evidence is skipped and ordinary branch/PR builds should use
+    # the committed evidence. On main, however, publication must not proceed
+    # after a failed full-evidence run: the PDF would otherwise be cut from a
+    # tree whose numerical evidence was not validated for that source state.
+    if: >-
+      ${{ !cancelled()
+          && (github.ref != 'refs/heads/main'
+              || needs['ou-evidence'].result == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
@@ -297,13 +300,11 @@ jobs:
           if-no-files-found: warn
           
   release:
-    # ou-evidence only runs on main, and a skipped job propagates through the
-    # graph: build survives it with !cancelled(), but release inherited the skip
-    # from build's ancestor and never ran off main. That is why v1.1.2 and
-    # v1.1.3 shipped with source code only while v1.1.1, tagged before the
-    # evidence job existed, got its assets. Naming a status function here stops
-    # the automatic skip, so the results of the two jobs that actually produce
-    # the assets are what decides.
+    # ou-evidence only runs on main. The build job explicitly survives a
+    # skipped evidence job off main, but requires evidence success on main.
+    # Naming a status function here likewise prevents an automatic skip from
+    # an ancestor and lets the two jobs that actually produce release assets
+    # decide whether release can proceed.
     if: >-
       ${{ !cancelled()
           && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')

--- a/.github/workflows/ou-full-evidence-branch.yml
+++ b/.github/workflows/ou-full-evidence-branch.yml
@@ -1,13 +1,13 @@
 name: ou-full-evidence-branch
 
 on:
-  push:
-    branches-ignore:
-      - main
+  workflow_dispatch:
 
-# Branch pushes get the same full evidence gate as main. The reusable workflow
-# decides from the conservative replay-input/results fingerprints whether the
-# expensive ~1,150 simulator replays are actually necessary.
+# Full branch evidence is intentionally opt-in. Main is the authoritative
+# automatic full-study path through build.yml. Keeping branch replays manual
+# prevents ordinary development pushes from duplicating the same ~1,150
+# simulator replays while still allowing an explicit pre-merge regeneration
+# when one is useful.
 concurrency:
   group: ou-full-evidence-branch-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ou-validation.yml
+++ b/.github/workflows/ou-validation.yml
@@ -25,6 +25,8 @@ on:
       - "doc/kalman_ou_iii/**"
       - "Makefile"
       - ".github/workflows/ou-validation.yml"
+      - ".github/workflows/build.yml"
+      - ".github/workflows/ou-full-evidence-branch.yml"
   workflow_dispatch:
     inputs:
       validation_mode:

--- a/tests/OU_REPLAY_EVIDENCE_GATE.md
+++ b/tests/OU_REPLAY_EVIDENCE_GATE.md
@@ -45,6 +45,8 @@ For a full OU publication/evidence run:
 5. After regeneration, the generated validation bundle, robustness bundle, mirrored manuscript inputs, and `reports/ou_evidence_fingerprint.json` are committed together.
 6. If a write retry rebases onto a newer branch tip, both fingerprints are checked again before regenerated evidence can be pushed.
 
+`main` is the authoritative automatic full-study path: a `main` build invokes the reusable OU evidence workflow in full mode before publication is built. The separate `ou-full-evidence-branch` workflow is manual-only. This avoids launching another complete ~1,150-replay study for every ordinary development-branch push while preserving an explicit pre-merge full-regeneration option when needed.
+
 The policy is intentionally asymmetric:
 
 > An unnecessary full replay is acceptable. Reusing stale evidence after a potentially relevant repository, test-data, simulation-data, or results-tree change is not.

--- a/tests/validation/test_workflow_contract.py
+++ b/tests/validation/test_workflow_contract.py
@@ -8,6 +8,61 @@ BRANCH_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ou-full-evidence-branch
 BUILD_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "build.yml"
 
 
+def _mapping_child_keys(text, section):
+    lines = text.splitlines()
+    start = lines.index(f"{section}:")
+    keys = set()
+    for line in lines[start + 1 :]:
+        if line and not line.startswith(" "):
+            break
+        if not line.startswith("  ") or line.startswith("    "):
+            continue
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or ":" not in stripped:
+            continue
+        keys.add(stripped.split(":", 1)[0])
+    return keys
+
+
+def _job_block(workflow, job_name, next_job_name):
+    start = workflow.index(f"  {job_name}:")
+    end = workflow.index(f"  {next_job_name}:", start)
+    return workflow[start:end]
+
+
+def _inline_sequence(stage, key):
+    prefix = f"{key}: ["
+    for line in stage.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(prefix) and stripped.endswith("]"):
+            values = stripped[len(prefix) : -1]
+            return [value.strip().strip("'\"") for value in values.split(",")]
+    raise AssertionError(f"inline sequence {key!r} not found")
+
+
+def _folded_scalar(stage, key):
+    lines = stage.splitlines()
+    marker = f"{key}: >-"
+    for index, line in enumerate(lines):
+        if line.strip() != marker:
+            continue
+        indent = len(line) - len(line.lstrip())
+        parts = []
+        for continuation in lines[index + 1 :]:
+            if not continuation.strip():
+                continue
+            continuation_indent = len(continuation) - len(continuation.lstrip())
+            if continuation_indent <= indent:
+                break
+            parts.append(continuation.strip())
+        return " ".join(parts)
+    raise AssertionError(f"folded scalar {key!r} not found")
+
+
+def _compact(expression):
+    return "".join(expression.split())
+
+
 class WorkflowContractTests(unittest.TestCase):
     def test_full_regeneration_validates_before_commit(self):
         workflow = WORKFLOW.read_text(encoding="utf-8")
@@ -117,8 +172,7 @@ class WorkflowContractTests(unittest.TestCase):
 
     def test_branch_full_evidence_is_manual_only(self):
         workflow = BRANCH_WORKFLOW.read_text(encoding="utf-8")
-        self.assertIn("workflow_dispatch:", workflow)
-        self.assertNotIn("\n  push:", workflow)
+        self.assertEqual(_mapping_child_keys(workflow, "on"), {"workflow_dispatch"})
         self.assertIn("validation_mode: full", workflow)
 
     def test_main_build_is_the_authoritative_automatic_full_evidence_path(self):
@@ -132,11 +186,9 @@ class WorkflowContractTests(unittest.TestCase):
 
     def test_main_pdf_build_uses_post_evidence_head_and_compiles_ou_iii(self):
         workflow = BUILD_WORKFLOW.read_text(encoding="utf-8")
-        build = workflow.index("  build:")
-        tuning = workflow.index("  ou-tuning:", build)
-        stage = workflow[build:tuning]
+        stage = _job_block(workflow, "build", "ou-tuning")
         self.assertIn("needs: [ou-evidence]", stage)
-        self.assertIn("kalman_ou_iii", stage)
+        self.assertIn("kalman_ou_iii", _inline_sequence(stage, "dir"))
         self.assertIn(
             "ref: ${{ github.ref == 'refs/heads/main' && 'refs/heads/main' || '' }}",
             stage,
@@ -146,12 +198,13 @@ class WorkflowContractTests(unittest.TestCase):
 
     def test_main_pdf_build_requires_successful_evidence(self):
         workflow = BUILD_WORKFLOW.read_text(encoding="utf-8")
-        build = workflow.index("  build:")
-        tuning = workflow.index("  ou-tuning:", build)
-        stage = workflow[build:tuning]
-        self.assertIn("github.ref != 'refs/heads/main'", stage)
-        self.assertIn("needs['ou-evidence'].result == 'success'", stage)
-        self.assertNotIn("if: ${{ !cancelled() }}", stage)
+        stage = _job_block(workflow, "build", "ou-tuning")
+        condition = _compact(_folded_scalar(stage, "if"))
+        self.assertEqual(
+            condition,
+            "${{!cancelled()&&(github.ref!='refs/heads/main'||"
+            "needs['ou-evidence'].result=='success')}}",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/validation/test_workflow_contract.py
+++ b/tests/validation/test_workflow_contract.py
@@ -4,6 +4,8 @@ import unittest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ou-validation.yml"
+BRANCH_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ou-full-evidence-branch.yml"
+BUILD_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "build.yml"
 
 
 class WorkflowContractTests(unittest.TestCase):
@@ -90,6 +92,12 @@ class WorkflowContractTests(unittest.TestCase):
         workflow = WORKFLOW.read_text(encoding="utf-8")
         self.assertIn('- "reports/results/**"', workflow)
 
+    def test_evidence_workflow_changes_trigger_smoke_validation(self):
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn('- ".github/workflows/ou-validation.yml"', workflow)
+        self.assertIn('- ".github/workflows/build.yml"', workflow)
+        self.assertIn('- ".github/workflows/ou-full-evidence-branch.yml"', workflow)
+
     def test_push_retry_revalidates_after_rebase(self):
         workflow = WORKFLOW.read_text(encoding="utf-8")
         start = workflow.index("for attempt in 1 2 3 4; do")
@@ -106,6 +114,44 @@ class WorkflowContractTests(unittest.TestCase):
         workflow = WORKFLOW.read_text(encoding="utf-8")
         self.assertNotIn("The regenerated bundle is committed, but", workflow)
         self.assertNotIn("Fail if the manuscript no longer matches", workflow)
+
+    def test_branch_full_evidence_is_manual_only(self):
+        workflow = BRANCH_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("workflow_dispatch:", workflow)
+        self.assertNotIn("\n  push:", workflow)
+        self.assertIn("validation_mode: full", workflow)
+
+    def test_main_build_is_the_authoritative_automatic_full_evidence_path(self):
+        workflow = BUILD_WORKFLOW.read_text(encoding="utf-8")
+        evidence = workflow.index("  ou-evidence:")
+        build = workflow.index("  build:", evidence)
+        stage = workflow[evidence:build]
+        self.assertIn("github.ref == 'refs/heads/main'", stage)
+        self.assertIn("uses: ./.github/workflows/ou-validation.yml", stage)
+        self.assertIn("validation_mode: full", stage)
+
+    def test_main_pdf_build_uses_post_evidence_head_and_compiles_ou_iii(self):
+        workflow = BUILD_WORKFLOW.read_text(encoding="utf-8")
+        build = workflow.index("  build:")
+        tuning = workflow.index("  ou-tuning:", build)
+        stage = workflow[build:tuning]
+        self.assertIn("needs: [ou-evidence]", stage)
+        self.assertIn("kalman_ou_iii", stage)
+        self.assertIn(
+            "ref: ${{ github.ref == 'refs/heads/main' && 'refs/heads/main' || '' }}",
+            stage,
+        )
+        self.assertIn("- name: Compile LaTeX document (${{ matrix.dir }})", stage)
+        self.assertIn("working_directory: doc/${{ matrix.dir }}", stage)
+
+    def test_main_pdf_build_requires_successful_evidence(self):
+        workflow = BUILD_WORKFLOW.read_text(encoding="utf-8")
+        build = workflow.index("  build:")
+        tuning = workflow.index("  ou-tuning:", build)
+        stage = workflow[build:tuning]
+        self.assertIn("github.ref != 'refs/heads/main'", stage)
+        self.assertIn("needs['ou-evidence'].result == 'success'", stage)
+        self.assertNotIn("if: ${{ !cancelled() }}", stage)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- resynced onto current `main` after #384 (large-angle source-funnel OU-III stability certificate rewrite)
- make the non-main full-evidence workflow manual-only so ordinary branch pushes cannot duplicate the authoritative `main` full study
- document that `main` is the single automatic full-regeneration path
- add workflow-contract tests that enforce both the manual-only branch path and the automatic `main` full-evidence path
- enforce that the post-evidence `main` build checks out the updated `main` head, includes `kalman_ou_iii`, and executes its LaTeX build from `doc/kalman_ou_iii`
- block the `main` PDF/release build if the full evidence workflow fails; off-main builds still proceed when the evidence job is intentionally skipped
- make PR changes to `build.yml` or the branch full-evidence workflow trigger the OU workflow-contract smoke gate

## Continuation from #380
PR #380 established the conservative replay-input fingerprint and complete `reports/results/**` fingerprint. This follow-up keeps the expensive study single-sourced and makes the publication closure explicit: regenerated evidence is landed and validated first, then the PDF build consumes the post-evidence `main` tree.

Because the conservative replay fingerprint intentionally includes `.github/**` and all `tests/**`, merging this PR will itself invalidate the replay fingerprint. The recent #382/#383/#384 stability work also changed `tests/**`, so the authoritative final full study remains the `main` run after #381 merges; running the same ~1,150-replay study automatically on the PR branch would only duplicate work.

The intent is to avoid concurrent equivalent full studies while preserving an explicit manual branch full-regeneration option when one is actually wanted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Workflow Improvements**
  - Main-branch releases now wait for successful full evidence validation before building and publishing assets.
  - Development-branch full evidence runs are now manual, reducing unnecessary automatic validation runs.
  - Changes to release and evidence workflows now trigger the appropriate validation checks.

- **Documentation**
  - Clarified the authoritative evidence and release process, including the manual pre-merge option.

- **Tests**
  - Added coverage to verify workflow triggers, evidence prerequisites, and post-validation build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->