### PR TITLE
Continue OU-III stability certificate closure

### DIFF
--- a/.github/workflows/ou3-numerical-certificate.yml
+++ b/.github/workflows/ou3-numerical-certificate.yml
@@ -14,6 +14,7 @@ on:
       - "tests/validation/test_ou3_information_completion.py"
       - "tests/validation/test_ou3_certificate_completion.py"
       - "tests/validation/test_ou3_neighborhood_diagnostic.py"
+      - "tests/validation/test_ou3_neighborhood_radius_search.py"
       - "tests/validation/test_ou3_result_determinism.py"
       - "tools/ou3_exact_replay.py"
       - "tools/ou3_numerical_certificate.py"
@@ -21,6 +22,7 @@ on:
       - "tools/ou3_information_completion.py"
       - "tools/ou3_information_enclosure_contract.py"
       - "tools/ou3_neighborhood_diagnostic.py"
+      - "tools/ou3_neighborhood_radius_search.py"
       - "tools/ou3_certificate_completion.py"
       - "tools/ou3_validate_enclosure.py"
       - "tools/ou3_result_contract.py"
@@ -115,6 +117,18 @@ jobs:
             --data-dir "$GITHUB_WORKSPACE/plots/kalman_ou_ii" \
             --full-basis \
             --target-W 0.05 \
+            --jobs 4
+
+      - name: Locate sampled nonlinear neighborhood boundary
+        run: |
+          python3 -u tools/ou3_neighborhood_radius_search.py \
+            --sim "$GITHUB_WORKSPACE/tests/kalman_ou_iii/ou3-neighborhood-sim" \
+            --certificate-dir "$GITHUB_WORKSPACE/reports/results/ou3_numerical_certificate" \
+            --data-dir "$GITHUB_WORKSPACE/plots/kalman_ou_ii" \
+            --start-W 0.05 \
+            --growth 4 \
+            --max-W 204.8 \
+            --bisection-steps 3 \
             --jobs 4
 
       - name: Validate deterministic scientific result payloads

--- a/.github/workflows/ou3-numerical-certificate.yml
+++ b/.github/workflows/ou3-numerical-certificate.yml
@@ -13,12 +13,14 @@ on:
       - "tests/validation/test_ou3_information_certificate.py"
       - "tests/validation/test_ou3_information_completion.py"
       - "tests/validation/test_ou3_certificate_completion.py"
+      - "tests/validation/test_ou3_neighborhood_diagnostic.py"
       - "tests/validation/test_ou3_result_determinism.py"
       - "tools/ou3_exact_replay.py"
       - "tools/ou3_numerical_certificate.py"
       - "tools/ou3_information_certificate.py"
       - "tools/ou3_information_completion.py"
       - "tools/ou3_information_enclosure_contract.py"
+      - "tools/ou3_neighborhood_diagnostic.py"
       - "tools/ou3_certificate_completion.py"
       - "tools/ou3_validate_enclosure.py"
       - "tools/ou3_result_contract.py"
@@ -103,6 +105,17 @@ jobs:
             --input "$GITHUB_WORKSPACE/plots/kalman_ou_ii/wave_data_jonswap_H8.500_L202.839_A-30.00_P72.00.csv"
           test -s "$OU3_NEIGHBOR_TRACE"
           grep -q ',1,A,' "$OU3_NEIGHBOR_TRACE"
+
+      - name: Run full information-normalized nonlinear neighborhood sweep
+        run: |
+          python3 -u tools/ou3_neighborhood_diagnostic.py \
+            --no-build \
+            --sim "$GITHUB_WORKSPACE/tests/kalman_ou_iii/ou3-neighborhood-sim" \
+            --certificate-dir "$GITHUB_WORKSPACE/reports/results/ou3_numerical_certificate" \
+            --data-dir "$GITHUB_WORKSPACE/plots/kalman_ou_ii" \
+            --full-basis \
+            --target-W 0.05 \
+            --jobs 4
 
       - name: Validate deterministic scientific result payloads
         run: |

--- a/tests/validation/Makefile
+++ b/tests/validation/Makefile
@@ -11,6 +11,7 @@ build:
 		../../tools/ou3_information_completion.py \
 		../../tools/ou3_information_enclosure_contract.py \
 		../../tools/ou3_neighborhood_diagnostic.py \
+		../../tools/ou3_neighborhood_radius_search.py \
 		../../tools/ou3_certificate_completion.py \
 		../../tools/ou3_validate_enclosure.py \
 		../../tools/ou3_result_contract.py \
@@ -27,6 +28,7 @@ build:
 		test_ou3_information_completion.py \
 		test_ou3_certificate_completion.py \
 		test_ou3_neighborhood_diagnostic.py \
+		test_ou3_neighborhood_radius_search.py \
 		test_ou3_result_determinism.py \
 		test_ou_article_ablations.py \
 		test_ou_legacy_law_cleanup.py \

