### PR TITLE
Bind OU-III proof promotion to current source domain

### DIFF
--- a/.github/workflows/ou3-proof-completion.yml
+++ b/.github/workflows/ou3-proof-completion.yml
@@ -6,8 +6,11 @@ on:
       - "tools/ou3_neighborhood_prefix_driver.py"
       - "tools/ou3_neighborhood_radius_search_fast.py"
       - "tools/ou3_deployment_gate.py"
+      - "tools/ou3_source_domain_contract.py"
+      - "tools/ou3_information_enclosure_contract.py"
       - "tests/validation/test_ou3_neighborhood_prefix_driver.py"
       - "tests/validation/test_ou3_deployment_gate.py"
+      - "tests/validation/test_ou3_source_domain_contract.py"
       - ".github/workflows/ou3-proof-completion.yml"
   workflow_dispatch:
 
@@ -32,16 +35,19 @@ jobs:
           sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
             g++ make libeigen3-dev python3-numpy unzip
 
-      - name: Unit-test new proof arithmetic and prefix replay
+      - name: Unit-test proof arithmetic, source domain and prefix replay
         run: |
           python3 -m py_compile \
             tools/ou3_neighborhood_prefix_driver.py \
             tools/ou3_neighborhood_radius_search_fast.py \
+            tools/ou3_source_domain_contract.py \
             tools/ou3_deployment_gate.py \
             tests/validation/test_ou3_neighborhood_prefix_driver.py \
+            tests/validation/test_ou3_source_domain_contract.py \
             tests/validation/test_ou3_deployment_gate.py
           python3 -m unittest -v \
             tests.validation.test_ou3_neighborhood_prefix_driver \
+            tests.validation.test_ou3_source_domain_contract \
             tests.validation.test_ou3_deployment_gate
 
       - name: Download versioned simulation data
@@ -69,7 +75,7 @@ jobs:
             --output-dir "$GITHUB_WORKSPACE/reports/results/ou3_numerical_certificate" \
             --diagnostic-log-dir "$GITHUB_WORKSPACE/reports/diagnostics/ou3_numerical_certificate/logs"
 
-      - name: Generate information certificate and continuous-source contract
+      - name: Generate information and implementation-domain contracts
         run: |
           python3 -u tools/ou3_information_certificate.py \
             --output-dir "$GITHUB_WORKSPACE/reports/results/ou3_numerical_certificate"
@@ -78,6 +84,8 @@ jobs:
             --data-dir "$GITHUB_WORKSPACE/plots/kalman_ou_ii"
           python3 -u tools/ou3_information_enclosure_contract.py \
             --certificate-dir "$GITHUB_WORKSPACE/reports/results/ou3_numerical_certificate"
+          python3 -u tools/ou3_source_domain_contract.py \
+            --output "$GITHUB_WORKSPACE/reports/results/ou3_numerical_certificate/source_domain_contract.json"
 
       - name: Verify W=0.05 full nonlinear basis with exact prefixes
         run: |

--- a/tests/validation/test_ou3_deployment_gate.py
+++ b/tests/validation/test_ou3_deployment_gate.py
@@ -1,8 +1,8 @@
+import copy
 import importlib.util
 import math
 from pathlib import Path
 import sys
-import tempfile
 import unittest
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -59,7 +59,34 @@ class DeploymentGateTests(unittest.TestCase):
         })
         self.assertTrue(s["pass"])
         self.assertLessEqual(s["finite_horizon_failure_probability_upper"], 0.1)
+        self.assertLess(s["finite_horizon_failure_probability_upper"], 1.0)
         self.assertGreater(s["gaussian_t_star_lower"], 0.0)
+
+    def test_source_domain_is_regenerated_and_compared_to_current_source(self):
+        expected = mod.SOURCE_DOMAIN.build(mod.SOURCE_DOMAIN.DEFAULT_HEADER.resolve())
+        out = mod.validate_source_domain(expected)
+        self.assertTrue(out["pass"], out["failures"])
+
+        stale = copy.deepcopy(expected)
+        stale["continuous_parameters"].pop("tau_aw_s")
+        out = mod.validate_source_domain(stale)
+        self.assertFalse(out["pass"])
+        self.assertTrue(any("continuous_parameters" in x for x in out["failures"]))
+
+    def test_required_hybrid_set_is_complete(self):
+        self.assertEqual(
+            mod.REQUIRED_HYBRID,
+            {
+                "startup_handoff",
+                "held_to_active",
+                "magnetic_lock",
+                "magnetic_regauge_refinement",
+                "tilt_reset",
+                "tilt_relock",
+                "cooldown_reentry",
+                "periodic_aw_covariance_sync",
+            },
+        )
 
 
 if __name__ == "__main__":

