### PR TITLE
Close OU-III hybrid and stochastic proof bookkeeping

### DIFF
--- a/.github/workflows/ou3-numerical-certificate.yml
+++ b/.github/workflows/ou3-numerical-certificate.yml
@@ -13,14 +13,17 @@ on:
       - "tests/validation/test_ou3_information_certificate.py"
       - "tests/validation/test_ou3_information_completion.py"
       - "tests/validation/test_ou3_certificate_completion.py"
+      - "tests/validation/test_ou3_source_noise_certificate.py"
       - "tests/validation/test_ou3_neighborhood_diagnostic.py"
       - "tests/validation/test_ou3_neighborhood_radius_search.py"
+      - "tests/validation/test_ou3_validate_enclosure.py"
       - "tests/validation/test_ou3_result_determinism.py"
       - "tools/ou3_exact_replay.py"
       - "tools/ou3_numerical_certificate.py"
       - "tools/ou3_information_certificate.py"
       - "tools/ou3_information_completion.py"
       - "tools/ou3_information_enclosure_contract.py"
+      - "tools/ou3_source_noise_certificate.py"
       - "tools/ou3_neighborhood_diagnostic.py"
       - "tools/ou3_neighborhood_radius_search.py"
       - "tools/ou3_certificate_completion.py"
@@ -91,6 +94,11 @@ jobs:
       - name: Generate continuous-source information enclosure contract
         run: |
           python3 -u tools/ou3_information_enclosure_contract.py \
+            --certificate-dir "$GITHUB_WORKSPACE/reports/results/ou3_numerical_certificate"
+
+      - name: Derive stochastic primitive-noise certificate from source
+        run: |
+          python3 -u tools/ou3_source_noise_certificate.py \
             --certificate-dir "$GITHUB_WORKSPACE/reports/results/ou3_numerical_certificate"
 
       - name: Smoke-test exact nonlinear pairwise word

--- a/tests/validation/Makefile
+++ b/tests/validation/Makefile
@@ -10,6 +10,7 @@ build:
 		../../tools/ou3_information_certificate.py \
 		../../tools/ou3_information_completion.py \
 		../../tools/ou3_information_enclosure_contract.py \
+		../../tools/ou3_source_noise_certificate.py \
 		../../tools/ou3_neighborhood_diagnostic.py \
 		../../tools/ou3_neighborhood_radius_search.py \
 		../../tools/ou3_certificate_completion.py \
@@ -27,8 +28,10 @@ build:
 		test_ou3_information_certificate.py \
 		test_ou3_information_completion.py \
 		test_ou3_certificate_completion.py \
+		test_ou3_source_noise_certificate.py \
 		test_ou3_neighborhood_diagnostic.py \
 		test_ou3_neighborhood_radius_search.py \
+		test_ou3_validate_enclosure.py \
 		test_ou3_result_determinism.py \
 		test_ou_article_ablations.py \
 		test_ou_legacy_law_cleanup.py \

--- a/tests/validation/test_ou3_result_determinism.py
+++ b/tests/validation/test_ou3_result_determinism.py
@@ -11,7 +11,9 @@ PRODUCERS = [
     ROOT / "tools" / "ou3_information_certificate.py",
     ROOT / "tools" / "ou3_information_completion.py",
     ROOT / "tools" / "ou3_information_enclosure_contract.py",
+    ROOT / "tools" / "ou3_source_noise_certificate.py",
     ROOT / "tools" / "ou3_neighborhood_diagnostic.py",
+    ROOT / "tools" / "ou3_neighborhood_radius_search.py",
     ROOT / "tools" / "ou3_certificate_completion.py",
     ROOT / "tools" / "ou3_validate_enclosure.py",
 ]

