### PR TITLE
Locate OU-III nonlinear sampled basin boundary

### DIFF
--- a/.github/workflows/ou3-numerical-certificate.yml
+++ b/.github/workflows/ou3-numerical-certificate.yml
@@ -121,7 +121,7 @@ jobs:
             --target-W 0.05 \
             --jobs 4
 
-      - name: Locate sampled nonlinear neighborhood boundary
+      - name: Locate sampled nonlinear H/A neighborhood boundaries
         run: |
           python3 -u tools/ou3_neighborhood_radius_search.py \
             --sim "$GITHUB_WORKSPACE/tests/kalman_ou_iii/ou3-neighborhood-sim" \
@@ -129,10 +129,11 @@ jobs:
             --data-dir "$GITHUB_WORKSPACE/plots/kalman_ou_ii" \
             --output-dir "$GITHUB_WORKSPACE/reports/results/ou3_numerical_certificate/neighborhood_radius_search" \
             --diagnostic-dir "$GITHUB_WORKSPACE/reports/diagnostics/ou3_numerical_certificate/neighborhood_radius" \
+            --modes H,A \
             --start-W 0.05 \
-            --growth 4 \
-            --max-W 204.8 \
-            --bisection-steps 3 \
+            --growth 16 \
+            --max-W 838860.8 \
+            --bisection-steps 5 \
             --jobs 4
 
       - name: Validate deterministic scientific result payloads

--- a/.github/workflows/ou3-numerical-certificate.yml
+++ b/.github/workflows/ou3-numerical-certificate.yml
@@ -115,6 +115,8 @@ jobs:
             --sim "$GITHUB_WORKSPACE/tests/kalman_ou_iii/ou3-neighborhood-sim" \
             --certificate-dir "$GITHUB_WORKSPACE/reports/results/ou3_numerical_certificate" \
             --data-dir "$GITHUB_WORKSPACE/plots/kalman_ou_ii" \
+            --output-dir "$GITHUB_WORKSPACE/reports/results/ou3_numerical_certificate/neighborhood_diagnostic" \
+            --diagnostic-dir "$GITHUB_WORKSPACE/reports/diagnostics/ou3_numerical_certificate/neighborhood_full" \
             --full-basis \
             --target-W 0.05 \
             --jobs 4
@@ -125,6 +127,8 @@ jobs:
             --sim "$GITHUB_WORKSPACE/tests/kalman_ou_iii/ou3-neighborhood-sim" \
             --certificate-dir "$GITHUB_WORKSPACE/reports/results/ou3_numerical_certificate" \
             --data-dir "$GITHUB_WORKSPACE/plots/kalman_ou_ii" \
+            --output-dir "$GITHUB_WORKSPACE/reports/results/ou3_numerical_certificate/neighborhood_radius_search" \
+            --diagnostic-dir "$GITHUB_WORKSPACE/reports/diagnostics/ou3_numerical_certificate/neighborhood_radius" \
             --start-W 0.05 \
             --growth 4 \
             --max-W 204.8 \

--- a/tests/validation/test_ou3_neighborhood_diagnostic.py
+++ b/tests/validation/test_ou3_neighborhood_diagnostic.py
@@ -1,8 +1,10 @@
 import importlib.util
 from pathlib import Path
+from types import SimpleNamespace
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 import numpy as np
 
@@ -31,6 +33,47 @@ class Ou3NeighborhoodDiagnosticTests(unittest.TestCase):
     def test_held_compact_basis_never_injects_accel_bias(self):
         self.assertTrue(all(i < 18 for i in MOD.COMPACT_H))
         self.assertIn(18, MOD.COMPACT_A)