--- a/tests/validation/test_ou3_source_domain_contract.py
+++ b/tests/validation/test_ou3_source_domain_contract.py
@@ -15,14 +15,36 @@ spec.loader.exec_module(mod)
 class SourceDomainContractTests(unittest.TestCase):
     def test_contract_uses_shipping_clamps_and_keeps_theorem_unpromoted(self):
         d = mod.build(mod.DEFAULT_HEADER)
+        self.assertEqual(d["schema"], 2)
         self.assertTrue(d["source_generated_not_trajectory_fit"])
         self.assertTrue(d["source_complete_parameter_domain"])
         self.assertFalse(d["validated_arithmetic"])
         self.assertFalse(d["outward_rounded"])
         self.assertEqual(d["continuous_parameters"]["tau_aw_s"], [0.02, 12.0])
-        self.assertEqual(d["continuous_parameters"]["sigma_aw_mps2"], [0.0, 6.0])
-        self.assertIn("periodic_aw_covariance_sync", d["hybrid_obligations"])
+        # apply_ou_tune_ enforces max(0.05, band_noise_floor_sigma_()) before
+        # writing the OU stationary standard deviation.
+        self.assertEqual(d["continuous_parameters"]["sigma_aw_mps2"], [0.05, 6.0])
         self.assertEqual(set(d["discrete_source_branches"]["mode"]), {"H", "A"})
+
+    def test_contract_names_every_hybrid_transition_required_for_deployment(self):
+        d = mod.build(mod.DEFAULT_HEADER)
+        self.assertEqual(
+            set(d["hybrid_obligations"]),
+            {
+                "startup_handoff",
+                "held_to_active",
+                "magnetic_lock",
+                "magnetic_regauge_refinement",
+                "tilt_reset",
+                "tilt_relock",
+                "cooldown_reentry",
+                "periodic_aw_covariance_sync",
+            },
+        )
+        self.assertEqual(
+            d["periodic_aw_covariance_sync_proof"]["required_mode"],
+            "PSD_NONEXPANSIVE",
+        )
 
 
 if __name__ == "__main__":

--- a/tools/ou3_deployment_gate.py
+++ b/tools/ou3_deployment_gate.py
@@ -2,8 +2,9 @@
 """Independent final composition gate for the OU-III deployment theorem.
 
 This gate deliberately recomputes stochastic concentration and finite capture
-from primitive validated constants.  It never trusts a supplied final failure
-probability, capture time, or deployment PASS bit.
+from primitive validated constants. It never trusts a supplied final failure
+probability, capture time, deployment PASS bit, or a self-asserted source-domain
+completeness flag.
 """
 from __future__ import annotations
 
@@ -11,6 +12,24 @@ import argparse
 import json
 import math
 from pathlib import Path
+
+import ou3_source_domain_contract as SOURCE_DOMAIN
+
+REQUIRED_HYBRID = set(SOURCE_DOMAIN.HYBRID_OBLIGATIONS)
+SOURCE_DOMAIN_KEYS = (
+    "schema",
+    "claim",
+    "source_generated_not_trajectory_fit",
+    "source_complete_parameter_domain",
+    "validated_arithmetic",
+    "outward_rounded",
+    "implementation_header",
+    "continuous_parameters",
+    "timing_constants_s",
+    "discrete_source_branches",
+    "hybrid_obligations",
+    "periodic_aw_covariance_sync_proof",
+)
 
 
 def pos(x) -> float:
@@ -32,8 +51,10 @@ def t_star_for_radius(radius2: float, m: float, v: float, b: float) -> float:
         return 0.0
     # Solve m + 2 sqrt(v t) + 2 b t = radius2 by monotone bisection.
     lo, hi = 0.0, 1.0
+
     def f(t: float) -> float:
         return m + 2.0 * math.sqrt(max(0.0, v * t)) + 2.0 * b * t
+
     while f(hi) < radius2:
         hi *= 2.0
         if hi > 1.0e12:
