### PR TITLE
Sharpen OU-III stochastic stability with Gaussian and martingale concentration

### DIFF
--- a/doc/kalman_ou_iii/w3d-conclusion-summary.tex-part
+++ b/doc/kalman_ou_iii/w3d-conclusion-summary.tex-part
@@ -70,10 +70,14 @@ stochastic qualification also uses the same metric.  A product-manifold distance
 combining $\SO(3)$ geodesic separation and additive-state separation bounds the
 localized noisy-to-zero-noise word endpoint; conditional second/fourth-moment
 bounds then give a constructive regional mean-square drift inequality without
-assuming that NIS gating preserves zero conditional mean.  Because Gaussian
+assuming that NIS gating preserves zero conditional mean.  Conditional Gaussian
+quadratic-form concentration gives an exponential localization-exit bound for
+raw pre-gate noise, while a centered word-boundary martingale decomposition and
+verified conditional increment/variance bounds give a Bernstein/Freedman
+finite-horizon excursion estimate for the funnel energy.  Because Gaussian
 noise has unbounded support, compact-funnel almost-sure invariance is not
-claimed; the exact Gaussian process receives a finite-horizon high-probability
-qualification through the localization-exit bound.
+claimed; the exact Gaussian process instead receives a finite-horizon
+high-probability bound combining those two exponential tails.
 
 The adaptation layer separates sea time scale, OU-prior amplitude, and integral
 regularization.  The measured sea period sets $\tau$, the physical band-limited
@@ -138,12 +142,13 @@ state bounds.  The widened stability theory is not yet a numerically
 instantiated deployed certificate: the continuous source graph and word
 families, path metrics $P_i$, group weights $a_{R,i}$, largest verified
 $\theta_{*,i}$, exact source-word margin $\mu_W$, handoff funnel levels and
-transition inequalities, hybrid cooldown/reset constants, and stochastic
-product-distance/noise constants must still be enclosed rigorously.  The
-ESP32--S3 exercise establishes source portability but not processor, memory,
-power, or deadline margins.  Reported displacement remains bounded wave motion
-about a local reference; no global navigation position is claimed without
-external aiding.
+transition inequalities, hybrid cooldown/reset constants, stochastic
+product-distance/noise constants, conditional covariance envelope
+$\overline\Sigma$, localization threshold $w_*$, and martingale fluctuation
+bounds $(b_W,v_W)$ must still be enclosed rigorously.  The ESP32--S3 exercise
+establishes source portability but not processor, memory, power, or deadline
+margins.  Reported displacement remains bounded wave motion about a local
+reference; no global navigation position is claimed without external aiding.
 
 \subsection*{Future work}
 \begin{itemize}[leftmargin=1.25em]
@@ -156,12 +161,9 @@ external aiding.
         the deployed source graph and source-complete word families, solve and
         verify the path metrics, determine the largest admissible large-angle
         sectors, bound $\mu_W$, initialize the handoff funnel directly from
-        $\mathcal H$, and evaluate hybrid and stochastic margins.  Report
-        diagnostic coordinate radii only after the funnel certificate itself is
-        established.
-  \item \textbf{Sharper stochastic concentration.}  Replace the present
-        finite-horizon moment/union bound with a stopped-supermartingale or
-        Gaussian quadratic-form concentration result on the same source funnel.
+        $\mathcal H$, and evaluate hybrid, Gaussian-localization, and martingale
+        concentration margins.  Report diagnostic coordinate radii only after
+        the funnel certificate itself is established.
   \item \textbf{Transition-aware regularizer amplitude.}  If the full-state
         model predicts a stationary--transition conflict outside the currently
         tested transition, preserve the steady-state regularizer mapping and

--- a/doc/kalman_ou_iii/w3d-finite-live-capture.tex-part
+++ b/doc/kalman_ou_iii/w3d-finite-live-capture.tex-part
@@ -267,24 +267,16 @@ Then
  +\frac{1-\lambda_s^n}{1-\lambda_s}\sigma_s^2.}
  \label{eq:capture-stochastic-ms}
 \end{equation}