+
+    def test_certified_source_selector_uses_complete_word_start(self):
+        maps = [
+            SimpleNamespace(t0=59.75 + 0.25 * i, t1=60.0 + 0.25 * i,
+                            start_live=True, end_live=True)
+            for i in range(6)
+        ]
+        covs = [SimpleNamespace(start=np.eye(21), end=np.eye(21)) for _ in maps]
+
+        def physical_word(_maps, _covs, mode, start, count):
+            self.assertEqual(mode, "A")
+            self.assertEqual(count, 2)
+            return np.eye(21), np.eye(21), np.eye(21)
+
+        with mock.patch.object(MOD.INFO, "pair_map_covariance",
+                               return_value=(maps, covs, {"ok": True})), \
+             mock.patch.object(MOD.INFO, "physical_word", side_effect=physical_word):
+            P, meta = MOD.certified_word_start_covariance(
+                Path("record_exact_maps.bin"), 60.11, 21, "A", 0.5
+            )
+
+        np.testing.assert_allclose(P, np.eye(21))
+        self.assertEqual(meta["side"], "start")
+        self.assertAlmostEqual(meta["selected_source_time_s"], 60.0)
+        self.assertAlmostEqual(meta["word_end_time_s"], 60.5)
+        self.assertAlmostEqual(meta["word_actual_duration_s"], 0.5)
+        self.assertEqual(meta["word_block_count"], 2)
+
+    def test_case_driver_preserves_exact_source_time_digits(self):
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            fake = SimpleNamespace(returncode=0, stdout="done")
+            with mock.patch.object(MOD.subprocess, "run", return_value=fake) as run:
+                MOD.run_case(
+                    Path("/tmp/fake-sim"), td / "data.csv", td / "trace.csv",
+                    td / "case.log", "A", 299.886962890625, 16.015625,
+                    np.zeros(21),
+                )
+            env = run.call_args.kwargs["env"]
+        self.assertEqual(env["OU3_NEIGHBOR_INJECT_TIME_S"], "299.886962890625")
+        self.assertEqual(env["OU3_NEIGHBOR_HORIZON_S"], "16.015625")
 
     def test_pair_trace_requires_source_match_and_contraction(self):
         header = (

--- a/tests/validation/test_ou3_neighborhood_radius_search.py
+++ b/tests/validation/test_ou3_neighborhood_radius_search.py
@@ -28,10 +28,17 @@ class Ou3NeighborhoodRadiusSearchTests(unittest.TestCase):
             "W1": 0.9,
         }
 
-    def test_source_word_failure_has_priority(self):
+    def test_measurement_gate_failure_has_priority_when_both_flags_drop(self):
         c = self.base_case()
         c["source_match_all"] = False
         c["measurement_acceptance_match_all"] = False
+        self.assertEqual(
+            MOD.classify_case_failure(c), "MEASUREMENT_GATING_CONSISTENCY"
+        )
+
+    def test_source_word_failure_is_distinct_without_gate_divergence(self):
+        c = self.base_case()
+        c["source_match_all"] = False
         self.assertEqual(MOD.classify_case_failure(c), "SOURCE_WORD_IDENTITY")
 
     def test_measurement_gate_failure_is_distinct(self):

--- a/tools/ou3_neighborhood_diagnostic.py
+++ b/tools/ou3_neighborhood_diagnostic.py
@@ -68,28 +68,65 @@ def record_index() -> dict[str, tuple[str, float, str]]:
     return out
 
 
-def nearest_covariance(map_path: Path, t: float, dim: int) -> tuple[np.ndarray, dict]:
-    maps, covs, meta = INFO.pair_map_covariance(map_path, map_path.stem.replace("_exact_maps", ""))
-    candidates = []
-    for i, (m, c) in enumerate(zip(maps, covs)):
-        candidates.append((abs(m.t0 - t), i, "start", c.start))
-        candidates.append((abs(m.t1 - t), i, "end", c.end))
-    if not candidates:
+def certified_word_start_covariance(map_path: Path, requested_t: float, dim: int,
+                                    mode: str, horizon_s: float) -> tuple[np.ndarray, dict]:
+    """Select an actual certified source-word start near the requested time.
+
+    Exact-map/covariance blocks are event/stride aligned, not aligned to round
+    wall-clock times such as 60 or 300 s.  The old driver required a covariance
+    endpoint within 20 ms of those round times, which could abort before any
+    nonlinear case ran.  Instead choose the closest *start* of a complete,
+    valid, live, non-hybrid information word in the requested mode and inject at
+    that exact source time.  This changes no tolerance and keeps the
+    perturbation normalized by the covariance at the source actually replayed.
+    """
+    maps, covs, pairing_meta = INFO.pair_map_covariance(
+        map_path, map_path.stem.replace("_exact_maps", "")
+    )
+    if not maps:
         raise RuntimeError(f"no covariance blocks in {map_path}")