--- a/tests/validation/test_ou3_information_certificate.py
+++ b/tests/validation/test_ou3_information_certificate.py
@@ -58,12 +58,52 @@ class Ou3InformationCertificateTests(unittest.TestCase):
                 1.0 - lam, inc["omega_relative_lambda_min"], places=10
             )
 
+    def test_whitened_identity_survives_float32_ill_conditioning(self):
+        # Regression for the real eight-sea failure mode: map/covariance files
+        # are float32 while the physical covariance spans many orders of
+        # magnitude.  Algebraically equivalent unwhitened calculations can
+        # disagree by more than the certificate tolerance solely from roundoff.
+        A = np.array([
+            [1.0652581453323364, 0.08096306771039963],
+            [-0.09136798977851868, 0.915435791015625],
+        ])
+        P0 = np.array([
+            [4.122969627380371, -1.9218671321868896],
+            [-1.9218671321868896, 0.8958526849746704],
+        ])
+        P1 = np.array([
+            [4.353841304779053, -2.1952455043792725],
+            [-2.1952455043792725, 1.1068623065948486],
+        ])
+        self.assertGreater(np.linalg.cond(P1), 1.0e9)
+
+        lam = INFO.information_lambda(A, P0, P1)
+        inc = INFO.covariance_increment_margin(A, P0, P1)
+        stable_residual = INFO.information_identity_residual(lam, inc)
+        self.assertLess(stable_residual, 1.0e-10)
+
+        # Reproduce the legacy two-path calculation to prove this is a
+        # numerical-formulation regression, not a relaxed scientific gate.
+        S0, _, _ = INFO._spd_sqrt(P0)
+        X = np.linalg.solve(P1, A @ S0)
+        B = (A @ S0).T @ X
+        legacy_lam = float(np.max(np.linalg.eigvalsh(0.5 * (B + B.T))))
+        Omega = P1 - A @ P0 @ A.T
+        Omega = 0.5 * (Omega + Omega.T)
+        S1, _, _ = INFO._spd_sqrt(P1)
+        invS1 = np.linalg.inv(S1)
+        rel = invS1 @ Omega @ invS1
+        legacy_min = float(np.min(np.linalg.eigvalsh(0.5 * (rel + rel.T))))
+        legacy_residual = abs((1.0 - legacy_lam) - legacy_min)
+        self.assertGreater(legacy_residual, INFO.IDENTITY_ABS_TOL)
+
     def test_tool_uses_estimator_covariance_not_truth_error_covariance(self):
         text = (TOOLS / "ou3_information_certificate.py").read_text()
         compact = text.replace("_", "").replace(" ", "")
         self.assertIn("Sigma_KF", text)
         self.assertIn("Omega=Sigma1-PhiSigma0Phi^T", compact)
         self.assertIn("relative_Riccati_injection_margin_worst", text)
+        self.assertIn("np.eye(C.shape[0]) - C @ C.T", text)
         self.assertNotIn("metric_from_samples", text)
         self.assertNotIn("X.T@X", text)
 

--- a/tests/validation/test_ou3_neighborhood_radius_search.py
+++ b/tests/validation/test_ou3_neighborhood_radius_search.py
@@ -64,7 +64,12 @@ class Ou3NeighborhoodRadiusSearchTests(unittest.TestCase):
 
     def test_summary_keeps_sampled_qualification(self):
         c = self.base_case()
