### PR TITLE
Document recursive AtomS3R sensor examples

### DIFF
--- a/sensors/README.md
+++ b/sensors/README.md
@@ -1,0 +1,54 @@
+# Sensor and M5Stack examples
+
+[ocean-imu](../README.md) / **sensors**
+
+<p align="center">
+  <img src="../img/devices/AtomS3R_device.svg" width="360" alt="M5Stack AtomS3R">
+</p>
+
+This directory contains the hardware-facing Arduino examples for `ocean-imu`. The current examples target the **M5Stack AtomS3R** and build upward from direct IMU access to tilt-compensated compass/AHRS applications and complete marine motion estimators.
+
+The examples intentionally form a progression. Start with the basic IMU sketch to verify the board, coordinate mapping, serial connection, and saved calibration. Move to the compass/AHRS examples once raw sensing is healthy, then use a full marine INS example when you want attitude, heading, and wave-motion estimation together.
+
+## Choose an example
+
+| Area | What it demonstrates | Start here |
+| --- | --- | --- |
+| [IMU basics](imu_basic/README.md) | M5Unified IMU access, body-to-NED mapping, saved calibration, serial diagnostics | First hardware bring-up |
+| [Compass / AHRS](compass_ahrs/README.md) | Tilt-compensated heading with Mahony or quaternion MEKF, display UI, NMEA output | Heading and attitude |
+| [Full marine INS](full_marine_ins/README.md) | Adaptive marine motion estimation with OU-II, OU-III, or PII observer | Vessel motion / wave estimation |
+
+## Hardware
+
+The sensor sketches are written for the M5Stack AtomS3R and use `M5Unified` for board and IMU access. Connect the AtomS3R over USB-C for power, programming, and serial output.
+
+The reusable filtering code under [`../src/`](../src/) is separate from these hardware examples; the `sensors/` tree shows how that library code is integrated on a real embedded target.
+
+## Arduino installation
+
+1. Install Arduino IDE 2.x or another Arduino-compatible build environment.
+2. Install the current Espressif **ESP32 Arduino core** and select the board profile you normally use for the AtomS3R.
+3. Install `ocean-imu` as an Arduino library. You can clone/copy this repository into your Arduino libraries directory, or download the repository as a ZIP and use **Sketch → Include Library → Add .ZIP Library…**.
+4. Install the library dependencies. [`library.properties`](../library.properties) declares `M5Unified` and `Eigen`; allow the Arduino IDE to install them when prompted, or install them manually with Library Manager.
+5. Connect the AtomS3R, select its serial port, open one of the `.ino` sketches linked below, and upload it.
+
+If you are bringing up a new board or a new installation, use [`imu_basic/atomS3R_imu_m5_basic`](imu_basic/atomS3R_imu_m5_basic/README.md) first. It is deliberately much simpler than the full estimators and makes wiring, board-package, sensor, mapping, and calibration problems easier to isolate.
+
+## Suggested bring-up order
+
+1. [Basic AtomS3R IMU](imu_basic/atomS3R_imu_m5_basic/README.md)
+2. [Mahony compass](compass_ahrs/atomS3R_compass_mahony/README.md) or [qMEKF compass](compass_ahrs/atomS3R_compass_qmekf/README.md)
+3. [OU-II marine INS](full_marine_ins/atomS3R_ins_kalman_ou2/README.md), [OU-III marine INS](full_marine_ins/atomS3R_ins_kalman_ou3/README.md), or [PII observer](full_marine_ins/atomS3R_ins_pii_observer/README.md)
+
+## Coordinate convention
+
+The AtomS3R helper layer converts device readings into the project body/NED-oriented convention used by the filters. Do not bypass that mapping in a full filter unless you also update the corresponding frame assumptions. The basic IMU example is the easiest place to inspect the mapped accelerometer, gyro, and magnetometer values before running an estimator.
+
+## Related repository areas
+
+- [`../src/AtomS3R/`](../src/AtomS3R/) — shared AtomS3R calibration, display, and UI helpers
+- [`../src/ahrs/`](../src/ahrs/) — attitude filters
+- [`../src/kalman_ou_ii/`](../src/kalman_ou_ii/) — OU-II marine Kalman filter
+- [`../src/kalman_ou_iii/`](../src/kalman_ou_iii/) — OU-III marine Kalman filter
+- [`../src/pii_observer/`](../src/pii_observer/) — lightweight PII observer
+- [Project README](../README.md) — algorithms, publications, tests, and repository-wide build information

