### PR TITLE
Fix main OU evidence build contracts

### DIFF
--- a/doc/kalman_ou_iii/w3d-init.tex-part
+++ b/doc/kalman_ou_iii/w3d-init.tex-part
@@ -138,6 +138,6 @@ For repeated re-locks, the cooldown supplies the dwell time in
 Eq.~\eqref{eq:hybrid-tilt-dwell}.  When the jump amplification and shortest
 admissible Live flow satisfy
 Eq.~\eqref{eq:widen-hybrid-mu},
-Theorem~\ref{thm:hybrid-live-recovery} gives a practical exponential bound on
+Theorem~\ref{thm:widen-hybrid-small-gain} gives a practical exponential bound on
 the reset-to-reset sequence rather than requiring complete recovery before each
 possible reset.

--- a/tools/ou_evidence_provenance.py
+++ b/tools/ou_evidence_provenance.py
@@ -206,10 +206,6 @@ def implementation_paths(study: str) -> list[Path]:
     return sorted(paths, key=repo_name)
 
 
-def implementation_records(study: str) -> dict[str, dict[str, object]]:
-    return {repo_name(path): file_record(path) for path in implementation_paths(study)}
-
-
 def _ou_iii_sim_build_contract(text: str) -> str:
     """Project the multi-target Makefile onto replay-producing semantics."""
     lines = text.splitlines()
@@ -234,6 +230,21 @@ def _ou_iii_sim_build_contract(text: str) -> str:
     return "\n".join(selected) + "\n"
 
 