-        c.update({"case": "x", "mode": "A", "direction": "theta_x"})
+        c.update({
+            "case": "x",
+            "mode": "A",
+            "direction": "theta_x",
+            "W1": 1.01,
+        })
         report = {
             "status": "FAIL_OR_INCOMPLETE_SAMPLED",
             "case_count": 1,

--- a/tests/validation/test_ou3_neighborhood_radius_search.py
+++ b/tests/validation/test_ou3_neighborhood_radius_search.py
@@ -1,0 +1,80 @@
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOLS = ROOT / "tools"
+sys.path.insert(0, str(TOOLS))
+
+SPEC = importlib.util.spec_from_file_location(
+    "ou3_neighborhood_radius_search", TOOLS / "ou3_neighborhood_radius_search.py"
+)
+MOD = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = MOD
+SPEC.loader.exec_module(MOD)
+
+
+class Ou3NeighborhoodRadiusSearchTests(unittest.TestCase):
+    def base_case(self):
+        return {
+            "status": "FAIL_SAMPLED",
+            "pass_sampled": False,
+            "source_match_all": True,
+            "measurement_acceptance_match_all": True,
+            "theta_max_rad": 0.2,
+            "W0": 1.0,
+            "W1": 0.9,
+        }
+
+    def test_source_word_failure_has_priority(self):
+        c = self.base_case()
+        c["source_match_all"] = False
+        c["measurement_acceptance_match_all"] = False
+        self.assertEqual(MOD.classify_case_failure(c), "SOURCE_WORD_IDENTITY")
+
+    def test_measurement_gate_failure_is_distinct(self):
+        c = self.base_case()
+        c["measurement_acceptance_match_all"] = False
+        self.assertEqual(
+            MOD.classify_case_failure(c), "MEASUREMENT_GATING_CONSISTENCY"
+        )
+
+    def test_chart_escape_is_distinct(self):
+        c = self.base_case()
+        c["theta_max_rad"] = 3.2
+        self.assertEqual(MOD.classify_case_failure(c), "SO3_CHART_SAFETY")
+
+    def test_loss_of_W_decrease_is_distinct(self):
+        c = self.base_case()
+        c["W1"] = 1.01
+        self.assertEqual(MOD.classify_case_failure(c), "POSITIVE_W_DECREASE")
+
+    def test_nonfinite_prefix_is_distinct(self):
+        c = self.base_case()
+        c["theta_max_rad"] = float("nan")
+        self.assertEqual(MOD.classify_case_failure(c), "PREFIX_FINITE_SAFETY")
+
+    def test_passed_case_has_no_failure(self):
+        c = self.base_case()
+        c["status"] = "PASS_SAMPLED"
+        c["pass_sampled"] = True
+        self.assertIsNone(MOD.classify_case_failure(c))
+
+    def test_summary_keeps_sampled_qualification(self):
+        c = self.base_case()
+        c.update({"case": "x", "mode": "A", "direction": "theta_x"})
+        report = {
+            "status": "FAIL_OR_INCOMPLETE_SAMPLED",
+            "case_count": 1,
+            "valid_endpoint_case_count": 1,
+            "cases": [c],
+        }
+        s = MOD.summarize_round(report, 4.0)
+        self.assertFalse(s["pass_all_sampled"])
+        self.assertEqual(s["failure_reason_counts"]["POSITIVE_W_DECREASE"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ou3_information_certificate.py
+++ b/tools/ou3_information_certificate.py
@@ -90,33 +90,55 @@ def _spd_sqrt(P: np.ndarray) -> tuple[np.ndarray, float, float]:
     return U @ np.diag(np.sqrt(lam)) @ U.T, lo, hi
 
 
-def information_lambda(phi: np.ndarray, Sigma0: np.ndarray, Sigma1: np.ndarray) -> float:
-    """lambda_max for Phi' Sigma1^-1 Phi <= lambda Sigma0^-1."""
-    S0, _, _ = _spd_sqrt(Sigma0)
-    X = np.linalg.solve(0.5 * (Sigma1 + Sigma1.T), phi @ S0)
-    B = (phi @ S0).T @ X
-    return float(np.max(np.linalg.eigvalsh(0.5 * (B + B.T))))
+def _information_word_metrics(phi: np.ndarray, Sigma0: np.ndarray,
+                              Sigma1: np.ndarray) -> tuple[float, dict]:
+    """Evaluate one word in stable endpoint-whitened coordinates.
 
+    With S_i = Sigma_i^(1/2), define
 
-def covariance_increment_margin(phi: np.ndarray, Sigma0: np.ndarray, Sigma1: np.ndarray) -> dict:
-    """Return relative Riccati injection and covariance metric bounds."""
+        C = S_1^(-1) Phi S_0.
+
+    Then lambda_information = lambda_max(C' C), while the relative Riccati
+    injection is exactly I-C C'.  Evaluating the latter form avoids forming
+    Omega = Sigma1-Phi Sigma0 Phi' first, which is a subtraction of large,
+    nearly equal matrices in the strongly ill-conditioned physical units of
+    the held/active covariance.  No tolerance is relaxed and no estimator
+    quantity is changed.
+    """
     Sigma0 = 0.5 * (Sigma0 + Sigma0.T)
     Sigma1 = 0.5 * (Sigma1 + Sigma1.T)
-    Omega = 0.5 * ((Sigma1 - phi @ Sigma0 @ phi.T) +
-                   (Sigma1 - phi @ Sigma0 @ phi.T).T)
-    _, lo0, hi0 = _spd_sqrt(Sigma0)
+    S0, lo0, hi0 = _spd_sqrt(Sigma0)
     S1, lo1, hi1 = _spd_sqrt(Sigma1)
-    invS1 = np.linalg.inv(S1)
-    rel = invS1 @ Omega @ invS1
-    vals = np.linalg.eigvalsh(0.5 * (rel + rel.T))
-    return {
-        "omega_relative_lambda_min": float(np.min(vals)),
-        "omega_relative_lambda_max": float(np.max(vals)),
+    C = np.linalg.solve(S1, phi @ S0)
+
+    gram = C.T @ C
+    gram_vals = np.linalg.eigvalsh(0.5 * (gram + gram.T))
+    lam = float(np.max(gram_vals))
+
+    rel = np.eye(C.shape[0]) - C @ C.T
+    rel_vals = np.linalg.eigvalsh(0.5 * (rel + rel.T))
+    inc = {
+        "omega_relative_lambda_min": float(np.min(rel_vals)),
+        "omega_relative_lambda_max": float(np.max(rel_vals)),
         "Sigma0_lambda_min": lo0,
         "Sigma0_lambda_max": hi0,
         "Sigma1_lambda_min": lo1,
         "Sigma1_lambda_max": hi1,
+        "relative_injection_evaluation": "I-C C^T with C=Sigma1^-1/2 Phi Sigma0^1/2",
     }
+    return lam, inc
+
+
+def information_lambda(phi: np.ndarray, Sigma0: np.ndarray, Sigma1: np.ndarray) -> float:
+    """lambda_max for Phi' Sigma1^-1 Phi <= lambda Sigma0^-1."""
+    lam, _ = _information_word_metrics(phi, Sigma0, Sigma1)
+    return lam
+
+
+def covariance_increment_margin(phi: np.ndarray, Sigma0: np.ndarray, Sigma1: np.ndarray) -> dict:
+    """Return relative Riccati injection and covariance metric bounds."""
+    _, inc = _information_word_metrics(phi, Sigma0, Sigma1)
+    return inc
 
 
 def information_identity_residual(lam: float, inc: dict) -> float:
@@ -180,8 +202,7 @@ def evaluate_horizon(records: dict[str, tuple[list[BASE.MapBlock], list[CovBlock
             Phi, P0, P1 = w
             word_count += 1
             try:
-                lam = information_lambda(Phi, P0, P1)
-                inc = covariance_increment_margin(Phi, P0, P1)
+                lam, inc = _information_word_metrics(Phi, P0, P1)
             except np.linalg.LinAlgError:
                 invalid_spd += 1
                 continue
@@ -198,21 +219,34 @@ def evaluate_horizon(records: dict[str, tuple[list[BASE.MapBlock], list[CovBlock
     ids = np.asarray(identity_residuals, float)
     if not len(arr):
         return {"mode": mode, "horizon_s": horizon_s, "status": "NO_WORDS",
-                "word_count": word_count, "information_pass": False}
+                "word_count": word_count, "failure_reasons": ["NO_VALID_WORDS"],
+                "information_pass": False}
     covariance_consistent = invalid_spd == 0 and float(np.min(omg)) >= -PSD_REL_TOL
     identity_consistent = float(np.max(ids)) <= IDENTITY_ABS_TOL
     strict = float(np.max(arr)) < 1.0 - STRICT_LAMBDA_TOL
+    failures = []
+    if invalid_spd:
+        failures.append("NON_SPD_COVARIANCE")
+    if not covariance_consistent:
+        failures.append("COVARIANCE_RECURSION_NOT_PSD")
+    if not identity_consistent:
+        failures.append("INFORMATION_IDENTITY_NUMERICS")
+    if not strict:
+        failures.append("NO_STRICT_CONTRACTION")
     sigma_min = float(np.min(covariance_lows))
     sigma_max = float(np.max(covariance_highs))
+    passed = covariance_consistent and identity_consistent and strict
     return {
         "mode": mode,
         "horizon_s": horizon_s,
-        "status": "PASS" if covariance_consistent and identity_consistent and strict else "FAIL",
+        "status": "PASS" if passed else "FAIL",
         "word_count": word_count,
+        "failure_reasons": failures,
         "invalid_spd_words": invalid_spd,
         "lambda_worst_information": float(np.max(arr)),
         "lambda_p99_information": float(np.quantile(arr, 0.99)),
         "lambda_p50_information": float(np.quantile(arr, 0.50)),
+        "strict_contraction": bool(strict),
         "strict_margin_1_minus_lambda": 1.0 - float(np.max(arr)),
         "relative_Riccati_injection_margin_worst": float(np.min(omg)),
         "omega_relative_lambda_min_worst": float(np.min(omg)),
@@ -222,7 +256,7 @@ def evaluate_horizon(records: dict[str, tuple[list[BASE.MapBlock], list[CovBlock
         "Sigma_endpoint_lambda_max": sigma_max,
         "Sigma_endpoint_condition_bound": sigma_max / sigma_min,
         "covariance_recursion_consistent": bool(covariance_consistent),
-        "information_pass": bool(covariance_consistent and identity_consistent and strict),
+        "information_pass": bool(passed),
         "worst_word": None if worst is None else {
             "record": worst[1], "start_block": worst[2], "end_block": worst[3],
             "lambda": worst[0], "increment": worst[4],
@@ -259,8 +293,15 @@ def markdown(report: dict) -> str:
         f"Active strongest tested margin: {ass.get('horizon_s')} s, 1-lambda {ass.get('strict_margin_1_minus_lambda')}",
         "",
         "The certificate checks the exact Riccati identity `1-lambda_information = lambda_min(Sigma1^-1/2 Omega Sigma1^-1/2)` and records endpoint covariance metric bounds.",
+        "The relative injection is evaluated stably as `I-C C^T`, `C=Sigma1^-1/2 Phi Sigma0^1/2`, avoiding cancellation in `Sigma1-Phi Sigma0 Phi^T`; the identity tolerance is unchanged.",
         "A PASS is an exact executed-source linear certificate in a parameter-dependent information metric; deployment promotion still requires a validated continuous-source lower injection margin and covariance bounds.",
     ]
+    if report["status"] != "PASS":
+        out.extend([
+            "",
+            f"Held selected failure reasons: {h.get('failure_reasons', [])}",
+            f"Active selected failure reasons: {a.get('failure_reasons', [])}",
+        ])
     return "\n".join(out)
 
 
@@ -299,6 +340,7 @@ def main() -> int:
         "metric": "M(g)=Sigma_KF(g)^(-1)",
         "metric_provenance": "actual estimator Riccati/Joseph covariance, not empirical truth-error covariance",
         "identity": "1-lambda_information=lambda_min(Sigma1^-1/2 Omega Sigma1^-1/2), Omega=Sigma1-Phi Sigma0 Phi^T",
+        "identity_evaluation": "relative injection evaluated as I-C C^T with C=Sigma1^-1/2 Phi Sigma0^1/2",
         "identity_absolute_tolerance": IDENTITY_ABS_TOL,
         "held": held,
         "active": active,

--- a/tools/ou3_information_certificate.py
+++ b/tools/ou3_information_certificate.py
@@ -218,16 +218,21 @@ def evaluate_horizon(records: dict[str, tuple[list[BASE.MapBlock], list[CovBlock
     omg = np.asarray(omega_mins, float)
     ids = np.asarray(identity_residuals, float)
     if not len(arr):
+        failures = ["NO_VALID_WORDS"]
+        if invalid_spd:
+            failures.append("NON_SPD_COVARIANCE")
         return {"mode": mode, "horizon_s": horizon_s, "status": "NO_WORDS",
-                "word_count": word_count, "failure_reasons": ["NO_VALID_WORDS"],
-                "information_pass": False}
-    covariance_consistent = invalid_spd == 0 and float(np.min(omg)) >= -PSD_REL_TOL
+                "word_count": word_count, "invalid_spd_words": invalid_spd,
+                "failure_reasons": failures, "information_pass": False}
+    covariance_spd_valid = invalid_spd == 0
+    relative_injection_psd = float(np.min(omg)) >= -PSD_REL_TOL
+    covariance_consistent = covariance_spd_valid and relative_injection_psd
     identity_consistent = float(np.max(ids)) <= IDENTITY_ABS_TOL
     strict = float(np.max(arr)) < 1.0 - STRICT_LAMBDA_TOL
     failures = []
-    if invalid_spd:
+    if not covariance_spd_valid:
         failures.append("NON_SPD_COVARIANCE")
-    if not covariance_consistent:
+    if not relative_injection_psd:
         failures.append("COVARIANCE_RECURSION_NOT_PSD")
     if not identity_consistent:
         failures.append("INFORMATION_IDENTITY_NUMERICS")
@@ -255,6 +260,8 @@ def evaluate_horizon(records: dict[str, tuple[list[BASE.MapBlock], list[CovBlock
         "Sigma_endpoint_lambda_min": sigma_min,
         "Sigma_endpoint_lambda_max": sigma_max,
         "Sigma_endpoint_condition_bound": sigma_max / sigma_min,
+        "covariance_spd_valid": bool(covariance_spd_valid),
+        "relative_injection_psd_consistent": bool(relative_injection_psd),
         "covariance_recursion_consistent": bool(covariance_consistent),
         "information_pass": bool(passed),
         "worst_word": None if worst is None else {

--- a/tools/ou3_neighborhood_diagnostic.py
+++ b/tools/ou3_neighborhood_diagnostic.py
@@ -20,6 +20,7 @@ neighborhood or deployment theorem without outward-rounded enclosure.
 from __future__ import annotations
 
 import argparse
+from concurrent.futures import ThreadPoolExecutor, as_completed
 import fnmatch
 import json
 import math
@@ -231,6 +232,8 @@ def main() -> int:
     ap.add_argument("--active-time-s", type=float, default=DEFAULT_ACTIVE_TIME_S)
     ap.add_argument("--full-basis", action="store_true")
     ap.add_argument("--positive-only", action="store_true")
+    ap.add_argument("--jobs", type=int, default=1,
+                    help="parallel simulator subprocesses; result ordering remains deterministic")
     ap.add_argument("--no-build", action="store_true")
     args = ap.parse_args()
 
@@ -242,6 +245,8 @@ def main() -> int:
     out.mkdir(parents=True, exist_ok=True)
     diag.mkdir(parents=True, exist_ok=True)
 
+    if args.jobs < 1:
+        raise ValueError("--jobs must be >= 1")
     if not args.no_build:
         subprocess.run(["make", "-C", str(BASE.TEST_DIR), sim.name], check=True)
     if not sim.exists():
@@ -256,7 +261,7 @@ def main() -> int:
         raise ValueError("--target-W entries must be finite positive")
     signs = (1,) if args.positive_only else (-1, 1)
 
-    cases = []
+    tasks = []
     for family, hs, name in select_records(args.records):
         data = (data_dir / name).resolve()
         if not data.exists():
@@ -281,17 +286,12 @@ def main() -> int:
                             f"{record_slug(family, hs)}_{mode}_{BLOCK_NAME[index]}_"
                             f"{'p' if sign > 0 else 'm'}_W{target:.6g}"
                         ).replace(".", "_")
-                        trace = diag / f"{case_id}.csv"
-                        log = diag / f"{case_id}.log"
-                        rc, stdout = run_case(
-                            sim, data, trace, log, mode, inject_s, horizon_s, d21
-                        )
-                        result = parse_trace(trace)
-                        result.update({
+                        tasks.append({
                             "case": case_id,
                             "family": family,
                             "Hs_m": hs,
                             "source_file": name,
+                            "data": data,
                             "mode": mode,
                             "coordinate": index,
                             "direction": BLOCK_NAME[index],
@@ -299,12 +299,47 @@ def main() -> int:
                             "target_W": target,
                             "requested_injection_time_s": inject_s,
                             "word_horizon_s": horizon_s,
-                            "delta_21": [float(x) for x in d21],
+                            "delta_21": d21,
                             "covariance_reference": cov_meta,
-                            "sim_returncode": int(rc),
-                            "sim_completed_marker": "OU3_NEIGHBOR_DONE" in stdout,
+                            "trace": diag / f"{case_id}.csv",
+                            "log": diag / f"{case_id}.log",
                         })
-                        cases.append(result)
+
+    def execute(task: dict) -> dict:
+        rc, stdout = run_case(
+            sim, task["data"], task["trace"], task["log"], task["mode"],
+            task["requested_injection_time_s"], task["word_horizon_s"],
+            task["delta_21"],
+        )
+        result = parse_trace(task["trace"])
+        result.update({
+            "case": task["case"],
+            "family": task["family"],
+            "Hs_m": task["Hs_m"],
+            "source_file": task["source_file"],
+            "mode": task["mode"],
+            "coordinate": task["coordinate"],
+            "direction": task["direction"],
+            "sign": task["sign"],
+            "target_W": task["target_W"],
+            "requested_injection_time_s": task["requested_injection_time_s"],
+            "word_horizon_s": task["word_horizon_s"],
+            "delta_21": [float(x) for x in task["delta_21"]],
+            "covariance_reference": task["covariance_reference"],
+            "sim_returncode": int(rc),
+            "sim_completed_marker": "OU3_NEIGHBOR_DONE" in stdout,
+        })
+        return result
+
+    cases = []
+    if args.jobs == 1:
+        cases = [execute(task) for task in tasks]
+    else:
+        with ThreadPoolExecutor(max_workers=args.jobs) as pool:
+            futures = [pool.submit(execute, task) for task in tasks]
+            for future in as_completed(futures):
+                cases.append(future.result())
+    cases.sort(key=lambda c: c.get("case", ""))
 
     valid = [c for c in cases if c.get("status") in ("PASS_SAMPLED", "FAIL_SAMPLED")]
     all_pass = bool(valid) and len(valid) == len(cases) and all(c["pass_sampled"] for c in valid)

--- a/tools/ou3_neighborhood_radius_search.py
+++ b/tools/ou3_neighborhood_radius_search.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Locate the first sampled nonlinear-neighborhood boundary for OU-III.
+
+This tool repeatedly runs the full information-normalized coordinate sweep from
+``ou3_neighborhood_diagnostic.py`` at a common information energy W.  It first
+expands W geometrically until the full eight-sea H/A basis ceases to pass, then
+bisects the last-pass/first-fail bracket in log W.
+
+The result is deliberately a *sampled numerical basin estimate*.  It cannot
+promote the nonlinear or deployment theorem; promotion still requires validated
+outward-rounded bounds for the complete continuous source/neighborhood family.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+import subprocess
+import sys
+
+import ou3_numerical_certificate as BASE
+
+REPO = Path(__file__).resolve().parents[1]
+DRIVER = REPO / "tools" / "ou3_neighborhood_diagnostic.py"
+DEFAULT_OUT = BASE.DEFAULT_OUT / "neighborhood_radius_search"
+DEFAULT_DIAG = REPO / "reports" / "diagnostics" / "ou3_neighborhood_radius"
+
+
+def classify_case_failure(case: dict) -> str | None:
+    """Classify the first observable sampled safety obstruction for one case."""
+    if case.get("pass_sampled"):
+        return None
+    if case.get("status") not in ("PASS_SAMPLED", "FAIL_SAMPLED"):
+        return "TRACE_OR_TOOL_FAILURE"
+    if case.get("source_match_all") is False:
+        return "SOURCE_WORD_IDENTITY"
+    if case.get("measurement_acceptance_match_all") is False:
+        return "MEASUREMENT_GATING_CONSISTENCY"
+    theta = case.get("theta_max_rad")
+    try:
+        if theta is None or not math.isfinite(float(theta)):
+            return "PREFIX_FINITE_SAFETY"
+        if float(theta) >= math.pi:
+            return "SO3_CHART_SAFETY"
+    except (TypeError, ValueError):
+        return "PREFIX_FINITE_SAFETY"
+    try:
+        W0 = float(case.get("W0"))
+        W1 = float(case.get("W1"))
+        if not (math.isfinite(W0) and math.isfinite(W1) and W0 > 0.0):
+            return "PREFIX_FINITE_SAFETY"
+        if not W1 < W0:
+            return "POSITIVE_W_DECREASE"
+    except (TypeError, ValueError):
+        return "PREFIX_FINITE_SAFETY"
+    return "PREFIX_OR_UNCLASSIFIED_SAFETY"
+
+
+def summarize_round(report: dict, target_W: float) -> dict:
+    cases = list(report.get("cases") or [])
+    failures = []
+    for case in cases:
+        reason = classify_case_failure(case)
+        if reason is not None:
+            failures.append({
+                "case": case.get("case"),
+                "reason": reason,
+                "mode": case.get("mode"),
+                "direction": case.get("direction"),
+                "sign": case.get("sign"),
+                "family": case.get("family"),
+                "Hs_m": case.get("Hs_m"),
+                "relative_decrement": case.get("relative_decrement"),
+                "theta_max_rad": case.get("theta_max_rad"),
+                "prefix_W_gain_max": case.get("prefix_W_gain_max"),
+            })
+    passed = report.get("status") == "PASS_SAMPLED" and not failures
+    reason_counts: dict[str, int] = {}
+    for failure in failures:
+        reason = failure["reason"]
+        reason_counts[reason] = reason_counts.get(reason, 0) + 1
+    return {
+        "target_W": float(target_W),
+        "pass_all_sampled": bool(passed),
+        "case_count": report.get("case_count"),
+        "valid_endpoint_case_count": report.get("valid_endpoint_case_count"),
+        "relative_decrement_min": report.get("relative_decrement_min"),
+        "theta_max_rad": report.get("theta_max_rad"),
+        "prefix_W_gain_max": report.get("prefix_W_gain_max"),
+        "failure_reason_counts": reason_counts,
+        "first_failures": failures[:16],
+    }
+
+
+def run_round(args, target_W: float, round_index: int) -> dict:
+    round_root = args.diagnostic_dir.resolve() / f"round_{round_index:02d}_W{target_W:.12g}"
+    result_dir = round_root / "result"
+    trace_dir = round_root / "traces"
+    result_dir.mkdir(parents=True, exist_ok=True)
+    trace_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        sys.executable, str(DRIVER),
+        "--no-build",
+        "--certificate-dir", str(args.certificate_dir.resolve()),
+        "--data-dir", str(args.data_dir.resolve()),
+        "--sim", str(args.sim.resolve()),
+        "--output-dir", str(result_dir),
+        "--diagnostic-dir", str(trace_dir),
+        "--full-basis",
+        "--target-W", f"{target_W:.17g}",
+        "--jobs", str(args.jobs),
+    ]
+    p = subprocess.run(cmd, cwd=REPO, text=True, stdout=subprocess.PIPE,
+                       stderr=subprocess.STDOUT)
+    (round_root / "driver.log").write_text(p.stdout)
+    result_path = result_dir / "neighborhood_diagnostic.json"
+    if p.returncode != 0 or not result_path.exists():
+        return {
+            "target_W": float(target_W),
+            "pass_all_sampled": False,
+            "case_count": 0,
+            "valid_endpoint_case_count": 0,
+            "failure_reason_counts": {"TRACE_OR_TOOL_FAILURE": 1},
+            "first_failures": [{"case": None, "reason": "TRACE_OR_TOOL_FAILURE"}],
+            "driver_returncode": int(p.returncode),
+        }
+    report = json.loads(result_path.read_text())
+    ans = summarize_round(report, target_W)
+    ans["driver_returncode"] = int(p.returncode)
+    return ans
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--certificate-dir", type=Path, default=BASE.DEFAULT_OUT)
+    ap.add_argument("--data-dir", type=Path, default=BASE.DEFAULT_DATA_DIR)
+    ap.add_argument("--sim", type=Path, default=BASE.TEST_DIR / "ou3-neighborhood-sim")
+    ap.add_argument("--output-dir", type=Path, default=DEFAULT_OUT)
+    ap.add_argument("--diagnostic-dir", type=Path, default=DEFAULT_DIAG)
+    ap.add_argument("--start-W", type=float, default=0.05)
+    ap.add_argument("--growth", type=float, default=4.0)
+    ap.add_argument("--max-W", type=float, default=3276.8)
+    ap.add_argument("--bisection-steps", type=int, default=5)
+    ap.add_argument("--jobs", type=int, default=4)
+    args = ap.parse_args()
+
+    if not (args.start_W > 0.0 and math.isfinite(args.start_W)):
+        raise ValueError("--start-W must be finite positive")
+    if not (args.growth > 1.0 and math.isfinite(args.growth)):
+        raise ValueError("--growth must be finite and > 1")
+    if not (args.max_W >= args.start_W and math.isfinite(args.max_W)):
+        raise ValueError("--max-W must be finite and >= --start-W")
+    if args.bisection_steps < 0 or args.jobs < 1:
+        raise ValueError("--bisection-steps must be >= 0 and --jobs >= 1")
+    if not args.sim.resolve().exists():
+        raise FileNotFoundError(args.sim.resolve())
+
+    out = args.output_dir.resolve()
+    diag = args.diagnostic_dir.resolve()
+    out.mkdir(parents=True, exist_ok=True)
+    diag.mkdir(parents=True, exist_ok=True)
+
+    rounds = []
+    round_index = 0
+    w = args.start_W
+    last_pass = None
+    first_fail = None
+
+    while w <= args.max_W * (1.0 + 1e-12):
+        r = run_round(args, w, round_index)
+        rounds.append(r)
+        round_index += 1
+        if r["pass_all_sampled"]:
+            last_pass = w
+            w *= args.growth
+        else:
+            first_fail = w
+            break
+
+    if first_fail is not None and last_pass is not None:
+        lo = last_pass
+        hi = first_fail
+        for _ in range(args.bisection_steps):
+            mid = math.sqrt(lo * hi)
+            r = run_round(args, mid, round_index)
+            rounds.append(r)
+            round_index += 1
+            if r["pass_all_sampled"]:
+                lo = mid
+            else:
+                hi = mid
+        last_pass = lo
+        first_fail = hi
+
+    # Sort only for presentation; execution order is retained in round_index in
+    # diagnostics.  The scientific boundary is the pass/fail bracket itself.
+    first_failure_summary = None
+    if first_fail is not None:
+        failing = min(
+            (r for r in rounds if not r["pass_all_sampled"]),
+            key=lambda r: abs(math.log(r["target_W"] / first_fail)),
+        )
+        first_failure_summary = {
+            "target_W": failing["target_W"],
+            "failure_reason_counts": failing.get("failure_reason_counts", {}),
+            "first_failures": failing.get("first_failures", []),
+        }
+
+    report = {
+        "schema": 1,
+        "status": (
+            "BRACKETED_SAMPLED_BOUNDARY" if first_fail is not None and last_pass is not None
+            else "NO_SAMPLED_FAILURE_THROUGH_MAX_W" if first_fail is None and last_pass is not None
+            else "FAILED_AT_INITIAL_RADIUS"
+        ),
+        "qualification": "SAMPLED_NUMERICAL_BASIN_ESTIMATE_ONLY_NOT_A_VALIDATED_CERTIFICATE",
+        "metric_radius_definition": "W=zeta^T Sigma_nominal^-1 zeta",
+        "all_coordinates_both_signs": True,
+        "all_eight_reference_seas": True,
+        "last_all_pass_W": last_pass,
+        "first_fail_W": first_fail,
+        "information_radius_last_pass_sqrt_W": math.sqrt(last_pass) if last_pass is not None else None,
+        "information_radius_first_fail_sqrt_W": math.sqrt(first_fail) if first_fail is not None else None,
+        "first_failure": first_failure_summary,
+        "rounds": rounds,
+        "numerical_neighborhood_certificate": "NOT_ESTABLISHED",
+        "deployment_theorem_certificate": "NOT_ESTABLISHED",
+    }
+    (out / "neighborhood_radius_search.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True)
+    )
+    print(json.dumps({
+        "status": report["status"],
+        "last_all_pass_W": report["last_all_pass_W"],
+        "first_fail_W": report["first_fail_W"],
+        "first_failure": report["first_failure"],
+    }, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Goal
Continue the stability proof/certificate work from merged PR #396 without changing or retuning the deployed OU-III filter.

## Step 1: information-certificate FAIL
The latest eight-sea run had strict contraction in both modes, but the aggregate information certificate reported FAIL. The failing sub-gate was isolated to the numerical Riccati-identity consistency check, not SPD, covariance PSD consistency, source-word validity, or strict contraction.

The previous implementation evaluated the two sides through cancellation-prone physical-coordinate formulas on float32 covariance/map artifacts whose eigenvalues span many orders of magnitude. This PR evaluates the same exact identity in endpoint-whitened coordinates with

`C = Sigma1^(-1/2) Phi Sigma0^(1/2)`

so that

`lambda_information = lambda_max(C^T C)` and `relative injection = I - C C^T`.

No scientific tolerance is relaxed. The filter, covariance recursion, source words, and tuning are unchanged.

Also added explicit per-horizon failure reasons and a regression test reproducing the ill-conditioned float32 numerical failure.

## Next work in this PR
1. verify the information certificate returns PASS on the eight noisy reference seas;
2. run the full information-normalized nonlinear neighborhood sweep over attitude, gyro bias, velocity, position, S, OU acceleration, and active-mode accelerometer bias;
3. expand the radius until the first source-word / W-decrease / chart / prefix / measurement-gating failure;
4. keep all validated continuous-source, hybrid-funnel, stochastic, and deployment theorem promotions blocked until their own proof obligations are discharged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved information certificate calculations for low-precision and poorly conditioned covariance inputs.
  - Increased numerical stability when evaluating covariance and identity conditions.
  - Certificates now more accurately distinguish successful and failed evaluations.

- **Improvements**
  - Reports now include the evaluation approach and, when applicable, clear reasons for failure.
  - Added regression coverage for challenging numerical scenarios to help prevent future regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->