### PR TITLE
Close OU-III information-metric neighborhood certificate

### DIFF
--- a/.github/workflows/ou3-numerical-certificate.yml
+++ b/.github/workflows/ou3-numerical-certificate.yml
@@ -59,8 +59,11 @@ jobs:
           mkdir -p plots/kalman_ou_ii
           unzip -o sim-data-files.zip -d plots/kalman_ou_ii >/dev/null
 
-      - name: Build exact-map and covariance observer
-        run: make -C tests/kalman_ou_iii ou3-information-certificate-sim
+      - name: Build exact-map, covariance and nonlinear observers
+        run: |
+          make -C tests/kalman_ou_iii \
+            ou3-information-certificate-sim \
+            ou3-neighborhood-sim
 
       - name: Generate exact maps and covariance on eight noisy seas
         run: |
@@ -85,6 +88,21 @@ jobs:
         run: |
           python3 -u tools/ou3_information_enclosure_contract.py \
             --certificate-dir "$GITHUB_WORKSPACE/reports/results/ou3_numerical_certificate"
+
+      - name: Smoke-test exact nonlinear pairwise word
+        env:
+          OU3_NEIGHBOR_TRACE: ${{ github.workspace }}/reports/diagnostics/ou3_numerical_certificate/neighborhood-smoke.csv
+          OU3_NEIGHBOR_INJECT_TIME_S: "300"
+          OU3_NEIGHBOR_HORIZON_S: "4"
+          OU3_NEIGHBOR_MODE: "A"
+          OU3_NEIGHBOR_DELTA: "0.01,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0"
+          W3D_WRITE_TIMESERIES: "0"
+        run: |
+          mkdir -p reports/diagnostics/ou3_numerical_certificate
+          tests/kalman_ou_iii/ou3-neighborhood-sim \
+            --input "$GITHUB_WORKSPACE/plots/kalman_ou_ii/wave_data_jonswap_H8.500_L202.839_A-30.00_P72.00.csv"
+          test -s "$OU3_NEIGHBOR_TRACE"
+          grep -q ',1,A,' "$OU3_NEIGHBOR_TRACE"
 
       - name: Validate deterministic scientific result payloads
         run: |

--- a/.github/workflows/ou3-numerical-certificate.yml
+++ b/.github/workflows/ou3-numerical-certificate.yml
@@ -18,6 +18,7 @@ on:
       - "tools/ou3_numerical_certificate.py"
       - "tools/ou3_information_certificate.py"
       - "tools/ou3_information_completion.py"
+      - "tools/ou3_information_enclosure_contract.py"
       - "tools/ou3_certificate_completion.py"
       - "tools/ou3_validate_enclosure.py"
       - "tools/ou3_result_contract.py"
@@ -79,6 +80,11 @@ jobs:
           python3 -u tools/ou3_information_completion.py \
             --certificate-dir "$GITHUB_WORKSPACE/reports/results/ou3_numerical_certificate" \
             --data-dir "$GITHUB_WORKSPACE/plots/kalman_ou_ii"
+
+      - name: Generate continuous-source information enclosure contract
+        run: |
+          python3 -u tools/ou3_information_enclosure_contract.py \
+            --certificate-dir "$GITHUB_WORKSPACE/reports/results/ou3_numerical_certificate"
 
       - name: Validate deterministic scientific result payloads
         run: |

--- a/docs/ou-iii-numerical-certificate.md
+++ b/docs/ou-iii-numerical-certificate.md
@@ -199,7 +199,43 @@ W^+\le(1-\delta_*)W^-,
 
 and bounded word length plus finite prefix gain gives UES of the homogeneous fixed-mode recursion on the validated source family.
 
-The old fixed-node/group-compatible SDP remains useful only as a diagnostic/comparison route; it is not the primary executed-source linear certificate.
+The old fixed-node/group-compatible SDP remains useful only as a diagnostic/comparison route; it is not the primary executed-source linear certificate or the deployment-promotion metric.
+
+## Information enclosure contract and promotion gate
+
+`tools/ou3_information_enclosure_contract.py` converts the executed information result into `information_enclosure_contract.json`. It does **not** turn replay minima into theorem bounds. Instead, it records the exact obligations a validated continuous-source backend must discharge.
+
+For each H/A mode the contract carries the strongest tested executed horizon as the recommended validation word and requires:
+
+- `source_complete = true`;
+- validated outward rounding;
+- `relative_Riccati_injection_margin_lower > 0`;
+- `Sigma_lambda_min_lower > 0`;
+- finite `Sigma_lambda_max_upper`;
+- finite positive `prefix_information_gain_upper`;
+- `0 < theta_star < pi`;
+- `mu_W_lower > 0` for the exact nonlinear information-metric word;
+- validation that every nonlinear word prefix remains inside its source/domain guards.
+
+The nonlinear lift is the full source-varying information metric in the geodesic chart,
+
+\[
+W(g,R_e,\xi)=\zeta^T\Sigma_{\rm KF}(g)^{-1}\zeta,
+\qquad
+\zeta=[\operatorname{Log}(R_e)^T,\xi^T]^T,
+\]
+
+on `theta < theta_star < pi`. This preserves the full covariance geometry instead of reintroducing a coarse fixed-node metric.
+
+`tools/ou3_validate_enclosure.py` consumes a schema-2 outward-rounded enclosure and recomputes the promotion logic. It also cross-checks continuous bounds against the executed reference points: because the validated source family must contain those points, a continuous lower bound cannot be larger than an observed minimum and a continuous upper bound cannot exclude an observed maximum.
+
+The validator reports three independent promotion layers:
+
+- `continuous_linear_information_certificate`;
+- `numerical_neighborhood_certificate`;
+- `deployment_theorem_certificate`.
+
+The last one additionally requires strict startup/held-active/magnetic/tilt/cooldown inward margins and source-uniform stochastic `Sigma_bar`, `b_W`, `v_W`, with a finite-horizon failure-probability bound strictly below one.
 
 ## Deterministic scientific results
 
@@ -232,11 +268,22 @@ python3 tools/ou3_information_completion.py \
   --certificate-dir reports/results/ou3_numerical_certificate \
   --data-dir plots/kalman_ou_ii
 