@@ -45,6 +66,22 @@ def t_star_for_radius(radius2: float, m: float, v: float, b: float) -> float:
         else:
             hi = mid
     return lo
+
+
+def validate_source_domain(payload: dict) -> dict:
+    """Bind promotion to the contract regenerated from the current source tree."""
+    expected = SOURCE_DOMAIN.build(SOURCE_DOMAIN.DEFAULT_HEADER.resolve())
+    failures = []
+    for key in SOURCE_DOMAIN_KEYS:
+        if payload.get(key) != expected.get(key):
+            failures.append(f"source-domain field {key!r} does not match current implementation")
+    return {
+        "pass": not failures,
+        "failures": failures,
+        "implementation_header": expected["implementation_header"],
+        "continuous_parameters": expected["continuous_parameters"],
+        "hybrid_obligations": expected["hybrid_obligations"],
+    }
 
 
 def derive_stochastic(s: dict) -> dict:
@@ -95,7 +132,9 @@ def derive_stochastic(s: dict) -> dict:
     excursion = 1.0
     if xstar > 0.0:
         denom = 2.0 * (VW + bW * xstar / 3.0)
-        excursion = 0.0 if denom == 0.0 else min(1.0, N * math.exp(-(xstar * xstar) / denom))
+        excursion = 0.0 if denom == 0.0 else min(
+            1.0, N * math.exp(-(xstar * xstar) / denom)
+        )
 
     tstar = t_star_for_radius(wstar * wstar, mSigma, vSigma, bSigma)
     localization = min(1.0, N * ell * math.exp(-tstar))
@@ -114,7 +153,7 @@ def derive_stochastic(s: dict) -> dict:
         "excursion_failure_probability_upper": excursion,
         "finite_horizon_failure_probability_upper": total,
         "failure_probability_budget": budget,
-        "pass": bool(xstar > 0.0 and total <= budget),
+        "pass": bool(xstar > 0.0 and total < 1.0 and total <= budget),
     }
 
 
@@ -149,18 +188,22 @@ def derive_capture(c: dict) -> dict:
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--validated-check", type=Path, required=True)
+    ap.add_argument("--source-domain", type=Path, required=True)
     ap.add_argument("--primitive-bounds", type=Path, required=True)
     ap.add_argument("--output", type=Path, required=True)
     args = ap.parse_args()
 
     check = json.loads(args.validated_check.read_text())
+    source_domain_payload = json.loads(args.source_domain.read_text())
     primitive = json.loads(args.primitive_bounds.read_text())
-    required_hybrid = {
-        "startup_handoff", "held_to_active", "magnetic_regauge",
-        "tilt_reset", "cooldown", "periodic_aw_covariance_sync",
-    }
+
+    source_domain = validate_source_domain(source_domain_payload)
     seen = set(check.get("hybrid", {}).get("seen", []))