--- a/tests/validation/test_ou3_source_noise_certificate.py
+++ b/tests/validation/test_ou3_source_noise_certificate.py
@@ -1,0 +1,45 @@
+import importlib.util
+import math
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "ou3_source_noise_certificate.py"
+
+
+def load_tool():
+    spec = importlib.util.spec_from_file_location("ou3_source_noise_certificate", TOOL)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class Ou3SourceNoiseCertificateTests(unittest.TestCase):
+    def test_source_generated_standardized_gaussian_bound(self):
+        tool = load_tool()
+        report = tool.build_certificate()
+        self.assertTrue(report["source_generated_not_trajectory_fit"])
+        z = report["standardized_increment"]
+        self.assertEqual(z["dimension"], 18)
+        self.assertTrue(z["covariance_upper_identity"])
+        self.assertEqual(z["Sigma_bar_norm_upper"], 1.0)
+        self.assertEqual(z["s2_upper"], 18.0)
+        self.assertEqual(z["s4_upper"], 360.0)
+
+    def test_physical_scales_match_deployed_validation_noise(self):
+        tool = load_tool()
+        p = tool.build_certificate()["physical_scales"]
+        self.assertAlmostEqual(p["imu_dt_s"], 0.005, places=12)
+        self.assertAlmostEqual(p["mag_odr_hz"], 25.0, places=12)
+        self.assertAlmostEqual(p["acc_white_std_mps2"], 1.51e-3 * 9.80665, places=12)
+        self.assertAlmostEqual(p["gyro_white_std_radps"], 0.00157, places=12)
+        self.assertAlmostEqual(p["acc_bias_rw_increment_std_mps2"], 0.0005 * math.sqrt(0.005), places=12)
+        self.assertAlmostEqual(p["gyro_bias_rw_increment_std_radps"], 1e-5 * math.sqrt(0.005), places=12)
+        self.assertAlmostEqual(p["mag_white_std_uT"], 0.80, places=12)
+        self.assertAlmostEqual(p["mag_bias_rw_increment_std_uT"], 0.01 * math.sqrt(1.0 / 25.0), places=12)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/validation/test_ou3_validate_enclosure.py
+++ b/tests/validation/test_ou3_validate_enclosure.py
@@ -1,0 +1,167 @@
+import importlib.util
+import pathlib
+import sys
+import types
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "ou3_validate_enclosure.py"
+
+
+def load_tool():
+    base = types.ModuleType("ou3_numerical_certificate")
+    base.DEFAULT_OUT = ROOT / "reports" / "results" / "ou3_numerical_certificate"
+    sys.modules.setdefault("ou3_numerical_certificate", base)
+    spec = importlib.util.spec_from_file_location("ou3_validate_enclosure", TOOL)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def contract_mode():
+    return {
+        "recommended_word_horizon_s": 16.0,
+        "executed_reference_only": {
+            "relative_Riccati_injection_margin_worst": 0.05,
+            "Sigma_endpoint_lambda_min": 0.01,
+            "Sigma_endpoint_lambda_max": 100.0,
+        },
+    }
+
+
+def mode_payload(level=10.0, ratio=0.8):
+    return {
+        "source_complete": True,
+        "outward_rounded": True,
+        "word_horizon_s": 16.0,
+        "relative_Riccati_injection_margin_lower": 0.04,
+        "Sigma_lambda_min_lower": 0.005,
+        "Sigma_lambda_max_upper": 120.0,
+        "prefix_information_gain_upper": 3.0,
+        "theta_star": 1.0,
+        "endpoint_W_ratio_upper": ratio,
+        "certified_level_W": level,
+        "all_word_prefixes_safe": True,
+    }
+
+
+class Ou3ValidatedEnclosureTests(unittest.TestCase):
+    def test_nonlinear_margin_is_derived_from_endpoint_ratio(self):
+        tool = load_tool()
+        out = tool.validate_mode("H", mode_payload(ratio=0.8), contract_mode())
+        self.assertTrue(out["pass"], out["failures"])
+        self.assertAlmostEqual(out["mu_W_lower"], 0.2)
+
+    def test_sampled_counterexample_caps_validated_level(self):
+        tool = load_tool()
+        out = tool.validate_mode(
+            "H", mode_payload(level=12.0), contract_mode(), {"first_fail_W": 11.0}
+        )
+        self.assertFalse(out["pass"])
+        self.assertTrue(any("sampled failure" in x for x in out["failures"]))
+
+    def test_hybrid_margin_is_recomputed_and_dimension_change_explicit(self):
+        tool = load_tool()
+        modes = {
+            "H": {"certified_level_W": 10.0},
+            "A": {"certified_level_W": 10.0},
+        }
+        common = dict(
+            source_complete=True,
+            outward_rounded=True,
+            source_level_W_upper=2.0,
+            jump_gain_upper=0.5,
+            additive_W_upper=0.2,
+            destination_level_W=5.0,
+            destination_mode="H",
+        )
+        rows = [
+            {"kind": "startup_handoff", **common},
+            {
+                "kind": "held_to_active",
+                **{**common, "destination_mode": "A"},
+                "source_dimension": 18,
+                "destination_dimension": 21,
+                "dimension_change_handled_by_embedding": True,
+                "new_coordinate_W_upper": 0.3,
+                "inward_margin_lower": 999.0,
+            },
+            {"kind": "magnetic_regauge", **common},
+            {"kind": "tilt_reset", **common},
+            {"kind": "cooldown", **common},
+        ]
+        out = tool.validate_hybrid(rows, modes)
+        self.assertTrue(out["pass"], out["failures"])
+        held = next(x for x in out["bounds"] if x["kind"] == "held_to_active")
+        self.assertAlmostEqual(held["post_jump_W_upper"], 1.5)
+        self.assertAlmostEqual(held["inward_margin_lower"], 3.5)
+
+    def test_stochastic_probability_is_recomputed_from_source_moments(self):
+        tool = load_tool()
+        modes = {
+            "H": {"endpoint_W_ratio_upper": 0.5, "certified_level_W": 100.0, "word_horizon_s": 0.01},
+            "A": {"endpoint_W_ratio_upper": 0.6, "certified_level_W": 100.0, "word_horizon_s": 0.01},
+        }
+        source_noise = {
+            "schema": 1,
+            "source_generated_not_trajectory_fit": True,
+            "standardized_increment": {"dimension": 18, "covariance_upper_identity": True},
+            "physical_scales": {"imu_dt_s": 0.005},
+        }
+        payload = {
+            "source_complete": True,
+            "outward_rounded": True,
+            "localization_prefix_safe": True,
+            "localization_radius_standardized": 20.0,
+            "word_samples_upper": 2,
+            "finite_horizon_words": 1,
+            "funnel_level_a": 100.0,
+            "W0_upper": 1.0,
+            "L_X_upper": 0.1,
+            "G_bar_upper": 1e-4,
+            "c_zw_upper": 0.0,
+            "r_star_upper": 1.0,
+            "c_ww_upper": 0.0,
+            "g_W_upper": 1e-4,
+            "h_W_upper": 1e-4,
+            "b_W_upper": 0.0,
+            "v_W_upper": 0.0,
+            "finite_horizon_failure_probability_upper": 0.0,
+        }
+        out = tool.validate_stochastic(payload, modes, source_noise)
+        self.assertTrue(out["pass"], out["failures"])
+        self.assertEqual(out["source_noise_moments"]["s2_upper"], 18.0)
+        self.assertEqual(out["source_noise_moments"]["s4_upper"], 360.0)
+        self.assertEqual(out["b_W_upper"], 100.0)
+        self.assertEqual(out["v_W_upper"], 2500.0)
+        self.assertLess(out["finite_horizon_failure_probability_upper"], 1.0)
+
+    def test_stochastic_localization_radius_must_exceed_gaussian_rms(self):
+        tool = load_tool()
+        modes = {
+            "H": {"endpoint_W_ratio_upper": 0.5, "certified_level_W": 10.0, "word_horizon_s": 0.01},
+            "A": {"endpoint_W_ratio_upper": 0.5, "certified_level_W": 10.0, "word_horizon_s": 0.01},
+        }
+        source_noise = {
+            "schema": 1,
+            "source_generated_not_trajectory_fit": True,
+            "standardized_increment": {"dimension": 18, "covariance_upper_identity": True},
+            "physical_scales": {"imu_dt_s": 0.005},
+        }
+        payload = {
+            "source_complete": True, "outward_rounded": True, "localization_prefix_safe": True,
+            "localization_radius_standardized": 4.0,
+            "word_samples_upper": 2, "finite_horizon_words": 1,
+            "funnel_level_a": 10.0, "W0_upper": 1.0,
+            "L_X_upper": 0.1, "G_bar_upper": 0.0, "c_zw_upper": 0.0,
+            "r_star_upper": 1.0, "c_ww_upper": 0.0, "g_W_upper": 0.0, "h_W_upper": 0.0,
+        }
+        out = tool.validate_stochastic(payload, modes, source_noise)
+        self.assertFalse(out["pass"])
+        self.assertTrue(any("Gaussian RMS" in x for x in out["failures"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ou3_information_enclosure_contract.py
+++ b/tools/ou3_information_enclosure_contract.py
@@ -1,34 +1,16 @@
 #!/usr/bin/env python3
 """Build the continuous-source promotion contract for adaptive OU-III.
 
-The executed certificate in ``ou3_information_certificate.py`` uses the actual
-Kalman covariance as a source-varying information metric,
-
-    M(g) = Sigma_KF(g)^(-1).
-
-For every deterministic source word,
-
-    Sigma_1 = Phi Sigma_0 Phi^T + Omega,
-
-and therefore
-
-    Phi^T Sigma_1^-1 Phi <= (1-eta) Sigma_0^-1
-
-whenever
-
-    Sigma_1^-1/2 Omega Sigma_1^-1/2 >= eta I,  eta > 0.
-
-This tool does not invent a validated lower bound eta.  It turns the successful
-eight-replay result into a deterministic, machine-readable contract specifying
-what a continuous-source interval/Taylor-model backend must prove.  Executed
-values are retained only as sanity anchors; they are never promoted by this
-stage.
+The executed information certificate supplies sanity anchors only.  This tool
+states the primitive outward-rounded quantities a source-complete validated
+backend must prove.  Final nonlinear, hybrid and stochastic margins are
+recomputed by ``ou3_validate_enclosure.py`` and are never accepted as asserted
+PASS values.
 """
 from __future__ import annotations
 
 import argparse
 import json
-import math
 from pathlib import Path
 
 import ou3_numerical_certificate as BASE
@@ -36,22 +18,7 @@ import ou3_numerical_certificate as BASE
 SCHEMA = 2
 
 
-def _finite_positive(value) -> bool:
-    try:
-        x = float(value)
-    except (TypeError, ValueError):
-        return False
-    return math.isfinite(x) and x > 0.0
-
-
 def mode_contract(info_mode: dict, completion_mode: dict, mode: str) -> dict:
-    """Return one deterministic continuous-source obligation set.
-
-    Prefer the tested horizon with the strongest executed information margin.
-    A longer word is allowed by the source-word theorem and gives the validated
-    backend more room to prove a robust positive Riccati injection.  The first
-    strict horizon is kept as a diagnostic anchor, not as a requirement.
-    """
     first = dict(info_mode.get("selected") or {})
     strongest = dict(info_mode.get("strongest_executed_margin") or first)
     horizon = strongest.get("horizon_s")
@@ -95,7 +62,8 @@ def mode_contract(info_mode: dict, completion_mode: dict, mode: str) -> dict:
         },
         "required_nonlinear_bounds": {
             "theta_star": "0 < theta_star < pi",
-            "mu_W_lower": "> 0",
+            "endpoint_W_ratio_upper": "0 <= ratio < 1; verifier derives mu_W=1-ratio",
+            "certified_level_W": "> 0",
             "all_word_prefixes_safe": True,
             "metric_lift": "zeta^T Sigma_KF(g)^(-1) zeta with zeta=[Log(R_e); xi]",
         },
@@ -120,19 +88,42 @@ def build_contract(info: dict, completion: dict) -> dict:
             "Omega=Sigma1-Phi Sigma0 Phi^T"
         ),
         "modes": modes,
-        "hybrid_requirements": [
-            "startup_handoff_into_certified_destination_sublevel",
-            "held_to_active_jump_into_certified_destination_sublevel",
-            "magnetic_regauge_jump_into_certified_destination_sublevel",
-            "tilt_reset_jump_into_certified_destination_sublevel",
-            "cooldown_reentry_into_certified_destination_sublevel",
-        ],
-        "stochastic_requirements": [
-            "source_uniform_Sigma_bar_norm_upper",
-            "source_uniform_b_W_upper",
-            "source_uniform_v_W_upper",
-            "finite_horizon_failure_probability_upper",
-        ],
+        "hybrid_requirements": {
+            "required_kinds": [
+                "startup_handoff", "held_to_active", "magnetic_regauge",
+                "tilt_reset", "cooldown",
+            ],
+            "primitive_bounds_per_jump": [
+                "source_complete", "outward_rounded", "source_level_W_upper",
+                "jump_gain_upper", "additive_W_upper", "destination_level_W",
+                "destination_mode",
+            ],
+            "held_to_active_extra": [
+                "source_dimension=18", "destination_dimension=21",
+                "dimension_change_handled_by_embedding=true",
+                "new_coordinate_W_upper",
+            ],
+            "verifier_formula": (
+                "post_W_upper=jump_gain_upper*source_level_W_upper+"
+                "additive_W_upper+new_coordinate_W_upper; "
+                "inward_margin=destination_level_W-post_W_upper>0"
+            ),
+        },
+        "stochastic_requirements": {
+            "source_noise": "source_noise_certificate.json; standardized pre-gate Gaussian primitive covariance <= I",
+            "validated_sensitivity_bounds": [
+                "source_complete", "outward_rounded", "localization_prefix_safe",
+                "localization_radius_standardized", "word_samples_upper",
+                "finite_horizon_words", "funnel_level_a", "W0_upper",
+                "L_X_upper", "G_bar_upper", "c_zw_upper", "r_star_upper",
+                "c_ww_upper", "g_W_upper", "h_W_upper",
+            ],
+            "verifier_derives": [
+                "s2", "s4", "nu1", "nu_W", "lambda_s", "sigma_s^2",
+                "b_W=a", "v_W=a^2/4", "Gaussian localization t_star",
+                "Freedman excursion probability", "total finite-horizon failure probability",
+            ],
+        },
         "validated_backend_requirements": [
             "validated arithmetic",
             "outward rounding",
@@ -141,7 +132,8 @@ def build_contract(info: dict, completion: dict) -> dict:
         ],
         "promotion_rule": (
             "executed replay values are sanity anchors only; deployment PASS requires "
-            "strict validated continuous-source linear, nonlinear, hybrid and stochastic bounds"
+            "strict validated continuous-source linear and nonlinear bounds, recomputed "
+            "hybrid inward margins, and recomputed stochastic concentration"
         ),
     }
 