-Moreover, for any $a>0$ and finite horizon $N$,
-\begin{equation}
- \boxed{
- \Pr\!\left(\max_{0\le n\le N}W_n\ge a\right)
- \le\frac1a\sum_{n=0}^{N}\left(
- \lambda_s^n\mathbb EW_0+
- \frac{\sigma_s^2}{1-\lambda_s}\right).}
- \label{eq:capture-stochastic-finite-hp}
-\end{equation}
 \end{theorem}
 
 \begin{proof}
 Taking expectations in Eq.~\eqref{eq:capture-stochastic-drift} and iterating
-gives Eq.~\eqref{eq:capture-stochastic-ms}.  Markov's inequality followed by a
-union bound over the finite horizon gives
-Eq.~\eqref{eq:capture-stochastic-finite-hp}.
+gives Eq.~\eqref{eq:capture-stochastic-ms}.
 \end{proof}
 
 Equation~\eqref{eq:capture-stochastic-drift} is a stochastic certificate
 condition for the exact implemented word map; it is not inferred from the
-deterministic bounded-input theorem.
+deterministic bounded-input theorem.  Finite-horizon high-probability statements
+are derived in Sec.~\ref{sec:stability-widening-phase-f} from conditional
+Gaussian quadratic-form concentration and a martingale Bernstein/Freedman
+bound, rather than from a Markov inequality on $W_n$.

--- a/doc/kalman_ou_iii/w3d-stability-widening-phase-f.tex-part
+++ b/doc/kalman_ou_iii/w3d-stability-widening-phase-f.tex-part
@@ -176,32 +176,198 @@ the deterministic funnel inequality and the product-distance sensitivity bound
 hold uniformly for every admissible branch.
 \end{proof}
 
-For the true unbounded process define the tail event over $K$ word blocks
+\subsubsection{Gaussian concentration for localization exit}
+
+For the true unbounded process, strengthen the raw-noise hypothesis to the
+source-faithful conditional Gaussian model
+\begin{equation}
+ \vct w_k\mid\mathscr F_k\sim\mathcal N(0,\Sigma_k),
+ \qquad
+ 0\preceq\Sigma_k\preceq\overline\Sigma.
+ \label{eq:widen-gaussian-conditional}
+\end{equation}
+This is imposed on the pre-gate increment.  The accepted innovation need not
+remain conditionally centered after NIS gating.
+
+Define
+\begin{equation}
+ m_\Sigma:=\operatorname{tr}\overline\Sigma,\qquad
+ v_\Sigma:=\operatorname{tr}(\overline\Sigma^2),\qquad
+ b_\Sigma:=\|\overline\Sigma\|_2.
+ \label{eq:widen-gaussian-tail-constants}
+\end{equation}
+
+\begin{lemma}[Conditional Gaussian quadratic-form tail]
+\label{lem:widen-gaussian-tail}
+Under Eq.~\eqref{eq:widen-gaussian-conditional}, for every $t\ge0$,
+\begin{equation}
+ \boxed{
+ \Pr\!\left(
+ \|w_k\|^2\ge
+ m_\Sigma+2\sqrt{v_\Sigma t}+2b_\Sigma t
+ \,\middle|\,\mathscr F_k\right)
+ \le e^{-t}.}
+ \label{eq:widen-gaussian-tail}
+\end{equation}
+\end{lemma}
+
+\begin{proof}
+Condition on $\mathscr F_k$, diagonalize $\Sigma_k$, and write
+$\|w_k\|^2$ as a weighted sum of independent squared standard normal
+coordinates.  Chernoff's method applied to the exact Gaussian quadratic-form
+moment-generating function gives
+$\Pr(\|w_k\|^2\ge
+\operatorname{tr}\Sigma_k+
+2\sqrt{\operatorname{tr}(\Sigma_k^2)t}+
+2\|\Sigma_k\|_2t\mid\mathscr F_k)\le e^{-t}$.
+Loewner monotonicity of the ordered eigenvalues under
+$\Sigma_k\preceq\overline\Sigma$ bounds the three covariance quantities by
+$(m_\Sigma,v_\Sigma,b_\Sigma)$ and yields
+Eq.~\eqref{eq:widen-gaussian-tail}.
+\end{proof}
+
+For a selected localization radius define
+\begin{equation}
+ \boxed{
+ t_*:=\sup\left\{t\ge0:
+ m_\Sigma+2\sqrt{v_\Sigma t}+2b_\Sigma t\le w_*^2
+ \right\}.}
+ \label{eq:widen-gaussian-tail-rate}
+\end{equation}
+When $w_*^2>m_\Sigma$, $t_*>0$.  Over $K$ certified words, define
 \begin{equation}
  \mathcal E_K^c:=
  \left\{\max_{0\le r<K}\max_{0\le q<\ell_+}
  \|w_{k_r+q}\|>w_*\right\}.
 \end{equation}