-    dt, i, side, P = min(candidates, key=lambda x: x[0])
-    if dt > 0.02:
-        raise RuntimeError(f"no covariance endpoint within 20 ms of t={t}: nearest {dt}")
+    durations = [b.t1 - b.t0 for b in maps if b.t1 > b.t0]
+    if not durations:
+        raise RuntimeError(f"no positive-duration map blocks in {map_path}")
+    base = float(np.median(durations))
+    count = max(1, int(round(horizon_s / base)))
+
+    candidates = []
+    for i in range(len(maps) - count + 1):
+        seq = maps[i:i + count]
+        if not all(b.start_live and b.end_live for b in seq):
+            continue
+        word = INFO.physical_word(maps, covs, mode, i, count)
+        if word is None:
+            continue
+        _, P0, _ = word
+        selected_t = float(seq[0].t0)
+        candidates.append((abs(selected_t - requested_t), selected_t, i, P0, seq[-1].t1))
+
+    if not candidates:
+        raise RuntimeError(
+            f"no complete live {mode} covariance word of {horizon_s:g}s in {map_path}"
+        )
+    distance, selected_t, i, P, word_end_t = min(candidates, key=lambda x: (x[0], x[1]))
     P = np.asarray(P[:dim, :dim], float)
     P = 0.5 * (P + P.T)
     eig = np.linalg.eigvalsh(P)
     if not np.all(np.isfinite(eig)) or float(np.min(eig)) <= 0.0:
-        raise RuntimeError(f"non-SPD covariance at {map_path} block {i} {side}")
+        raise RuntimeError(f"non-SPD covariance at {map_path} block {i} start")
     return P, {
-        "block": i,
-        "side": side,
-        "time_distance_s": float(dt),
+        "block": int(i),
+        "side": "start",
+        "requested_reference_time_s": float(requested_t),
+        "selected_source_time_s": float(selected_t),
+        "reference_time_shift_s": float(selected_t - requested_t),
+        "reference_time_distance_s": float(distance),
+        "word_end_time_s": float(word_end_t),
+        "word_block_count": int(count),
+        "word_horizon_requested_s": float(horizon_s),
+        "block_duration_median_s": float(base),
         "lambda_min": float(np.min(eig)),
         "lambda_max": float(np.max(eig)),
+        "pairing": pairing_meta,
     }
 
 
@@ -273,9 +310,12 @@ def main() -> int:
 
         for mode in modes:
             dim = 18 if mode == "H" else 21
-            inject_s = args.held_time_s if mode == "H" else args.active_time_s
+            preferred_inject_s = args.held_time_s if mode == "H" else args.active_time_s
             horizon_s = float(contract["modes"][mode]["recommended_word_horizon_s"])
-            P, cov_meta = nearest_covariance(map_path, inject_s, dim)
+            P, cov_meta = certified_word_start_covariance(
+                map_path, preferred_inject_s, dim, mode, horizon_s
+            )
+            inject_s = float(cov_meta["selected_source_time_s"])
             indices = tuple(range(dim)) if args.full_basis else (COMPACT_H if mode == "H" else COMPACT_A)
             for target in targets:
                 for index in indices:
@@ -297,6 +337,7 @@ def main() -> int:
                             "direction": BLOCK_NAME[index],
                             "sign": sign,
                             "target_W": target,
+                            "preferred_injection_time_s": preferred_inject_s,
                             "requested_injection_time_s": inject_s,
                             "word_horizon_s": horizon_s,
                             "delta_21": d21,
@@ -322,6 +363,7 @@ def main() -> int:
             "direction": task["direction"],
             "sign": task["sign"],
             "target_W": task["target_W"],
+            "preferred_injection_time_s": task["preferred_injection_time_s"],
             "requested_injection_time_s": task["requested_injection_time_s"],
             "word_horizon_s": task["word_horizon_s"],
             "delta_21": [float(x) for x in task["delta_21"]],