@@ -155,7 +147,7 @@ def main() -> int:
     completion = json.loads((cert / "information_completion.json").read_text())
     contract = build_contract(info, completion)
     path = cert / "information_enclosure_contract.json"
-    path.write_text(json.dumps(contract, indent=2, sort_keys=True))
+    path.write_text(json.dumps(contract, indent=2, sort_keys=True), encoding="utf-8")
     print(json.dumps({
         "schema": contract["schema"],
         "linear": contract["upstream_executed_information_certificate"],
@@ -163,7 +155,6 @@ def main() -> int:
         "H_horizon_s": contract["modes"]["H"]["recommended_word_horizon_s"],
         "A_horizon_s": contract["modes"]["A"]["recommended_word_horizon_s"],
     }, indent=2, sort_keys=True))
-    # An upstream mathematical FAIL is scientific output, not a contract-tool crash.
     return 0
 
 

--- a/tools/ou3_source_noise_certificate.py
+++ b/tools/ou3_source_noise_certificate.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Source-derived stochastic primitive-noise certificate for adaptive OU-III.
+
+This certificate deliberately does not estimate noise from replay trajectories.
+It reads the simulator/source constants that define the OU-III validation noise
+model and expresses each physical Gaussian draw as a scale times a standardized
+primitive coordinate.  With six 3-vectors reserved per IMU sample,
+
+    z_k = [z_a, z_g, z_ba, z_bg, z_m, z_bm] in R^18,
+
+magnetometer coordinates are simply unused (zero gain) on non-mag samples.
+Consequently the pre-gate standardized conditional covariance satisfies
+
+    0 <= Cov(z_k | F_k) <= I_18
+
+uniformly.  Physical units stay in the source-map sensitivity, not in this
+covariance bound.  This is the normalization used by the stochastic enclosure
+backend and avoids mixing m/s^2, rad/s and microtesla in one Euclidean norm.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+DEFAULT_CERT = REPO / "reports" / "results" / "ou3_numerical_certificate"
+SIM_H = REPO / "src" / "util" / "W3dSimCommon.h"
+SIM_CPP = REPO / "src" / "util" / "W3dSimCommon.cpp"
+CERT_SIM = REPO / "tests" / "kalman_ou_iii" / "ou3-certificate-sim.cpp"
+SCHEMA = 1
+PRIMITIVE_DIMENSION = 18
+
+
+def _one(pattern: str, text: str, label: str) -> float:
+    m = re.search(pattern, text, flags=re.MULTILINE | re.DOTALL)
+    if not m:
+        raise RuntimeError(f"cannot locate source noise constant {label}")
+    return float(m.group(1))
+
+
+def _source_constants() -> dict:
+    h = SIM_H.read_text(encoding="utf-8")
+    cpp = SIM_CPP.read_text(encoding="utf-8")
+    cert = CERT_SIM.read_text(encoding="utf-8")
+
+    g = _one(r"g_std\s*=\s*([0-9.eE+-]+)f", cpp, "g_std")
+    dt_den = _one(r"constexpr\s+float\s+kDt\s*=\s*1\.0f\s*/\s*([0-9.eE+-]+)f", cert, "kDt")
+    dt = 1.0 / dt_den
+    mag_odr = _one(r"constexpr\s+float\s+kMagOdrHz\s*=\s*([0-9.eE+-]+)f", cert, "kMagOdrHz")
+    mag_dt = 1.0 / mag_odr
+
+    acc_mult = _one(r"const\s+float\s+acc_sigma\s*=\s*([0-9.eE+-]+)f\s*\*\s*g_std", h, "acc_sigma/g")
+    gyro_white = _one(r"const\s+float\s+gyr_sigma\s*=\s*([0-9.eE+-]+)f", h, "gyr_sigma")
+    acc_bias_mult = _one(r"const\s+float\s+acc_bias_range\s*=\s*([0-9.eE+-]+)f\s*\*\s*g_std", h, "acc_bias_range/g")
+    gyro_bias_deg = _one(r"const\s+float\s+gyr_bias_range\s*=\s*([0-9.eE+-]+)f\s*\*\s*float\(std::numbers::pi_v<float>\s*/\s*180\.0f\)", h, "gyr_bias_range_deg")
+    acc_bias_rw = _one(r"const\s+float\s+acc_bias_rw\s*=\s*([0-9.eE+-]+)f", h, "acc_bias_rw")
+    gyro_bias_rw = _one(r"const\s+float\s+gyr_bias_rw\s*=\s*([0-9.eE+-]+)f", h, "gyr_bias_rw")
+
+    m = re.search(
+        r"const\s+float\s+mag_sigma_uT\s*=\s*\(mag_odr_hz\s*<=\s*20\.0f\)\s*\?\s*([0-9.eE+-]+)f\s*:\s*([0-9.eE+-]+)f",
+        h,
+    )
+    if not m:
+        raise RuntimeError("cannot locate mag_sigma_uT source branch")
+    mag_sigma_low = float(m.group(1))
+    mag_sigma_high = float(m.group(2))
+    mag_white = mag_sigma_low if mag_odr <= 20.0 else mag_sigma_high
+
+    m = re.search(
+        r"make_mag_noise_model\(\s*mag_sigma_uT\s*,\s*([0-9.eE+-]+)f\s*,\s*([0-9.eE+-]+)f\s*,\s*([0-9.eE+-]+)f\s*,\s*([0-9.eE+-]+)f\s*,\s*([0-9.eE+-]+)f",
+        h,
+        flags=re.MULTILINE,
+    )
+    if not m:
+        raise RuntimeError("cannot locate make_mag_noise_model source parameters")
+    mag_bias_range, mag_bias_rw, mag_scale, mag_cross, mag_misalign_deg = map(float, m.groups())
+
+    return {
+        "g_std_mps2": g,
+        "imu_dt_s": dt,
+        "imu_rate_hz": 1.0 / dt,
+        "mag_odr_hz": mag_odr,
+        "mag_dt_s": mag_dt,
+        "acc_white_std_mps2": acc_mult * g,
+        "gyro_white_std_radps": gyro_white,
+        "acc_bias_rw_density_mps2_sqrt_s": acc_bias_rw,
+        "gyro_bias_rw_density_radps_sqrt_s": gyro_bias_rw,
+        "acc_bias_rw_increment_std_mps2": acc_bias_rw * math.sqrt(dt),
+        "gyro_bias_rw_increment_std_radps": gyro_bias_rw * math.sqrt(dt),
+        "mag_white_std_uT": mag_white,
+        "mag_bias_rw_density_uT_sqrt_s": mag_bias_rw,
+        "mag_bias_rw_increment_std_uT": mag_bias_rw * math.sqrt(mag_dt),
+        "acc_initial_bias_half_range_mps2": acc_bias_mult * g,
+        "gyro_initial_bias_half_range_radps": gyro_bias_deg * math.pi / 180.0,
+        "mag_initial_bias_half_range_uT": mag_bias_range,
+        "mag_scale_error_abs_max": mag_scale,
+        "mag_cross_axis_abs_max": mag_cross,
+        "mag_misalignment_abs_max_deg": mag_misalign_deg,
+    }
+
+
+def build_certificate() -> dict:
+    c = _source_constants()
+    d = PRIMITIVE_DIMENSION
+    return {
+        "schema": SCHEMA,
+        "claim": "OU3_SOURCE_GAUSSIAN_PRIMITIVE_NOISE_CERTIFICATE",
+        "qualification": "SOURCE_GENERATED_NOT_TRAJECTORY_FIT",
+        "source_generated_not_trajectory_fit": True,
+        "standardized_increment": {
+            "definition": "z=[acc_white(3),gyro_white(3),acc_bias_rw(3),gyro_bias_rw(3),mag_white(3),mag_bias_rw(3)]",
+            "dimension": d,
+            "covariance_upper_identity": True,
+            "Sigma_bar_norm_upper": 1.0,
+            "trace_Sigma_bar_upper": float(d),
+            "trace_Sigma_bar_squared_upper": float(d),
+            "s2_upper": float(d),
+            "s4_upper": float(d * d + 2 * d),
+            "mag_coordinates_zero_gain_between_mag_ticks": True,
+        },
+        "physical_scales": {
+            k: c[k]
+            for k in (
+                "imu_dt_s", "imu_rate_hz", "mag_odr_hz", "mag_dt_s",
+                "acc_white_std_mps2", "gyro_white_std_radps",
+                "acc_bias_rw_density_mps2_sqrt_s", "gyro_bias_rw_density_radps_sqrt_s",
+                "acc_bias_rw_increment_std_mps2", "gyro_bias_rw_increment_std_radps",
+                "mag_white_std_uT", "mag_bias_rw_density_uT_sqrt_s",
+                "mag_bias_rw_increment_std_uT",
+            )
+        },
+        "initialization_support": {
+            "distribution": "BOUNDED_INITIALIZATION_SUPPORT_NOT_PER_SAMPLE_GAUSSIAN_NOISE",
+            "acc_bias_half_range_mps2": c["acc_initial_bias_half_range_mps2"],
+            "gyro_bias_half_range_radps": c["gyro_initial_bias_half_range_radps"],
+            "mag_bias_half_range_uT": c["mag_initial_bias_half_range_uT"],
+            "mag_scale_error_abs_max": c["mag_scale_error_abs_max"],
+            "mag_cross_axis_abs_max": c["mag_cross_axis_abs_max"],
+            "mag_misalignment_abs_max_deg": c["mag_misalignment_abs_max_deg"],
+        },
+        "proof_use": {
+            "normalization": "physical increments equal diagonal/source map scales times standardized z coordinates",
+            "conditional_covariance": "0 <= Cov(z_k|F_k) <= I_18",
+            "gating_note": "bound is pre-gate; accepted innovations need not remain conditionally centered",
+        },
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--certificate-dir", type=Path, default=DEFAULT_CERT)
+    args = ap.parse_args()
+    out = args.certificate_dir.resolve()
+    out.mkdir(parents=True, exist_ok=True)
+    report = build_certificate()
+    path = out / "source_noise_certificate.json"
+    path.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+    print(json.dumps({
+        "claim": report["claim"],
+        "dimension": report["standardized_increment"]["dimension"],
+        "Sigma_bar_norm_upper": report["standardized_increment"]["Sigma_bar_norm_upper"],
+        "s2_upper": report["standardized_increment"]["s2_upper"],
+        "s4_upper": report["standardized_increment"]["s4_upper"],
+    }, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ou3_validate_enclosure.py
+++ b/tools/ou3_validate_enclosure.py
@@ -1,31 +1,19 @@
 #!/usr/bin/env python3
-"""Validate a rigorous OU-III information-metric source enclosure.
+"""Validate a rigorous OU-III source enclosure and recompute promotion margins.
 
-This is the promotion gate from the executed information certificate to the
-continuous-source stability theorem.  It intentionally uses the same metric as
-the primary numerical certificate,
+The validated backend supplies only outward-rounded primitive bounds.  This
+verifier derives the theorem quantities it can derive algebraically instead of
+trusting supplied PASS flags or final margins:
 
-    M(g) = Sigma_KF(g)^(-1),
+* linear information factor: lambda <= 1 - eta;
+* nonlinear word margin: mu_W >= 1 - endpoint_W_ratio_upper;
+* hybrid inward margins from source level, jump gain and additive terms;
+* Gaussian moments from the source-defined standardized primitive covariance;
+* localized stochastic drift and finite-horizon Gaussian/Freedman probability.
 
-and does not depend on the superseded coarse ``path_metrics.npz`` route.
-
-For a source word with covariance recursion
-
-    Sigma_1 = Phi Sigma_0 Phi^T + Omega,
-
-strict linear contraction follows exactly from a validated uniform bound
-
-    Sigma_1^-1/2 Omega Sigma_1^-1/2 >= eta I,   eta > 0,
-
-because ``lambda_information <= 1-eta < 1``.  The validator also requires
-uniform covariance eigenvalue bounds (metric equivalence), finite prefix gain,
-a nonzero SO(3) chart with positive nonlinear word dissipation, strict hybrid
-inward margins, and non-empirical stochastic constants.
-
-The validator never trusts a supplied PASS flag.  It recomputes every logical
-promotion condition from the supplied outward-rounded bounds and cross-checks
-continuous bounds against executed reference points recorded in
-``information_enclosure_contract.json``.
+Executed replay values remain sanity anchors only.  A deployment PASS still
+requires source-complete validated arithmetic for the continuous H/A word,
+nonlinear, hybrid and sensitivity bounds.
 """
 from __future__ import annotations
 
@@ -37,6 +25,7 @@ from pathlib import Path
 import ou3_numerical_certificate as BASE
 
 SCHEMA = 2
+SOURCE_NOISE_SCHEMA = 1
 ANCHOR_REL_TOL = 5.0e-6
 
 
@@ -57,18 +46,17 @@ def finite_nonnegative(value) -> bool:
 
 
 def _anchor_upper(value: float, anchor: float) -> bool:
-    """A continuous lower bound cannot exceed an included executed minimum."""
     tol = ANCHOR_REL_TOL * max(1.0, abs(anchor))
     return value <= anchor + tol
 
 
 def _anchor_lower(value: float, anchor: float) -> bool:
-    """A continuous upper bound cannot be below an included executed maximum."""
     tol = ANCHOR_REL_TOL * max(1.0, abs(anchor))
     return value + tol >= anchor
 
 
-def validate_mode(mode: str, payload: dict, contract_mode: dict) -> dict:
+def validate_mode(mode: str, payload: dict, contract_mode: dict,
+                  sampled_mode: dict | None = None) -> dict:
     failures: list[str] = []
     if not payload.get("source_complete", False):
         failures.append("source family is not declared source-complete")
@@ -104,9 +92,6 @@ def validate_mode(mode: str, payload: dict, contract_mode: dict) -> dict:
     if not finite_positive(prefix):
         failures.append("prefix_information_gain_upper is not finite positive")
 
-    # Since the continuous source set is required to contain the executed
-    # reference family, its lower/upper bounds must contain those observed
-    # points.  This catches accidentally optimistic or fabricated enclosures.
     ref = contract_mode.get("executed_reference_only", {})
     ref_eta = ref.get("relative_Riccati_injection_margin_worst")
     if finite_positive(eta) and finite_positive(ref_eta):
@@ -144,11 +129,28 @@ def validate_mode(mode: str, payload: dict, contract_mode: dict) -> dict:
     theta = payload.get("theta_star")
     if not finite_positive(theta) or not float(theta) < math.pi:
         failures.append("theta_star is not in (0, pi)")
-    mu = payload.get("mu_W_lower")
-    if not finite_positive(mu):
-        failures.append("nonlinear mu_W lower bound is not strictly positive")
+
+    endpoint_ratio = payload.get("endpoint_W_ratio_upper")
+    mu = None
+    if not finite_nonnegative(endpoint_ratio) or not float(endpoint_ratio) < 1.0:
+        failures.append("endpoint_W_ratio_upper is not in [0,1)")
+    else:
+        mu = 1.0 - float(endpoint_ratio)
+
+    certified_level = payload.get("certified_level_W")
+    if not finite_positive(certified_level):
+        failures.append("certified_level_W is not finite positive")
     if not payload.get("all_word_prefixes_safe", False):
         failures.append("nonlinear word prefixes are not validated safe")
+
+    # A rigorous enclosure cannot contradict an included sampled counterexample.
+    if sampled_mode and finite_positive(certified_level):
+        first_fail = sampled_mode.get("first_fail_W")
+        if finite_positive(first_fail) and float(certified_level) >= float(first_fail):
+            failures.append(
+                "certified nonlinear level reaches/exceeds a sampled failure "
+                f"({certified_level} >= {first_fail})"
+            )
 
     return {
         "mode": mode,
@@ -166,11 +168,13 @@ def validate_mode(mode: str, payload: dict, contract_mode: dict) -> dict:
         "information_metric_lambda_max_upper": metric_upper,
         "prefix_information_gain_upper": prefix,
         "theta_star": theta,
+        "endpoint_W_ratio_upper": endpoint_ratio,
         "mu_W_lower": mu,
+        "certified_level_W": certified_level,
     }
 
 
-def validate_hybrid(payload: list[dict]) -> dict:
+def validate_hybrid(payload: list[dict], modes: dict) -> dict:
     required = {
         "startup_handoff",
         "held_to_active",
@@ -181,42 +185,276 @@ def validate_hybrid(payload: list[dict]) -> dict:
     seen: set[str] = set()
     failures: list[str] = []
     rows = []
+
     for i, jump in enumerate(payload):
         kind = str(jump.get("kind", ""))
         seen.add(kind)
-        margin = jump.get("inward_margin_lower")
-        if not finite_positive(margin):
-            failures.append(f"hybrid[{i}] {kind}: inward margin is not strictly positive")
+        row_failures: list[str] = []
+        if not jump.get("source_complete", False):
+            row_failures.append("source family is not source-complete")
         if not jump.get("outward_rounded", False):
-            failures.append(f"hybrid[{i}] {kind}: not outward-rounded")
-        rows.append({"kind": kind, "inward_margin_lower": margin})
+            row_failures.append("bounds are not outward-rounded")
+
+        source = jump.get("source_level_W_upper")
+        gain = jump.get("jump_gain_upper")
+        additive = jump.get("additive_W_upper")
+        dest = jump.get("destination_level_W")
+        new_coord = jump.get("new_coordinate_W_upper", 0.0)
+        for label, value in (
+            ("source_level_W_upper", source),
+            ("jump_gain_upper", gain),
+            ("additive_W_upper", additive),
+            ("new_coordinate_W_upper", new_coord),
+        ):
+            if not finite_nonnegative(value):
+                row_failures.append(f"{label} missing/nonfinite/negative")
+        if not finite_positive(dest):
+            row_failures.append("destination_level_W missing/nonfinite/nonpositive")
+
+        dest_mode = str(jump.get("destination_mode", ""))
+        if dest_mode not in modes:
+            row_failures.append("destination_mode must be H or A")
+        elif finite_positive(dest):
+            mode_level = modes[dest_mode].get("certified_level_W")
+            if not finite_positive(mode_level) or float(dest) > float(mode_level):
+                row_failures.append(
+                    "destination level is outside the certified same-mode level"
+                )
+
+        if kind == "held_to_active":
+            if jump.get("dimension_change_handled_by_embedding") is not True:
+                row_failures.append("held_to_active must declare explicit dimension embedding")
+            if jump.get("source_dimension") != 18 or jump.get("destination_dimension") != 21:
+                row_failures.append("held_to_active dimensions must be 18 -> 21")
+            if "new_coordinate_W_upper" not in jump:
+                row_failures.append("held_to_active must bound the new bias-coordinate energy")
+
+        post = None
+        margin = None
+        if (
+            finite_nonnegative(source) and finite_nonnegative(gain)
+            and finite_nonnegative(additive) and finite_nonnegative(new_coord)
+            and finite_positive(dest)
+        ):
+            post = float(gain) * float(source) + float(additive) + float(new_coord)
+            margin = float(dest) - post
+            if not margin > 0.0:
+                row_failures.append("recomputed inward margin is not strictly positive")
+
+        if row_failures:
+            failures.extend(f"hybrid[{i}] {kind}: {f}" for f in row_failures)
+        rows.append({
+            "kind": kind,
+            "destination_mode": dest_mode,
+            "source_level_W_upper": source,
+            "jump_gain_upper": gain,
+            "additive_W_upper": additive,
+            "new_coordinate_W_upper": new_coord,
+            "post_jump_W_upper": post,
+            "destination_level_W": dest,
+            "inward_margin_lower": margin,
+            "pass": not row_failures,
+        })
+
     missing = sorted(required - seen)
     if missing:
         failures.append(f"missing hybrid obligations: {missing}")
     return {"pass": not failures, "failures": failures, "seen": sorted(seen), "bounds": rows}
 
 
-def validate_stochastic(payload: dict) -> dict:
+def source_noise_moments(payload: dict) -> tuple[dict, list[str]]:
     failures: list[str] = []
-    for key in ("Sigma_bar_norm_upper", "b_W_upper", "v_W_upper"):
-        if not finite_nonnegative(payload.get(key)):
-            failures.append(f"{key} missing/nonfinite/negative")
-    prob = payload.get("finite_horizon_failure_probability_upper")
+    if payload.get("schema") != SOURCE_NOISE_SCHEMA:
+        failures.append("source noise certificate schema mismatch")
+    if not payload.get("source_generated_not_trajectory_fit", False):
+        failures.append("noise certificate is not source-generated")
+    std = payload.get("standardized_increment", {})
+    d = std.get("dimension")
+    if not isinstance(d, int) or d <= 0:
+        failures.append("standardized primitive dimension is not positive integer")
+        d = 0
+    if std.get("covariance_upper_identity") is not True:
+        failures.append("standardized covariance is not certified <= identity")
+    # Recompute rather than trusting copied final moment constants.
+    moments = {
+        "dimension": d,
+        "Sigma_bar_norm_upper": 1.0 if d else None,
+        "trace_Sigma_bar_upper": float(d) if d else None,
+        "trace_Sigma_bar_squared_upper": float(d) if d else None,
+        "s2_upper": float(d) if d else None,
+        "s4_upper": float(d * d + 2 * d) if d else None,
+    }
+    return moments, failures
+
+
+def _geometric_square_sum(L: float, n: int) -> float:
+    if n <= 0:
+        return 0.0
+    q = L * L
+    if abs(q - 1.0) <= 1e-12:
+        return float(n)
     try:
-        p = float(prob)
-    except (TypeError, ValueError):
-        p = math.nan
-    if not math.isfinite(p) or not (0.0 <= p < 1.0):
-        failures.append("finite_horizon_failure_probability_upper must be in [0,1)")
+        p = q ** n
+        ans = (p - 1.0) / (q - 1.0)
+    except OverflowError:
+        return math.inf
+    return ans if math.isfinite(ans) and ans >= 0.0 else math.inf
+
+
+def _gaussian_t_star(w_star: float, m: float, v: float, b: float) -> float | None:
+    w2 = w_star * w_star
+    if not (w2 > m and b > 0.0 and v >= 0.0):
+        return None
+    # Solve m + 2 sqrt(v t) + 2 b t = w_star^2 using y=sqrt(t).
+    root = math.sqrt(v + 2.0 * b * (w2 - m))
+    y = (root - math.sqrt(v)) / (2.0 * b)
+    return y * y if y > 0.0 and math.isfinite(y) else None
+
+
+def validate_stochastic(payload: dict, modes: dict, source_noise: dict) -> dict:
+    failures: list[str] = []
+    if not payload.get("source_complete", False):
+        failures.append("stochastic source family is not source-complete")
     if not payload.get("outward_rounded", False):
-        failures.append("stochastic bounds are not outward-rounded")
+        failures.append("stochastic sensitivity bounds are not outward-rounded")
+    if not payload.get("localization_prefix_safe", False):
+        failures.append("localized word prefixes are not validated safe")
+
+    moments, noise_failures = source_noise_moments(source_noise)
+    failures.extend(noise_failures)
+
+    names = (
+        "L_X_upper", "G_bar_upper", "c_zw_upper", "r_star_upper",
+        "c_ww_upper", "g_W_upper", "h_W_upper",
+    )
+    vals = {}
+    for name in names:
+        value = payload.get(name)
+        if not finite_nonnegative(value):
+            failures.append(f"{name} missing/nonfinite/negative")
+        else:
+            vals[name] = float(value)
+
+    w_star = payload.get("localization_radius_standardized")
+    if not finite_positive(w_star):
+        failures.append("localization_radius_standardized is not finite positive")
+    else:
+        w_star = float(w_star)
+
+    ell = payload.get("word_samples_upper")
+    if not isinstance(ell, int) or ell <= 0:
+        failures.append("word_samples_upper must be a positive integer")
+        ell = 0
+    N = payload.get("finite_horizon_words")
+    if not isinstance(N, int) or N <= 0:
+        failures.append("finite_horizon_words must be a positive integer")
+        N = 0
+
+    a = payload.get("funnel_level_a")
+    W0 = payload.get("W0_upper")
+    if not finite_positive(a):
+        failures.append("funnel_level_a is not finite positive")
+    else:
+        a = float(a)
+        mode_levels = [m.get("certified_level_W") for m in modes.values()]
+        if any(not finite_positive(x) for x in mode_levels) or a > min(float(x) for x in mode_levels):
+            failures.append("stochastic funnel level exceeds a certified deterministic mode level")
+    if not finite_nonnegative(W0):
+        failures.append("W0_upper missing/nonfinite/negative")
+    elif finite_positive(a) and not float(W0) < float(a):
+        failures.append("W0_upper must be strictly inside funnel_level_a")
+    else:
+        W0 = float(W0)
+
+    ratios = [m.get("endpoint_W_ratio_upper") for m in modes.values()]
+    lambda_W = None
+    if any(not finite_nonnegative(r) or not float(r) < 1.0 for r in ratios):
+        failures.append("deterministic mode contraction factors are unavailable")
+    else:
+        lambda_W = max(float(r) for r in ratios)
+
+    dt = source_noise.get("physical_scales", {}).get("imu_dt_s")
+    horizons = [m.get("word_horizon_s") for m in modes.values()]
+    if finite_positive(dt) and ell > 0 and all(finite_positive(h) for h in horizons):
+        minimum_samples = math.ceil(max(float(h) for h in horizons) / float(dt) - 1e-12)
+        if ell < minimum_samples:
+            failures.append(
+                f"word_samples_upper {ell} is below source horizon minimum {minimum_samples}"
+            )
+    else:
+        failures.append("cannot connect word_samples_upper to source sample period")
+
+    nu1 = nu_W = lambda_s = sigma_s2 = None
+    b_W = v_W = V_W = drift_max = x_star = None
+    t_star = p_localization = p_freedman = p_total = None
+
+    if not failures:
+        s2 = moments["s2_upper"]
+        s4 = moments["s4_upper"]
+        g_star = vals["G_bar_upper"] + vals["c_zw_upper"] * vals["r_star_upper"]
+        nu1 = 2.0 * g_star * g_star * s2 + 2.0 * vals["c_ww_upper"] ** 2 * s4
+        geom = _geometric_square_sum(vals["L_X_upper"], ell)
+        nu_W = float(ell) * nu1 * geom
+        if not math.isfinite(nu_W):
+            failures.append("localized source-word noise moment bound overflowed")
+        else:
+            lambda_s = 0.5 * (1.0 + lambda_W)
+            sigma_s2 = (
+                vals["h_W_upper"]
+                + vals["g_W_upper"] ** 2 * lambda_W / (2.0 * (1.0 - lambda_W))
+            ) * nu_W
+            fixed = sigma_s2 / (1.0 - lambda_s)
+            lamN = lambda_s ** N
+            WN = lamN * W0 + (1.0 - lamN) * fixed
+            drift_max = max(W0, WN)
+            x_star = a - drift_max
+            if not x_star > 0.0:
+                failures.append("stochastic drift envelope reaches/exceeds the funnel boundary")
+
+            # W in [0,a] gives zeta=W-E[W|F] <= a and Var(zeta|F)<=a^2/4.
+            b_W = a
+            v_W = a * a / 4.0
+            V_W = v_W / (1.0 - lambda_s * lambda_s)
+
+            t_star = _gaussian_t_star(
+                w_star,
+                moments["trace_Sigma_bar_upper"],
+                moments["trace_Sigma_bar_squared_upper"],
+                moments["Sigma_bar_norm_upper"],
+            )
+            if t_star is None:
+                failures.append("localization radius does not exceed the source Gaussian RMS threshold")
+
+            if x_star > 0.0 and t_star is not None:
+                exponent = -x_star * x_star / (2.0 * (V_W + b_W * x_star / 3.0))
+                p_freedman = float(N) * math.exp(exponent)
+                p_localization = float(N * ell) * math.exp(-t_star)
+                p_total = p_freedman + p_localization
+                if not (math.isfinite(p_total) and 0.0 <= p_total < 1.0):
+                    failures.append("recomputed finite-horizon stochastic failure probability is not < 1")
+
     return {
         "pass": not failures,
         "failures": failures,
-        "finite_horizon_failure_probability_upper": prob,
-        "Sigma_bar_norm_upper": payload.get("Sigma_bar_norm_upper"),
-        "b_W_upper": payload.get("b_W_upper"),
-        "v_W_upper": payload.get("v_W_upper"),
+        "source_noise_moments": moments,
+        "lambda_W_upper": lambda_W,
+        "lambda_s_upper": lambda_s,
+        "nu1_upper": nu1,
+        "nu_W_upper": nu_W,
+        "sigma_s2_upper": sigma_s2,
+        "funnel_level_a": a,
+        "W0_upper": W0,
+        "b_W_upper": b_W,
+        "v_W_upper": v_W,
+        "V_W_upper": V_W,
+        "drift_envelope_max_upper": drift_max,
+        "excursion_margin_x_star_lower": x_star,
+        "gaussian_t_star_lower": t_star,
+        "localization_failure_probability_upper": p_localization,
+        "freedman_failure_probability_upper": p_freedman,
+        "finite_horizon_failure_probability_upper": p_total,
+        "word_samples_upper": ell,
+        "finite_horizon_words": N,
     }
 
 
@@ -224,6 +462,7 @@ def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--certificate-dir", type=Path, default=BASE.DEFAULT_OUT)
     ap.add_argument("--enclosure", type=Path, required=True)
+    ap.add_argument("--source-noise", type=Path, default=None)
     args = ap.parse_args()
     cert = args.certificate_dir.resolve()
     inp = json.loads(args.enclosure.read_text())
@@ -236,6 +475,17 @@ def main() -> int:
     contract = json.loads(contract_path.read_text())
     if contract.get("schema") != SCHEMA:
         raise RuntimeError("information enclosure contract schema mismatch")
+
+    source_noise_path = args.source_noise or (cert / "source_noise_certificate.json")
+    if not source_noise_path.exists():
+        raise FileNotFoundError(source_noise_path)
+    source_noise = json.loads(source_noise_path.read_text())
+
+    radius_path = cert / "neighborhood_radius_search" / "neighborhood_radius_search.json"
+    sampled_modes = {}
+    if radius_path.exists():
+        radius = json.loads(radius_path.read_text())
+        sampled_modes = radius.get("modes", {})
 
     prov = inp.get("provenance", {})
     provenance_ok = (
@@ -251,14 +501,18 @@ def main() -> int:
             mode,
             inp.get("modes", {}).get(mode, {}),
             contract.get("modes", {}).get(mode, {}),
+            sampled_modes.get(mode),
         )
 
-    hybrid = validate_hybrid(inp.get("hybrid", []))
-    stochastic = validate_stochastic(inp.get("stochastic", {}))
+    hybrid = validate_hybrid(inp.get("hybrid", []), modes)
+    stochastic = validate_stochastic(inp.get("stochastic", {}), modes, source_noise)
 
     linear_pass = provenance_ok and all(modes[m]["linear_pass"] for m in modes)
-    neighborhood_pass = provenance_ok and all(modes[m]["nonlinear_pass"] for m in modes) and hybrid["pass"]
-    deployment_pass = neighborhood_pass and stochastic["pass"]
+    nonlinear_pass = provenance_ok and all(modes[m]["nonlinear_pass"] for m in modes)
+    neighborhood_pass = nonlinear_pass
+    hybrid_pass = provenance_ok and nonlinear_pass and hybrid["pass"]
+    stochastic_pass = provenance_ok and nonlinear_pass and hybrid["pass"] and stochastic["pass"]
+    deployment_pass = linear_pass and nonlinear_pass and hybrid_pass and stochastic_pass
 
     out = {
         "schema": SCHEMA,
@@ -269,15 +523,19 @@ def main() -> int:
         "stochastic": stochastic,
         "continuous_linear_information_certificate": "PASS" if linear_pass else "FAIL",
         "numerical_neighborhood_certificate": "PASS" if neighborhood_pass else "FAIL",
+        "hybrid_funnel_certificate": "PASS" if hybrid_pass else "FAIL",
+        "stochastic_certificate": "PASS" if stochastic_pass else "FAIL",
         "deployment_theorem_certificate": "PASS" if deployment_pass else "FAIL",
         "promotion_is_machine_verified": True,
     }
     (cert / "validated_enclosure_check.json").write_text(
-        json.dumps(out, indent=2, sort_keys=True)
+        json.dumps(out, indent=2, sort_keys=True), encoding="utf-8"
     )
     print(json.dumps({
         "continuous_linear_information_certificate": out["continuous_linear_information_certificate"],
         "numerical_neighborhood_certificate": out["numerical_neighborhood_certificate"],
+        "hybrid_funnel_certificate": out["hybrid_funnel_certificate"],
+        "stochastic_certificate": out["stochastic_certificate"],
         "deployment_theorem_certificate": out["deployment_theorem_certificate"],
         "H": modes["H"]["pass"],
         "A": modes["A"]["pass"],


### PR DESCRIPTION
## Goal
Continue the OU-III proof closure from merged PR #399 using the current `main` as the exact base.

PR #399 established the exact executed-source linear certificate and completed a 624-case full nonlinear baseline sweep at W=0.05. That sweep passed every H/A coordinate, both signs and all eight seas. Its later wide radius search was cancelled only because #399 was merged while the job was running; the preserved diagnostics already bracket H sampled loss of W-decrease between W=209715.2 (pass) and W=419430.4 (fail), limited by PM-Stokes Hs=8.5 m, gyro-bias x.

## This PR
1. derives the primitive stochastic noise covariance from source configuration rather than trajectory fitting;
2. normalizes the six Gaussian 3-vector streams into an 18-dimensional standardized primitive with source-uniform Cov(z|F) <= I, giving s2<=18 and s4<=360;
3. changes the deployment validator so nonlinear mu_W is recomputed from an outward-rounded endpoint ratio instead of trusted as a supplied margin;
4. recomputes every hybrid inward margin from primitive source/jump/destination bounds, with an explicit 18->21 embedding and new-coordinate budget for H->A;
5. recomputes Gaussian localization, localized second-moment drift, b_W, v_W, Freedman excursion probability, and the total finite-horizon stochastic failure probability instead of trusting supplied final constants;
6. keeps all theorem gates blocked until the remaining source-complete interval bounds are actually supplied and pass those recomputations;
7. reruns the exact-map, information, full nonlinear baseline and independent H/A radius workflow on the new branch.

No production filter behavior, tuning law, acceptance tolerance, or scientific gate is relaxed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added source-derived noise certification for standardized Gaussian noise and physical sensor scales.
  * Enhanced enclosure validation with recomputed nonlinear, hybrid, stochastic, and finite-horizon safety metrics.
  * Added explicit validation for state-dimension transitions, localization limits, sampled failures, and source-noise bounds.

* **Bug Fixes**
  * Prevented validation from relying on copied PASS flags or unverified margin values.

* **Tests**
  * Added comprehensive tests for noise certificates, enclosure validation, determinism, and build-time validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->