-A union bound followed by Markov's inequality and the raw moment bounds gives
+Taking conditional expectations of Eq.~\eqref{eq:widen-gaussian-tail} and
+summing only over the at most $K\ell_+$ physical increments gives
 \begin{equation}
  \boxed{
  \Pr(\mathcal E_K^c)
- \le K\ell_+\min\!\left\{
- \frac{s_2}{w_*^2},\frac{s_4}{w_*^4}\right\}.}
+ \le K\ell_+e^{-t_*}.}
  \label{eq:widen-stochastic-exit}
 \end{equation}
-On $\mathcal E_K$ the raw and localized trajectories coincide over the complete
-horizon, so the true process inherits the same certified regional path and
-word-boundary comparison over that horizon.  A Gaussian quadratic-form tail may
-replace Eq.~\eqref{eq:widen-stochastic-exit} when the sharper probabilistic
-certificate of the next stage is constructed.
+No independence between physical samples or source words is required.  Relative
+to the previous moment/Markov estimate, the localization penalty now decays
+exponentially in the certified Gaussian threshold parameter.
+
+\subsubsection{Freedman--Bernstein concentration of funnel excursions}
+
+The mean-square drift controls the expected funnel energy but does not by itself
+control a finite-horizon maximum sharply.  For the localized process define the
+word-boundary martingale difference
+\begin{equation}
+ \boxed{
+ \zeta_{n+1}:=
+ W_{n+1}-\mathbb E[W_{n+1}\mid\mathscr F_n].}
+ \label{eq:widen-stochastic-martingale-difference}
+\end{equation}
+This centering is an identity and does not assume that gating preserves the
+conditional mean of a physical innovation.
+
+Because the localized source funnel and all admissible word maps are compact,
+a deployed stochastic certificate can rigorously enclose finite constants
+$b_W,v_W$ satisfying
+\begin{equation}
+ \boxed{
+ \zeta_{n+1}\le b_W,\qquad
+ \mathbb E[\zeta_{n+1}^2\mid\mathscr F_n]\le v_W}
+ \label{eq:widen-stochastic-martingale-bounds}
+\end{equation}
+for every certified word boundary.  The verifier may use exact source-word
+enclosures to make these constants considerably sharper than the trivial
+compact-range bounds.
+
+Condition on $\mathscr F_0$ and define the deterministic drift envelope
+\begin{equation}
+ \bar W_n:=
+ \lambda_s^nW_0+
+ \frac{1-\lambda_s^n}{1-\lambda_s}\sigma_s^2.
+ \label{eq:widen-stochastic-drift-envelope}
+\end{equation}
+Recursion of Eq.~\eqref{eq:widen-stochastic-drift} and
+Eq.~\eqref{eq:widen-stochastic-martingale-difference} gives
+\begin{equation}
+ W_n\le \bar W_n+
+ \sum_{j=1}^{n}\lambda_s^{\,n-j}\zeta_j.
+ \label{eq:widen-stochastic-martingale-recursion}
+\end{equation}
+For every fixed terminal $n$, the weighted sum is a martingale with increments
+bounded above by $b_W$ and predictable quadratic variation no larger than
+\begin{equation}
+ \boxed{
+ V_W:=\frac{v_W}{1-\lambda_s^2}.}
+ \label{eq:widen-stochastic-freedman-variance}
+\end{equation}
+
+\begin{theorem}[Finite-horizon source-funnel concentration]
+\label{thm:widen-stochastic-concentration}
+Assume the localized drift theorem and
+Eq.~\eqref{eq:widen-stochastic-martingale-bounds}.  For a word horizon $N\ge1$
+let
+\begin{equation}
+ \bar W_N^{\max}:=\max_{0\le n\le N}\bar W_n,
+ \qquad
+ x_*:=a-\bar W_N^{\max}>0.
+ \label{eq:widen-stochastic-excursion-margin}
+\end{equation}
+Then the localized process obeys
+\begin{equation}
+ \boxed{
+ \Pr\!\left(
+ \max_{0\le n\le N}W_n\ge a
+ \,\middle|\,\mathscr F_0\right)
+ \le
+ N\exp\!\left[
+ -\frac{x_*^2}
+ {2\left(V_W+b_Wx_*/3\right)}
+ \right].}
+ \label{eq:widen-stochastic-freedman}
+\end{equation}
+If in addition the raw increments satisfy
+Eq.~\eqref{eq:widen-gaussian-conditional}, the exact unlocalized process
+satisfies
+\begin{equation}
+ \boxed{
+ \Pr\!\left(\max_{0\le n\le N}W_n^{\rm raw}\ge a\right)
+ \le
+ N\exp\!\left[
+ -\frac{x_*^2}
+ {2\left(V_W+b_Wx_*/3\right)}
+ \right]
+ +N\ell_+e^{-t_*}.}
+ \label{eq:widen-stochastic-total-tail}
+\end{equation}
+\end{theorem}
+
+\begin{proof}
+For fixed $n$, Eq.~\eqref{eq:widen-stochastic-martingale-recursion} writes the
+excess over $\bar W_n$ as a weighted martingale sum.  Its increments are at
+most $b_W$ and its conditional variance sum is bounded by $V_W$.
+The exponential supermartingale proof of the Bernstein/Freedman inequality
+therefore gives, for every $x>0$,
+\begin{equation}
+ \Pr(W_n-\bar W_n\ge x\mid\mathscr F_0)
+ \le
+ \exp\!\left[-\frac{x^2}{2(V_W+b_Wx/3)}\right].
+\end{equation}
+If $W_n\ge a$, the excess is at least $x_*$; summing this exponential bound over
+the $N$ possible positive terminal indices proves
+Eq.~\eqref{eq:widen-stochastic-freedman}.  On $\mathcal E_N$ the raw and
+localized trajectories coincide, while Eq.~\eqref{eq:widen-stochastic-exit}
+bounds $\Pr(\mathcal E_N^c)$.  Splitting according to this event gives
+Eq.~\eqref{eq:widen-stochastic-total-tail}.
+\end{proof}
 
 \begin{remark}[Scope of the stochastic result]
 \label{rem:widen-stochastic-scope}
 The stochastic certificate uses the same $W_i$, source graph, word family, and
 geodesic funnel as the deterministic theory and does not assume that innovation