+def _implementation_record(path: Path) -> dict[str, object]:
+    """Hash replay semantics, not unrelated targets in the OU-III Makefile."""
+    if repo_name(path) != _OU_III_MAKEFILE_REPO_NAME:
+        return file_record(path)
+    projected = _ou_iii_sim_build_contract(path.read_text(encoding="utf-8")).encode("utf-8")
+    return {"sha256": sha256_bytes(projected), "size_bytes": len(projected)}
+
+
+def implementation_records(study: str) -> dict[str, dict[str, object]]:
+    return {
+        repo_name(path): _implementation_record(path)
+        for path in implementation_paths(study)
+    }
+
+
 def implementation_record_matches(
     name: str,
     expected: Mapping[str, Any],
@@ -241,15 +252,15 @@ def implementation_record_matches(
 ) -> bool:
     """Compare replay implementation records without weakening source hashes.
 
-    The only non-bytewise compatibility case is the historically over-broad
-    OU-III Makefile record.  It is accepted only for the one known immutable
-    historical hash and only while the simulator-producing projection remains
-    exactly equal to the recorded build contract.  Fresh replay manifests still
-    record the complete current Makefile through ``implementation_records``.
+    Fresh replay manifests record the OU-III simulator-producing Makefile
+    projection, while every other implementation dependency remains byte-for-byte.
+    The only legacy compatibility case is the historically over-broad OU-III
+    Makefile record, accepted only for its one known immutable full-file hash and
+    only while the simulator-producing projection matches the recorded contract.
     """
     path = REPO_ROOT / name
     current = normalize_record(actual) if actual is not None else (
-        file_record(path) if path.is_file() else None
+        _implementation_record(path) if path.is_file() else None
     )
     if current is not None and normalize_record(expected) == current:
         return True

--- a/tools/ou_robustness.py
+++ b/tools/ou_robustness.py
@@ -8,6 +8,7 @@ follow the deployed SpectralMSE law rather than the retired cubic relation.
 """
 from __future__ import annotations
 
+import json
 import math
 import re
 from dataclasses import replace
@@ -16,6 +17,11 @@ from typing import Any, Mapping, Sequence
 
 import ou_robustness_core as _core
 from ou_robustness_core import *  # noqa: F401,F403
+
+_ORIGINAL_SCALED_TUNING_POINT = _core.scaled_tuning_point
+_ORIGINAL_WRITE_SENSITIVITY_PLOT = _core.write_sensitivity_plot
+_ORIGINAL_WRITE_PUBLICATION_TABLE = _core.write_publication_table
+_ORIGINAL_CODE_SOURCE_PATHS = tuple(_core.CODE_SOURCE_PATHS)
 
 # The source uses T_S = clip((0.015/1.1) tau, 0.005, 0.25) at the default
 # 200-Hz schedule. Keep the exact cadence in the coupled tau perturbation so
@@ -168,9 +174,6 @@ def write_sensitivity_plot(path: Path, summary: Sequence[Mapping[str, Any]]) -> 
     _core.plt.close(fig)
 
 
-_ORIGINAL_WRITE_PUBLICATION_TABLE = _core.write_publication_table
-
-
 def write_publication_table(
     path: Path,
     summary: Sequence[Mapping[str, Any]],
@@ -219,11 +222,91 @@ def _activate_current_study() -> None:
     _core.write_sensitivity_plot = write_sensitivity_plot
     _core.write_publication_table = write_publication_table
     paths = [Path(__file__).resolve(), Path(_core.__file__).resolve()]
-    for item in _core.CODE_SOURCE_PATHS:
+    for item in _ORIGINAL_CODE_SOURCE_PATHS:
         resolved = Path(item).resolve()
         if resolved not in paths:
             paths.append(resolved)
     _core.CODE_SOURCE_PATHS = tuple(paths)
+
+
+def _activate_legacy_study() -> None:
+    """Restore the historical core hooks for a legacy archived ensemble."""
+    _core.scaled_tuning_point = _ORIGINAL_SCALED_TUNING_POINT
+    _core.write_sensitivity_plot = _ORIGINAL_WRITE_SENSITIVITY_PLOT
+    _core.write_publication_table = _ORIGINAL_WRITE_PUBLICATION_TABLE
+    _core.CODE_SOURCE_PATHS = _ORIGINAL_CODE_SOURCE_PATHS
+
+
+def _rows_use_current_spectral_mse(rows: Sequence[Mapping[str, Any]]) -> bool:
+    """Identify the coupling from replayed tuning values, not editorial text.
+
+    The legacy study coupled ``r_S`` linearly to ``sigma_aw``. The deployed
+    SpectralMSE study uses the realized ``sigma_aw`` ratio to the 6/7 power.
+    A non-unit coupled sensitivity row therefore distinguishes the two archived
+    ensembles without trusting a caption or the current source revision.
+    """
+    by_repetition: dict[int, list[Mapping[str, Any]]] = {}
+    for row in rows:
+        if row.get("experiment") != "sensitivity" or row.get("parameter") != "sigma_aw_rs":
+            continue
+        by_repetition.setdefault(int(row["repetition"]), []).append(row)
+
+    for repetition_rows in by_repetition.values():
+        reference = next(
+            (
+                row
+                for row in repetition_rows
+                if math.isclose(float(row["scale_label"]), 1.0, abs_tol=1e-12)
+            ),
+            None,
+        )
+        if reference is None:
+            continue
+        sigma_ref = float(reference["configured_sigma_aw_mps2"])
+        rs_ref = float(reference["configured_r_s_ms"])
+        if not (sigma_ref > 0.0 and rs_ref > 0.0):
+            continue
+        for row in repetition_rows:
+            if math.isclose(float(row["scale_label"]), 1.0, abs_tol=1e-12):
+                continue
+            sigma_ratio = float(row["configured_sigma_aw_mps2"]) / sigma_ref
+            rs_ratio = float(row["configured_r_s_ms"]) / rs_ref
+            current_ratio = sigma_ratio ** (6.0 / 7.0)
+            legacy_ratio = sigma_ratio
+            separation = abs(current_ratio - legacy_ratio)
+            if separation <= 1e-10:
+                continue
+            tolerance = 1e-7 * max(1.0, abs(rs_ratio), abs(current_ratio))
+            if abs(rs_ratio - current_ratio) <= tolerance:
+                return True
+            if abs(rs_ratio - legacy_ratio) <= tolerance:
+                return False
+            raise ValueError(
+                "archived sigma_aw/r_S sensitivity rows match neither the "
+                "legacy cubic coupling nor the deployed SpectralMSE coupling"
+            )
+    raise ValueError("cannot identify robustness coupling from archived sensitivity rows")
+
+
+def restat_bundle(
+    source: Path,
+    output_dir: Path,
+    bootstrap_resamples: int,
+    stats_seed: int,
+) -> int:
+    """Restate using the coupling that produced the archived replay rows."""
+    with source.open(encoding="utf-8") as stream:
+        bundle = json.load(stream)
+    if _rows_use_current_spectral_mse(bundle.get("raw_runs", [])):
+        _activate_current_study()
+    else:
+        _activate_legacy_study()
+    return _core.restat_bundle(
+        source,
+        output_dir,
+        bootstrap_resamples=bootstrap_resamples,
+        stats_seed=stats_seed,
+    )
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tools/ou_robustness.py
+++ b/tools/ou_robustness.py
@@ -297,7 +297,18 @@ def restat_bundle(
     """Restate using the coupling that produced the archived replay rows."""
     with source.open(encoding="utf-8") as stream:
         bundle = json.load(stream)
-    if _rows_use_current_spectral_mse(bundle.get("raw_runs", [])):
+    rows = bundle.get("raw_runs", [])
+    if not rows:
+        # Preserve the core provenance/error ordering. In particular, a bare
+        # empty JSON file must fail as an unprovenanced source bundle before any
+        # coupling inference is attempted.
+        return _core.restat_bundle(
+            source,
+            output_dir,
+            bootstrap_resamples=bootstrap_resamples,
+            stats_seed=stats_seed,
+        )
+    if _rows_use_current_spectral_mse(rows):
         _activate_current_study()
     else:
         _activate_legacy_study()


### PR DESCRIPTION
Fixes the evidence/build failures from main workflow run 32646933204, rebased onto current main f100eea71a6265acd2631303cabf648827e88e47.

Current diff is intentionally narrow because PR #386 already absorbed the stability prose-contract fixes:
- make robustness restatement infer the archived coupling from replayed tuning rows, so legacy cubic bundles remain byte-reproducible while freshly regenerated SpectralMSE bundles restate with the current analytical law;
- fingerprint the OU-III Makefile by its simulator-producing build projection for fresh replay provenance, so unrelated Makefile targets do not invalidate evidence while compiler flags and simulator recipes still do;
- point the repeated re-lock sentence at the recurrent tilt-reset small-gain theorem that actually owns `eq:widen-hybrid-mu`.

The previous PR smoke reduced the original eight failures to one; this rebased revision addresses that remaining restatement failure without breaking legacy archive reproduction.