--- a/sensors/compass_ahrs/README.md
+++ b/sensors/compass_ahrs/README.md
@@ -1,0 +1,32 @@
+# Compass and AHRS examples
+
+[ocean-imu](../../README.md) / [sensors](../README.md) / **compass_ahrs**
+
+<p align="center">
+  <img src="../../img/devices/AtomS3R_device.svg" width="300" alt="M5Stack AtomS3R">
+</p>
+
+These examples turn the AtomS3R into a **tilt-compensated electronic compass / AHRS**. Both applications share the same AtomS3R calibration, sensor conditioning, display, and compass application framework; the attitude estimator is the part that changes.
+
+## Examples
+
+| Example | Estimator | Good choice when |
+| --- | --- | --- |
+| [atomS3R_compass_mahony](atomS3R_compass_mahony/README.md) | Mahony AHRS | You want a compact, computationally light attitude solution |
+| [atomS3R_compass_qmekf](atomS3R_compass_qmekf/README.md) | Quaternion MEKF | You want covariance-based attitude estimation and explicit sensor-noise modeling |
+
+Both sketches default to the graphical compass UI and can emit NMEA 0183 compass/attitude data over serial. The source currently enables `HDM`, `XDR`, and `ROT`-style output through the shared compass application.
+
+## Installation
+
+Follow the common [sensor installation instructions](../README.md#arduino-installation), then open the README for the estimator you want. If this is the first sketch you are running on the board, verify the hardware first with [Basic IMU](../imu_basic/README.md).
+
+## Calibration and magnetic environment
+
+Heading quality depends on magnetometer calibration and installation environment. Keep the device away from temporary magnetic disturbances during evaluation, and use the shared calibration support before treating the heading as a meaningful vessel reference.
+
+## Next step
+
+For heave, 3-D displacement, sea-state adaptation, and wave-motion outputs, continue to [Full marine INS](../full_marine_ins/README.md).
+
+[Back to all sensor examples](../README.md)

--- a/sensors/compass_ahrs/atomS3R_compass_mahony/README.md
+++ b/sensors/compass_ahrs/atomS3R_compass_mahony/README.md
@@ -1,0 +1,36 @@
+# AtomS3R Mahony compass
+
+[ocean-imu](../../../README.md) / [sensors](../../README.md) / [compass_ahrs](../README.md) / **atomS3R_compass_mahony**
+
+<p align="center">
+  <img src="../../../img/devices/AtomS3R_device.svg" width="240" alt="M5Stack AtomS3R">
+</p>
+
+This sketch implements a tilt-compensated AtomS3R compass using the project’s **Mahony AHRS** backend and shared AtomS3R compass application framework.
+
+Open the sketch: [`atomS3R_compass_mahony.ino`](atomS3R_compass_mahony.ino).
+
+## What it provides
+
+- fused roll, pitch, and yaw from gyro/accelerometer data;
+- calibrated magnetometer updates when healthy magnetic data are available;
+- graphical compass UI by default;
+- NMEA 0183 serial output by default (`HDM`, `XDR`, and `ROT` through the shared app);
+- the common AtomS3R IMU calibration workflow.
+
+The Mahony backend is a good embedded baseline when you want a small and responsive attitude estimator without the covariance machinery of the qMEKF.
+
+## Install and upload
+
+1. Complete the common [`sensors/` Arduino setup](../../README.md#arduino-installation).
+2. If the board has not been checked yet, run the [basic IMU example](../../imu_basic/atomS3R_imu_m5_basic/README.md) first.
+3. Open `atomS3R_compass_mahony.ino`, select the AtomS3R-compatible board/port, compile, and upload.
+4. Use the on-device UI for heading/attitude and the USB serial connection for NMEA or debugging.
+
+The compile-time switches near the top of the sketch let you change the default graphics mode, serial NMEA mode, and NMEA talker ID.
+
+## Compare
+
+For the same hardware/application shell with a quaternion multiplicative EKF backend, see [AtomS3R qMEKF compass](../atomS3R_compass_qmekf/README.md).
+
+[Back to Compass / AHRS](../README.md) · [All sensor examples](../../README.md)

--- a/sensors/compass_ahrs/atomS3R_compass_qmekf/README.md
+++ b/sensors/compass_ahrs/atomS3R_compass_qmekf/README.md
@@ -1,0 +1,37 @@
+# AtomS3R qMEKF compass
+
+[ocean-imu](../../../README.md) / [sensors](../../README.md) / [compass_ahrs](../README.md) / **atomS3R_compass_qmekf**
+
+<p align="center">
+  <img src="../../../img/devices/AtomS3R_device.svg" width="240" alt="M5Stack AtomS3R">
+</p>
+
+This sketch implements a tilt-compensated AtomS3R compass using the project’s **Quaternion MEKF (qMEKF)** attitude estimator and the same shared AtomS3R application/calibration framework as the Mahony example.
+
+Open the sketch: [`atomS3R_compass_qmekf.ino`](atomS3R_compass_qmekf.ino).
+
+## What it provides
+
+- quaternion attitude estimation with explicit accelerometer, gyro, and magnetometer noise parameters;
+- initialization from accelerometer plus magnetometer when magnetic data are available, otherwise accelerometer-only initialization;
+- accelerometer correction each filter cycle and fresh-magnetometer updates when available;
+- graphical compass UI by default;
+- NMEA 0183 serial output by default through the shared compass application;
+- the common AtomS3R IMU calibration workflow.
+
+Use this version when you want the attitude solution to be expressed as a probabilistic error-state filter rather than the lighter Mahony feedback filter.
+
+## Install and upload
+
+1. Complete the common [`sensors/` Arduino setup](../../README.md#arduino-installation).
+2. Verify the device first with [Basic IMU](../../imu_basic/atomS3R_imu_m5_basic/README.md) if this is a new setup.
+3. Open `atomS3R_compass_qmekf.ino`, select the AtomS3R-compatible board/port, compile, and upload.
+4. Read heading/attitude from the display and NMEA/debug output from USB serial.
+
+The compile-time switches at the top of the sketch control graphics mode, NMEA mode, and the NMEA talker ID.
+
+## Compare
+
+For the lighter feedback-filter implementation using the same application shell, see [AtomS3R Mahony compass](../atomS3R_compass_mahony/README.md).
+
+[Back to Compass / AHRS](../README.md) · [All sensor examples](../../README.md)

--- a/sensors/full_marine_ins/README.md
+++ b/sensors/full_marine_ins/README.md
@@ -1,0 +1,37 @@
+# Full marine INS examples
+
+[ocean-imu](../../README.md) / [sensors](../README.md) / **full_marine_ins**
+
+<p align="center">
+  <img src="../../img/devices/AtomS3R_device.svg" width="300" alt="M5Stack AtomS3R">
+</p>
+
+These are the most complete AtomS3R applications in the repository. They combine calibrated IMU input, attitude/heading estimation, marine-motion processing, on-device UI, and serial/NMEA output.
+
+They are intended for **marine motion estimation**, where accelerometer measurements contain both gravity and wave-induced translational acceleration and the system may need to initialize while already moving.
+
+## Available estimators
+
+| Example | Method | Main character |
+| --- | --- | --- |
+| [atomS3R_ins_kalman_ou2](atomS3R_ins_kalman_ou2/README.md) | Adaptive OU-II Kalman INS | More direct integral-drift correction; responsive sea-state adaptation |
+| [atomS3R_ins_kalman_ou3](atomS3R_ins_kalman_ou3/README.md) | Adaptive OU-III Kalman INS | Higher-order integral regularization; main 3-D navigation implementation |
+| [atomS3R_ins_pii_observer](atomS3R_ins_pii_observer/README.md) | Adaptive PII observer + Mahony | Much lighter computation; primarily vertical/heave-oriented motion estimation |
+
+The OU-II and OU-III sketches learn tilt during startup, perform a one-shot magnetic north lock in the sea-state fusion filter, and then use filter yaw as the primary heading output. The PII application uses Mahony attitude with a lightweight adaptive vertical observer.
+
+## Installation and bring-up
+
+Follow the common [Arduino installation instructions](../README.md#arduino-installation). Before debugging one of these larger applications, first verify the same board with [Basic IMU](../imu_basic/README.md) and preferably one of the [Compass / AHRS](../compass_ahrs/README.md) examples. That separates sensor/calibration problems from full estimator behavior.
+
+The full sketches enable the shared IMU calibration wizard by default through `SEA_STATE_ENABLE_WIZARD=1`. They also default to graphical UI and NMEA serial output; those behaviors can be changed with the compile-time switches near the top of each sketch.
+
+## Which should I use?
+
+Start with **OU-III** if you want the project’s primary full 3-D marine navigation estimator. Try **OU-II** when you prefer its more direct drift regularization and adaptation response. Use the **PII observer** when MCU cost and simplicity matter more than the full Kalman-state solution.
+
+## Related material
+
+The mathematical descriptions and validation links are collected in the [project README](../../README.md). Source implementations live under [`../../src/kalman_ou_ii/`](../../src/kalman_ou_ii/), [`../../src/kalman_ou_iii/`](../../src/kalman_ou_iii/), and [`../../src/pii_observer/`](../../src/pii_observer/).
+
+[Back to all sensor examples](../README.md)

--- a/sensors/full_marine_ins/atomS3R_ins_kalman_ou2/README.md
+++ b/sensors/full_marine_ins/atomS3R_ins_kalman_ou2/README.md
@@ -1,0 +1,41 @@
+# AtomS3R marine INS — Kalman OU-II
+
+[ocean-imu](../../../README.md) / [sensors](../../README.md) / [full_marine_ins](../README.md) / **atomS3R_ins_kalman_ou2**
+
+<p align="center">
+  <img src="../../../img/devices/AtomS3R_device.svg" width="240" alt="M5Stack AtomS3R">
+</p>
+
+This sketch runs the adaptive **SeaStateFusion OU-II** marine estimator on the M5Stack AtomS3R.
+
+Open the sketch: [`atomS3R_ins_kalman_ou2.ino`](atomS3R_ins_kalman_ou2.ino).
+
+## What it does
+
+- reads and calibrates the AtomS3R IMU through the shared hardware layer;
+- runs the sea-state fusion loop at 200 Hz;
+- learns tilt during startup rather than requiring a perfectly stationary boot;
+- performs the filter’s one-shot magnetic north lock;
+- uses filter yaw as the main heading output after north lock;
+- estimates vessel motion using the adaptive OU-II process and integral-drift regularization;
+- provides graphical UI plus serial/NMEA output;
+- includes the shared IMU calibration wizard by default.
+
+OU-II uses the repository’s more direct integral drift correction and is useful when you want a full Kalman marine estimator with relatively responsive adaptation to changes in sea state.
+
+## Install and upload
+
+1. Complete the common [`sensors/` Arduino setup](../../README.md#arduino-installation).
+2. Verify [Basic IMU](../../imu_basic/atomS3R_imu_m5_basic/README.md) and, ideally, a [Compass / AHRS](../../compass_ahrs/README.md) example first.
+3. Open `atomS3R_ins_kalman_ou2.ino` in Arduino IDE.
+4. Select the AtomS3R-compatible board and USB port, then compile and upload.
+5. Keep the device away from strong local magnetic disturbances while evaluating north lock and heading.
+
+The top-of-file switches control the calibration wizard, graphics UI, NMEA output, and talker ID.
+
+## Compare
+
+- [OU-III marine INS](../atomS3R_ins_kalman_ou3/README.md) — higher-order integral regularization and the main 3-D navigation implementation
+- [PII observer](../atomS3R_ins_pii_observer/README.md) — lighter observer-based alternative
+
+[Back to Full marine INS](../README.md) · [All sensor examples](../../README.md)

--- a/sensors/full_marine_ins/atomS3R_ins_kalman_ou3/README.md
+++ b/sensors/full_marine_ins/atomS3R_ins_kalman_ou3/README.md
@@ -1,0 +1,44 @@
+# AtomS3R marine INS — Kalman OU-III
+
+[ocean-imu](../../../README.md) / [sensors](../../README.md) / [full_marine_ins](../README.md) / **atomS3R_ins_kalman_ou3**
+
+<p align="center">
+  <img src="../../../img/devices/AtomS3R_device.svg" width="240" alt="M5Stack AtomS3R">
+</p>
+
+This sketch runs the adaptive **SeaStateFusion OU-III** estimator on the M5Stack AtomS3R. It is the hardware application corresponding to the repository’s main higher-order 3-D marine navigation filter.
+
+Open the sketch: [`atomS3R_ins_kalman_ou3.ino`](atomS3R_ins_kalman_ou3.ino).
+
+## What it does
+
+- reads and calibrates the AtomS3R IMU using the shared device layer;
+- runs the estimator at 200 Hz;
+- learns tilt during startup while the vessel may already be moving;
+- performs a one-shot magnetic north lock inside the sea-state fusion filter;
+- uses filter yaw as the primary heading after north lock while retaining tilt-compensated magnetic heading for diagnostics;
+- estimates 3-D marine motion with the OU-III wave/process model and higher-order integral regularization;
+- adapts the sea-state-dependent estimator parameters used by the full filter;
+- provides on-device graphics and serial/NMEA output;
+- enables the shared IMU calibration wizard by default.
+
+## Install and upload
+
+1. Complete the common [`sensors/` Arduino setup](../../README.md#arduino-installation).
+2. Verify [Basic IMU](../../imu_basic/atomS3R_imu_m5_basic/README.md) and a [Compass / AHRS](../../compass_ahrs/README.md) example first when commissioning new hardware.
+3. Open `atomS3R_ins_kalman_ou3.ino`.
+4. Select the AtomS3R-compatible board profile and USB port, compile, and upload.
+5. Evaluate startup and magnetic north lock in the intended mounting orientation and away from strong transient magnetic disturbances.
+
+The compile-time controls at the top of the sketch include calibration-wizard enable, graphics mode, NMEA mode, and NMEA talker ID.
+
+## More about OU-III
+
+The root [project README](../../../README.md) links the OU-III paper, startup/stability/adaptation studies, and the simulation validation material. The implementation used by this sketch lives under [`../../../src/kalman_ou_iii/`](../../../src/kalman_ou_iii/).
+
+## Compare
+
+- [OU-II marine INS](../atomS3R_ins_kalman_ou2/README.md) — more direct integral drift correction
+- [PII observer](../atomS3R_ins_pii_observer/README.md) — much lighter observer-based alternative
+
+[Back to Full marine INS](../README.md) · [All sensor examples](../../README.md)

--- a/sensors/full_marine_ins/atomS3R_ins_pii_observer/README.md
+++ b/sensors/full_marine_ins/atomS3R_ins_pii_observer/README.md
@@ -1,0 +1,37 @@
+# AtomS3R marine motion estimator — PII observer
+
+[ocean-imu](../../../README.md) / [sensors](../../README.md) / [full_marine_ins](../README.md) / **atomS3R_ins_pii_observer**
+
+<p align="center">
+  <img src="../../../img/devices/AtomS3R_device.svg" width="240" alt="M5Stack AtomS3R">
+</p>
+
+This sketch combines the project’s **Mahony attitude solution** with the adaptive **vertical PII observer** for a lower-cost marine motion estimator on the M5Stack AtomS3R.
+
+Open the sketch: [`atomS3R_ins_pii_observer.ino`](atomS3R_ins_pii_observer.ino).
+
+## What it provides
+
+- magnetic compass heading derived from Mahony yaw;
+- AHRS roll, pitch, and yaw;
+- heave / vertical displacement estimate;
+- wave-envelope estimate;
+- common AtomS3R calibration support and optional calibration wizard;
+- on-device UI and serial/NMEA output.
+
+The sketch explicitly maps the calibrated device/body NED convention into the Z-up convention used by its Mahony implementation. It also seeds Mahony once from accelerometer plus magnetometer data at startup so heading does not have to converge slowly from an identity quaternion.
+
+## Install and upload
+
+1. Complete the common [`sensors/` Arduino setup](../../README.md#arduino-installation).
+2. Verify [Basic IMU](../../imu_basic/atomS3R_imu_m5_basic/README.md) first on new hardware.
+3. Open `atomS3R_ins_pii_observer.ino`, select the AtomS3R-compatible board and USB port, then compile and upload.
+4. Check attitude and magnetic heading before relying on the vertical motion output.
+
+The calibration wizard is enabled by default. Graphics/NMEA behavior and true-versus-magnetic heading options are controlled by compile-time switches near the top of the sketch.
+
+## When to use it
+
+Choose this example when you want a computationally light embedded marine motion solution and primarily care about attitude plus vertical/heave behavior. For the repository’s full covariance-based 3-D estimators, use [OU-II](../atomS3R_ins_kalman_ou2/README.md) or [OU-III](../atomS3R_ins_kalman_ou3/README.md).
+
+[Back to Full marine INS](../README.md) · [All sensor examples](../../README.md)

--- a/sensors/imu_basic/README.md
+++ b/sensors/imu_basic/README.md
@@ -1,0 +1,26 @@
+# Basic IMU examples
+
+[ocean-imu](../../README.md) / [sensors](../README.md) / **imu_basic**
+
+<p align="center">
+  <img src="../../img/devices/AtomS3R_device.svg" width="300" alt="M5Stack AtomS3R">
+</p>
+
+Use this directory for **first hardware bring-up**. These sketches stay close to the M5Unified sensor API and the AtomS3R calibration/mapping helpers so you can verify the device before adding an AHRS or marine motion filter.
+
+## Examples
+
+- [**atomS3R_imu_m5_basic**](atomS3R_imu_m5_basic/README.md) — reads the AtomS3R IMU through M5Unified, maps the measurements into the project frame, loads saved calibration from NVS when available, and prints accelerometer, gyro, magnetometer, and calibrated magnetometer diagnostics.
+
+## Before running
+
+Follow the common [Arduino installation instructions](../README.md#arduino-installation). For a new setup, confirm that the sketch uploads successfully and that serial output appears before moving on to the compass or full INS examples.
+
+## Next steps
+
+Once raw/mapped sensing looks reasonable:
+
+- continue to [Compass / AHRS](../compass_ahrs/README.md) for roll, pitch, and heading;
+- continue to [Full marine INS](../full_marine_ins/README.md) for vessel motion and wave estimation.
+
+[Back to all sensor examples](../README.md)

--- a/sensors/imu_basic/atomS3R_imu_m5_basic/README.md
+++ b/sensors/imu_basic/atomS3R_imu_m5_basic/README.md
@@ -1,0 +1,42 @@
+# AtomS3R basic IMU
+
+[ocean-imu](../../../README.md) / [sensors](../../README.md) / [imu_basic](../README.md) / **atomS3R_imu_m5_basic**
+
+<p align="center">
+  <img src="../../../img/devices/AtomS3R_device.svg" width="240" alt="M5Stack AtomS3R">
+</p>
+
+This is the recommended **first sketch to run on an AtomS3R**. It exercises the M5Unified IMU path and the shared `ocean-imu` AtomS3R helpers without adding an attitude or navigation estimator.
+
+## What it does
+
+The sketch:
+
+- initializes M5Unified and the internal IMU;
+- runs the IMU loop at the project default IMU rate;
+- maps accelerometer, gyro, and magnetometer readings into the project frame;
+- loads the saved calibration blob from NVS when one is present;
+- applies saved magnetometer calibration for a calibrated diagnostic channel;
+- prints timing, update status, and sensor values over serial.
+
+Open the sketch here: [`atomS3R_imu_m5_basic.ino`](atomS3R_imu_m5_basic.ino).
+
+## Install and upload
+
+1. Complete the common [`sensors/` Arduino setup](../../README.md#arduino-installation).
+2. Open `atomS3R_imu_m5_basic.ino` in Arduino IDE.
+3. Select the AtomS3R-compatible ESP32-S3 board profile and the USB serial port.
+4. Compile and upload.
+5. Open Serial Monitor at **115200 baud**.
+
+A successful run prints an initialization message and then periodic IMU diagnostic rows. If no saved calibration exists, the sketch says so explicitly and leaves the magnetometer correction at identity/zero for the diagnostic output.
+
+## What to verify
+
+Before moving to a filter, check that acceleration reacts on the expected axis when the board is tilted, gyro rates react to rotations, and magnetometer values change smoothly when the board is turned away from nearby ferrous objects.
+
+## Continue
+
+- [Mahony compass](../../compass_ahrs/atomS3R_compass_mahony/README.md)
+- [qMEKF compass](../../compass_ahrs/atomS3R_compass_qmekf/README.md)
+- [All sensor examples](../../README.md)


### PR DESCRIPTION
## Summary

Adds a self-navigating README hierarchy under `sensors/` for the current M5Stack AtomS3R hardware examples.

- adds `sensors/README.md` as the hardware/application entry point
- fills the existing `imu_basic`, `compass_ahrs`, and `full_marine_ins` README files
- adds a README beside every current AtomS3R `.ino` sketch
- adds breadcrumb navigation plus sibling/up-level links throughout the hierarchy
- reuses the repository-owned `img/devices/AtomS3R_device.svg` from every level instead of adding or hot-linking another device image
- adds common Arduino installation/upload guidance and per-example bring-up notes
- describes the actual Mahony, qMEKF, OU-II, OU-III, and PII example behavior from the current sketches
- recommends a hardware bring-up path from raw IMU -> compass/AHRS -> full marine INS

Documentation-only change; no estimator or device code is modified.