-gating preserves zero conditional mean.  It does not turn the regional MEKF
-into a global Gaussian system.  With unbounded Gaussian noise the rigorous claim
-remains finite-horizon and high-probability unless additional global recovery
-bounds are proved.
+gating preserves zero conditional mean.  The high-probability qualification now
+uses exponential Gaussian and martingale concentration rather than a
+moment/Markov tail for either raw-noise localization or funnel excursions.  It
+does not turn the regional MEKF into a global Gaussian system.  With unbounded
+Gaussian noise the rigorous claim remains finite-horizon and high-probability
+unless additional global recovery bounds are proved.
 \end{remark}

--- a/tests/validation/Makefile
+++ b/tests/validation/Makefile
@@ -24,6 +24,7 @@ build:
 		test_ou_stability_widening.py \
 		test_ou_stability_large_angle_funnel.py \
 		test_ou_stability_source_path_widening.py \
+		test_ou_stochastic_concentration.py \
 		test_source_archive_provenance.py \
 		test_record_conventions.py \
 		test_publication_references.py \

--- a/tests/validation/test_ou_stochastic_concentration.py
+++ b/tests/validation/test_ou_stochastic_concentration.py
@@ -74,6 +74,15 @@ class OUIIIStochasticConcentrationContractTests(unittest.TestCase):
         self.assertIn("raw and localized trajectories coincide", flat)
         self.assertIn("finite-horizon and high-probability", flat)
 