-    hybrid_pass = bool(check.get("hybrid", {}).get("pass")) and required_hybrid <= seen
+    hybrid_pass = (
+        source_domain["pass"]
+        and bool(check.get("hybrid", {}).get("pass"))
+        and REQUIRED_HYBRID <= seen
+    )
     modes = check.get("modes", {})
     continuous_pass = all(
         modes.get(m, {}).get("linear_pass") and modes.get(m, {}).get("nonlinear_pass")
@@ -182,16 +225,22 @@ def main() -> int:
 
     capture_pass = all(capture[m]["pass"] for m in ("H", "A"))
     final_pass = bool(
-        provenance_pass and continuous_pass and hybrid_pass
-        and stochastic.get("pass") and capture_pass
+        source_domain["pass"]
+        and provenance_pass
+        and continuous_pass
+        and hybrid_pass
+        and stochastic.get("pass")
+        and capture_pass
     )
     out = {
-        "schema": 1,
+        "schema": 2,
         "qualification": "INDEPENDENT_DEPLOYMENT_THEOREM_COMPOSITION_GATE",
+        "source_domain": source_domain,
+        "source_domain_pass": source_domain["pass"],
         "validated_provenance_pass": provenance_pass,
         "continuous_linear_and_nonlinear_pass": continuous_pass,
         "hybrid_pass": hybrid_pass,
-        "hybrid_required": sorted(required_hybrid),
+        "hybrid_required": sorted(REQUIRED_HYBRID),
         "hybrid_seen": sorted(seen),
         "stochastic": stochastic,
         "capture": capture,

--- a/tools/ou3_information_enclosure_contract.py
+++ b/tools/ou3_information_enclosure_contract.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """Build the continuous-source promotion contract for adaptive OU-III.
 
-The executed information certificate supplies sanity anchors only.  This tool
+The executed information certificate supplies sanity anchors only. This tool
 states the primitive outward-rounded quantities a source-complete validated
-backend must prove.  Final nonlinear, hybrid and stochastic margins are
-recomputed by ``ou3_validate_enclosure.py`` and are never accepted as asserted
-PASS values.
+backend must prove. Final nonlinear, hybrid and stochastic margins are
+recomputed by ``ou3_validate_enclosure.py`` and ``ou3_deployment_gate.py`` and
+are never accepted as asserted PASS values.
 """
 from __future__ import annotations
 
@@ -14,6 +14,7 @@ import json
 from pathlib import Path
 
 import ou3_numerical_certificate as BASE
+import ou3_source_domain_contract as SOURCE_DOMAIN
 
 SCHEMA = 2
 
@@ -88,11 +89,16 @@ def build_contract(info: dict, completion: dict) -> dict:
             "Omega=Sigma1-Phi Sigma0 Phi^T"
         ),
         "modes": modes,
+        "source_domain_requirement": {
+            "producer": "tools/ou3_source_domain_contract.py",
+            "claim": "OU3_SOURCE_COMPLETE_IMPLEMENTATION_DOMAIN_CONTRACT",
+            "validation": (
+                "final deployment gate regenerates the source-domain contract from the current "
+                "implementation and rejects stale, truncated, or self-asserted domain artifacts"
+            ),
+        },
         "hybrid_requirements": {
-            "required_kinds": [
-                "startup_handoff", "held_to_active", "magnetic_regauge",
-                "tilt_reset", "cooldown",
-            ],
+            "required_kinds": list(SOURCE_DOMAIN.HYBRID_OBLIGATIONS),
             "primitive_bounds_per_jump": [
                 "source_complete", "outward_rounded", "source_level_W_upper",
                 "jump_gain_upper", "additive_W_upper", "destination_level_W",
@@ -102,6 +108,11 @@ def build_contract(info: dict, completion: dict) -> dict:
                 "source_dimension=18", "destination_dimension=21",
                 "dimension_change_handled_by_embedding=true",
                 "new_coordinate_W_upper",
+            ],
+            "periodic_aw_covariance_sync_extra": [
+                "proof_mode=PSD_NONEXPANSIVE",
+                "P_plus=P_minus+E_a Delta_plus E_a^T with Delta_plus>=0",
+                "inverse-covariance information energy nonexpansive",
             ],
             "verifier_formula": (
                 "post_W_upper=jump_gain_upper*source_level_W_upper+"
@@ -129,11 +140,13 @@ def build_contract(info: dict, completion: dict) -> dict:
             "outward rounding",
             "source-generated enclosure, not trajectory fitting",
             "complete continuous source coverage",
+            "source-domain artifact exactly matches current implementation-generated contract",
         ],
         "promotion_rule": (
             "executed replay values are sanity anchors only; deployment PASS requires "
             "strict validated continuous-source linear and nonlinear bounds, recomputed "
-            "hybrid inward margins, and recomputed stochastic concentration"
+            "hybrid inward margins, recomputed stochastic concentration, independently "
+            "recomputed finite capture, and exact binding to the current implementation domain"
         ),
     }
 

--- a/tools/ou3_source_domain_contract.py
+++ b/tools/ou3_source_domain_contract.py
@@ -9,7 +9,9 @@ must cover.
 from __future__ import annotations
 
 import argparse
+import ast
 import json
+import math
 import re
 from pathlib import Path
 
@@ -34,27 +36,55 @@ HYBRID_OBLIGATIONS = (
     "periodic_aw_covariance_sync",
 )
 
+CONST_RE = re.compile(
+    r"constexpr\s+float\s+([A-Za-z_]\w*)\s*=\s*([^;]+);", re.MULTILINE
+)
+
+
+def _strip_float_suffixes(expr: str) -> str:
+    return re.sub(r"(?<=\d)[fF]\b", "", expr)
+
+
+def _eval_constexpr(node: ast.AST, text: str, stack: tuple[str, ...]) -> float:
+    if isinstance(node, ast.Expression):
+        return _eval_constexpr(node.body, text, stack)
+    if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+        return float(node.value)
+    if isinstance(node, ast.Name):
+        return parse_const(text, node.id, stack)
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
+        x = _eval_constexpr(node.operand, text, stack)
+        return x if isinstance(node.op, ast.UAdd) else -x
+    if isinstance(node, ast.BinOp):
+        a = _eval_constexpr(node.left, text, stack)
+        b = _eval_constexpr(node.right, text, stack)
+        if isinstance(node.op, ast.Add):
+            return a + b
+        if isinstance(node.op, ast.Sub):
+            return a - b
+        if isinstance(node.op, ast.Mult):
+            return a * b
+        if isinstance(node.op, ast.Div):
+            return a / b
+    raise RuntimeError(f"unsupported constexpr expression node: {ast.dump(node)}")
+
 
 def parse_const(text: str, name: str, stack: tuple[str, ...] = ()) -> float:
-    """Resolve a scalar constexpr float literal or direct scalar alias."""
+    """Resolve a scalar constexpr using only names, numbers and +,-,*,/."""
     if name in stack:
         raise RuntimeError(f"cyclic implementation constant alias: {' -> '.join((*stack, name))}")
-    pat = re.compile(
-        rf"constexpr\s+float\s+{re.escape(name)}\s*=\s*([^;]+)\s*;"
-    )
-    m = pat.search(text)
-    if not m:
+    expressions = {n: expr for n, expr in CONST_RE.findall(text)}
+    if name not in expressions:
         raise RuntimeError(f"cannot extract implementation constant {name}")
-    expr = m.group(1).strip()
-    literal = re.fullmatch(r"([0-9.+\-eE]+)f?", expr)
-    if literal:
-        return float(literal.group(1))
-    alias = re.fullmatch(r"([A-Za-z_][A-Za-z0-9_]*)", expr)
-    if alias:
-        return parse_const(text, alias.group(1), (*stack, name))
-    raise RuntimeError(
-        f"implementation constant {name} is no longer a scalar literal/alias: {expr!r}"
-    )
+    expr = " ".join(_strip_float_suffixes(expressions[name]).split())
+    try:
+        tree = ast.parse(expr, mode="eval")
+        value = _eval_constexpr(tree, text, (*stack, name))
+    except (SyntaxError, ZeroDivisionError) as exc:
+        raise RuntimeError(f"cannot evaluate implementation constant {name}: {expr!r}") from exc
+    if not math.isfinite(value):
+        raise RuntimeError(f"implementation constant {name} is non-finite: {expr!r}")
+    return float(value)
 
 
 def parse_aw_sigma_floor(text: str) -> float:

--- a/tools/ou3_source_domain_contract.py
+++ b/tools/ou3_source_domain_contract.py
@@ -3,7 +3,8 @@
 
 This producer intentionally does not infer bounds from the eight reference
 trajectories. It parses the shipping implementation's safety/clamp constants
-and records every discrete branch the validated backend must cover.
+and records every discrete branch and hybrid transition the validated backend
+must cover.
 """
 from __future__ import annotations
 
@@ -20,6 +21,17 @@ REQUIRED = (
     "MAX_SIGMA_A", "MIN_R_S", "MAX_R_S",
     "PSEUDO_UPDATE_PERIOD_MIN_S_DEFAULT", "PSEUDO_UPDATE_PERIOD_MAX_S_DEFAULT",
     "MAG_DELAY_SEC", "ONLINE_TUNE_WARMUP_SEC",
+)
+
+HYBRID_OBLIGATIONS = (
+    "startup_handoff",
+    "held_to_active",
+    "magnetic_lock",
+    "magnetic_regauge_refinement",
+    "tilt_reset",
+    "tilt_relock",
+    "cooldown_reentry",
+    "periodic_aw_covariance_sync",
 )
 
 
@@ -45,11 +57,24 @@ def parse_const(text: str, name: str, stack: tuple[str, ...] = ()) -> float:
     )
 
 
+def parse_aw_sigma_floor(text: str) -> float:
+    """Extract the deployed lower floor used before setting Sigma_aw_stat."""
+    pat = re.compile(
+        r"const\s+float\s+sigma_floor\s*=\s*std::max\(\s*"
+        r"([0-9.+\-eE]+)f?\s*,\s*band_noise_floor_sigma_\(\)\s*\)\s*;"
+    )
+    m = pat.search(text)
+    if not m:
+        raise RuntimeError("cannot extract deployed a_w stationary-std floor")
+    return float(m.group(1))
+
+
 def build(header: Path) -> dict:
     text = header.read_text()
     c = {name: parse_const(text, name) for name in REQUIRED}
+    sigma_floor = parse_aw_sigma_floor(text)
     return {
-        "schema": 1,
+        "schema": 2,
         "claim": "OU3_SOURCE_COMPLETE_IMPLEMENTATION_DOMAIN_CONTRACT",
         "source_generated_not_trajectory_fit": True,
         "source_complete_parameter_domain": True,
@@ -59,7 +84,7 @@ def build(header: Path) -> dict:
         "continuous_parameters": {
             "wave_tune_frequency_hz": [c["MIN_TUNE_FREQ_HZ"], c["MAX_TUNE_FREQ_HZ"]],
             "tau_aw_s": [c["MIN_TAU_S"], c["MAX_TAU_S"]],
-            "sigma_aw_mps2": [0.0, c["MAX_SIGMA_A"]],
+            "sigma_aw_mps2": [sigma_floor, c["MAX_SIGMA_A"]],
             "R_S_base": [c["MIN_R_S"], c["MAX_R_S"]],
             "pseudo_update_period_s": [
                 c["PSEUDO_UPDATE_PERIOD_MIN_S_DEFAULT"],
@@ -76,12 +101,15 @@ def build(header: Path) -> dict:
             "magnetometer_gate": ["not_due", "accepted", "rejected"],
             "S_zero_pseudo": ["not_due", "due"],
             "magnetic_gauge": ["unlocked", "locked", "refined"],
+            "tilt_recovery": ["normal", "reset", "relock", "cooldown_reentry"],
             "aw_covariance_sync": ["not_due", "due_psd_increment"],
         },
-        "hybrid_obligations": [
-            "startup_handoff", "held_to_active", "magnetic_regauge",
-            "tilt_reset", "cooldown", "periodic_aw_covariance_sync",
-        ],
+        "hybrid_obligations": list(HYBRID_OBLIGATIONS),
+        "periodic_aw_covariance_sync_proof": {
+            "required_mode": "PSD_NONEXPANSIVE",
+            "operation": "P_plus=P_minus+E_a Delta_plus E_a^T with Delta_plus>=0",
+            "metric_consequence": "inverse-covariance information energy is nonexpansive",
+        },
         "promotion_rule": (
             "these implementation bounds define the source domain only; theorem promotion "
             "still requires outward-rounded interval/Taylor-model propagation over the full domain"


### PR DESCRIPTION
## Synced scope

Rebased onto current `main` at `c1179a8a3b361b93ed82ca47a3882c06096981ee` after PR #402 merged. Duplicate prefix-search and deployment-gate machinery from #402 has been dropped; this PR now contains only the remaining non-duplicate proof-closure hardening.

### Source-domain binding
- `ou3_source_domain_contract.py` is generated from shipping implementation guards, not replay extrema.
- The deployed OU stationary-standard-deviation floor is extracted from `apply_ou_tune_()` (`0.05 m/s^2`), tightening the implementation domain from the conservative zero lower bound.
- The independent deployment gate regenerates the expected source-domain contract from the current source tree and rejects stale, truncated, or self-asserted domain artifacts.

### Complete hybrid closure contract
The required deployment transitions are now explicit and independent:
- startup handoff;
- H -> A 18-to-21 dimensional embedding;
- magnetic lock;
- magnetic regauge/refinement;
- tilt reset;
- tilt relock;
- cooldown/re-entry;
- periodic `a_w` covariance synchronization.

The periodic covariance synchronization obligation explicitly requires the `PSD_NONEXPANSIVE` inverse-covariance argument.

### Stochastic and finite-capture gate
The stronger implementation already on current `main` is retained: the gate recomputes stochastic concentration and finite capture from primitives. A stochastic result cannot pass with a vacuous probability bound: the recomputed finite-horizon failure probability must be strictly below one and below its declared budget.

### CI
The proof-completion workflow now unit-tests the source-domain and deployment-gate contracts and emits `source_domain_contract.json` with the numerical proof artifacts.

This PR does not claim the deployment theorem itself. It hardens the promotion gate so a future outward-rounded continuous-source/nonlinear enclosure cannot be promoted unless it is tied to the current deployed source domain and closes every required hybrid transition.