### PR TITLE
Fix OU-III LaTeX accent grouping errors

### DIFF
--- a/doc/kalman_ou_iii/w3d-analytical-stability-widening.tex-part
+++ b/doc/kalman_ou_iii/w3d-analytical-stability-widening.tex-part
@@ -96,7 +96,7 @@ time scale $T_{bg}>0$ and define
 \begin{equation}
  \widetilde{\vct b}_g:=T_{bg}\delta\vct b_g,
  \qquad
- \widetilde\mat\Gamma_g:=\mat\Gamma_g/T_{bg},
+ \widetilde{\mat\Gamma}_g:=\mat\Gamma_g/T_{bg},
  \qquad
  \gamma_-:=g_-/T_{bg}>0.
  \label{eq:widen-bg-scaling}
@@ -124,19 +124,19 @@ After whitening each packet by its information square root,
 Lemma~\ref{lem:widen-vector-coercivity} bounds the two packet outputs below by
 $\sqrt{\mu_\theta}$ times
 \begin{equation}
- \widetilde\mat T_g=
+ \widetilde{\mat T}_g=
  \begin{bmatrix}
   \mat I&0\\
-  \mat\Phi_\theta&\widetilde\mat\Gamma_g
+  \mat\Phi_\theta&\widetilde{\mat\Gamma}_g
  \end{bmatrix}.
 \end{equation}
 Given outputs $(\vct y_0,\vct y_1)$,
 $\delta\vct\theta_0=\vct y_0$ and
-$\widetilde\vct b_g=\widetilde\mat\Gamma_g^{-1}
+$\widetilde{\vct b}_g=\widetilde{\mat\Gamma}_g^{-1}
 (\vct y_1-\mat\Phi_\theta\vct y_0)$.  Orthogonality of
 $\mat\Phi_\theta$, Eq.~\eqref{eq:widen-bg-scaling}, and
 $(a+b)^2\le2(a^2+b^2)$ give
-$\|\widetilde\mat T_g^{-1}\|^2\le1+2/\gamma_-^2$, which yields
+$\|\widetilde{\mat T}_g^{-1}\|^2\le1+2/\gamma_-^2$, which yields
 Eq.~\eqref{eq:widen-alpha6}.  Boundedness of the same finite stacked operator
 gives the upper Gramian bound.
 \end{proof}

--- a/doc/kalman_ou_iii/w3d-stability-widening-source-path.tex-part
+++ b/doc/kalman_ou_iii/w3d-stability-widening-source-path.tex-part
@@ -29,7 +29,7 @@ compact cells of covariance and scheduled parameters.  Each edge
 $e=(i,j)\in\mathscr E_m$ carries the compact matrix family
 \begin{equation}
  \mathscr A_e:=\left\{
- \widetilde\mat A_{k,m}^{\rm cl}:
+ \widetilde{\mat A}_{k,m}^{\rm cl}:
  \text{the implemented source can move from node $i$ to node $j$}
  \right\}.
  \label{eq:widen-src-edge-family}


### PR DESCRIPTION
## Summary

Fixes the current OU-III manuscript LuaLaTeX parser failures caused by applying `\widetilde` directly to the one-argument `\mat` / `\vct` macros.

The first LaTeX attempt reports this class of source error as `Missing { inserted`. Because the build step is retried with `continue-on-error`, the relevant source diagnostic can otherwise be easy to miss in the first-attempt log.

### Changes
- group all affected `\widetilde{...}` matrix/vector expressions in `w3d-analytical-stability-widening.tex-part`
- group the affected source-edge matrix expression in `w3d-stability-widening-source-path.tex-part`
- no estimator, theorem, numerical evidence, tests, or workflow changes

## Scope

This is deliberately TeX-only. It does not touch `tests/**` or `.github/**`, so it does not introduce a new replay-input change beyond the publication source itself.

## Verification

- Minimal LuaLaTeX reproduction of the original form (for example `\widetilde\mat\Gamma_g`) fails with `Missing { inserted`; the grouped forms compile successfully.
- PR build run 5169 is green.
- Crucially, `build (kalman_ou_iii)` passed **the first** `Compile LaTeX document (kalman_ou_iii)` step and the retry step was skipped, confirming the source error is fixed rather than hidden by the retry.

## Existing validation failures

The separate `ou-validation` smoke check remains red because of six stability/publication-contract failures already present in files untouched by this PR (for example the stale `eq:hybrid-cooldown-capture-condition` reference in `w3d-init.tex-part` and text-contract assertions in the conclusion/capture/Phase-C material). Those are not LaTeX parser failures and are intentionally not mixed into this TeX-only fix.