+    def test_conclusion_no_longer_lists_concentration_as_future_work(self):
+        conclusion = _read("w3d-conclusion-summary.tex-part")
+        flat = _flat(conclusion)
+        self.assertNotIn("Sharper stochastic concentration", conclusion)
+        self.assertIn("Conditional Gaussian quadratic-form concentration", flat)
+        self.assertIn("Bernstein/Freedman", flat)
+        self.assertIn(r"$\overline\Sigma$", conclusion)
+        self.assertIn(r"$(b_W,v_W)$", conclusion)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/validation/test_ou_stochastic_concentration.py
+++ b/tests/validation/test_ou_stochastic_concentration.py
@@ -1,0 +1,79 @@
+"""Publication contract for the OU--III stochastic concentration certificate."""
+
+import re
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOC = REPO_ROOT / "doc" / "kalman_ou_iii"
+
+
+def _read(name: str) -> str:
+    return (DOC / name).read_text(encoding="utf-8")
+
+
+def _flat(text: str) -> str:
+    return re.sub(r"\s+", " ", text)
+
+
+class OUIIIStochasticConcentrationContractTests(unittest.TestCase):
+    def test_capture_keeps_mean_square_drift_without_markov_tail(self):
+        capture = _read("w3d-finite-live-capture.tex-part")
+        self.assertIn(r"\label{thm:capture-stochastic-live}", capture)
+        self.assertIn(r"\label{eq:capture-stochastic-drift}", capture)
+        self.assertIn(r"\label{eq:capture-stochastic-ms}", capture)
+        self.assertNotIn(r"\label{eq:capture-stochastic-finite-hp}", capture)
+        self.assertNotIn("Markov's inequality", capture)
+        flat = _flat(capture)
+        self.assertIn("conditional Gaussian quadratic-form concentration", flat)
+        self.assertIn("martingale Bernstein/Freedman", flat)
+
+    def test_phase_f_has_conditional_gaussian_quadratic_tail(self):
+        proof = _read("w3d-stability-widening-phase-f.tex-part")
+        for marker in (
+            r"\label{eq:widen-gaussian-conditional}",
+            r"\label{eq:widen-gaussian-tail-constants}",
+            r"\label{lem:widen-gaussian-tail}",
+            r"\label{eq:widen-gaussian-tail}",
+            r"\label{eq:widen-gaussian-tail-rate}",
+            r"\label{eq:widen-stochastic-exit}",
+        ):
+            self.assertIn(marker, proof)
+        flat = _flat(proof)
+        self.assertIn(r"K\ell_+e^{-t_*}", proof)
+        self.assertIn("No independence between physical samples or source words is required", flat)
+        self.assertNotIn(r"\frac{s_2}{w_*^2}", proof)
+        self.assertNotIn(r"\frac{s_4}{w_*^4}", proof)
+
+    def test_phase_f_has_freedman_word_excursion_bound(self):
+        proof = _read("w3d-stability-widening-phase-f.tex-part")
+        for marker in (
+            r"\label{eq:widen-stochastic-martingale-difference}",
+            r"\label{eq:widen-stochastic-martingale-bounds}",
+            r"\label{eq:widen-stochastic-drift-envelope}",
+            r"\label{eq:widen-stochastic-martingale-recursion}",
+            r"\label{eq:widen-stochastic-freedman-variance}",
+            r"\label{thm:widen-stochastic-concentration}",
+            r"\label{eq:widen-stochastic-excursion-margin}",
+            r"\label{eq:widen-stochastic-freedman}",
+            r"\label{eq:widen-stochastic-total-tail}",
+        ):
+            self.assertIn(marker, proof)
+        flat = _flat(proof)
+        self.assertIn("Bernstein/Freedman inequality", flat)
+        self.assertIn("does not assume that gating preserves the conditional mean", flat)
+        self.assertIn("exponential Gaussian and martingale concentration", flat)
+        self.assertNotIn("Markov's inequality", proof)
+
+    def test_total_tail_combines_excursion_and_localization_events(self):
+        proof = _read("w3d-stability-widening-phase-f.tex-part")
+        flat = _flat(proof)
+        self.assertIn(r"+N\ell_+e^{-t_*}", proof)
+        self.assertIn(r"V_W:=\frac{v_W}{1-\lambda_s^2}", proof)
+        self.assertIn("raw and localized trajectories coincide", flat)
+        self.assertIn("finite-horizon and high-probability", flat)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements the remaining stochastic-certificate widening item on top of current `main` (`288bc832`). No estimator, tuner, covariance recursion, gating rule, pseudo-measurement, or adaptation behavior is changed.