--- a/tools/ou3_neighborhood_diagnostic.py
+++ b/tools/ou3_neighborhood_diagnostic.py
@@ -121,6 +121,7 @@ def certified_word_start_covariance(map_path: Path, requested_t: float, dim: int
         "reference_time_shift_s": float(selected_t - requested_t),
         "reference_time_distance_s": float(distance),
         "word_end_time_s": float(word_end_t),
+        "word_actual_duration_s": float(word_end_t - selected_t),
         "word_block_count": int(count),
         "word_horizon_requested_s": float(horizon_s),
         "block_duration_median_s": float(base),
@@ -234,8 +235,8 @@ def run_case(sim: Path, data: Path, trace: Path, log: Path,
     env = os.environ.copy()
     env.update({
         "OU3_NEIGHBOR_TRACE": str(trace.resolve()),
-        "OU3_NEIGHBOR_INJECT_TIME_S": f"{inject_s:.9g}",
-        "OU3_NEIGHBOR_HORIZON_S": f"{horizon_s:.9g}",
+        "OU3_NEIGHBOR_INJECT_TIME_S": f"{inject_s:.17g}",
+        "OU3_NEIGHBOR_HORIZON_S": f"{horizon_s:.17g}",
         "OU3_NEIGHBOR_MODE": mode,
         "OU3_NEIGHBOR_DELTA": ",".join(f"{x:.17g}" for x in delta21),
         "OU3_NEIGHBOR_TRACE_STRIDE": "50",
@@ -311,11 +312,12 @@ def main() -> int:
         for mode in modes:
             dim = 18 if mode == "H" else 21
             preferred_inject_s = args.held_time_s if mode == "H" else args.active_time_s
-            horizon_s = float(contract["modes"][mode]["recommended_word_horizon_s"])
+            certified_horizon_s = float(contract["modes"][mode]["recommended_word_horizon_s"])
             P, cov_meta = certified_word_start_covariance(
-                map_path, preferred_inject_s, dim, mode, horizon_s
+                map_path, preferred_inject_s, dim, mode, certified_horizon_s
             )
             inject_s = float(cov_meta["selected_source_time_s"])
+            replay_horizon_s = float(cov_meta["word_actual_duration_s"])
             indices = tuple(range(dim)) if args.full_basis else (COMPACT_H if mode == "H" else COMPACT_A)
             for target in targets:
                 for index in indices:
@@ -339,7 +341,8 @@ def main() -> int:
                             "target_W": target,
                             "preferred_injection_time_s": preferred_inject_s,
                             "requested_injection_time_s": inject_s,
-                            "word_horizon_s": horizon_s,
+                            "certified_word_horizon_s": certified_horizon_s,
+                            "word_horizon_s": replay_horizon_s,
                             "delta_21": d21,
                             "covariance_reference": cov_meta,
                             "trace": diag / f"{case_id}.csv",
@@ -365,12 +368,33 @@ def main() -> int:
             "target_W": task["target_W"],
             "preferred_injection_time_s": task["preferred_injection_time_s"],
             "requested_injection_time_s": task["requested_injection_time_s"],
+            "certified_word_horizon_s": task["certified_word_horizon_s"],
             "word_horizon_s": task["word_horizon_s"],
             "delta_21": [float(x) for x in task["delta_21"]],
             "covariance_reference": task["covariance_reference"],
             "sim_returncode": int(rc),
             "sim_completed_marker": "OU3_NEIGHBOR_DONE" in stdout,
         })
+        if result.get("actual_injection_time_s") is not None:
+            inject_err = abs(
+                float(result["actual_injection_time_s"])
+                - float(task["covariance_reference"]["selected_source_time_s"])
+            )
+            result["injection_source_time_error_s"] = inject_err
+        if result.get("actual_endpoint_time_s") is not None:
+            endpoint_err = abs(
+                float(result["actual_endpoint_time_s"])
+                - float(task["covariance_reference"]["word_end_time_s"])
+            )
+            result["endpoint_source_time_error_s"] = endpoint_err
+        aligned = (
+            result.get("injection_source_time_error_s", math.inf) <= 1.0e-5
+            and result.get("endpoint_source_time_error_s", math.inf) <= 6.0e-3
+        )
+        result["source_time_alignment_ok"] = bool(aligned)
+        if result.get("status") in ("PASS_SAMPLED", "FAIL_SAMPLED") and not aligned:
+            result["status"] = "SOURCE_TIME_MISALIGNMENT"
+            result["pass_sampled"] = False
         return result
 
     cases = []

--- a/tools/ou3_neighborhood_radius_search.py
+++ b/tools/ou3_neighborhood_radius_search.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Locate the first sampled nonlinear-neighborhood boundary for OU-III.
+"""Locate sampled nonlinear-neighborhood boundaries for OU-III H and A modes.
 
-This tool repeatedly runs the full information-normalized coordinate sweep from
-``ou3_neighborhood_diagnostic.py`` at a common information energy W.  It first
-expands W geometrically until the full eight-sea H/A basis ceases to pass, then
-bisects the last-pass/first-fail bracket in log W.
+For each requested mode this tool repeatedly runs the full information-normalized
+coordinate sweep from ``ou3_neighborhood_diagnostic.py`` at a common information
+energy W.  It expands W geometrically until that mode's full eight-sea basis
+ceases to pass, then bisects the last-pass/first-fail bracket in log W.
 
 The result is deliberately a *sampled numerical basin estimate*.  It cannot
 promote the nonlinear or deployment theorem; promotion still requires validated
@@ -31,12 +31,20 @@ def classify_case_failure(case: dict) -> str | None:
     """Classify the first observable sampled safety obstruction for one case."""
     if case.get("pass_sampled"):
         return None
-    if case.get("status") not in ("PASS_SAMPLED", "FAIL_SAMPLED"):
+    status = case.get("status")
+    if status == "SOURCE_TIME_MISALIGNMENT":
+        return "SOURCE_TIME_ALIGNMENT"
+    if status not in ("PASS_SAMPLED", "FAIL_SAMPLED"):
         return "TRACE_OR_TOOL_FAILURE"
-    if case.get("source_match_all") is False:
-        return "SOURCE_WORD_IDENTITY"
+
+    # The simulator's historical source_match field also drops when an
+    # acceptance decision differs.  Use the dedicated gate fields first so a
+    # gate bifurcation is not mislabeled as a source-parameter divergence.
     if case.get("measurement_acceptance_match_all") is False:
         return "MEASUREMENT_GATING_CONSISTENCY"
+    if case.get("source_match_all") is False:
+        return "SOURCE_WORD_IDENTITY"
+
     theta = case.get("theta_max_rad")
     try:
         if theta is None or not math.isfinite(float(theta)):
@@ -57,7 +65,7 @@ def classify_case_failure(case: dict) -> str | None:
     return "PREFIX_OR_UNCLASSIFIED_SAFETY"
 
 
-def summarize_round(report: dict, target_W: float) -> dict:
+def summarize_round(report: dict, target_W: float, mode: str | None = None) -> dict:
     cases = list(report.get("cases") or [])
     failures = []
     for case in cases:
@@ -74,6 +82,8 @@ def summarize_round(report: dict, target_W: float) -> dict:
                 "relative_decrement": case.get("relative_decrement"),
                 "theta_max_rad": case.get("theta_max_rad"),
                 "prefix_W_gain_max": case.get("prefix_W_gain_max"),
+                "W0": case.get("W0"),
+                "W1": case.get("W1"),
             })
     passed = report.get("status") == "PASS_SAMPLED" and not failures
     reason_counts: dict[str, int] = {}
@@ -81,6 +91,7 @@ def summarize_round(report: dict, target_W: float) -> dict:
         reason = failure["reason"]
         reason_counts[reason] = reason_counts.get(reason, 0) + 1
     return {
+        "mode": mode,
         "target_W": float(target_W),
         "pass_all_sampled": bool(passed),
         "case_count": report.get("case_count"),
@@ -89,12 +100,15 @@ def summarize_round(report: dict, target_W: float) -> dict:
         "theta_max_rad": report.get("theta_max_rad"),
         "prefix_W_gain_max": report.get("prefix_W_gain_max"),
         "failure_reason_counts": reason_counts,
-        "first_failures": failures[:16],
+        "first_failures": failures[:32],
     }
 
 
-def run_round(args, target_W: float, round_index: int) -> dict:
-    round_root = args.diagnostic_dir.resolve() / f"round_{round_index:02d}_W{target_W:.12g}"
+def run_round(args, mode: str, target_W: float, round_index: int) -> dict:
+    round_root = (
+        args.diagnostic_dir.resolve() / mode /
+        f"round_{round_index:02d}_W{target_W:.12g}"
+    )
     result_dir = round_root / "result"
     trace_dir = round_root / "traces"
     result_dir.mkdir(parents=True, exist_ok=True)
@@ -107,60 +121,37 @@ def run_round(args, target_W: float, round_index: int) -> dict:
         "--sim", str(args.sim.resolve()),
         "--output-dir", str(result_dir),
         "--diagnostic-dir", str(trace_dir),
+        "--modes", mode,
         "--full-basis",
         "--target-W", f"{target_W:.17g}",
         "--jobs", str(args.jobs),
     ]
-    p = subprocess.run(cmd, cwd=REPO, text=True, stdout=subprocess.PIPE,
-                       stderr=subprocess.STDOUT)
+    p = subprocess.run(
+        cmd, cwd=REPO, text=True, stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT
+    )
     (round_root / "driver.log").write_text(p.stdout)
     result_path = result_dir / "neighborhood_diagnostic.json"
     if p.returncode != 0 or not result_path.exists():
         return {
+            "mode": mode,
             "target_W": float(target_W),
             "pass_all_sampled": False,
             "case_count": 0,
             "valid_endpoint_case_count": 0,
             "failure_reason_counts": {"TRACE_OR_TOOL_FAILURE": 1},
-            "first_failures": [{"case": None, "reason": "TRACE_OR_TOOL_FAILURE"}],
+            "first_failures": [{
+                "case": None, "reason": "TRACE_OR_TOOL_FAILURE", "mode": mode
+            }],
             "driver_returncode": int(p.returncode),
         }
     report = json.loads(result_path.read_text())
-    ans = summarize_round(report, target_W)
+    ans = summarize_round(report, target_W, mode)
     ans["driver_returncode"] = int(p.returncode)
     return ans
 
 
-def main() -> int:
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--certificate-dir", type=Path, default=BASE.DEFAULT_OUT)
-    ap.add_argument("--data-dir", type=Path, default=BASE.DEFAULT_DATA_DIR)
-    ap.add_argument("--sim", type=Path, default=BASE.TEST_DIR / "ou3-neighborhood-sim")
-    ap.add_argument("--output-dir", type=Path, default=DEFAULT_OUT)
-    ap.add_argument("--diagnostic-dir", type=Path, default=DEFAULT_DIAG)
-    ap.add_argument("--start-W", type=float, default=0.05)
-    ap.add_argument("--growth", type=float, default=4.0)
-    ap.add_argument("--max-W", type=float, default=3276.8)
-    ap.add_argument("--bisection-steps", type=int, default=5)
-    ap.add_argument("--jobs", type=int, default=4)
-    args = ap.parse_args()
-
-    if not (args.start_W > 0.0 and math.isfinite(args.start_W)):
-        raise ValueError("--start-W must be finite positive")
-    if not (args.growth > 1.0 and math.isfinite(args.growth)):
-        raise ValueError("--growth must be finite and > 1")
-    if not (args.max_W >= args.start_W and math.isfinite(args.max_W)):
-        raise ValueError("--max-W must be finite and >= --start-W")
-    if args.bisection_steps < 0 or args.jobs < 1:
-        raise ValueError("--bisection-steps must be >= 0 and --jobs >= 1")
-    if not args.sim.resolve().exists():
-        raise FileNotFoundError(args.sim.resolve())
-
-    out = args.output_dir.resolve()
-    diag = args.diagnostic_dir.resolve()
-    out.mkdir(parents=True, exist_ok=True)
-    diag.mkdir(parents=True, exist_ok=True)
-
+def search_mode(args, mode: str) -> dict:
     rounds = []
     round_index = 0
     w = args.start_W
@@ -168,7 +159,7 @@ def main() -> int:
     first_fail = None
 
     while w <= args.max_W * (1.0 + 1e-12):
-        r = run_round(args, w, round_index)
+        r = run_round(args, mode, w, round_index)
         rounds.append(r)
         round_index += 1
         if r["pass_all_sampled"]:
@@ -183,7 +174,7 @@ def main() -> int:
         hi = first_fail
         for _ in range(args.bisection_steps):
             mid = math.sqrt(lo * hi)
-            r = run_round(args, mid, round_index)
+            r = run_round(args, mode, mid, round_index)
             rounds.append(r)
             round_index += 1
             if r["pass_all_sampled"]:
@@ -193,8 +184,13 @@ def main() -> int:
         last_pass = lo
         first_fail = hi
 
-    # Sort only for presentation; execution order is retained in round_index in
-    # diagnostics.  The scientific boundary is the pass/fail bracket itself.
+    if first_fail is not None and last_pass is not None:
+        status = "BRACKETED_SAMPLED_BOUNDARY"
+    elif first_fail is None and last_pass is not None:
+        status = "NO_SAMPLED_FAILURE_THROUGH_MAX_W"
+    else:
+        status = "FAILED_AT_INITIAL_RADIUS"
+
     first_failure_summary = None
     if first_fail is not None:
         failing = min(
@@ -204,26 +200,83 @@ def main() -> int:
         first_failure_summary = {
             "target_W": failing["target_W"],
             "failure_reason_counts": failing.get("failure_reason_counts", {}),
-            "first_failures": failing.get("first_failures", []),
+            "limiting_cases": failing.get("first_failures", []),
         }
 
-    report = {
-        "schema": 1,
-        "status": (
-            "BRACKETED_SAMPLED_BOUNDARY" if first_fail is not None and last_pass is not None
-            else "NO_SAMPLED_FAILURE_THROUGH_MAX_W" if first_fail is None and last_pass is not None
-            else "FAILED_AT_INITIAL_RADIUS"
+    return {
+        "mode": mode,
+        "status": status,
+        "last_all_pass_W": last_pass,
+        "first_fail_W": first_fail,
+        "information_radius_last_pass_sqrt_W": (
+            math.sqrt(last_pass) if last_pass is not None else None
         ),
+        "information_radius_first_fail_sqrt_W": (
+            math.sqrt(first_fail) if first_fail is not None else None
+        ),
+        "first_failure": first_failure_summary,
+        "rounds": rounds,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--certificate-dir", type=Path, default=BASE.DEFAULT_OUT)
+    ap.add_argument("--data-dir", type=Path, default=BASE.DEFAULT_DATA_DIR)
+    ap.add_argument("--sim", type=Path, default=BASE.TEST_DIR / "ou3-neighborhood-sim")
+    ap.add_argument("--output-dir", type=Path, default=DEFAULT_OUT)
+    ap.add_argument("--diagnostic-dir", type=Path, default=DEFAULT_DIAG)
+    ap.add_argument("--modes", default="H,A")
+    ap.add_argument("--start-W", type=float, default=0.05)
+    ap.add_argument("--growth", type=float, default=16.0)
+    ap.add_argument("--max-W", type=float, default=838860.8)
+    ap.add_argument("--bisection-steps", type=int, default=5)
+    ap.add_argument("--jobs", type=int, default=4)
+    args = ap.parse_args()
+
+    if not (args.start_W > 0.0 and math.isfinite(args.start_W)):
+        raise ValueError("--start-W must be finite positive")
+    if not (args.growth > 1.0 and math.isfinite(args.growth)):
+        raise ValueError("--growth must be finite and > 1")
+    if not (args.max_W >= args.start_W and math.isfinite(args.max_W)):
+        raise ValueError("--max-W must be finite and >= --start-W")
+    if args.bisection_steps < 0 or args.jobs < 1:
+        raise ValueError("--bisection-steps must be >= 0 and --jobs >= 1")
+    if not args.sim.resolve().exists():
+        raise FileNotFoundError(args.sim.resolve())
+    modes = [x.strip() for x in args.modes.split(",") if x.strip()]
+    if not modes or any(mode not in ("H", "A") for mode in modes):
+        raise ValueError("--modes accepts H,A")
+    modes = list(dict.fromkeys(modes))
+
+    out = args.output_dir.resolve()
+    diag = args.diagnostic_dir.resolve()
+    out.mkdir(parents=True, exist_ok=True)
+    diag.mkdir(parents=True, exist_ok=True)
+
+    mode_reports = {mode: search_mode(args, mode) for mode in modes}
+    statuses = [mode_reports[m]["status"] for m in modes]
+    if all(s == "BRACKETED_SAMPLED_BOUNDARY" for s in statuses):
+        status = "BRACKETED_H_A_SAMPLED_BOUNDARIES" if set(modes) == {"H", "A"} else statuses[0]
+    elif all(s == "NO_SAMPLED_FAILURE_THROUGH_MAX_W" for s in statuses):
+        status = "NO_SAMPLED_FAILURE_THROUGH_MAX_W"
+    else:
+        status = "INCOMPLETE_OR_MIXED_SAMPLED_BOUNDARIES"
+
+    report = {
+        "schema": 2,
+        "status": status,
         "qualification": "SAMPLED_NUMERICAL_BASIN_ESTIMATE_ONLY_NOT_A_VALIDATED_CERTIFICATE",
         "metric_radius_definition": "W=zeta^T Sigma_nominal^-1 zeta",
         "all_coordinates_both_signs": True,
         "all_eight_reference_seas": True,
-        "last_all_pass_W": last_pass,
-        "first_fail_W": first_fail,
-        "information_radius_last_pass_sqrt_W": math.sqrt(last_pass) if last_pass is not None else None,
-        "information_radius_first_fail_sqrt_W": math.sqrt(first_fail) if first_fail is not None else None,
-        "first_failure": first_failure_summary,
-        "rounds": rounds,
+        "search": {
+            "start_W": float(args.start_W),
+            "growth": float(args.growth),
+            "max_W": float(args.max_W),
+            "bisection_steps": int(args.bisection_steps),
+        },
+        "modes": mode_reports,
         "numerical_neighborhood_certificate": "NOT_ESTABLISHED",
         "deployment_theorem_certificate": "NOT_ESTABLISHED",
     }
@@ -232,9 +285,15 @@ def main() -> int:
     )
     print(json.dumps({
         "status": report["status"],
-        "last_all_pass_W": report["last_all_pass_W"],
-        "first_fail_W": report["first_fail_W"],
-        "first_failure": report["first_failure"],
+        "modes": {
+            mode: {
+                "status": mode_reports[mode]["status"],
+                "last_all_pass_W": mode_reports[mode]["last_all_pass_W"],
+                "first_fail_W": mode_reports[mode]["first_fail_W"],
+                "first_failure": mode_reports[mode]["first_failure"],
+            }
+            for mode in modes
+        },
     }, indent=2, sort_keys=True))
     return 0
 


### PR DESCRIPTION
## Goal
Continue the OU-III stability closure from merged PR #398, starting at the first unresolved obstruction: the full information-normalized nonlinear neighborhood sweep.

## First fix
The previous workflow wrote the full-sweep and radius-search case logs outside the only diagnostics subtree uploaded by CI. An incomplete sweep therefore discarded the evidence needed to distinguish simulator/driver failure from a genuine nonlinear obstruction.

This PR first routes both diagnostic trees under `reports/diagnostics/ou3_numerical_certificate/` while keeping scientific result payloads under `reports/results/ou3_numerical_certificate/`.

## Next in this PR
1. rerun all H/A coordinate directions, both signs, all eight seas at the baseline information energy;
2. classify any failure as execution/trace vs source-word, measurement-gating, W-decrease, SO(3)-chart, or finite-prefix obstruction;
3. once the baseline runs cleanly, expand and bisect the sampled information radius to obtain H/A pass/fail basin brackets and the limiting sea/state direction;
4. keep theorem-level nonlinear, continuous-source, hybrid, stochastic, and deployment gates blocked unless their independent proof obligations are met.

No filter tuning, production dynamics, scientific tolerance, or certificate qualification is relaxed.