+python3 tools/ou3_information_enclosure_contract.py \
+  --certificate-dir reports/results/ou3_numerical_certificate
+
 python3 tools/ou3_result_contract.py \
   reports/results/ou3_numerical_certificate
 ```
 
 The GitHub workflow performs those stages and uploads scientific results separately from raw diagnostic logs.
+
+Once a validated schema-2 continuous-source enclosure exists, promotion is checked with:
+
+```sh
+python3 tools/ou3_validate_enclosure.py \
+  --certificate-dir reports/results/ou3_numerical_certificate \
+  --enclosure validated_information_enclosure.json
+```
 
 ## Reading a failure
 
@@ -245,10 +292,11 @@ The first active obstruction is the scientific result:
 - RMS/quality failure -> filter regression problem;
 - exact-map residual or map/covariance alignment failure -> certificate instrumentation problem;
 - no strict information contraction at tested horizons -> local/source-word dynamics or source-family problem;
-- executed linear contraction passes but nonlinear neighborhood does not -> nonlinear certificate bottleneck;
+- continuous Riccati injection/covariance bounds fail -> continuous-source linear bottleneck;
+- executed/continuous linear contraction passes but nonlinear neighborhood does not -> nonlinear certificate bottleneck;
 - nonlinear words pass but startup/hybrid destination inequalities fail -> handoff/hybrid bottleneck;
 - deterministic neighborhood passes but stochastic localization is ineffective -> stochastic bound bottleneck;
-- numerical neighborhood passes but validated continuous-source injection/covariance bounds fail -> source-envelope/theorem conservatism bottleneck.
+- all numerical layers pass but outward-rounded continuous-source enclosure fails -> source-envelope/theorem conservatism bottleneck.
 
 ## Ultimate question
 

--- a/tests/kalman_ou_iii/Makefile
+++ b/tests/kalman_ou_iii/Makefile
@@ -21,7 +21,7 @@ LDFLAGS  =
 # Tell make to look for source files in src/util
 VPATH = $(REPO_ROOT)/src/util
 
-TARGETS = kalman_ou_iii-sim ou3-certificate-sim ou3-information-certificate-sim kalman_ou_common-test aw_covariance_policy-test acc_bias_ou-test channel_freeze-test wave_period-test mag_hard_iron-test continuous_mag_hard_iron-test tuner_coupling-test tuner_schedule-test wave_band_sigma-test iss_contract-test rs_law-test startup_init-test
+TARGETS = kalman_ou_iii-sim ou3-certificate-sim ou3-information-certificate-sim ou3-neighborhood-sim kalman_ou_common-test aw_covariance_policy-test acc_bias_ou-test channel_freeze-test wave_period-test mag_hard_iron-test continuous_mag_hard_iron-test tuner_coupling-test tuner_schedule-test wave_band_sigma-test iss_contract-test rs_law-test startup_init-test
 
 all: build test
 
@@ -40,6 +40,9 @@ ou3-certificate-sim: ou3-certificate-sim.o W3dSimCommon.o
 	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
 
 ou3-information-certificate-sim: ou3-information-certificate-sim.o W3dSimCommon.o
+	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
+
+ou3-neighborhood-sim: ou3-neighborhood-sim.o W3dSimCommon.o
 	$(CC) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
 
 kalman_ou_common-test: kalman_ou_common-test.o

--- a/tests/kalman_ou_iii/ou3-neighborhood-sim.cpp
+++ b/tests/kalman_ou_iii/ou3-neighborhood-sim.cpp
@@ -1,0 +1,497 @@
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdlib>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#define EIGEN_NON_ARDUINO
+
+#include "util/W3dSimCommon.h"
+
+// Host-only nonlinear certificate observer.  No production visibility or
+// behavior is changed: this translation unit exposes the MEKF internals only so
+// a controlled error can be injected into a second estimator that receives the
+// exact same noisy measurements as the nominal estimator.
+#define private public
+#include "kalman_ou_iii/Kalman3D_Wave_OU_III.h"
+#undef private
+#include "kalman_ou_iii/SeaStateFusionFilter_OU_III.h"
+
+using Eigen::Matrix3f;
+using Eigen::Quaternionf;
+using Eigen::Vector3f;
+
+namespace {
+
+constexpr float kSigmaARescale = 0.71f;
+constexpr float kSigmaGRescale = 0.05f;
+constexpr float kSigmaMRescale = 2.0f;
+constexpr float kMagOdrHz = 25.0f;
+constexpr float kDt = 1.0f / 200.0f;
+constexpr int kNX = 21;
+constexpr int kOffBg = 3;
+constexpr int kOffV = 6;
+constexpr int kOffP = 9;
+constexpr int kOffS = 12;
+constexpr int kOffAw = 15;
+constexpr int kOffBa = 18;
+using Vector21f = Eigen::Matrix<float, kNX, 1>;
+using Matrix21f = Eigen::Matrix<float, kNX, kNX>;
+
+float env_float(const char* name, float fallback)
+{
+    if (const char* raw = std::getenv(name)) {
+        char* end = nullptr;
+        const float x = std::strtof(raw, &end);
+        if (end != raw && std::isfinite(x)) return x;
+    }
+    return fallback;
+}
+
+int env_positive_int(const char* name, int fallback)
+{
+    if (const char* raw = std::getenv(name)) {
+        const int x = std::atoi(raw);
+        if (x > 0) return x;
+    }
+    return fallback;
+}
+
+std::string env_string(const char* name, const std::string& fallback)
+{
+    if (const char* raw = std::getenv(name)) {
+        if (*raw) return raw;
+    }
+    return fallback;
+}
+
+Vector21f parse_delta()
+{
+    Vector21f d = Vector21f::Zero();
+    const char* raw = std::getenv("OU3_NEIGHBOR_DELTA");
+    if (!raw || !*raw) return d;
+
+    std::stringstream ss(raw);
+    std::string token;
+    int i = 0;
+    while (std::getline(ss, token, ',')) {
+        if (i >= kNX)
+            throw std::runtime_error("OU3_NEIGHBOR_DELTA has more than 21 entries");
+        char* end = nullptr;
+        const float x = std::strtof(token.c_str(), &end);
+        if (end == token.c_str() || !std::isfinite(x))
+            throw std::runtime_error("OU3_NEIGHBOR_DELTA contains a non-finite/non-numeric entry");
+        d(i++) = x;
+    }
+    if (i != kNX)
+        throw std::runtime_error("OU3_NEIGHBOR_DELTA must contain exactly 21 comma-separated entries");
+    return d;
+}
+
+Vector3f quaternion_log(const Quaternionf& q_in)
+{
+    Quaternionf q = q_in;
+    if (!(q.norm() > 1.0e-12f) || !q.coeffs().allFinite())
+        return Vector3f::Constant(std::numeric_limits<float>::quiet_NaN());
+    q.normalize();
+    if (q.w() < 0.0f) q.coeffs() *= -1.0f;
+    const Vector3f v(q.x(), q.y(), q.z());
+    const float nv = v.norm();
+    if (nv < 1.0e-9f) return 2.0f * v;
+    const float angle = 2.0f * std::atan2(nv, std::max(0.0f, q.w()));
+    return (angle / nv) * v;
+}
+
+bool close_source_scalar(float a, float b)
+{
+    const float scale = std::max({1.0f, std::abs(a), std::abs(b)});
+    return std::abs(a - b) <= 2.0e-6f * scale;
+}
+
+class NeighborhoodAdapter final : public IW3dFusionAdapter {
+public:
+    using Fusion = SeaStateFusion_OU_III<TrackerType::KALMANF>;
+    using Mekf = std::remove_reference_t<decltype(std::declval<Fusion&>().raw().mekf())>;
+
+    NeighborhoodAdapter(bool with_mag,
+                        const Vector3f& sigma_a_init,
+                        const Vector3f& sigma_g,
+                        const Vector3f& sigma_m)
+        : inject_requested_s_(env_float("OU3_NEIGHBOR_INJECT_TIME_S", 300.0f)),
+          horizon_s_(env_float("OU3_NEIGHBOR_HORIZON_S", 4.0f)),
+          requested_mode_(env_string("OU3_NEIGHBOR_MODE", "A")),
+          trace_stride_(env_positive_int("OU3_NEIGHBOR_TRACE_STRIDE", 50)),
+          delta_(parse_delta())
+    {
+        if (!(horizon_s_ > 0.0f))
+            throw std::runtime_error("OU3_NEIGHBOR_HORIZON_S must be positive");
+        if (requested_mode_ != "H" && requested_mode_ != "A")
+            throw std::runtime_error("OU3_NEIGHBOR_MODE must be H or A");
+        if (requested_mode_ == "H" && delta_.tail<3>().norm() > 0.0f)
+            throw std::runtime_error("held-mode perturbation must have zero accelerometer-bias entries");
+
+        Fusion::Config cfg;
+        cfg.with_mag = with_mag;
+        cfg.sigma_a = sigma_a_init * kSigmaARescale;
+        cfg.sigma_g = sigma_g * kSigmaGRescale;
+        cfg.sigma_m = sigma_m * kSigmaMRescale;
+        cfg.mag_delay_sec = MAG_DELAY_SEC;
+        cfg.freeze_acc_bias_until_live = true;
+        cfg.Racc_warmup_std = 0.5f;
+
+        nominal_.begin(cfg);
+        perturbed_.begin(cfg);
+        configure_filter(nominal_);
+        configure_filter(perturbed_);
+
+        const char* path = std::getenv("OU3_NEIGHBOR_TRACE");
+        if (!path || !*path)
+            throw std::runtime_error("OU3_NEIGHBOR_TRACE must name the pairwise trace CSV");
+        trace_.open(path);
+        if (!trace_) throw std::runtime_error("cannot open OU3_NEIGHBOR_TRACE");
+        trace_ << std::setprecision(10);
+        write_header();
+    }
+
+    void updateMag(const Vector3f& mag_body_ned) override
+    {
+        if (finished_) return;
+        nominal_.updateMag(mag_body_ned);
+        perturbed_.updateMag(mag_body_ned);
+        const bool a = nominal_.raw().mekf().lastMagDiag().accepted;
+        const bool b = perturbed_.raw().mekf().lastMagDiag().accepted;
+        last_mag_accept_match_ = (a == b);
+        if (injected_ && !last_mag_accept_match_) source_match_ = false;
+        if (injected_) check_source_match();
+    }
+
+    void update(float dt,
+                const Vector3f& gyr_meas_ned,
+                const Vector3f& acc_meas_ned,
+                float temperature_c) override
+    {
+        if (finished_) {
+            time_s_ += dt;
+            return;
+        }
+
+        maybe_inject();
+
+        nominal_.update(dt, gyr_meas_ned, acc_meas_ned, temperature_c);
+        perturbed_.update(dt, gyr_meas_ned, acc_meas_ned, temperature_c);
+        time_s_ += dt;
+        ++sample_index_;
+
+        const bool aa = nominal_.raw().mekf().lastAccDiag().accepted;
+        const bool ab = perturbed_.raw().mekf().lastAccDiag().accepted;
+        last_acc_accept_match_ = (aa == ab);
+        if (injected_ && !last_acc_accept_match_) source_match_ = false;
+
+        if (!injected_) return;
+        check_source_match();
+        update_prefix_stats();
+
+        const bool stride_due =
+            samples_since_injection_ % static_cast<unsigned>(trace_stride_) == 0u;
+        const bool endpoint_due = time_s_ + 0.5f * dt >= inject_actual_s_ + horizon_s_;
+        if (stride_due || endpoint_due) write_row(endpoint_due ? 1 : 0);
+        ++samples_since_injection_;
+
+        if (endpoint_due) {
+            finished_ = true;
+            std::cout << "OU3_NEIGHBOR_DONE"
+                      << " inject_s=" << inject_actual_s_
+                      << " horizon_s=" << horizon_s_
+                      << " mode=" << injected_mode_
+                      << " source_match=" << (source_match_ ? 1 : 0)
+                      << " max_theta_deg=" << rad_to_deg(max_theta_rad_)
+                      << " max_cov_rel=" << max_cov_rel_
+                      << "\n";
+        }
+    }
+
+    FilterSnapshot snapshot() const override
+    {
+        const auto& filter = nominal_.raw();
+        const auto& mekf = filter.mekf();
+        FilterSnapshot s;
+        s.disp_est_zu = ned_to_zu(mekf.get_position());
+        s.vel_est_zu = ned_to_zu(mekf.get_velocity());
+        s.acc_est_zu = ned_to_zu(mekf.get_world_accel());
+        const Quaternionf q_bw_ned = mekf.quaternion_boat().normalized();
+        float roll = 0.0f, pitch = 0.0f, yaw = 0.0f;
+        quat_to_euler_nautical(q_bw_ned, roll, pitch, yaw);
+        s.euler_nautical_deg = Vector3f(roll, pitch, wrapDeg(yaw));
+        s.acc_bias_est_ned = mekf.get_acc_bias();
+        s.gyro_bias_est_ned = mekf.gyroscope_bias();
+        s.mag_bias_est_ned_uT = get_mag_bias_est_uT(mekf) + nominal_.magHardIronBodyUT();
+        s.tau_target = filter.getTauTarget();
+        s.sigma_target = filter.getSigmaTarget();
+        s.tuning_target = filter.getRSTarget();
+        s.tau_applied = filter.getTauApplied();
+        s.sigma_applied = filter.getSigmaApplied();
+        s.tuning_applied = filter.getRSApplied();
+        s.freq_hz = filter.getFreqHz();
+        s.wave_period_sec = filter.getWavePeriodSec();
+        s.period_sec = filter.getPeriodSec();
+        s.accel_variance = filter.getAccelVariance();
+        s.displacement_scale_m = filter.getDisplacementScale();
+        s.velocity_scale_mps = filter.getVerticalSpeedEnvelopeMps(true);
+        return s;
+    }
+
+private:
+    static void configure_filter(Fusion& f)
+    {
+        auto& filter = f.raw();
+        filter.setPeriodicAwCovarianceSync(true);
+        filter.setAwCovarianceSyncCongruent(false);
+        filter.enableLinearBlock(true);
+        filter.enableTuner(true);
+        filter.enableClamp(true);
+    }
+
+    bool source_ready(const Fusion& f) const
+    {
+        const auto& m = f.raw().mekf();
+        if (!f.isLive() || !m.linear_block_enabled()) return false;
+        const bool active = m.acc_bias_updates_enabled();
+        return requested_mode_ == (active ? "A" : "H");
+    }
+
+    void maybe_inject()
+    {
+        if (injected_ || time_s_ + 1.0e-7f < inject_requested_s_) return;
+        if (!source_ready(nominal_) || !source_ready(perturbed_)) return;
+        check_source_match();
+        if (!source_match_) return;
+
+        inject_delta(perturbed_.raw().mekf(), delta_);
+        injected_ = true;
+        inject_actual_s_ = time_s_;
+        injected_mode_ = nominal_.raw().mekf().acc_bias_updates_enabled() ? "A" : "H";
+        samples_since_injection_ = 0;
+        update_prefix_stats();
+        write_row(0);
+        std::cout << "OU3_NEIGHBOR_INJECT"
+                  << " requested_s=" << inject_requested_s_
+                  << " actual_s=" << inject_actual_s_
+                  << " mode=" << injected_mode_
+                  << " W0=" << information_energy(nominal_.raw().mekf())
+                  << " theta_deg=" << rad_to_deg(pair_error().head<3>().norm())
+                  << "\n";
+    }
+
+    static void inject_delta(Mekf& m, const Vector21f& d)
+    {
+        // Attitude uses the filter's exact left-error retraction and covariance
+        // reset.  Remaining coordinates are ordinary additive states.
+        m.xext.template head<3>() = d.template head<3>();
+        m.applyQuaternionCorrectionFromErrorState();
+        m.xext.template segment<3>(kOffBg) += d.template segment<3>(kOffBg);
+        m.xext.template segment<3>(kOffV) += d.template segment<3>(kOffV);
+        m.xext.template segment<3>(kOffP) += d.template segment<3>(kOffP);
+        m.xext.template segment<3>(kOffS) += d.template segment<3>(kOffS);
+        m.xext.template segment<3>(kOffAw) += d.template segment<3>(kOffAw);
+        if (m.acc_bias_updates_enabled())
+            m.xext.template segment<3>(kOffBa) += d.template segment<3>(kOffBa);
+    }
+
+    Vector21f pair_error() const
+    {
+        const auto& n = nominal_.raw().mekf();
+        const auto& p = perturbed_.raw().mekf();
+        Vector21f e = Vector21f::Zero();
+
+        // qref is WORLD->BODY'.  The left-error quaternion that maps the
+        // nominal local frame to the perturbed local frame is q_p q_n^{-1}; at
+        // injection this is exactly Exp(delta_theta).
+        const Quaternionf qrel = p.qref * n.qref.conjugate();
+        e.template head<3>() = quaternion_log(qrel);
+        e.template segment<3>(kOffBg) =
+            p.xext.template segment<3>(kOffBg) - n.xext.template segment<3>(kOffBg);
+        e.template segment<3>(kOffV) =
+            p.xext.template segment<3>(kOffV) - n.xext.template segment<3>(kOffV);
+        e.template segment<3>(kOffP) =
+            p.xext.template segment<3>(kOffP) - n.xext.template segment<3>(kOffP);
+        e.template segment<3>(kOffS) =
+            p.xext.template segment<3>(kOffS) - n.xext.template segment<3>(kOffS);
+        e.template segment<3>(kOffAw) =
+            p.xext.template segment<3>(kOffAw) - n.xext.template segment<3>(kOffAw);
+        e.template segment<3>(kOffBa) =
+            p.xext.template segment<3>(kOffBa) - n.xext.template segment<3>(kOffBa);
+        return e;
+    }
+
+    float information_energy(const Mekf& reference) const
+    {
+        const Vector21f e = pair_error();
+        const int dim = injected_mode_ == "H" ? 18 : 21;
+        const Matrix21f Pfull = reference.covariance_full();
+        if (dim == 18) {
+            const Eigen::Matrix<float,18,18> P =
+                0.5f * (Pfull.topLeftCorner<18,18>() + Pfull.topLeftCorner<18,18>().transpose());
+            Eigen::LDLT<Eigen::Matrix<float,18,18>> ldlt(P);
+            if (ldlt.info() != Eigen::Success) return std::numeric_limits<float>::quiet_NaN();
+            const Eigen::Matrix<float,18,1> x = e.head<18>();
+            return x.dot(ldlt.solve(x));
+        }
+        const Matrix21f P = 0.5f * (Pfull + Pfull.transpose());
+        Eigen::LDLT<Matrix21f> ldlt(P);
+        if (ldlt.info() != Eigen::Success) return std::numeric_limits<float>::quiet_NaN();
+        return e.dot(ldlt.solve(e));
+    }
+
+    float covariance_relative_difference() const
+    {
+        const Matrix21f Pn = nominal_.raw().mekf().covariance_full();
+        const Matrix21f Pp = perturbed_.raw().mekf().covariance_full();
+        return (Pp - Pn).norm() / std::max(1.0e-12f, Pn.norm());
+    }
+
+    void check_source_match()
+    {
+        if (!injected_) return;
+        const auto& nf = nominal_.raw();
+        const auto& pf = perturbed_.raw();
+        const auto& n = nf.mekf();
+        const auto& p = pf.mekf();
+        const bool flags =
+            nominal_.isLive() == perturbed_.isLive()
+            && n.linear_block_enabled() == p.linear_block_enabled()
+            && n.acc_bias_updates_enabled() == p.acc_bias_updates_enabled()
+            && nominal_.hasMagNorthLock() == perturbed_.hasMagNorthLock()
+            && nominal_.hasRefinedMagReference() == perturbed_.hasRefinedMagReference();
+        const bool params =
+            close_source_scalar(nf.getTauApplied(), pf.getTauApplied())
+            && close_source_scalar(nf.getSigmaApplied(), pf.getSigmaApplied())
+            && close_source_scalar(nf.getRSApplied(), pf.getRSApplied())
+            && close_source_scalar(n.get_pseudo_update_period_s(), p.get_pseudo_update_period_s());
+        if (!(flags && params && last_acc_accept_match_ && last_mag_accept_match_))
+            source_match_ = false;
+    }
+
+    void update_prefix_stats()
+    {
+        const Vector21f e = pair_error();
+        const float theta = e.head<3>().norm();
+        max_theta_rad_ = std::max(max_theta_rad_, theta);
+        const float c = covariance_relative_difference();
+        if (std::isfinite(c)) max_cov_rel_ = std::max(max_cov_rel_, c);
+    }
+
+    void write_header()
+    {
+        trace_ << "time_s,time_from_injection_s,endpoint,mode,source_match,"
+                  "acc_accept_match,mag_accept_match,W_nominal,W_perturbed,"
+                  "theta_rad,error_norm,covariance_rel_fro,"
+                  "nom_live,nom_active,nom_mag_lock,nom_mag_refined,"
+                  "nom_tau,nom_sigma,nom_rs,pert_tau,pert_sigma,pert_rs";
+        for (int i = 0; i < kNX; ++i) trace_ << ",e" << i;
+        trace_ << '\n';
+    }
+
+    void write_row(int endpoint)
+    {
+        const auto& nf = nominal_.raw();
+        const auto& pf = perturbed_.raw();
+        const auto& n = nf.mekf();
+        const auto& p = pf.mekf();
+        const Vector21f e = pair_error();
+        trace_ << time_s_ << ',' << (time_s_ - inject_actual_s_) << ',' << endpoint
+               << ',' << injected_mode_ << ',' << (source_match_ ? 1 : 0)
+               << ',' << (last_acc_accept_match_ ? 1 : 0)
+               << ',' << (last_mag_accept_match_ ? 1 : 0)
+               << ',' << information_energy(n)
+               << ',' << information_energy(p)
+               << ',' << e.head<3>().norm()
+               << ',' << e.norm()
+               << ',' << covariance_relative_difference()
+               << ',' << (nominal_.isLive() ? 1 : 0)
+               << ',' << (n.acc_bias_updates_enabled() ? 1 : 0)
+               << ',' << (nominal_.hasMagNorthLock() ? 1 : 0)
+               << ',' << (nominal_.hasRefinedMagReference() ? 1 : 0)
+               << ',' << nf.getTauApplied() << ',' << nf.getSigmaApplied() << ',' << nf.getRSApplied()
+               << ',' << pf.getTauApplied() << ',' << pf.getSigmaApplied() << ',' << pf.getRSApplied();
+        for (int i = 0; i < kNX; ++i) trace_ << ',' << e(i);
+        trace_ << '\n';
+    }
+
+    mutable Fusion nominal_;
+    mutable Fusion perturbed_;
+    std::ofstream trace_;
+    float inject_requested_s_ = 300.0f;
+    float inject_actual_s_ = std::numeric_limits<float>::quiet_NaN();
+    float horizon_s_ = 4.0f;
+    std::string requested_mode_ = "A";
+    std::string injected_mode_ = "";
+    int trace_stride_ = 50;
+    Vector21f delta_ = Vector21f::Zero();
+    float time_s_ = 0.0f;
+    unsigned sample_index_ = 0;
+    unsigned samples_since_injection_ = 0;
+    bool injected_ = false;
+    bool finished_ = false;
+    bool source_match_ = true;
+    bool last_acc_accept_match_ = true;
+    bool last_mag_accept_match_ = true;
+    float max_theta_rad_ = 0.0f;
+    float max_cov_rel_ = 0.0f;
+};
+
+void process_one(const std::string& filename,
+                 bool with_mag,
+                 const W3dRandomSeeds& seeds)
+{
+    auto result = process_wave_file_for_tracker<NeighborhoodAdapter>(
+        filename, kDt, with_mag, true, kMagOdrHz,
+        "_fusion_ou3_neighbor", "_fusion_ou3_neighbor_nomag", seeds, false);
+    if (!result) throw std::runtime_error("neighborhood simulation did not produce a result");
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    bool with_mag = true;
+    std::vector<std::string> files;
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--nomag") with_mag = false;
+        else if (arg == "--input" && i + 1 < argc) files.emplace_back(argv[++i]);
+        else if (arg == "--help") {
+            std::cout << "Usage: " << argv[0] << " [--nomag] --input PATH\n"
+                      << "Environment: OU3_NEIGHBOR_TRACE, OU3_NEIGHBOR_DELTA (21 CSV values), "
+                      << "OU3_NEIGHBOR_INJECT_TIME_S, OU3_NEIGHBOR_HORIZON_S, OU3_NEIGHBOR_MODE=H|A\n";
+            return 0;
+        } else {
+            std::cerr << "ERROR: unknown or incomplete argument: " << arg << "\n";
+            return 2;
+        }
+    }
+    if (files.size() != 1u) {
+        std::cerr << "ERROR: ou3-neighborhood-sim requires exactly one --input\n";
+        return 2;
+    }
+
+    W3dRandomSeeds seeds;
+    try { seeds = w3d_random_seeds_from_env(); }
+    catch (const std::exception& e) {
+        std::cerr << "ERROR: " << e.what() << "\n";
+        return 2;
+    }
+
+    try { process_one(files.front(), with_mag, seeds); }
+    catch (const std::exception& e) {
+        std::cerr << "ERROR: " << e.what() << "\n";
+        return 2;
+    }
+    return 0;
+}

--- a/tests/validation/Makefile
+++ b/tests/validation/Makefile
@@ -10,6 +10,7 @@ build:
 		../../tools/ou3_information_certificate.py \
 		../../tools/ou3_information_completion.py \
 		../../tools/ou3_information_enclosure_contract.py \
+		../../tools/ou3_neighborhood_diagnostic.py \
 		../../tools/ou3_certificate_completion.py \
 		../../tools/ou3_validate_enclosure.py \
 		../../tools/ou3_result_contract.py \
@@ -25,6 +26,7 @@ build:
 		test_ou3_information_certificate.py \
 		test_ou3_information_completion.py \
 		test_ou3_certificate_completion.py \
+		test_ou3_neighborhood_diagnostic.py \
 		test_ou3_result_determinism.py \
 		test_ou_article_ablations.py \
 		test_ou_legacy_law_cleanup.py \

--- a/tests/validation/Makefile
+++ b/tests/validation/Makefile
@@ -9,6 +9,7 @@ build:
 		../../tools/ou3_numerical_certificate.py \
 		../../tools/ou3_information_certificate.py \
 		../../tools/ou3_information_completion.py \
+		../../tools/ou3_information_enclosure_contract.py \
 		../../tools/ou3_certificate_completion.py \
 		../../tools/ou3_validate_enclosure.py \
 		../../tools/ou3_result_contract.py \

--- a/tests/validation/test_ou3_certificate_completion.py
+++ b/tests/validation/test_ou3_certificate_completion.py
@@ -22,12 +22,14 @@ def load(name: str):
 
 BASE = load("ou3_numerical_certificate")
 COMP = load("ou3_certificate_completion")
+CONTRACT = load("ou3_information_enclosure_contract")
 ENC = load("ou3_validate_enclosure")
 
 
 class Ou3CertificateCompletionTests(unittest.TestCase):
     def test_group_metric_matches_exact_so3_energy(self):
-        # P00=1 -> a_R=2; zero xi; theta=pi/2 gives V_R=1 and W=2.
+        # Legacy path-metric completion remains a diagnostic utility. P00=1 ->
+        # a_R=2; zero xi; theta=pi/2 gives V_R=1 and W=2.
         P = np.eye(21)
         e = np.zeros(21)
         e[0] = math.pi / 2
@@ -42,39 +44,105 @@ class Ou3CertificateCompletionTests(unittest.TestCase):
         r = COMP.recurrence_capture(c0=10.0, lam=1.01, gamma=0.1, b=1.0)
         self.assertEqual(r["status"], "NOT_AVAILABLE")
 
-    def test_robust_matrix_box_lmi_accepts_strict_contraction(self):
-        P = np.eye(3)
-        ans = ENC.robust_box_lmi_upper(0.8*np.eye(3), np.zeros((3,3)), P, P)
-        self.assertTrue(ans["pass"])
-        self.assertLess(ans["robust_difference_lambda_upper"], 0.0)
+    @staticmethod
+    def contract_mode():
+        return {
+            "mode": "A",
+            "recommended_word_horizon_s": 4.0,
+            "executed_reference_only": {
+                "relative_Riccati_injection_margin_worst": 0.01,
+                "Sigma_endpoint_lambda_min": 1.0e-6,
+                "Sigma_endpoint_lambda_max": 100.0,
+            },
+        }
 
-    def test_robust_matrix_box_lmi_rejects_expansion(self):
-        P = np.eye(3)
-        ans = ENC.robust_box_lmi_upper(1.05*np.eye(3), np.zeros((3,3)), P, P)
-        self.assertFalse(ans["pass"])
-        self.assertGreater(ans["robust_difference_lambda_upper"], 0.0)
+    @staticmethod
+    def valid_mode_payload():
+        return {
+            "source_complete": True,
+            "outward_rounded": True,
+            "word_horizon_s": 4.0,
+            "relative_Riccati_injection_margin_lower": 0.005,
+            "Sigma_lambda_min_lower": 5.0e-7,
+            "Sigma_lambda_max_upper": 120.0,
+            "prefix_information_gain_upper": 2.0,
+            "theta_star": 1.0,
+            "mu_W_lower": 1.0e-4,
+            "all_word_prefixes_safe": True,
+        }
 
-    def test_interval_radius_is_penalized(self):
-        P = np.eye(2)
-        exact = ENC.robust_box_lmi_upper(0.7*np.eye(2), np.zeros((2,2)), P, P)
-        box = ENC.robust_box_lmi_upper(0.7*np.eye(2), 0.05*np.ones((2,2)), P, P)
-        self.assertGreater(box["robust_difference_lambda_upper"],
-                           exact["robust_difference_lambda_upper"])
+    def test_information_mode_accepts_strict_continuous_bounds(self):
+        ans = ENC.validate_mode("A", self.valid_mode_payload(), self.contract_mode())
+        self.assertTrue(ans["linear_pass"])
+        self.assertTrue(ans["nonlinear_pass"])
+        self.assertAlmostEqual(ans["lambda_information_upper"], 0.995)
+        self.assertAlmostEqual(ans["information_metric_lambda_min_lower"], 1.0 / 120.0)
+        self.assertAlmostEqual(ans["information_metric_lambda_max_upper"], 2.0e6)
+
+    def test_information_mode_rejects_zero_injection(self):
+        payload = self.valid_mode_payload()
+        payload["relative_Riccati_injection_margin_lower"] = 0.0
+        ans = ENC.validate_mode("A", payload, self.contract_mode())
+        self.assertFalse(ans["linear_pass"])
+        self.assertTrue(any("Riccati" in x for x in ans["failures"]))
+
+    def test_information_mode_rejects_optimistic_anchor_exclusion(self):
+        payload = self.valid_mode_payload()
+        # The continuous source family contains the executed reference points,
+        # so its minimum cannot exceed the observed minimum.
+        payload["relative_Riccati_injection_margin_lower"] = 0.02
+        ans = ENC.validate_mode("A", payload, self.contract_mode())
+        self.assertFalse(ans["linear_pass"])
+        self.assertTrue(any("exceeds included executed minimum" in x for x in ans["failures"]))
+
+    def test_contract_prefers_strongest_executed_information_horizon(self):
+        info = {
+            "status": "PASS",
+            "held": {
+                "selected": {"horizon_s": 2.0, "lambda_worst_information": 0.9999},
+                "strongest_executed_margin": {
+                    "horizon_s": 16.0,
+                    "lambda_worst_information": 0.95,
+                    "relative_Riccati_injection_margin_worst": 0.05,
+                    "Sigma_endpoint_lambda_min": 1e-7,
+                    "Sigma_endpoint_lambda_max": 10.0,
+                },
+            },
+            "active": {
+                "selected": {"horizon_s": 2.0, "lambda_worst_information": 0.999},
+                "strongest_executed_margin": {
+                    "horizon_s": 4.0,
+                    "lambda_worst_information": 0.99,
+                    "relative_Riccati_injection_margin_worst": 0.01,
+                    "Sigma_endpoint_lambda_min": 1e-7,
+                    "Sigma_endpoint_lambda_max": 10.0,
+                },
+            },
+        }
+        completion = {
+            "status": "PASS_EXECUTED_REPLAY",
+            "held": {"asymptotic_floor_b_star_replay": 10.0},
+            "active": {"asymptotic_floor_b_star_replay": 20.0},
+        }
+        c = CONTRACT.build_contract(info, completion)
+        self.assertEqual(c["modes"]["H"]["recommended_word_horizon_s"], 16.0)
+        self.assertEqual(c["modes"]["A"]["recommended_word_horizon_s"], 4.0)
+        self.assertEqual(c["metric"], "source-varying inverse estimator covariance")
 
     def test_completion_does_not_promote_sampled_replay(self):
-        text = (TOOLS / "ou3_certificate_completion.py").read_text()
-        self.assertIn('"neighborhood_numerical_certificate": "NOT_ESTABLISHED"', text)
+        text = (TOOLS / "ou3_information_completion.py").read_text()
+        self.assertIn('"numerical_neighborhood_certificate": "NOT_ESTABLISHED"', text)
         self.assertIn('"deployment_theorem_certificate": "NOT_ESTABLISHED"', text)
-        self.assertIn("enclosure_contract.json", text)
 
-    def test_enclosure_gate_requires_validated_provenance(self):
+    def test_enclosure_gate_uses_information_metric_not_old_path_metrics(self):
         text = (TOOLS / "ou3_validate_enclosure.py").read_text()
-        self.assertIn("validated_arithmetic", text)
-        self.assertIn("outward_rounding", text)
-        self.assertIn("source_generated_not_trajectory_fit", text)
-        self.assertIn("robust_box_lmi_upper", text)
+        self.assertIn("relative_Riccati_injection_margin_lower", text)
+        self.assertIn("Sigma_lambda_min_lower", text)
+        self.assertIn("prefix_information_gain_upper", text)
         self.assertIn("mu_W_lower", text)
         self.assertIn("theta_star", text)
+        self.assertNotIn("path_metrics.npz", text)
+        self.assertNotIn("robust_box_lmi_upper", text)
 
 
 if __name__ == "__main__":

--- a/tests/validation/test_ou3_certificate_completion.py
+++ b/tests/validation/test_ou3_certificate_completion.py
@@ -134,15 +134,18 @@ class Ou3CertificateCompletionTests(unittest.TestCase):
         self.assertIn('"numerical_neighborhood_certificate": "NOT_ESTABLISHED"', text)
         self.assertIn('"deployment_theorem_certificate": "NOT_ESTABLISHED"', text)
 
-    def test_enclosure_gate_uses_information_metric_not_old_path_metrics(self):
+    def test_enclosure_gate_uses_information_metric_not_old_path_solver(self):
         text = (TOOLS / "ou3_validate_enclosure.py").read_text()
         self.assertIn("relative_Riccati_injection_margin_lower", text)
         self.assertIn("Sigma_lambda_min_lower", text)
         self.assertIn("prefix_information_gain_upper", text)
         self.assertIn("mu_W_lower", text)
         self.assertIn("theta_star", text)
-        self.assertNotIn("path_metrics.npz", text)
-        self.assertNotIn("robust_box_lmi_upper", text)
+        # Prose may name the retired artifact for contrast. The implementation
+        # must not load any old matrix archive or call the old box-LMI helper.
+        self.assertNotIn("np.load(", text)
+        self.assertNotIn("load_metrics(", text)
+        self.assertNotIn("robust_box_lmi_upper(", text)
 
 
 if __name__ == "__main__":

--- a/tests/validation/test_ou3_neighborhood_diagnostic.py
+++ b/tests/validation/test_ou3_neighborhood_diagnostic.py
@@ -1,0 +1,83 @@
+import importlib.util
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOLS = ROOT / "tools"
+sys.path.insert(0, str(TOOLS))
+
+SPEC = importlib.util.spec_from_file_location(
+    "ou3_neighborhood_diagnostic", TOOLS / "ou3_neighborhood_diagnostic.py"
+)
+MOD = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = MOD
+SPEC.loader.exec_module(MOD)
+
+
+class Ou3NeighborhoodDiagnosticTests(unittest.TestCase):
+    def test_information_normalization_hits_requested_energy(self):
+        P = np.diag([4.0, 9.0, 16.0])
+        d = MOD.information_normalize(P, 1, target_W=0.25, sign=-1)
+        W = float(d @ np.linalg.solve(P, d))
+        self.assertAlmostEqual(W, 0.25, places=13)
+        self.assertLess(d[1], 0.0)
+        self.assertEqual(np.count_nonzero(d), 1)
+
+    def test_held_compact_basis_never_injects_accel_bias(self):
+        self.assertTrue(all(i < 18 for i in MOD.COMPACT_H))
+        self.assertIn(18, MOD.COMPACT_A)
+
+    def test_pair_trace_requires_source_match_and_contraction(self):
+        header = (
+            "time_s,time_from_injection_s,endpoint,mode,source_match,"
+            "acc_accept_match,mag_accept_match,W_nominal,W_perturbed,"
+            "theta_rad,error_norm,covariance_rel_fro,nom_live,nom_active,"
+            "nom_mag_lock,nom_mag_refined,nom_tau,nom_sigma,nom_rs,"
+            "pert_tau,pert_sigma,pert_rs"
+        )
+        rows = [
+            "300,0,0,A,1,1,1,1.0,1.0,0.01,0.01,0,1,1,1,1,2,1,4,2,1,4",
+            "304,4,1,A,1,1,1,0.8,0.81,0.005,0.008,0.01,1,1,1,1,2,1,4,2,1,4",
+        ]
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "trace.csv"
+            p.write_text(header + "\n" + "\n".join(rows) + "\n")
+            result = MOD.parse_trace(p)
+        self.assertEqual(result["status"], "PASS_SAMPLED")
+        self.assertTrue(result["pass_sampled"])
+        self.assertAlmostEqual(result["relative_decrement"], 0.2)
+
+    def test_pair_trace_rejects_source_word_divergence(self):
+        header = (
+            "time_s,time_from_injection_s,endpoint,mode,source_match,"
+            "acc_accept_match,mag_accept_match,W_nominal,W_perturbed,"
+            "theta_rad,error_norm,covariance_rel_fro,nom_live,nom_active,"
+            "nom_mag_lock,nom_mag_refined,nom_tau,nom_sigma,nom_rs,"
+            "pert_tau,pert_sigma,pert_rs"
+        )
+        rows = [
+            "300,0,0,A,1,1,1,1.0,1.0,0.01,0.01,0,1,1,1,1,2,1,4,2,1,4",
+            "304,4,1,A,0,0,1,0.7,0.7,0.005,0.008,0.01,1,1,1,1,2,1,4,2,1,4",
+        ]
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "trace.csv"
+            p.write_text(header + "\n" + "\n".join(rows) + "\n")
+            result = MOD.parse_trace(p)
+        self.assertEqual(result["status"], "FAIL_SAMPLED")
+        self.assertFalse(result["source_match_all"])
+        self.assertFalse(result["measurement_acceptance_match_all"])
+
+    def test_sampled_diagnostic_cannot_promote_theorem(self):
+        text = (TOOLS / "ou3_neighborhood_diagnostic.py").read_text()
+        self.assertIn("SAMPLED_PAIRWISE_NONLINEAR_DIAGNOSTIC_ONLY", text)
+        self.assertIn('"numerical_neighborhood_certificate": "NOT_ESTABLISHED"', text)
+        self.assertIn('"deployment_theorem_certificate": "NOT_ESTABLISHED"', text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/validation/test_ou3_result_determinism.py
+++ b/tests/validation/test_ou3_result_determinism.py
@@ -10,6 +10,7 @@ PRODUCERS = [
     ROOT / "tools" / "ou3_numerical_certificate.py",
     ROOT / "tools" / "ou3_information_certificate.py",
     ROOT / "tools" / "ou3_information_completion.py",
+    ROOT / "tools" / "ou3_information_enclosure_contract.py",
     ROOT / "tools" / "ou3_certificate_completion.py",
     ROOT / "tools" / "ou3_validate_enclosure.py",
 ]

--- a/tests/validation/test_ou3_result_determinism.py
+++ b/tests/validation/test_ou3_result_determinism.py
@@ -11,6 +11,7 @@ PRODUCERS = [
     ROOT / "tools" / "ou3_information_certificate.py",
     ROOT / "tools" / "ou3_information_completion.py",
     ROOT / "tools" / "ou3_information_enclosure_contract.py",
+    ROOT / "tools" / "ou3_neighborhood_diagnostic.py",
     ROOT / "tools" / "ou3_certificate_completion.py",
     ROOT / "tools" / "ou3_validate_enclosure.py",
 ]

--- a/tools/ou3_information_enclosure_contract.py
+++ b/tools/ou3_information_enclosure_contract.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Build the continuous-source promotion contract for adaptive OU-III.
+
+The executed certificate in ``ou3_information_certificate.py`` uses the actual
+Kalman covariance as a source-varying information metric,
+
+    M(g) = Sigma_KF(g)^(-1).
+
+For every deterministic source word,
+
+    Sigma_1 = Phi Sigma_0 Phi^T + Omega,
+
+and therefore
+
+    Phi^T Sigma_1^-1 Phi <= (1-eta) Sigma_0^-1
+
+whenever
+
+    Sigma_1^-1/2 Omega Sigma_1^-1/2 >= eta I,  eta > 0.
+
+This tool does not invent a validated lower bound eta.  It turns the successful
+eight-replay result into a deterministic, machine-readable contract specifying
+what a continuous-source interval/Taylor-model backend must prove.  Executed
+values are retained only as sanity anchors; they are never promoted by this
+stage.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+import ou3_numerical_certificate as BASE
+
+SCHEMA = 2
+
+
+def _finite_positive(value) -> bool:
+    try:
+        x = float(value)
+    except (TypeError, ValueError):
+        return False
+    return math.isfinite(x) and x > 0.0
+
+
+def mode_contract(info_mode: dict, completion_mode: dict, mode: str) -> dict:
+    """Return one deterministic continuous-source obligation set.
+
+    Prefer the tested horizon with the strongest executed information margin.
+    A longer word is allowed by the source-word theorem and gives the validated
+    backend more room to prove a robust positive Riccati injection.  The first
+    strict horizon is kept as a diagnostic anchor, not as a requirement.
+    """
+    first = dict(info_mode.get("selected") or {})
+    strongest = dict(info_mode.get("strongest_executed_margin") or first)
+    horizon = strongest.get("horizon_s")
+    if horizon is None:
+        horizon = first.get("horizon_s")
+
+    executed = {
+        "first_strict_horizon_s": first.get("horizon_s"),
+        "first_strict_lambda_worst": first.get("lambda_worst_information"),
+        "recommended_horizon_s": horizon,
+        "lambda_worst_information": strongest.get("lambda_worst_information"),
+        "relative_Riccati_injection_margin_worst": strongest.get(
+            "relative_Riccati_injection_margin_worst",
+            strongest.get("omega_relative_lambda_min_worst"),
+        ),
+        "Sigma_endpoint_lambda_min": strongest.get("Sigma_endpoint_lambda_min"),
+        "Sigma_endpoint_lambda_max": strongest.get("Sigma_endpoint_lambda_max"),
+        "Sigma_endpoint_condition_bound": strongest.get("Sigma_endpoint_condition_bound"),
+        "information_identity_residual_max": strongest.get("information_identity_residual_max"),
+        "replay_asymptotic_floor_b_star": completion_mode.get(
+            "asymptotic_floor_b_star_replay",
+            completion_mode.get("invariant_level_b_replay"),
+        ),
+        "replay_finite_capture_level_b_eta": completion_mode.get(
+            "finite_capture_level_b_eta_replay"
+        ),
+    }
+
+    return {
+        "mode": mode,
+        "metric": "M(g)=Sigma_KF(g)^(-1)",
+        "recommended_word_horizon_s": horizon,
+        "executed_reference_only": executed,
+        "required_continuous_bounds": {
+            "source_complete": True,
+            "outward_rounded": True,
+            "relative_Riccati_injection_margin_lower": "> 0",
+            "Sigma_lambda_min_lower": "> 0",
+            "Sigma_lambda_max_upper": "finite",
+            "prefix_information_gain_upper": "finite positive",
+        },
+        "required_nonlinear_bounds": {
+            "theta_star": "0 < theta_star < pi",
+            "mu_W_lower": "> 0",
+            "all_word_prefixes_safe": True,
+            "metric_lift": "zeta^T Sigma_KF(g)^(-1) zeta with zeta=[Log(R_e); xi]",
+        },
+    }
+
+
+def build_contract(info: dict, completion: dict) -> dict:
+    info_pass = info.get("status") == "PASS"
+    replay_pass = completion.get("status") == "PASS_EXECUTED_REPLAY"
+    modes = {
+        "H": mode_contract(info.get("held", {}), completion.get("held", {}), "H"),
+        "A": mode_contract(info.get("active", {}), completion.get("active", {}), "A"),
+    }
+    return {
+        "schema": SCHEMA,
+        "claim": "OU3_INFORMATION_METRIC_DEPLOYMENT_PROMOTION_CONTRACT",
+        "upstream_executed_information_certificate": "PASS" if info_pass else "FAIL",
+        "upstream_executed_replay_funnel": "PASS" if replay_pass else "FAIL",
+        "metric": "source-varying inverse estimator covariance",
+        "linear_identity": (
+            "1-lambda_information=lambda_min(Sigma1^-1/2 Omega Sigma1^-1/2), "
+            "Omega=Sigma1-Phi Sigma0 Phi^T"
+        ),
+        "modes": modes,
+        "hybrid_requirements": [
+            "startup_handoff_into_certified_destination_sublevel",
+            "held_to_active_jump_into_certified_destination_sublevel",
+            "magnetic_regauge_jump_into_certified_destination_sublevel",
+            "tilt_reset_jump_into_certified_destination_sublevel",
+            "cooldown_reentry_into_certified_destination_sublevel",
+        ],
+        "stochastic_requirements": [
+            "source_uniform_Sigma_bar_norm_upper",
+            "source_uniform_b_W_upper",
+            "source_uniform_v_W_upper",
+            "finite_horizon_failure_probability_upper",
+        ],
+        "validated_backend_requirements": [
+            "validated arithmetic",
+            "outward rounding",
+            "source-generated enclosure, not trajectory fitting",
+            "complete continuous source coverage",
+        ],
+        "promotion_rule": (
+            "executed replay values are sanity anchors only; deployment PASS requires "
+            "strict validated continuous-source linear, nonlinear, hybrid and stochastic bounds"
+        ),
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--certificate-dir", type=Path, default=BASE.DEFAULT_OUT)
+    args = ap.parse_args()
+    cert = args.certificate_dir.resolve()
+    info = json.loads((cert / "information_certificate.json").read_text())
+    completion = json.loads((cert / "information_completion.json").read_text())
+    contract = build_contract(info, completion)
+    path = cert / "information_enclosure_contract.json"
+    path.write_text(json.dumps(contract, indent=2, sort_keys=True))
+    print(json.dumps({
+        "schema": contract["schema"],
+        "linear": contract["upstream_executed_information_certificate"],
+        "replay": contract["upstream_executed_replay_funnel"],
+        "H_horizon_s": contract["modes"]["H"]["recommended_word_horizon_s"],
+        "A_horizon_s": contract["modes"]["A"]["recommended_word_horizon_s"],
+    }, indent=2, sort_keys=True))
+    # An upstream mathematical FAIL is scientific output, not a contract-tool crash.
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ou3_neighborhood_diagnostic.py
+++ b/tools/ou3_neighborhood_diagnostic.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Deterministic nonzero-neighborhood diagnostic for adaptive OU-III.
+
+This stage drives ``ou3-neighborhood-sim``.  The simulator runs a nominal and a
+perturbed copy of the unchanged adaptive filter under *identical* noisy sensor
+samples.  At a source point the perturbed copy receives one exact MEKF error
+retraction/additive-state perturbation.  The pair is then propagated over one
+certified information word.
+
+Perturbations are normalized in the local Kalman information metric: for a raw
+direction ``v`` and nominal covariance ``Sigma`` we choose ``d`` so that
+
+    d^T Sigma^-1 d = target_W.
+
+This removes the unit/conditioning ambiguity between attitude, biases, v, p, S
+and a_w.  The resulting sampled search is a diagnostic only.  It may locate an
+active nonlinear/source-guard constraint, but it can never promote the
+neighborhood or deployment theorem without outward-rounded enclosure.
+"""
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import math
+import os
+from pathlib import Path
+import subprocess
+
+import numpy as np
+
+import ou3_numerical_certificate as BASE
+import ou3_information_certificate as INFO
+
+DEFAULT_RESULTS = BASE.DEFAULT_OUT / "neighborhood_diagnostic"
+DEFAULT_DIAGNOSTICS = BASE.REPO / "reports" / "diagnostics" / "ou3_neighborhood"
+DEFAULT_SIM = BASE.TEST_DIR / "ou3-neighborhood-sim"
+DEFAULT_HELD_TIME_S = 60.0
+DEFAULT_ACTIVE_TIME_S = 300.0
+DEFAULT_TARGET_W = (0.05,)
+
+# Compact deterministic basis for first-pass constraint discovery.  A full
+# coordinate basis is available with --full-basis.
+COMPACT_H = (0, 1, 2, 3, 4, 5, 6, 9, 12, 15)
+COMPACT_A = COMPACT_H + (18,)
+BLOCK_NAME = {
+    0: "theta_x", 1: "theta_y", 2: "theta_z",
+    3: "bg_x", 4: "bg_y", 5: "bg_z",
+    6: "v_x", 7: "v_y", 8: "v_z",
+    9: "p_x", 10: "p_y", 11: "p_z",
+    12: "S_x", 13: "S_y", 14: "S_z",
+    15: "aw_x", 16: "aw_y", 17: "aw_z",
+    18: "ba_x", 19: "ba_y", 20: "ba_z",
+}
+
+
+def record_slug(family: str, hs: float) -> str:
+    return f"{family.lower().replace('-', '_')}_{hs:.2f}".replace(".", "_")
+
+
+def record_index() -> dict[str, tuple[str, float, str]]:
+    out = {}
+    for family, hs, name in BASE.RECORDS:
+        slug = record_slug(family, hs)
+        out[slug] = (family, hs, name)
+        out[Path(name).stem] = (family, hs, name)
+    return out
+
+
+def nearest_covariance(map_path: Path, t: float, dim: int) -> tuple[np.ndarray, dict]:
+    maps, covs, meta = INFO.pair_map_covariance(map_path, map_path.stem.replace("_exact_maps", ""))
+    candidates = []
+    for i, (m, c) in enumerate(zip(maps, covs)):
+        candidates.append((abs(m.t0 - t), i, "start", c.start))
+        candidates.append((abs(m.t1 - t), i, "end", c.end))
+    if not candidates:
+        raise RuntimeError(f"no covariance blocks in {map_path}")
+    dt, i, side, P = min(candidates, key=lambda x: x[0])
+    if dt > 0.02:
+        raise RuntimeError(f"no covariance endpoint within 20 ms of t={t}: nearest {dt}")
+    P = np.asarray(P[:dim, :dim], float)
+    P = 0.5 * (P + P.T)
+    eig = np.linalg.eigvalsh(P)
+    if not np.all(np.isfinite(eig)) or float(np.min(eig)) <= 0.0:
+        raise RuntimeError(f"non-SPD covariance at {map_path} block {i} {side}")
+    return P, {
+        "block": i,
+        "side": side,
+        "time_distance_s": float(dt),
+        "lambda_min": float(np.min(eig)),
+        "lambda_max": float(np.max(eig)),
+    }
+
+
+def information_normalize(P: np.ndarray, index: int, target_W: float, sign: int) -> np.ndarray:
+    if not (target_W > 0.0 and math.isfinite(target_W)):
+        raise ValueError("target_W must be finite positive")
+    dim = P.shape[0]
+    if not (0 <= index < dim):
+        raise ValueError(f"coordinate {index} outside dimension {dim}")
+    v = np.zeros(dim)
+    v[index] = float(sign)
+    w = float(v @ np.linalg.solve(P, v))
+    if not (w > 0.0 and math.isfinite(w)):
+        raise RuntimeError(f"invalid information norm for coordinate {index}: {w}")
+    return v * math.sqrt(target_W / w)
+
+
+def to_21(delta: np.ndarray) -> np.ndarray:
+    out = np.zeros(21)
+    out[: len(delta)] = delta
+    return out
+
+
+def parse_trace(path: Path) -> dict:
+    if not path.exists() or path.stat().st_size == 0:
+        return {"status": "NO_TRACE", "pass_sampled": False}
+    a = np.genfromtxt(path, delimiter=",", names=True, dtype=None, encoding=None)
+    if a.shape == ():
+        a = np.asarray([a], dtype=a.dtype)
+    if len(a) == 0:
+        return {"status": "NO_ROWS", "pass_sampled": False}
+
+    endpoint = np.flatnonzero(np.asarray(a["endpoint"], int) == 1)
+    if len(endpoint) == 0:
+        return {
+            "status": "NO_ENDPOINT",
+            "pass_sampled": False,
+            "row_count": int(len(a)),
+            "source_match_all": bool(np.all(np.asarray(a["source_match"], int) == 1)),
+        }
+
+    i1 = int(endpoint[-1])
+    W = np.asarray(a["W_nominal"], float)
+    theta = np.asarray(a["theta_rad"], float)
+    covrel = np.asarray(a["covariance_rel_fro"], float)
+    W0 = float(W[0])
+    W1 = float(W[i1])
+    ratio = W1 / W0 if W0 > 0.0 else math.inf
+    source_match = bool(np.all(np.asarray(a["source_match"][: i1 + 1], int) == 1))
+    acceptance_match = bool(
+        np.all(np.asarray(a["acc_accept_match"][: i1 + 1], int) == 1)
+        and np.all(np.asarray(a["mag_accept_match"][: i1 + 1], int) == 1)
+    )
+    finite = bool(
+        np.all(np.isfinite(W[: i1 + 1]))
+        and np.all(np.isfinite(theta[: i1 + 1]))
+        and np.all(np.isfinite(covrel[: i1 + 1]))
+    )
+    theta_max = float(np.max(theta[: i1 + 1])) if finite else math.inf
+    prefix_W_gain = float(np.max(W[: i1 + 1]) / W0) if finite and W0 > 0.0 else math.inf
+    decrement = 1.0 - ratio
+    passed = bool(
+        finite and source_match and acceptance_match and theta_max < math.pi
+        and W0 > 0.0 and W1 < W0
+    )
+    return {
+        "status": "PASS_SAMPLED" if passed else "FAIL_SAMPLED",
+        "pass_sampled": passed,
+        "row_count": int(i1 + 1),
+        "source_match_all": source_match,
+        "measurement_acceptance_match_all": acceptance_match,
+        "W0": W0,
+        "W1": W1,
+        "endpoint_ratio_W1_over_W0": ratio,
+        "relative_decrement": decrement,
+        "prefix_W_gain_max": prefix_W_gain,
+        "theta_max_rad": theta_max,
+        "theta_max_deg": math.degrees(theta_max) if math.isfinite(theta_max) else None,
+        "covariance_relative_difference_max": float(np.max(covrel[: i1 + 1])) if finite else None,
+        "actual_injection_time_s": float(a["time_s"][0]),
+        "actual_endpoint_time_s": float(a["time_s"][i1]),
+        "qualification": "SAMPLED_PAIRWISE_NONLINEAR_DIAGNOSTIC_ONLY",
+    }
+
+
+def select_records(patterns: list[str]) -> list[tuple[str, float, str]]:
+    rows = list(BASE.RECORDS)
+    if not patterns:
+        return rows
+    selected = []
+    for family, hs, name in rows:
+        slug = record_slug(family, hs)
+        if any(fnmatch.fnmatch(slug, p) or fnmatch.fnmatch(Path(name).stem, p) for p in patterns):
+            selected.append((family, hs, name))
+    if not selected:
+        raise ValueError(f"record patterns matched nothing: {patterns}")
+    return selected
+
+
+def run_case(sim: Path, data: Path, trace: Path, log: Path,
+             mode: str, inject_s: float, horizon_s: float,
+             delta21: np.ndarray) -> tuple[int, str]:
+    trace.parent.mkdir(parents=True, exist_ok=True)
+    log.parent.mkdir(parents=True, exist_ok=True)
+    env = os.environ.copy()
+    env.update({
+        "OU3_NEIGHBOR_TRACE": str(trace.resolve()),
+        "OU3_NEIGHBOR_INJECT_TIME_S": f"{inject_s:.9g}",
+        "OU3_NEIGHBOR_HORIZON_S": f"{horizon_s:.9g}",
+        "OU3_NEIGHBOR_MODE": mode,
+        "OU3_NEIGHBOR_DELTA": ",".join(f"{x:.17g}" for x in delta21),
+        "OU3_NEIGHBOR_TRACE_STRIDE": "50",
+        "W3D_WRITE_TIMESERIES": "0",
+        "W3D_VALIDATION_WINDOW_SEC": "0",
+    })
+    p = subprocess.run(
+        [str(sim.resolve()), "--input", str(data.resolve())],
+        cwd=data.parent,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    log.write_text(p.stdout)
+    return p.returncode, p.stdout
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--certificate-dir", type=Path, default=BASE.DEFAULT_OUT)
+    ap.add_argument("--data-dir", type=Path, default=BASE.DEFAULT_DATA_DIR)
+    ap.add_argument("--sim", type=Path, default=DEFAULT_SIM)
+    ap.add_argument("--output-dir", type=Path, default=DEFAULT_RESULTS)
+    ap.add_argument("--diagnostic-dir", type=Path, default=DEFAULT_DIAGNOSTICS)
+    ap.add_argument("--records", action="append", default=[],
+                    help="glob against certificate slug/source stem; repeatable")
+    ap.add_argument("--modes", default="H,A")
+    ap.add_argument("--target-W", default=",".join(str(x) for x in DEFAULT_TARGET_W))
+    ap.add_argument("--held-time-s", type=float, default=DEFAULT_HELD_TIME_S)
+    ap.add_argument("--active-time-s", type=float, default=DEFAULT_ACTIVE_TIME_S)
+    ap.add_argument("--full-basis", action="store_true")
+    ap.add_argument("--positive-only", action="store_true")
+    ap.add_argument("--no-build", action="store_true")
+    args = ap.parse_args()
+
+    cert = args.certificate_dir.resolve()
+    data_dir = args.data_dir.resolve()
+    sim = args.sim.resolve()
+    out = args.output_dir.resolve()
+    diag = args.diagnostic_dir.resolve()
+    out.mkdir(parents=True, exist_ok=True)
+    diag.mkdir(parents=True, exist_ok=True)
+
+    if not args.no_build:
+        subprocess.run(["make", "-C", str(BASE.TEST_DIR), sim.name], check=True)
+    if not sim.exists():
+        raise FileNotFoundError(sim)
+
+    contract = json.loads((cert / "information_enclosure_contract.json").read_text())
+    modes = [x.strip() for x in args.modes.split(",") if x.strip()]
+    if any(m not in ("H", "A") for m in modes):
+        raise ValueError("--modes accepts H,A")
+    targets = [float(x) for x in args.target_W.split(",") if x.strip()]
+    if any(not (x > 0.0 and math.isfinite(x)) for x in targets):
+        raise ValueError("--target-W entries must be finite positive")
+    signs = (1,) if args.positive_only else (-1, 1)
+
+    cases = []
+    for family, hs, name in select_records(args.records):
+        data = (data_dir / name).resolve()
+        if not data.exists():
+            raise FileNotFoundError(data)
+        stem = Path(name).stem
+        map_path = cert / f"{stem}_exact_maps.bin"
+        if not map_path.exists():
+            raise FileNotFoundError(map_path)
+
+        for mode in modes:
+            dim = 18 if mode == "H" else 21
+            inject_s = args.held_time_s if mode == "H" else args.active_time_s
+            horizon_s = float(contract["modes"][mode]["recommended_word_horizon_s"])
+            P, cov_meta = nearest_covariance(map_path, inject_s, dim)
+            indices = tuple(range(dim)) if args.full_basis else (COMPACT_H if mode == "H" else COMPACT_A)
+            for target in targets:
+                for index in indices:
+                    for sign in signs:
+                        d = information_normalize(P, index, target, sign)
+                        d21 = to_21(d)
+                        case_id = (
+                            f"{record_slug(family, hs)}_{mode}_{BLOCK_NAME[index]}_"
+                            f"{'p' if sign > 0 else 'm'}_W{target:.6g}"
+                        ).replace(".", "_")
+                        trace = diag / f"{case_id}.csv"
+                        log = diag / f"{case_id}.log"
+                        rc, stdout = run_case(
+                            sim, data, trace, log, mode, inject_s, horizon_s, d21
+                        )
+                        result = parse_trace(trace)
+                        result.update({
+                            "case": case_id,
+                            "family": family,
+                            "Hs_m": hs,
+                            "source_file": name,
+                            "mode": mode,
+                            "coordinate": index,
+                            "direction": BLOCK_NAME[index],
+                            "sign": sign,
+                            "target_W": target,
+                            "requested_injection_time_s": inject_s,
+                            "word_horizon_s": horizon_s,
+                            "delta_21": [float(x) for x in d21],
+                            "covariance_reference": cov_meta,
+                            "sim_returncode": int(rc),
+                            "sim_completed_marker": "OU3_NEIGHBOR_DONE" in stdout,
+                        })
+                        cases.append(result)
+
+    valid = [c for c in cases if c.get("status") in ("PASS_SAMPLED", "FAIL_SAMPLED")]
+    all_pass = bool(valid) and len(valid) == len(cases) and all(c["pass_sampled"] for c in valid)
+    decrements = [float(c["relative_decrement"]) for c in valid
+                  if c.get("relative_decrement") is not None and math.isfinite(float(c["relative_decrement"]))]
+    theta = [float(c["theta_max_rad"]) for c in valid
+             if c.get("theta_max_rad") is not None and math.isfinite(float(c["theta_max_rad"]))]
+    prefix = [float(c["prefix_W_gain_max"]) for c in valid
+              if c.get("prefix_W_gain_max") is not None and math.isfinite(float(c["prefix_W_gain_max"]))]
+    worst = min(valid, key=lambda c: c.get("relative_decrement", -math.inf)) if valid else None
+    report = {
+        "schema": 1,
+        "status": "PASS_SAMPLED" if all_pass else "FAIL_OR_INCOMPLETE_SAMPLED",
+        "qualification": "DENSE_OR_STRUCTURED_SAMPLING_IS_NOT_A_NEIGHBORHOOD_CERTIFICATE",
+        "metric": "pairwise zeta^T Sigma_nominal^-1 zeta",
+        "case_count": len(cases),
+        "valid_endpoint_case_count": len(valid),
+        "relative_decrement_min": min(decrements) if decrements else None,
+        "theta_max_rad": max(theta) if theta else None,
+        "theta_max_deg": math.degrees(max(theta)) if theta else None,
+        "prefix_W_gain_max": max(prefix) if prefix else None,
+        "worst_case": worst,
+        "cases": cases,
+        "numerical_neighborhood_certificate": "NOT_ESTABLISHED",
+        "deployment_theorem_certificate": "NOT_ESTABLISHED",
+    }
+    (out / "neighborhood_diagnostic.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True)
+    )
+    print(json.dumps({
+        "status": report["status"],
+        "case_count": report["case_count"],
+        "relative_decrement_min": report["relative_decrement_min"],
+        "theta_max_deg": report["theta_max_deg"],
+        "prefix_W_gain_max": report["prefix_W_gain_max"],
+        "worst_case": None if worst is None else worst.get("case"),
+    }, indent=2, sort_keys=True))
+    # Sampled failure is scientific diagnostic output; only simulator/tool
+    # malfunction is represented through missing/invalid cases in the JSON.
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ou3_validate_enclosure.py
+++ b/tools/ou3_validate_enclosure.py
@@ -1,17 +1,31 @@
 #!/usr/bin/env python3
-"""Validate a rigorous OU-III source-cell enclosure against solved path metrics.
+"""Validate a rigorous OU-III information-metric source enclosure.
 
-This is the promotion gate from numerical replay evidence to the deployment
-source/path theorem.  It does not generate interval/Taylor-model bounds itself;
-it verifies their provenance/coverage and independently checks every robust
-matrix-box path LMI against path_metrics.npz.
+This is the promotion gate from the executed information certificate to the
+continuous-source stability theorem.  It intentionally uses the same metric as
+the primary numerical certificate,
 
-Expected enclosure JSON (schema 1) contains, for each H/A mode:
-  source_complete: true
-  words: [{start,end,phi_center,phi_radius,prefix_gain_upper,
-           theta_star,alpha_R_lower,beta_R_upper,mu_W_lower}]
-and top-level hybrid/stochastic validated bounds.  phi_radius is an entrywise
-absolute radius obtained with outward-rounded validated arithmetic.
+    M(g) = Sigma_KF(g)^(-1),
+
+and does not depend on the superseded coarse ``path_metrics.npz`` route.
+
+For a source word with covariance recursion
+
+    Sigma_1 = Phi Sigma_0 Phi^T + Omega,
+
+strict linear contraction follows exactly from a validated uniform bound
+
+    Sigma_1^-1/2 Omega Sigma_1^-1/2 >= eta I,   eta > 0,
+
+because ``lambda_information <= 1-eta < 1``.  The validator also requires
+uniform covariance eigenvalue bounds (metric equivalence), finite prefix gain,
+a nonzero SO(3) chart with positive nonlinear word dissipation, strict hybrid
+inward margins, and non-empirical stochastic constants.
+
+The validator never trusts a supplied PASS flag.  It recomputes every logical
+promotion condition from the supplied outward-rounded bounds and cross-checks
+continuous bounds against executed reference points recorded in
+``information_enclosure_contract.json``.
 """
 from __future__ import annotations
 
@@ -20,192 +34,258 @@ import json
 import math
 from pathlib import Path
 
-import numpy as np
+import ou3_numerical_certificate as BASE
 
-REPO = Path(__file__).resolve().parents[1]
-DEFAULT_CERT = REPO / "reports" / "results" / "ou3_numerical_certificate"
-
-
-def load_metrics(path: Path) -> dict[str, dict[str, np.ndarray]]:
-    z = np.load(path, allow_pickle=False)
-    ans = {"H": {}, "A": {}}
-    for mode in ("H", "A"):
-        lk, pk = f"{mode}_labels", f"{mode}_P_local"
-        if lk in z and pk in z:
-            labels = [str(x) for x in z[lk]]
-            mats = np.asarray(z[pk], float)
-            ans[mode] = {label: mats[i] for i, label in enumerate(labels)}
-    return ans
+SCHEMA = 2
+ANCHOR_REL_TOL = 5.0e-6
 
 
-def robust_box_lmi_upper(C: np.ndarray, R: np.ndarray,
-                         Pi: np.ndarray, Pj: np.ndarray) -> dict:
-    """Sound spectral upper bound for all Phi=C+Delta, |Delta|<=R.
+def finite_positive(value) -> bool:
+    try:
+        x = float(value)
+    except (TypeError, ValueError):
+        return False
+    return math.isfinite(x) and x > 0.0
 
-    Because ||Delta||_2 <= ||R||_F for an entrywise interval box,
-      Delta' Pj C + C' Pj Delta + Delta' Pj Delta
-    has spectral norm at most
-      2 ||Pj C||_2 r + ||Pj||_2 r^2, r=||R||_F.
-    Hence strict negativity of the returned upper bound proves
-    Phi'PjPhi-Pi << 0 throughout the entire supplied matrix box.
-    """
-    C = np.asarray(C, float); R = np.asarray(R, float)
-    Pi = np.asarray(Pi, float); Pj = np.asarray(Pj, float)
-    if C.shape != R.shape or C.shape != Pi.shape or Pi.shape != Pj.shape:
-        raise ValueError("matrix shape mismatch")
-    if np.any(R < 0) or not np.all(np.isfinite(C)) or not np.all(np.isfinite(R)):
-        raise ValueError("invalid interval matrix")
-    M0 = C.T @ Pj @ C - Pi
-    M0 = 0.5 * (M0 + M0.T)
-    nominal_upper = float(np.max(np.linalg.eigvalsh(M0)))
-    r = float(np.linalg.norm(R, "fro"))
-    perturb = 2.0 * float(np.linalg.norm(Pj @ C, 2)) * r \
-              + float(np.linalg.norm(Pj, 2)) * r * r
-    upper = nominal_upper + perturb
+
+def finite_nonnegative(value) -> bool:
+    try:
+        x = float(value)
+    except (TypeError, ValueError):
+        return False
+    return math.isfinite(x) and x >= 0.0
+
+
+def _anchor_upper(value: float, anchor: float) -> bool:
+    """A continuous lower bound cannot exceed an included executed minimum."""
+    tol = ANCHOR_REL_TOL * max(1.0, abs(anchor))
+    return value <= anchor + tol
+
+
+def _anchor_lower(value: float, anchor: float) -> bool:
+    """A continuous upper bound cannot be below an included executed maximum."""
+    tol = ANCHOR_REL_TOL * max(1.0, abs(anchor))
+    return value + tol >= anchor
+
+
+def validate_mode(mode: str, payload: dict, contract_mode: dict) -> dict:
+    failures: list[str] = []
+    if not payload.get("source_complete", False):
+        failures.append("source family is not declared source-complete")
+    if not payload.get("outward_rounded", False):
+        failures.append("mode bounds are not declared outward-rounded")
+
+    expected_horizon = contract_mode.get("recommended_word_horizon_s")
+    horizon = payload.get("word_horizon_s")
+    if not finite_positive(horizon):
+        failures.append("word_horizon_s is not finite positive")
+    elif expected_horizon is not None and not math.isclose(
+        float(horizon), float(expected_horizon), rel_tol=0.0, abs_tol=1e-9
+    ):
+        failures.append(
+            f"word_horizon_s {horizon} does not match contract horizon {expected_horizon}"
+        )
+
+    eta = payload.get("relative_Riccati_injection_margin_lower")
+    sigma_lo = payload.get("Sigma_lambda_min_lower")
+    sigma_hi = payload.get("Sigma_lambda_max_upper")
+    prefix = payload.get("prefix_information_gain_upper")
+
+    if not finite_positive(eta):
+        failures.append("relative Riccati injection lower bound is not strictly positive")
+    elif float(eta) >= 1.0:
+        failures.append("relative Riccati injection lower bound must be < 1")
+    if not finite_positive(sigma_lo):
+        failures.append("Sigma_lambda_min_lower is not strictly positive")
+    if not finite_positive(sigma_hi):
+        failures.append("Sigma_lambda_max_upper is not finite positive")
+    if finite_positive(sigma_lo) and finite_positive(sigma_hi) and float(sigma_hi) < float(sigma_lo):
+        failures.append("Sigma eigenvalue upper bound is below lower bound")
+    if not finite_positive(prefix):
+        failures.append("prefix_information_gain_upper is not finite positive")
+
+    # Since the continuous source set is required to contain the executed
+    # reference family, its lower/upper bounds must contain those observed
+    # points.  This catches accidentally optimistic or fabricated enclosures.
+    ref = contract_mode.get("executed_reference_only", {})
+    ref_eta = ref.get("relative_Riccati_injection_margin_worst")
+    if finite_positive(eta) and finite_positive(ref_eta):
+        if not _anchor_upper(float(eta), float(ref_eta)):
+            failures.append(
+                "validated Riccati lower bound exceeds included executed minimum "
+                f"({eta} > {ref_eta})"
+            )
+    ref_sigma_lo = ref.get("Sigma_endpoint_lambda_min")
+    if finite_positive(sigma_lo) and finite_positive(ref_sigma_lo):
+        if not _anchor_upper(float(sigma_lo), float(ref_sigma_lo)):
+            failures.append(
+                "validated Sigma lower bound exceeds included executed minimum "
+                f"({sigma_lo} > {ref_sigma_lo})"
+            )
+    ref_sigma_hi = ref.get("Sigma_endpoint_lambda_max")
+    if finite_positive(sigma_hi) and finite_positive(ref_sigma_hi):
+        if not _anchor_lower(float(sigma_hi), float(ref_sigma_hi)):
+            failures.append(
+                "validated Sigma upper bound excludes an executed maximum "
+                f"({sigma_hi} < {ref_sigma_hi})"
+            )
+
+    linear_failures = list(failures)
+    lambda_upper = None
+    metric_lower = None
+    metric_upper = None
+    if finite_positive(eta) and float(eta) < 1.0:
+        lambda_upper = 1.0 - float(eta)
+    if finite_positive(sigma_hi):
+        metric_lower = 1.0 / float(sigma_hi)
+    if finite_positive(sigma_lo):
+        metric_upper = 1.0 / float(sigma_lo)
+
+    theta = payload.get("theta_star")
+    if not finite_positive(theta) or not float(theta) < math.pi:
+        failures.append("theta_star is not in (0, pi)")
+    mu = payload.get("mu_W_lower")
+    if not finite_positive(mu):
+        failures.append("nonlinear mu_W lower bound is not strictly positive")
+    if not payload.get("all_word_prefixes_safe", False):
+        failures.append("nonlinear word prefixes are not validated safe")
+
     return {
-        "nominal_lambda_max_difference": nominal_upper,
-        "matrix_box_spectral_radius_bound": r,
-        "perturbation_upper": perturb,
-        "robust_difference_lambda_upper": upper,
-        "pass": bool(upper < 0.0),
+        "mode": mode,
+        "linear_pass": not linear_failures,
+        "nonlinear_pass": not failures,
+        "pass": not failures,
+        "failures": failures,
+        "linear_failures": linear_failures,
+        "word_horizon_s": horizon,
+        "relative_Riccati_injection_margin_lower": eta,
+        "lambda_information_upper": lambda_upper,
+        "Sigma_lambda_min_lower": sigma_lo,
+        "Sigma_lambda_max_upper": sigma_hi,
+        "information_metric_lambda_min_lower": metric_lower,
+        "information_metric_lambda_max_upper": metric_upper,
+        "prefix_information_gain_upper": prefix,
+        "theta_star": theta,
+        "mu_W_lower": mu,
     }
 
 
-def finite_positive(x) -> bool:
-    try:
-        x = float(x)
-        return math.isfinite(x) and x > 0.0
-    except (TypeError, ValueError):
-        return False
-
-
-def validate_mode(mode: str, payload: dict,
-                  metrics: dict[str, np.ndarray], expected_nodes: set[str]) -> dict:
-    failures = []
-    if not payload.get("source_complete", False):
-        failures.append("source family not declared source-complete")
-    if not payload.get("outward_rounded", False):
-        failures.append("validated arithmetic is not declared outward-rounded")
-    words = payload.get("words", [])
-    touched = set()
-    checked = []
-    for i, w in enumerate(words):
-        start, end = w.get("start"), w.get("end")
-        tag = f"word[{i}] {start}->{end}"
-        if start not in metrics or end not in metrics:
-            failures.append(f"{tag}: missing solved metric")
-            continue
-        touched.update((start, end))
-        try:
-            C = np.asarray(w["phi_center"], float)
-            R = np.asarray(w["phi_radius"], float)
-            lmi = robust_box_lmi_upper(C, R, metrics[start], metrics[end])
-        except Exception as exc:
-            failures.append(f"{tag}: invalid matrix enclosure: {exc}")
-            continue
-        if not lmi["pass"]:
-            failures.append(f"{tag}: robust path LMI not strict ({lmi['robust_difference_lambda_upper']})")
-        prefix = w.get("prefix_gain_upper")
-        if not finite_positive(prefix):
-            failures.append(f"{tag}: prefix gain not finite positive")
-        theta = w.get("theta_star")
-        if not finite_positive(theta) or not float(theta) < math.pi:
-            failures.append(f"{tag}: theta_star not in (0,pi)")
-        if not finite_positive(w.get("alpha_R_lower")):
-            failures.append(f"{tag}: alpha_R lower bound is not strictly positive")
-        beta = w.get("beta_R_upper")
-        if beta is None or not math.isfinite(float(beta)) or float(beta) < 0:
-            failures.append(f"{tag}: beta_R upper bound invalid")
-        if not finite_positive(w.get("mu_W_lower")):
-            failures.append(f"{tag}: nonlinear mu_W lower bound is not strictly positive")
-        checked.append({"start": start, "end": end, "lmi": lmi,
-                        "theta_star": theta, "alpha_R_lower": w.get("alpha_R_lower"),
-                        "beta_R_upper": beta, "mu_W_lower": w.get("mu_W_lower"),
-                        "prefix_gain_upper": prefix})
-    missing_nodes = sorted(expected_nodes - touched)
-    if missing_nodes:
-        failures.append(f"source metric nodes not touched by validated words: {missing_nodes}")
-    if not words:
-        failures.append("no validated words supplied")
-    return {"mode": mode, "pass": not failures, "failures": failures,
-            "validated_word_count": len(checked), "checked_words": checked,
-            "missing_nodes": missing_nodes}
-
-
 def validate_hybrid(payload: list[dict]) -> dict:
-    required = {"startup_handoff", "held_to_active", "magnetic_regauge",
-                "tilt_reset", "cooldown"}
-    seen = set(); failures = []
-    for i, j in enumerate(payload):
-        kind = str(j.get("kind", "")); seen.add(kind)
-        margin = j.get("inward_margin_lower")
-        if margin is None or not math.isfinite(float(margin)) or float(margin) < 0.0:
-            failures.append(f"hybrid[{i}] {kind}: inward margin lower bound is negative/nonfinite")
-        if not j.get("outward_rounded", False):
+    required = {
+        "startup_handoff",
+        "held_to_active",
+        "magnetic_regauge",
+        "tilt_reset",
+        "cooldown",
+    }
+    seen: set[str] = set()
+    failures: list[str] = []
+    rows = []
+    for i, jump in enumerate(payload):
+        kind = str(jump.get("kind", ""))
+        seen.add(kind)
+        margin = jump.get("inward_margin_lower")
+        if not finite_positive(margin):
+            failures.append(f"hybrid[{i}] {kind}: inward margin is not strictly positive")
+        if not jump.get("outward_rounded", False):
             failures.append(f"hybrid[{i}] {kind}: not outward-rounded")
+        rows.append({"kind": kind, "inward_margin_lower": margin})
     missing = sorted(required - seen)
     if missing:
         failures.append(f"missing hybrid obligations: {missing}")
-    return {"pass": not failures, "failures": failures, "seen": sorted(seen)}
+    return {"pass": not failures, "failures": failures, "seen": sorted(seen), "bounds": rows}
 
 
 def validate_stochastic(payload: dict) -> dict:
-    failures = []
+    failures: list[str] = []
     for key in ("Sigma_bar_norm_upper", "b_W_upper", "v_W_upper"):
-        v = payload.get(key)
-        if v is None or not math.isfinite(float(v)) or float(v) < 0:
+        if not finite_nonnegative(payload.get(key)):
             failures.append(f"{key} missing/nonfinite/negative")
     prob = payload.get("finite_horizon_failure_probability_upper")
-    if prob is None or not math.isfinite(float(prob)) or not (0.0 <= float(prob) <= 1.0):
-        failures.append("finite_horizon_failure_probability_upper invalid")
+    try:
+        p = float(prob)
+    except (TypeError, ValueError):
+        p = math.nan
+    if not math.isfinite(p) or not (0.0 <= p < 1.0):
+        failures.append("finite_horizon_failure_probability_upper must be in [0,1)")
     if not payload.get("outward_rounded", False):
         failures.append("stochastic bounds are not outward-rounded")
-    return {"pass": not failures, "failures": failures,
-            "finite_horizon_failure_probability_upper": prob}
+    return {
+        "pass": not failures,
+        "failures": failures,
+        "finite_horizon_failure_probability_upper": prob,
+        "Sigma_bar_norm_upper": payload.get("Sigma_bar_norm_upper"),
+        "b_W_upper": payload.get("b_W_upper"),
+        "v_W_upper": payload.get("v_W_upper"),
+    }
 
 
 def main() -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--certificate-dir", type=Path, default=DEFAULT_CERT)
+    ap.add_argument("--certificate-dir", type=Path, default=BASE.DEFAULT_OUT)
     ap.add_argument("--enclosure", type=Path, required=True)
     args = ap.parse_args()
     cert = args.certificate_dir.resolve()
     inp = json.loads(args.enclosure.read_text())
-    if inp.get("schema") != 1:
-        raise RuntimeError("unsupported validated enclosure schema")
+    if inp.get("schema") != SCHEMA:
+        raise RuntimeError(f"unsupported validated enclosure schema: {inp.get('schema')}")
+
+    contract_path = cert / "information_enclosure_contract.json"
+    if not contract_path.exists():
+        raise FileNotFoundError(contract_path)
+    contract = json.loads(contract_path.read_text())
+    if contract.get("schema") != SCHEMA:
+        raise RuntimeError("information enclosure contract schema mismatch")
+
     prov = inp.get("provenance", {})
-    provenance_ok = bool(prov.get("validated_arithmetic")) and bool(prov.get("outward_rounding")) \
+    provenance_ok = (
+        bool(prov.get("validated_arithmetic"))
+        and bool(prov.get("outward_rounding"))
         and bool(prov.get("source_generated_not_trajectory_fit"))
-    metrics = load_metrics(cert / "path_metrics.npz")
-    contract = json.loads((cert / "enclosure_contract.json").read_text())
-    expected = {}
-    for m in contract.get("required_modes", []):
-        expected[m["mode"]] = set(m.get("metric_nodes", []))
+        and bool(prov.get("continuous_source_coverage"))
+    )
+
     modes = {}
     for mode in ("H", "A"):
-        modes[mode] = validate_mode(mode, inp.get("modes", {}).get(mode, {}),
-                                    metrics[mode], expected.get(mode, set()))
+        modes[mode] = validate_mode(
+            mode,
+            inp.get("modes", {}).get(mode, {}),
+            contract.get("modes", {}).get(mode, {}),
+        )
+
     hybrid = validate_hybrid(inp.get("hybrid", []))
     stochastic = validate_stochastic(inp.get("stochastic", {}))
-    passed = provenance_ok and all(modes[m]["pass"] for m in modes) \
-             and hybrid["pass"] and stochastic["pass"]
+
+    linear_pass = provenance_ok and all(modes[m]["linear_pass"] for m in modes)
+    neighborhood_pass = provenance_ok and all(modes[m]["nonlinear_pass"] for m in modes) and hybrid["pass"]
+    deployment_pass = neighborhood_pass and stochastic["pass"]
+
     out = {
-        "schema": 1,
+        "schema": SCHEMA,
+        "metric": "M(g)=Sigma_KF(g)^(-1)",
         "validated_enclosure_provenance_pass": provenance_ok,
         "modes": modes,
         "hybrid": hybrid,
         "stochastic": stochastic,
-        "deployment_theorem_certificate": "PASS" if passed else "FAIL",
+        "continuous_linear_information_certificate": "PASS" if linear_pass else "FAIL",
+        "numerical_neighborhood_certificate": "PASS" if neighborhood_pass else "FAIL",
+        "deployment_theorem_certificate": "PASS" if deployment_pass else "FAIL",
         "promotion_is_machine_verified": True,
     }
-    (cert / "validated_enclosure_check.json").write_text(json.dumps(out, indent=2, sort_keys=True))
+    (cert / "validated_enclosure_check.json").write_text(
+        json.dumps(out, indent=2, sort_keys=True)
+    )
     print(json.dumps({
+        "continuous_linear_information_certificate": out["continuous_linear_information_certificate"],
+        "numerical_neighborhood_certificate": out["numerical_neighborhood_certificate"],
         "deployment_theorem_certificate": out["deployment_theorem_certificate"],
-        "H": modes["H"]["pass"], "A": modes["A"]["pass"],
-        "hybrid": hybrid["pass"], "stochastic": stochastic["pass"],
+        "H": modes["H"]["pass"],
+        "A": modes["A"]["pass"],
+        "hybrid": hybrid["pass"],
+        "stochastic": stochastic["pass"],
         "provenance": provenance_ok,
     }, indent=2, sort_keys=True))
-    return 0 if passed else 2
+    return 0 if deployment_pass else 2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Goal
Continue the OU-III stability work after merged PR #386 and close the remaining nonzero-neighborhood / continuous-source certificate without changing or retuning the deployed adaptive filter.

## Implemented first stage
- branch starts exactly from the #386 merge commit on `main`
- add deterministic `information_enclosure_contract.json` generated from the successful source-varying Kalman information certificate
- replace the stale theorem-promotion dependency on `path_metrics.npz` with the primary metric `M(g)=Sigma_KF(g)^(-1)`
- promote the exact Riccati identity through a continuous-source obligation: uniform positive relative Riccati injection, covariance metric-equivalence bounds, and finite prefix gain
- require the same schema to carry nonzero SO(3) `theta_star`, positive nonlinear `mu_W`, prefix safety, strict hybrid inward margins, and non-empirical stochastic bounds
- cross-check validated source bounds against executed reference extrema so a claimed continuous enclosure cannot exclude source points already observed in the eight-sea run
- wire contract generation into CI and deterministic-result validation
- update tests and certificate documentation

## Next work in this PR
1. add the exact nonlinear source-word perturbation/checkpoint driver
2. run dense nonzero-neighborhood diagnostics to locate the first active constraint
3. turn the diagnostic domain into validated/outward-rounded bounds for `theta_star`, `mu_W`, and prefix safety
4. close startup/held-active/magnetic/tilt/cooldown destination inequalities
5. derive non-empirical stochastic `b_W`/`v_W` bounds
6. rerun all eight noisy seas and report the first remaining obstruction quantitatively

No Schmidt restriction, block-diagonal S correction, fixed tuning, proof-specific gain, or filter retuning is allowed.