### 1. Replace the raw-noise Markov tail by Gaussian quadratic-form concentration

For conditionally Gaussian pre-gate increments

`w_k | F_k ~ N(0, Sigma_k)`, `0 <= Sigma_k <= Sigma_bar`,

the paper now uses the exponential quadratic-form bound

`P(||w_k||^2 >= tr(Sigma_bar) + 2 sqrt(tr(Sigma_bar^2) t) + 2 ||Sigma_bar|| t | F_k) <= exp(-t)`.

The localization exit penalty over `K` source words becomes

`P(E_K^c) <= K ell_+ exp(-t_*)`,

where `t_*` is the largest threshold parameter admitted by the certified localization radius. This replaces the previous polynomial `min{s2/w_*^2, s4/w_*^4}` Markov estimate. No independence between samples or words is assumed.

### 2. Replace the Lyapunov Markov/union excursion bound by a Freedman--Bernstein bound

The word-boundary fluctuation is centered exactly as

`zeta_{n+1} = W_{n+1} - E[W_{n+1} | F_n]`.

This is a martingale difference by definition and therefore does not assume that NIS gating preserves zero conditional mean of physical innovations.

On the compact localized funnel, the verifier must rigorously enclose finite `b_W` and `v_W` such that

`zeta_{n+1} <= b_W`, `E[zeta_{n+1}^2 | F_n] <= v_W`.

Combining these with the existing source-word drift

`E[W_{n+1} | F_n] <= lambda_s W_n + sigma_s^2`

gives a weighted martingale representation and the finite-horizon bound

`P(max_{0<=n<=N} W_n >= a | F_0) <= N exp(-x_*^2 / (2(V_W + b_W x_*/3)))`,

with `V_W = v_W/(1-lambda_s^2)` and `x_*` the margin above the deterministic drift envelope.

For the exact unlocalized Gaussian process the final certified tail is the sum of the martingale excursion term and the Gaussian localization-exit term.

### 3. Keep the same source-funnel metric

The stochastic result remains on the same `W_i`, source graph, source-complete words, and `SO(3) x R^n` product geometry as the deterministic certificate. It does not introduce another Euclidean tube or a second stability route.

### 4. Publication synchronization and contract

- updates the conclusion to describe the completed Gaussian/martingale concentration result and removes it from future work;
- adds the new deployed-instantiation obligations `Sigma_bar`, `w_*`, `b_W`, and `v_W`;
- adds `test_ou_stochastic_concentration.py` and wires it into validation;
- rejects reintroduction of the old polynomial Markov tails or the stale future-work item.

## Scope

This widens the **probabilistic** certificate, not the deterministic basin. Numerical deployment still requires rigorous enclosure of the source-funnel constants, now including the stochastic fluctuation constants `b_W`, `v_W`, the covariance envelope `Sigma_bar`, and the localization threshold `w_*`. The rigorous claim remains finite-horizon/high-probability because exact Gaussian noise has unbounded support.