### PR TITLE
Continue OU-III theorem certificate closure

### DIFF
--- a/README.tmp-proof-sync-placeholder
+++ b/README.tmp-proof-sync-placeholder
@@ -1,0 +1,1 @@
+placeholder

--- a/README.tmp-proof-sync-placeholder
+++ b/README.tmp-proof-sync-placeholder
@@ -1,1 +1,0 @@
-placeholder

--- a/tests/validation/test_ou3_source_domain_contract.py
+++ b/tests/validation/test_ou3_source_domain_contract.py
@@ -32,9 +32,6 @@ class SourceDomainContractTests(unittest.TestCase):
         self.assertEqual(
             d["continuous_parameters"]["tau_aw_s"], [f32(0.02), f32(12.0)]
         )
-        # apply_ou_tune_ enforces max(0.05f, band_noise_floor_sigma_()) before
-        # writing the OU stationary standard deviation.  The contract records
-        # the actually deployed binary32 floor, not the decimal source token.
         self.assertEqual(
             d["continuous_parameters"]["sigma_aw_mps2"], [f32(0.05), f32(6.0)]
         )
@@ -92,9 +89,6 @@ class SourceDomainContractTests(unittest.TestCase):
         )
 
     def test_rational_taylor_ou_primitive_box_contains_direct_evaluations(self):
-        # This is the range the proof backend will use once deployment supplies
-        # a finite accepted-step upper guard.  It deliberately spans the full
-        # current tau safety range, including the x=h/tau=12.5 corner.
         box = mod.validated_ou_primitives((0.001, 0.25), (0.02, 12.0))
         self.assertTrue(box["validated_arithmetic"])
         self.assertTrue(box["outward_rounded"])
@@ -114,6 +108,34 @@ class SourceDomainContractTests(unittest.TestCase):
                 self.assertGreaterEqual(box["phi_pa_s2"][1], phi_pa)
                 self.assertLessEqual(box["phi_Sa_s3"][0], phi_sa)
                 self.assertGreaterEqual(box["phi_Sa_s3"][1], phi_sa)
+
+    def test_validated_axis_transition_contains_deployed_formula_grid(self):
+        box = mod.validated_phi_axis4((0.001, 0.25), (0.02, 12.0))
+        self.assertTrue(box["validated_arithmetic"])
+        self.assertTrue(box["outward_rounded"])
+        self.assertEqual(box["state_order"], ["v", "p", "S", "a_w"])
+        M = box["Phi_interval"]
+
+        def contains(i, j, value):
+            self.assertLessEqual(M[i][j][0], value, (i, j, value, M[i][j]))
+            self.assertGreaterEqual(M[i][j][1], value, (i, j, value, M[i][j]))
+
+        for h in (0.001, 0.005, 0.05, 0.25):
+            for tau in (0.02, 0.1, 1.0, 12.0):
+                x = h / tau
+                alpha = math.exp(-x)
+                phi_va = tau * (1.0 - alpha)
+                phi_pa = tau * tau * (x + math.expm1(-x))
+                phi_sa = tau ** 3 * (0.5 * x * x - x - math.expm1(-x))
+                exact = (
+                    (1.0, 0.0, 0.0, phi_va),
+                    (h, 1.0, 0.0, phi_pa),
+                    (0.5 * h * h, h, 1.0, phi_sa),
+                    (0.0, 0.0, 0.0, alpha),
+                )
+                for i in range(4):
+                    for j in range(4):
+                        contains(i, j, exact[i][j])
 
     def test_contract_names_every_hybrid_transition_required_for_deployment(self):
         d = mod.build(mod.DEFAULT_HEADER)

--- a/tests/validation/test_ou3_source_domain_contract.py
+++ b/tests/validation/test_ou3_source_domain_contract.py
@@ -80,6 +80,41 @@ class SourceDomainContractTests(unittest.TestCase):
             self.assertEqual(lo, math.nextafter(source_value, -math.inf))
             self.assertEqual(hi, math.nextafter(source_value, math.inf))
 
+    def test_deployment_step_domain_exposes_missing_finite_upper_guard(self):
+        d = mod.build(mod.DEFAULT_HEADER)
+        step = d["accepted_update_step_domain_s"]
+        self.assertEqual(step["lower_open"], 0.0)
+        self.assertIsNone(step["upper"])
+        self.assertFalse(step["source_complete_finite_upper_bound"])
+        self.assertEqual(
+            d["validated_ou_primitive_backend"]["theorem_promotion"],
+            "BLOCKED_BY_UNBOUNDED_ACCEPTED_DT",
+        )
+
+    def test_rational_taylor_ou_primitive_box_contains_direct_evaluations(self):
+        # This is the range the proof backend will use once deployment supplies
+        # a finite accepted-step upper guard.  It deliberately spans the full
+        # current tau safety range, including the x=h/tau=12.5 corner.
+        box = mod.validated_ou_primitives((0.001, 0.25), (0.02, 12.0))
+        self.assertTrue(box["validated_arithmetic"])
+        self.assertTrue(box["outward_rounded"])
+        self.assertLessEqual(box["alpha"][0], box["alpha"][1])
+        self.assertLessEqual(box["phi_pa_s2"][0], box["phi_pa_s2"][1])
+        self.assertLessEqual(box["phi_Sa_s3"][0], box["phi_Sa_s3"][1])
+
+        for h in (0.001, 0.005, 0.05, 0.25):
+            for tau in (0.02, 0.1, 1.0, 12.0):
+                x = h / tau
+                alpha = math.exp(-x)
+                phi_pa = tau * tau * (x + math.expm1(-x))
+                phi_sa = tau ** 3 * (0.5 * x * x - x - math.expm1(-x))
+                self.assertLessEqual(box["alpha"][0], alpha)
+                self.assertGreaterEqual(box["alpha"][1], alpha)
+                self.assertLessEqual(box["phi_pa_s2"][0], phi_pa)
+                self.assertGreaterEqual(box["phi_pa_s2"][1], phi_pa)
+                self.assertLessEqual(box["phi_Sa_s3"][0], phi_sa)
+                self.assertGreaterEqual(box["phi_Sa_s3"][1], phi_sa)
+
     def test_contract_names_every_hybrid_transition_required_for_deployment(self):
         d = mod.build(mod.DEFAULT_HEADER)
         self.assertEqual(

--- a/tests/validation/test_ou3_source_domain_contract.py
+++ b/tests/validation/test_ou3_source_domain_contract.py
@@ -18,6 +18,26 @@ def f32(value):
     return struct.unpack(">f", struct.pack(">f", float(value)))[0]
 
 
+def approximate_qd(h, tau, sigma2, n=4096):
+    dr = h / n
+    out = [[0.0] * 4 for _ in range(4)]
+    qc = 2.0 * sigma2 / tau
+    for k in range(n):
+        r = (k + 0.5) * dr
+        x = r / tau
+        a = math.exp(-x)
+        g = (
+            tau * (1.0 - a),
+            tau * tau * (x + math.expm1(-x)),
+            tau ** 3 * (0.5 * x * x - x - math.expm1(-x)),
+            a,
+        )
+        for i in range(4):
+            for j in range(4):
+                out[i][j] += qc * g[i] * g[j] * dr
+    return out
+
+
 class SourceDomainContractTests(unittest.TestCase):
     def test_contract_uses_shipping_clamps_and_keeps_theorem_unpromoted(self):
         d = mod.build(mod.DEFAULT_HEADER)
@@ -154,36 +174,54 @@ class SourceDomainContractTests(unittest.TestCase):
         self.assertFalse(box["shipping_psd_cleanup_enclosed"])
         Q = box["Qd_interval"]
 
-        def approximate(h, tau, sigma2, n=4096):
-            dr = h / n
-            out = [[0.0] * 4 for _ in range(4)]
-            qc = 2.0 * sigma2 / tau
-            for k in range(n):
-                r = (k + 0.5) * dr
-                x = r / tau
-                a = math.exp(-x)
-                g = (
-                    tau * (1.0 - a),
-                    tau * tau * (x + math.expm1(-x)),
-                    tau ** 3 * (0.5 * x * x - x - math.expm1(-x)),
-                    a,
-                )
-                for i in range(4):
-                    for j in range(4):
-                        out[i][j] += qc * g[i] * g[j] * dr
-            return out
-
         for h, tau, sigma2 in (
             (0.001, 0.02, 0.0025),
             (0.005, 0.1, 0.25),
             (0.02, 1.0, 1.0),
             (0.05, 2.0, 4.0),
         ):
-            q = approximate(h, tau, sigma2)
+            q = approximate_qd(h, tau, sigma2)
             for i in range(4):
                 for j in range(4):
                     self.assertLessEqual(Q[i][j][0], q[i][j] + 1e-15)
                     self.assertGreaterEqual(Q[i][j][1] + 1e-15, q[i][j])
+
+    def test_validated_covariance_prediction_contains_direct_point_prediction(self):
+        P0 = [
+            [[0.5, 0.5], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
+            [[0.0, 0.0], [1.0, 1.0], [0.0, 0.0], [0.0, 0.0]],
+            [[0.0, 0.0], [0.0, 0.0], [2.0, 2.0], [0.0, 0.0]],
+            [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.1, 0.1]],
+        ]
+        h, tau, sigma2 = 0.005, 1.0, 0.25
+        out = mod.validated_covariance_predict_axis4(
+            P0, (h, h), (tau, tau), (sigma2, sigma2), cells=12
+        )
+        self.assertTrue(out["validated_arithmetic"])
+        self.assertTrue(out["mathematical_prediction_enclosed"])
+        self.assertFalse(out["shipping_covariance_prediction_enclosed"])
+        Pbox = out["P_predicted_interval"]
+
+        x = h / tau
+        a = math.exp(-x)
+        Phi = [
+            [1.0, 0.0, 0.0, tau * (1.0 - a)],
+            [h, 1.0, 0.0, tau * tau * (x + math.expm1(-x))],
+            [0.5 * h * h, h, 1.0,
+             tau ** 3 * (0.5 * x * x - x - math.expm1(-x))],
+            [0.0, 0.0, 0.0, a],
+        ]
+        Ppoint = [[P0[i][j][0] for j in range(4)] for i in range(4)]
+        AP = [[sum(Phi[i][k] * Ppoint[k][j] for k in range(4))
+               for j in range(4)] for i in range(4)]
+        pred = [[sum(AP[i][k] * Phi[j][k] for k in range(4))
+                 for j in range(4)] for i in range(4)]
+        q = approximate_qd(h, tau, sigma2)
+        for i in range(4):
+            for j in range(4):
+                value = pred[i][j] + q[i][j]
+                self.assertLessEqual(Pbox[i][j][0], value + 1e-15)
+                self.assertGreaterEqual(Pbox[i][j][1] + 1e-15, value)
 
     def test_contract_names_every_hybrid_transition_required_for_deployment(self):
         d = mod.build(mod.DEFAULT_HEADER)

--- a/tests/validation/test_ou3_source_domain_contract.py
+++ b/tests/validation/test_ou3_source_domain_contract.py
@@ -83,9 +83,13 @@ class SourceDomainContractTests(unittest.TestCase):
         self.assertEqual(step["lower_open"], 0.0)
         self.assertIsNone(step["upper"])
         self.assertFalse(step["source_complete_finite_upper_bound"])
-        self.assertEqual(
+        self.assertIn(
+            "UNBOUNDED_ACCEPTED_DT",
             d["validated_ou_primitive_backend"]["theorem_promotion"],
-            "BLOCKED_BY_UNBOUNDED_ACCEPTED_DT",
+        )
+        self.assertFalse(
+            d["validated_ou_primitive_backend"]
+            ["process_covariance_shipping_float_path_enclosed"]
         )
 
     def test_rational_taylor_ou_primitive_box_contains_direct_evaluations(self):
@@ -136,6 +140,50 @@ class SourceDomainContractTests(unittest.TestCase):
                 for i in range(4):
                     for j in range(4):
                         contains(i, j, exact[i][j])
+
+    def test_validated_process_covariance_contains_midpoint_quadrature_samples(self):
+        # The interval construction itself is proof-producing; this numerical
+        # quadrature is only a regression oracle against several interior
+        # parameter points.  It must lie inside every elementwise interval.
+        box = mod.validated_qd_axis4_kernel(
+            (0.001, 0.05), (0.02, 2.0), (0.0025, 4.0), cells=12
+        )
+        self.assertTrue(box["validated_arithmetic"])
+        self.assertTrue(box["mathematical_integral_enclosed"])
+        self.assertFalse(box["shipping_binary32_closed_form_enclosed"])
+        self.assertFalse(box["shipping_psd_cleanup_enclosed"])
+        Q = box["Qd_interval"]
+
+        def approximate(h, tau, sigma2, n=4096):
+            dr = h / n
+            out = [[0.0] * 4 for _ in range(4)]
+            qc = 2.0 * sigma2 / tau
+            for k in range(n):
+                r = (k + 0.5) * dr
+                x = r / tau
+                a = math.exp(-x)
+                g = (
+                    tau * (1.0 - a),
+                    tau * tau * (x + math.expm1(-x)),
+                    tau ** 3 * (0.5 * x * x - x - math.expm1(-x)),
+                    a,
+                )
+                for i in range(4):
+                    for j in range(4):
+                        out[i][j] += qc * g[i] * g[j] * dr
+            return out
+
+        for h, tau, sigma2 in (
+            (0.001, 0.02, 0.0025),
+            (0.005, 0.1, 0.25),
+            (0.02, 1.0, 1.0),
+            (0.05, 2.0, 4.0),
+        ):
+            q = approximate(h, tau, sigma2)
+            for i in range(4):
+                for j in range(4):
+                    self.assertLessEqual(Q[i][j][0], q[i][j] + 1e-15)
+                    self.assertGreaterEqual(Q[i][j][1] + 1e-15, q[i][j])
 
     def test_contract_names_every_hybrid_transition_required_for_deployment(self):
         d = mod.build(mod.DEFAULT_HEADER)

--- a/tests/validation/test_ou3_source_domain_contract.py
+++ b/tests/validation/test_ou3_source_domain_contract.py
@@ -77,14 +77,17 @@ class SourceDomainContractTests(unittest.TestCase):
             self.assertEqual(lo, math.nextafter(source_value, -math.inf))
             self.assertEqual(hi, math.nextafter(source_value, math.inf))
 
-    def test_deployment_step_domain_exposes_missing_finite_upper_guard(self):
+    def test_deployment_step_domain_distinguishes_type_bound_from_supported_guard(self):
         d = mod.build(mod.DEFAULT_HEADER)
         step = d["accepted_update_step_domain_s"]
-        self.assertEqual(step["lower_open"], 0.0)
-        self.assertIsNone(step["upper"])
-        self.assertFalse(step["source_complete_finite_upper_bound"])
+        self.assertGreater(step["lower_closed"], 0.0)
+        self.assertTrue(math.isfinite(step["upper_closed"]))
+        self.assertGreater(step["upper_closed"], 1.0e30)
+        self.assertTrue(step["type_level_finite_upper_bound"])
+        self.assertFalse(step["operational_safety_upper_guard"])
+        self.assertFalse(step["proof_usable_supported_upper_bound"])
         self.assertIn(
-            "UNBOUNDED_ACCEPTED_DT",
+            "NO_PROOF_USABLE_ACCEPTED_DT_GUARD",
             d["validated_ou_primitive_backend"]["theorem_promotion"],
         )
         self.assertFalse(
@@ -142,9 +145,6 @@ class SourceDomainContractTests(unittest.TestCase):
                         contains(i, j, exact[i][j])
 
     def test_validated_process_covariance_contains_midpoint_quadrature_samples(self):
-        # The interval construction itself is proof-producing; this numerical
-        # quadrature is only a regression oracle against several interior
-        # parameter points.  It must lie inside every elementwise interval.
         box = mod.validated_qd_axis4_kernel(
             (0.001, 0.05), (0.02, 2.0), (0.0025, 4.0), cells=12
         )

--- a/tools/ou3_source_domain_contract.py
+++ b/tools/ou3_source_domain_contract.py
@@ -23,17 +23,18 @@ covariance using the positive impulse-response kernel
 
     Qd = (2 sigma^2 / tau) integral_0^h g(r) g(r)^T dr.
 
-The kernel integral is subdivided into cells.  Every cell uses the validated
+The kernel integral is subdivided into cells. Every cell uses the validated
 transition/OU primitive bounds, and every sum/product is accumulated as an
-exact Fraction.  This avoids the cancellation-heavy closed-form covariance
-expressions.  The claim is intentionally narrow: it encloses the mathematical
+exact Fraction. This avoids the cancellation-heavy closed-form covariance
+expressions. The claim is intentionally narrow: it encloses the mathematical
 continuous OU covariance, while the shipping binary32 closed-form computation
 and its PSD cleanup remain a separate implementation-arithmetic obligation.
 
-All word-level arithmetic is intentionally parameterized by an accepted-step
-interval: the deployed wrapper presently checks only dt>0 and finiteness, so
-the source contract records the missing finite upper step guard as an explicit
-theorem blocker instead of silently substituting the nominal 200 Hz period.
+The public wrapper accepts every positive finite binary32 ``dt``. That set is
+technically finite -- [2^-149, FLT_MAX] -- but it has no operational safety
+upper guard. A deployment theorem therefore still needs a source/configuration
+supported-step bound that is small enough for finite, physically meaningful
+transition and covariance enclosures; nominal 200 Hz is not silently assumed.
 """
 from __future__ import annotations
 
@@ -382,18 +383,7 @@ def validated_qd_axis4_kernel(h_bounds: tuple[float, float] | list[float],
                               tau_bounds: tuple[float, float] | list[float],
                               sigma2_bounds: tuple[float, float] | list[float],
                               cells: int = 24, order: int = 96) -> dict:
-    """Rigorous elementwise enclosure of the mathematical integrated-OU Qd.
-
-    The chain impulse response from the white driving noise to [v,p,S,a] is
-    exactly the fourth column of the transition matrix evaluated at elapsed
-    time r.  All four components are nonnegative for r>=0,tau>0. Therefore
-    each covariance entry is a monotone-in-h integral of a nonnegative product.
-
-    This routine bounds the minimum at h_lo and maximum at h_hi by cellwise
-    interval integration and then applies qc=2*sigma2/tau. Dependencies are
-    discarded conservatively.  It does not yet claim enclosure of the shipping
-    binary32 closed-form evaluation or regularize_psd_if_needed() perturbation.
-    """
+    """Rigorous elementwise enclosure of the mathematical integrated-OU Qd."""
     h_lo_f, h_hi_f = map(float, h_bounds)
     t_lo_f, t_hi_f = map(float, tau_bounds)
     s_lo_f, s_hi_f = map(float, sigma2_bounds)
@@ -477,6 +467,8 @@ def build(header: Path) -> dict:
         "nonlinear_word_enclosed": False,
         "theorem_promotion": "NOT_ESTABLISHED",
     }
+    min_positive_f32 = float(_bits_to_positive_fraction(1))
+    max_finite_f32 = float(_bits_to_positive_fraction(_FLOAT32_MAX_BITS))
     return {
         "schema": 2,
         "claim": "OU3_SOURCE_COMPLETE_IMPLEMENTATION_DOMAIN_CONTRACT",
@@ -494,27 +486,31 @@ def build(header: Path) -> dict:
         "timing_constants_s": timing,
         "validated_parameter_box": parameter_box,
         "accepted_update_step_domain_s": {
-            "lower_open": 0.0,
-            "upper": None,
-            "source_complete_finite_upper_bound": False,
+            "lower_closed": min_positive_f32,
+            "upper_closed": max_finite_f32,
+            "type_level_finite_upper_bound": True,
+            "operational_safety_upper_guard": False,
+            "proof_usable_supported_upper_bound": False,
             "implementation_observation": (
-                "SeaStateFusionFilter_OU_III::updateCore_ rejects nonpositive/nonfinite dt "
-                "but currently has no finite upper accepted-step guard"
+                "SeaStateFusionFilter_OU_III::updateCore_ accepts every positive finite binary32 dt; "
+                "the IEEE-754 type supplies a finite maximum but the implementation supplies no "
+                "operationally meaningful maximum supported step"
             ),
             "theorem_effect": (
-                "continuous H/A transition and process-noise enclosure cannot be source-complete "
-                "until accepted dt has a finite implementation/configuration upper bound"
+                "a source-complete type-level domain exists, but its FLT_MAX upper endpoint is not a "
+                "finite-state operational domain for the transition/covariance formulas; theorem "
+                "promotion requires a source/configuration supported-step guard or equivalent caller contract"
             ),
         },
         "validated_ou_primitive_backend": {
             "available": True,
-            "requires_finite_h_upper": True,
+            "requires_proof_usable_h_upper": True,
             "backend": "EXACT_RATIONAL_TAYLOR_WITH_LAGRANGE_REMAINDER",
             "transition_matrix_backend": "VALIDATED_INTERVAL_4X4_INTEGRATED_OU_CHAIN",
             "process_covariance_backend": "POSITIVE_KERNEL_CELL_INTERVAL_EXACT_RATIONAL_ACCUMULATION",
             "process_covariance_mathematical_integral_enclosed": True,
             "process_covariance_shipping_float_path_enclosed": False,
-            "theorem_promotion": "BLOCKED_BY_UNBOUNDED_ACCEPTED_DT_AND_SHIPPING_QD_FLOAT_PATH",
+            "theorem_promotion": "BLOCKED_BY_NO_PROOF_USABLE_ACCEPTED_DT_GUARD_AND_SHIPPING_QD_FLOAT_PATH",
         },
         "discrete_source_branches": {
             "mode": ["H", "A"],
@@ -533,9 +529,9 @@ def build(header: Path) -> dict:
         },
         "promotion_rule": (
             "source-boundary scalar arithmetic, exact per-axis transition and mathematical OU process "
-            "covariance are now enclosed; deployment promotion still requires a finite source-derived "
-            "accepted-dt upper bound, enclosure of the shipping binary32 Qd/PSD-cleanup path, full H/A "
-            "Riccati propagation, nonlinear SO(3) remainder bounds and remaining jump certificates"
+            "covariance are now enclosed; deployment promotion still requires a proof-usable source-derived "
+            "accepted-dt upper guard/contract, enclosure of the shipping binary32 Qd/PSD-cleanup path, full "
+            "H/A Riccati propagation, nonlinear SO(3) remainder bounds and remaining jump certificates"
         ),
     }
 

--- a/tools/ou3_source_domain_contract.py
+++ b/tools/ou3_source_domain_contract.py
@@ -16,8 +16,11 @@ exact binary64 representation of the deployed binary32 value.
 The producer also contains the first transcendental enclosure used by the
 continuous-word proof. ``validated_ou_primitives`` bounds exp(-h/tau), phi_pa
 and phi_Sa using exact rational Taylor arithmetic plus an explicit Lagrange
-remainder. It is intentionally parameterized by an accepted-step interval:
-the deployed wrapper presently checks only dt>0 and finiteness, so the source
+remainder. ``validated_phi_axis4`` lifts those scalar bounds to the exact 4x4
+[v,p,S,a] transition used by IntegratedOUChain<T,3>::transition.
+
+Both are intentionally parameterized by an accepted-step interval: the
+deployed wrapper presently checks only dt>0 and finiteness, so the source
 contract records the missing finite upper step guard as an explicit theorem
 blocker instead of silently substituting the nominal 200 Hz period.
 """
@@ -79,12 +82,7 @@ def _bits_to_positive_fraction(bits: int) -> Fraction:
 
 
 def _round_fraction_binary32(value: Fraction) -> Fraction:
-    """Round an exact rational to finite binary32, nearest/ties-to-even.
-
-    Python binary64 is used only to locate a nearby candidate. The final choice
-    is made by exact rational distances over that candidate and its neighbours,
-    so possible binary64 double-rounding cannot change the selected binary32.
-    """
+    """Round an exact rational to finite binary32, nearest/ties-to-even."""
     if value == 0:
         return Fraction(0, 1)
     sign = -1 if value < 0 else 1
@@ -188,7 +186,6 @@ def parse_aw_sigma_floor(text: str) -> float:
 
 
 def _outward_point(x: float) -> list[float]:
-    """Return an explicit binary64 enclosure of an exact deployed binary32."""
     x = float(x)
     if not math.isfinite(x):
         raise RuntimeError(f"non-finite source-domain endpoint {x!r}")
@@ -196,7 +193,6 @@ def _outward_point(x: float) -> list[float]:
 
 
 def _outward_box(lo: float, hi: float) -> list[float]:
-    """Return an outward-rounded binary64 box containing two source endpoints."""
     lo = float(lo)
     hi = float(hi)
     if not (math.isfinite(lo) and math.isfinite(hi)) or lo > hi:
@@ -205,7 +201,6 @@ def _outward_box(lo: float, hi: float) -> list[float]:
 
 
 def _fraction_down(q: Fraction) -> float:
-    """Greatest convenient binary64 lower enclosure of exact rational q."""
     y = float(q)
     if Fraction.from_float(y) > q:
         y = math.nextafter(y, -math.inf)
@@ -213,7 +208,6 @@ def _fraction_down(q: Fraction) -> float:
 
 
 def _fraction_up(q: Fraction) -> float:
-    """Least convenient binary64 upper enclosure of exact rational q."""
     y = float(q)
     if Fraction.from_float(y) < q:
         y = math.nextafter(y, math.inf)
@@ -221,13 +215,7 @@ def _fraction_up(q: Fraction) -> float:
 
 
 def _exp_neg_point_rational(x: Fraction, order: int = 96) -> tuple[Fraction, Fraction]:
-    """Validated enclosure of exp(-x), x>=0, by exact Taylor arithmetic.
-
-    For f(x)=exp(-x), every derivative on [0,x] has magnitude <=1.  The
-    order-N Taylor polynomial at zero therefore has Lagrange remainder bounded
-    by x^(N+1)/(N+1)!.  All polynomial arithmetic here is exact Fraction
-    arithmetic, so only the final conversion to binary64 needs outward rounding.
-    """
+    """Validated enclosure of exp(-x), x>=0, by exact Taylor arithmetic."""
     if x < 0:
         raise ValueError("exp(-x) enclosure requires x>=0")
     if order < 1:
@@ -245,18 +233,7 @@ def _exp_neg_point_rational(x: Fraction, order: int = 96) -> tuple[Fraction, Fra
 def validated_ou_primitives(h_bounds: tuple[float, float] | list[float],
                             tau_bounds: tuple[float, float] | list[float],
                             order: int = 96) -> dict:
-    """Outward enclosure of the deployed scalar OU transition primitives.
-
-    The implementation uses
-      alpha  = exp(-x), x=h/tau
-      phi_pa = tau^2 (x + exp(-x) - 1)
-      phi_Sa = tau^3 (0.5 x^2 - x - exp(-x) + 1).
-
-    The returned bounds use exact-rational interval arithmetic. Correlation
-    between tau and x is deliberately discarded, which can widen the box but
-    cannot invalidate it. The nonnegative lower clamp uses the analytic fact
-    that both integral coefficients are >=0 for h>=0,tau>0.
-    """
+    """Outward enclosure of the deployed scalar OU transition primitives."""
     h_lo, h_hi = map(Fraction.from_float, map(float, h_bounds))
     t_lo, t_hi = map(Fraction.from_float, map(float, tau_bounds))
     if h_lo < 0 or h_hi < h_lo:
@@ -271,11 +248,8 @@ def validated_ou_primitives(h_bounds: tuple[float, float] | list[float],
     alpha_lo = max(Fraction(0, 1), alpha_lo)
     alpha_hi = min(Fraction(1, 1), alpha_hi)
 
-    # x + alpha - 1, with independent interval terms.
     pa_core_lo = max(Fraction(0, 1), x_lo + alpha_lo - 1)
     pa_core_hi = x_hi + alpha_hi - 1
-
-    # 0.5*x^2 - x - alpha + 1. Independent interval arithmetic is used.
     sa_core_lo = max(Fraction(0, 1), Fraction(1, 2) * x_lo * x_lo - x_hi - alpha_hi + 1)
     sa_core_hi = Fraction(1, 2) * x_hi * x_hi - x_lo - alpha_lo + 1
 
@@ -296,6 +270,55 @@ def validated_ou_primitives(h_bounds: tuple[float, float] | list[float],
         "alpha": [_fraction_down(alpha_lo), _fraction_up(alpha_hi)],
         "phi_pa_s2": [_fraction_down(phi_pa_lo), _fraction_up(phi_pa_hi)],
         "phi_Sa_s3": [_fraction_down(phi_sa_lo), _fraction_up(phi_sa_hi)],
+    }
+
+
+def _mul_nonnegative_bounds(a: list[float], b: list[float]) -> list[float]:
+    if a[0] < 0 or b[0] < 0:
+        raise ValueError("nonnegative interval multiplication received a negative lower bound")
+    return [
+        math.nextafter(float(a[0]) * float(b[0]), -math.inf),
+        math.nextafter(float(a[1]) * float(b[1]), math.inf),
+    ]
+
+
+def validated_phi_axis4(h_bounds: tuple[float, float] | list[float],
+                        tau_bounds: tuple[float, float] | list[float],
+                        order: int = 96) -> dict:
+    """Enclose the exact deployed IntegratedOUChain<T,3>::transition matrix."""
+    p = validated_ou_primitives(h_bounds, tau_bounds, order)
+    h_lo, h_hi = map(float, h_bounds)
+    t_lo, t_hi = map(float, tau_bounds)
+    if h_lo < 0 or h_hi < h_lo or t_lo <= 0 or t_hi < t_lo:
+        raise ValueError("invalid h/tau transition domain")
+
+    zero = [0.0, 0.0]
+    one = [1.0, 1.0]
+    h = _outward_box(h_lo, h_hi)
+    half_h2 = [
+        math.nextafter(0.5 * h_lo * h_lo, -math.inf),
+        math.nextafter(0.5 * h_hi * h_hi, math.inf),
+    ]
+    one_minus_alpha = [
+        max(0.0, math.nextafter(1.0 - p["alpha"][1], -math.inf)),
+        math.nextafter(1.0 - p["alpha"][0], math.inf),
+    ]
+    tau = _outward_box(t_lo, t_hi)
+    phi_va = _mul_nonnegative_bounds(tau, one_minus_alpha)
+
+    M = [
+        [one, zero, zero, phi_va],
+        [h, one, zero, p["phi_pa_s2"]],
+        [half_h2, h, one, p["phi_Sa_s3"]],
+        [zero, zero, zero, p["alpha"]],
+    ]
+    return {
+        "validated_arithmetic": True,
+        "outward_rounded": True,
+        "implementation": "IntegratedOUChain<T,3>::transition",
+        "state_order": ["v", "p", "S", "a_w"],
+        "scalar_primitives": p,
+        "Phi_interval": M,
     }
 
 
@@ -366,6 +389,7 @@ def build(header: Path) -> dict:
             "available": True,
             "requires_finite_h_upper": True,
             "backend": "EXACT_RATIONAL_TAYLOR_WITH_LAGRANGE_REMAINDER",
+            "transition_matrix_backend": "VALIDATED_INTERVAL_4X4_INTEGRATED_OU_CHAIN",
             "theorem_promotion": "BLOCKED_BY_UNBOUNDED_ACCEPTED_DT",
         },
         "discrete_source_branches": {
@@ -384,9 +408,9 @@ def build(header: Path) -> dict:
             "metric_consequence": "inverse-covariance information energy is nonexpansive",
         },
         "promotion_rule": (
-            "the validated_parameter_box closes source-boundary scalar arithmetic, and a validated "
-            "OU primitive backend now exists; deployment promotion still requires a finite source-derived "
-            "accepted-dt upper bound followed by full H/A matrix/Taylor propagation, nonlinear SO(3) "
+            "source-boundary scalar arithmetic and the exact per-axis transition enclosure are now "
+            "validated; deployment promotion still requires a finite source-derived accepted-dt upper "
+            "bound, validated process-covariance and full H/A Riccati propagation, nonlinear SO(3) "
             "remainder bounds and remaining jump certificates"
         ),
     }

--- a/tools/ou3_source_domain_contract.py
+++ b/tools/ou3_source_domain_contract.py
@@ -12,6 +12,14 @@ Python binary64. This parser therefore evaluates every literal and arithmetic
 operation as IEEE-754 binary32, using exact rationals between operations and an
 explicit nearest/ties-to-even rounding step. The returned Python float is an
 exact binary64 representation of the deployed binary32 value.
+
+The producer also contains the first transcendental enclosure used by the
+continuous-word proof. ``validated_ou_primitives`` bounds exp(-h/tau), phi_pa
+and phi_Sa using exact rational Taylor arithmetic plus an explicit Lagrange
+remainder. It is intentionally parameterized by an accepted-step interval:
+the deployed wrapper presently checks only dt>0 and finiteness, so the source
+contract records the missing finite upper step guard as an explicit theorem
+blocker instead of silently substituting the nominal 200 Hz period.
 """
 from __future__ import annotations
 
@@ -98,7 +106,6 @@ def _round_fraction_binary32(value: Fraction) -> Fraction:
 
     def rank(item: tuple[Fraction, int]) -> tuple[Fraction, int]:
         exact, bits = item
-        # Exact midpoint: ties-to-even means an even low significand bit.
         return (abs(exact - x), bits & 1)
 
     exact, _ = min(choices, key=rank)
@@ -197,6 +204,101 @@ def _outward_box(lo: float, hi: float) -> list[float]:
     return [math.nextafter(lo, -math.inf), math.nextafter(hi, math.inf)]
 
 
+def _fraction_down(q: Fraction) -> float:
+    """Greatest convenient binary64 lower enclosure of exact rational q."""
+    y = float(q)
+    if Fraction.from_float(y) > q:
+        y = math.nextafter(y, -math.inf)
+    return y
+
+
+def _fraction_up(q: Fraction) -> float:
+    """Least convenient binary64 upper enclosure of exact rational q."""
+    y = float(q)
+    if Fraction.from_float(y) < q:
+        y = math.nextafter(y, math.inf)
+    return y
+
+
+def _exp_neg_point_rational(x: Fraction, order: int = 96) -> tuple[Fraction, Fraction]:
+    """Validated enclosure of exp(-x), x>=0, by exact Taylor arithmetic.
+
+    For f(x)=exp(-x), every derivative on [0,x] has magnitude <=1.  The
+    order-N Taylor polynomial at zero therefore has Lagrange remainder bounded
+    by x^(N+1)/(N+1)!.  All polynomial arithmetic here is exact Fraction
+    arithmetic, so only the final conversion to binary64 needs outward rounding.
+    """
+    if x < 0:
+        raise ValueError("exp(-x) enclosure requires x>=0")
+    if order < 1:
+        raise ValueError("Taylor order must be positive")
+    term = Fraction(1, 1)
+    total = term
+    for n in range(1, order + 1):
+        term *= -x
+        term /= n
+        total += term
+    rem = x ** (order + 1) / math.factorial(order + 1)
+    return total - rem, total + rem
+
+
+def validated_ou_primitives(h_bounds: tuple[float, float] | list[float],
+                            tau_bounds: tuple[float, float] | list[float],
+                            order: int = 96) -> dict:
+    """Outward enclosure of the deployed scalar OU transition primitives.
+
+    The implementation uses
+      alpha  = exp(-x), x=h/tau
+      phi_pa = tau^2 (x + exp(-x) - 1)
+      phi_Sa = tau^3 (0.5 x^2 - x - exp(-x) + 1).
+
+    The returned bounds use exact-rational interval arithmetic. Correlation
+    between tau and x is deliberately discarded, which can widen the box but
+    cannot invalidate it. The nonnegative lower clamp uses the analytic fact
+    that both integral coefficients are >=0 for h>=0,tau>0.
+    """
+    h_lo, h_hi = map(Fraction.from_float, map(float, h_bounds))
+    t_lo, t_hi = map(Fraction.from_float, map(float, tau_bounds))
+    if h_lo < 0 or h_hi < h_lo:
+        raise ValueError("invalid nonnegative step interval")
+    if t_lo <= 0 or t_hi < t_lo:
+        raise ValueError("invalid positive tau interval")
+
+    x_lo = h_lo / t_hi
+    x_hi = h_hi / t_lo
+    alpha_lo, _ = _exp_neg_point_rational(x_hi, order)
+    _, alpha_hi = _exp_neg_point_rational(x_lo, order)
+    alpha_lo = max(Fraction(0, 1), alpha_lo)
+    alpha_hi = min(Fraction(1, 1), alpha_hi)
+
+    # x + alpha - 1, with independent interval terms.
+    pa_core_lo = max(Fraction(0, 1), x_lo + alpha_lo - 1)
+    pa_core_hi = x_hi + alpha_hi - 1
+
+    # 0.5*x^2 - x - alpha + 1. Independent interval arithmetic is used.
+    sa_core_lo = max(Fraction(0, 1), Fraction(1, 2) * x_lo * x_lo - x_hi - alpha_hi + 1)
+    sa_core_hi = Fraction(1, 2) * x_hi * x_hi - x_lo - alpha_lo + 1
+
+    tau2_lo, tau2_hi = t_lo * t_lo, t_hi * t_hi
+    tau3_lo, tau3_hi = tau2_lo * t_lo, tau2_hi * t_hi
+    phi_pa_lo = tau2_lo * pa_core_lo
+    phi_pa_hi = tau2_hi * max(Fraction(0, 1), pa_core_hi)
+    phi_sa_lo = tau3_lo * sa_core_lo
+    phi_sa_hi = tau3_hi * max(Fraction(0, 1), sa_core_hi)
+
+    return {
+        "validated_arithmetic": True,
+        "outward_rounded": True,
+        "backend": f"EXACT_RATIONAL_TAYLOR_ORDER_{order}_LAGRANGE_REMAINDER",
+        "h_s": [_fraction_down(h_lo), _fraction_up(h_hi)],
+        "tau_s": [_fraction_down(t_lo), _fraction_up(t_hi)],
+        "x_h_over_tau": [_fraction_down(x_lo), _fraction_up(x_hi)],
+        "alpha": [_fraction_down(alpha_lo), _fraction_up(alpha_hi)],
+        "phi_pa_s2": [_fraction_down(phi_pa_lo), _fraction_up(phi_pa_hi)],
+        "phi_Sa_s3": [_fraction_down(phi_sa_lo), _fraction_up(phi_sa_hi)],
+    }
+
+
 def build(header: Path) -> dict:
     text = header.read_text()
     c = {name: parse_const(text, name) for name in REQUIRED}
@@ -236,8 +338,6 @@ def build(header: Path) -> dict:
         "claim": "OU3_SOURCE_COMPLETE_IMPLEMENTATION_DOMAIN_CONTRACT",
         "source_generated_not_trajectory_fit": True,
         "source_complete_parameter_domain": True,
-        # These top-level flags remain false until the whole H/A word is
-        # propagated with validated matrix/transcendental arithmetic.
         "validated_arithmetic": False,
         "outward_rounded": False,
         "implementation_header": str(header.relative_to(REPO)),
@@ -249,6 +349,25 @@ def build(header: Path) -> dict:
         "continuous_parameters": continuous,
         "timing_constants_s": timing,
         "validated_parameter_box": parameter_box,
+        "accepted_update_step_domain_s": {
+            "lower_open": 0.0,
+            "upper": None,
+            "source_complete_finite_upper_bound": False,
+            "implementation_observation": (
+                "SeaStateFusionFilter_OU_III::updateCore_ rejects nonpositive/nonfinite dt "
+                "but currently has no finite upper accepted-step guard"
+            ),
+            "theorem_effect": (
+                "continuous H/A transition and process-noise enclosure cannot be source-complete "
+                "until accepted dt has a finite implementation/configuration upper bound"
+            ),
+        },
+        "validated_ou_primitive_backend": {
+            "available": True,
+            "requires_finite_h_upper": True,
+            "backend": "EXACT_RATIONAL_TAYLOR_WITH_LAGRANGE_REMAINDER",
+            "theorem_promotion": "BLOCKED_BY_UNBOUNDED_ACCEPTED_DT",
+        },
         "discrete_source_branches": {
             "mode": ["H", "A"],
             "accelerometer_gate": ["accepted", "rejected"],
@@ -265,9 +384,10 @@ def build(header: Path) -> dict:
             "metric_consequence": "inverse-covariance information energy is nonexpansive",
         },
         "promotion_rule": (
-            "the validated_parameter_box closes only the source-boundary arithmetic; theorem "
-            "promotion still requires outward-rounded interval/Taylor-model propagation of "
-            "the complete H/A Riccati words, nonlinear SO(3) remainder and remaining jumps"
+            "the validated_parameter_box closes source-boundary scalar arithmetic, and a validated "
+            "OU primitive backend now exists; deployment promotion still requires a finite source-derived "
+            "accepted-dt upper bound followed by full H/A matrix/Taylor propagation, nonlinear SO(3) "
+            "remainder bounds and remaining jump certificates"
         ),
     }
 

--- a/tools/ou3_source_domain_contract.py
+++ b/tools/ou3_source_domain_contract.py
@@ -17,18 +17,19 @@ The producer also contains the first validated continuous-word arithmetic:
 ``validated_ou_primitives`` bounds exp(-h/tau), phi_pa and phi_Sa using exact
 rational Taylor arithmetic plus an explicit Lagrange remainder;
 ``validated_phi_axis4`` lifts those scalar bounds to the exact 4x4
-[v,p,S,a] transition used by IntegratedOUChain<T,3>::transition; and
+[v,p,S,a] transition used by IntegratedOUChain<T,3>::transition;
 ``validated_qd_axis4_kernel`` encloses the exact mathematical OU process
-covariance using the positive impulse-response kernel
+covariance using the positive impulse-response kernel; and
+``validated_covariance_predict_axis4`` performs the interval covariance
+prediction Phi P Phi^T + Qd with exact-rational interval matrix arithmetic.
 
-    Qd = (2 sigma^2 / tau) integral_0^h g(r) g(r)^T dr.
-
-The kernel integral is subdivided into cells. Every cell uses the validated
+The Qd kernel integral is subdivided into cells. Every cell uses the validated
 transition/OU primitive bounds, and every sum/product is accumulated as an
 exact Fraction. This avoids the cancellation-heavy closed-form covariance
 expressions. The claim is intentionally narrow: it encloses the mathematical
-continuous OU covariance, while the shipping binary32 closed-form computation
-and its PSD cleanup remain a separate implementation-arithmetic obligation.
+continuous OU covariance/prediction, while the shipping binary32 closed-form
+Qd computation and its PSD cleanup remain a separate implementation-arithmetic
+obligation.
 
 The public wrapper accepts every positive finite binary32 ``dt``. That set is
 technically finite -- [2^-149, FLT_MAX] -- but it has no operational safety
@@ -79,7 +80,6 @@ def _strip_float_suffixes(expr: str) -> str:
 
 
 def _bits_to_positive_fraction(bits: int) -> Fraction:
-    """Return the exact nonnegative finite binary32 value for ``bits``."""
     if not 0 <= bits <= _FLOAT32_MAX_BITS:
         raise ValueError(f"not a finite positive binary32 pattern: 0x{bits:08x}")
     exponent = (bits >> 23) & 0xFF
@@ -94,7 +94,6 @@ def _bits_to_positive_fraction(bits: int) -> Fraction:
 
 
 def _round_fraction_binary32(value: Fraction) -> Fraction:
-    """Round an exact rational to finite binary32, nearest/ties-to-even."""
     if value == 0:
         return Fraction(0, 1)
     sign = -1 if value < 0 else 1
@@ -106,18 +105,15 @@ def _round_fraction_binary32(value: Fraction) -> Fraction:
     candidate &= 0x7FFFFFFF
     if candidate > _FLOAT32_MAX_BITS:
         raise RuntimeError(f"binary32 constant overflow for {value}")
-
     choices: list[tuple[Fraction, int]] = []
     for bits in (candidate - 1, candidate, candidate + 1):
         if 0 <= bits <= _FLOAT32_MAX_BITS:
             choices.append((_bits_to_positive_fraction(bits), bits))
     if not choices:
         raise RuntimeError(f"cannot round binary32 constant {value}")
-
     def rank(item: tuple[Fraction, int]) -> tuple[Fraction, int]:
         exact, bits = item
         return (abs(exact - x), bits & 1)
-
     exact, _ = min(choices, key=rank)
     return exact if sign > 0 else -exact
 
@@ -164,7 +160,6 @@ def _eval_constexpr32(node: ast.AST, expr: str, text: str,
 
 def parse_const_fraction(text: str, name: str,
                          stack: tuple[str, ...] = ()) -> Fraction:
-    """Resolve a scalar ``constexpr float`` with deployed binary32 semantics."""
     if name in stack:
         raise RuntimeError(f"cyclic implementation constant alias: {' -> '.join((*stack, name))}")
     expressions = {n: expr for n, expr in CONST_RE.findall(text)}
@@ -186,7 +181,6 @@ def parse_const(text: str, name: str, stack: tuple[str, ...] = ()) -> float:
 
 
 def parse_aw_sigma_floor(text: str) -> float:
-    """Extract the deployed lower floor used before setting Sigma_aw_stat."""
     pat = re.compile(
         r"const\s+float\s+sigma_floor\s*=\s*std::max\(\s*"
         r"([0-9.+\-eE]+)f?\s*,\s*band_noise_floor_sigma_\(\)\s*\)\s*;"
@@ -227,7 +221,6 @@ def _fraction_up(q: Fraction) -> float:
 
 
 def _exp_neg_point_rational(x: Fraction, order: int = 96) -> tuple[Fraction, Fraction]:
-    """Validated enclosure of exp(-x), x>=0, by exact Taylor arithmetic."""
     if x < 0:
         raise ValueError("exp(-x) enclosure requires x>=0")
     if order < 1:
@@ -245,33 +238,28 @@ def _exp_neg_point_rational(x: Fraction, order: int = 96) -> tuple[Fraction, Fra
 def validated_ou_primitives(h_bounds: tuple[float, float] | list[float],
                             tau_bounds: tuple[float, float] | list[float],
                             order: int = 96) -> dict:
-    """Outward enclosure of the deployed scalar OU transition primitives."""
     h_lo, h_hi = map(Fraction.from_float, map(float, h_bounds))
     t_lo, t_hi = map(Fraction.from_float, map(float, tau_bounds))
     if h_lo < 0 or h_hi < h_lo:
         raise ValueError("invalid nonnegative step interval")
     if t_lo <= 0 or t_hi < t_lo:
         raise ValueError("invalid positive tau interval")
-
     x_lo = h_lo / t_hi
     x_hi = h_hi / t_lo
     alpha_lo, _ = _exp_neg_point_rational(x_hi, order)
     _, alpha_hi = _exp_neg_point_rational(x_lo, order)
     alpha_lo = max(Fraction(0, 1), alpha_lo)
     alpha_hi = min(Fraction(1, 1), alpha_hi)
-
     pa_core_lo = max(Fraction(0, 1), x_lo + alpha_lo - 1)
     pa_core_hi = x_hi + alpha_hi - 1
     sa_core_lo = max(Fraction(0, 1), Fraction(1, 2) * x_lo * x_lo - x_hi - alpha_hi + 1)
     sa_core_hi = Fraction(1, 2) * x_hi * x_hi - x_lo - alpha_lo + 1
-
     tau2_lo, tau2_hi = t_lo * t_lo, t_hi * t_hi
     tau3_lo, tau3_hi = tau2_lo * t_lo, tau2_hi * t_hi
     phi_pa_lo = tau2_lo * pa_core_lo
     phi_pa_hi = tau2_hi * max(Fraction(0, 1), pa_core_hi)
     phi_sa_lo = tau3_lo * sa_core_lo
     phi_sa_hi = tau3_hi * max(Fraction(0, 1), sa_core_hi)
-
     return {
         "validated_arithmetic": True,
         "outward_rounded": True,
@@ -297,13 +285,11 @@ def _mul_nonnegative_bounds(a: list[float], b: list[float]) -> list[float]:
 def validated_phi_axis4(h_bounds: tuple[float, float] | list[float],
                         tau_bounds: tuple[float, float] | list[float],
                         order: int = 96) -> dict:
-    """Enclose the exact deployed IntegratedOUChain<T,3>::transition matrix."""
     p = validated_ou_primitives(h_bounds, tau_bounds, order)
     h_lo, h_hi = map(float, h_bounds)
     t_lo, t_hi = map(float, tau_bounds)
     if h_lo < 0 or h_hi < h_lo or t_lo <= 0 or t_hi < t_lo:
         raise ValueError("invalid h/tau transition domain")
-
     zero = [0.0, 0.0]
     one = [1.0, 1.0]
     h = _outward_box(h_lo, h_hi)
@@ -317,7 +303,6 @@ def validated_phi_axis4(h_bounds: tuple[float, float] | list[float],
     ]
     tau = _outward_box(t_lo, t_hi)
     phi_va = _mul_nonnegative_bounds(tau, one_minus_alpha)
-
     M = [
         [one, zero, zero, phi_va],
         [h, one, zero, p["phi_pa_s2"]],
@@ -337,7 +322,6 @@ def validated_phi_axis4(h_bounds: tuple[float, float] | list[float],
 def _kernel_interval_on_cell(r_lo: Fraction, r_hi: Fraction,
                              tau_bounds: tuple[float, float] | list[float],
                              order: int) -> list[tuple[Fraction, Fraction]]:
-    """Return validated impulse-response intervals [v,p,S,a] on one r-cell."""
     lo = _fraction_down(r_lo)
     hi = _fraction_up(r_hi)
     M = validated_phi_axis4((lo, hi), tau_bounds, order)["Phi_interval"]
@@ -353,7 +337,6 @@ def _kernel_interval_on_cell(r_lo: Fraction, r_hi: Fraction,
 def _integrate_kernel_bounds(h: Fraction,
                              tau_bounds: tuple[float, float] | list[float],
                              cells: int, order: int) -> tuple[list[list[Fraction]], list[list[Fraction]]]:
-    """Bound integral_0^h g g^T dr by exact-rational cell sums."""
     if h < 0:
         raise ValueError("integration horizon must be nonnegative")
     if cells <= 0:
@@ -383,7 +366,6 @@ def validated_qd_axis4_kernel(h_bounds: tuple[float, float] | list[float],
                               tau_bounds: tuple[float, float] | list[float],
                               sigma2_bounds: tuple[float, float] | list[float],
                               cells: int = 24, order: int = 96) -> dict:
-    """Rigorous elementwise enclosure of the mathematical integrated-OU Qd."""
     h_lo_f, h_hi_f = map(float, h_bounds)
     t_lo_f, t_hi_f = map(float, tau_bounds)
     s_lo_f, s_hi_f = map(float, sigma2_bounds)
@@ -393,19 +375,16 @@ def validated_qd_axis4_kernel(h_bounds: tuple[float, float] | list[float],
         raise ValueError("invalid tau interval")
     if s_lo_f < 0 or s_hi_f < s_lo_f:
         raise ValueError("invalid sigma2 interval")
-
     h_lo = Fraction.from_float(h_lo_f)
     h_hi = Fraction.from_float(h_hi_f)
     t_lo = Fraction.from_float(t_lo_f)
     t_hi = Fraction.from_float(t_hi_f)
     s_lo = Fraction.from_float(s_lo_f)
     s_hi = Fraction.from_float(s_hi_f)
-
     int_lo, _ = _integrate_kernel_bounds(h_lo, tau_bounds, cells, order)
     _, int_hi = _integrate_kernel_bounds(h_hi, tau_bounds, cells, order)
     qc_lo = Fraction(2, 1) * s_lo / t_hi
     qc_hi = Fraction(2, 1) * s_hi / t_lo
-
     Q: list[list[list[float]]] = []
     for i in range(4):
         row: list[list[float]] = []
@@ -414,7 +393,6 @@ def validated_qd_axis4_kernel(h_bounds: tuple[float, float] | list[float],
             qhi = qc_hi * int_hi[i][j]
             row.append([_fraction_down(qlo), _fraction_up(qhi)])
         Q.append(row)
-
     return {
         "validated_arithmetic": True,
         "outward_rounded": True,
@@ -429,6 +407,88 @@ def validated_qd_axis4_kernel(h_bounds: tuple[float, float] | list[float],
         "mathematical_integral_enclosed": True,
         "shipping_binary32_closed_form_enclosed": False,
         "shipping_psd_cleanup_enclosed": False,
+        "theorem_promotion": "NOT_ESTABLISHED",
+    }
+
+
+def _iv_from_float(bounds: list[float]) -> tuple[Fraction, Fraction]:
+    if len(bounds) != 2:
+        raise ValueError("interval needs two endpoints")
+    lo, hi = map(float, bounds)
+    if not (math.isfinite(lo) and math.isfinite(hi)) or lo > hi:
+        raise ValueError(f"invalid finite interval {bounds!r}")
+    return Fraction.from_float(lo), Fraction.from_float(hi)
+
+
+def _iv_add(a: tuple[Fraction, Fraction],
+            b: tuple[Fraction, Fraction]) -> tuple[Fraction, Fraction]:
+    return a[0] + b[0], a[1] + b[1]
+
+
+def _iv_mul(a: tuple[Fraction, Fraction],
+            b: tuple[Fraction, Fraction]) -> tuple[Fraction, Fraction]:
+    p = (a[0] * b[0], a[0] * b[1], a[1] * b[0], a[1] * b[1])
+    return min(p), max(p)
+
+
+def _iv_matrix_from_float(M: list[list[list[float]]]) -> list[list[tuple[Fraction, Fraction]]]:
+    return [[_iv_from_float(x) for x in row] for row in M]
+
+
+def _iv_transpose(M: list[list[tuple[Fraction, Fraction]]]) -> list[list[tuple[Fraction, Fraction]]]:
+    return [list(row) for row in zip(*M)]
+
+
+def _iv_matmul(A: list[list[tuple[Fraction, Fraction]]],
+               B: list[list[tuple[Fraction, Fraction]]]) -> list[list[tuple[Fraction, Fraction]]]:
+    if not A or not B or len(A[0]) != len(B):
+        raise ValueError("interval matrix dimensions do not conform")
+    out: list[list[tuple[Fraction, Fraction]]] = []
+    for i in range(len(A)):
+        row: list[tuple[Fraction, Fraction]] = []
+        for j in range(len(B[0])):
+            acc = (Fraction(0, 1), Fraction(0, 1))
+            for k in range(len(B)):
+                acc = _iv_add(acc, _iv_mul(A[i][k], B[k][j]))
+            row.append(acc)
+        out.append(row)
+    return out
+
+
+def validated_covariance_predict_axis4(
+        P_interval: list[list[list[float]]],
+        h_bounds: tuple[float, float] | list[float],
+        tau_bounds: tuple[float, float] | list[float],
+        sigma2_bounds: tuple[float, float] | list[float],
+        cells: int = 24, order: int = 96) -> dict:
+    """Enclose one mathematical covariance prediction Phi P Phi^T + Qd."""
+    if len(P_interval) != 4 or any(len(row) != 4 for row in P_interval):
+        raise ValueError("P_interval must be 4x4")
+    phi = validated_phi_axis4(h_bounds, tau_bounds, order)
+    qd = validated_qd_axis4_kernel(h_bounds, tau_bounds, sigma2_bounds, cells, order)
+    A = _iv_matrix_from_float(phi["Phi_interval"])
+    P = _iv_matrix_from_float(P_interval)
+    Q = _iv_matrix_from_float(qd["Qd_interval"])
+    AP = _iv_matmul(A, P)
+    APA = _iv_matmul(AP, _iv_transpose(A))
+    pred: list[list[list[float]]] = []
+    for i in range(4):
+        row: list[list[float]] = []
+        for j in range(4):
+            lo, hi = _iv_add(APA[i][j], Q[i][j])
+            row.append([_fraction_down(lo), _fraction_up(hi)])
+        pred.append(row)
+    return {
+        "validated_arithmetic": True,
+        "outward_rounded": True,
+        "claim": "MATHEMATICAL_OU_AXIS_COVARIANCE_PREDICTION_ENCLOSURE",
+        "state_order": ["v", "p", "S", "a_w"],
+        "Phi": phi,
+        "Qd": qd,
+        "P_prior_interval": P_interval,
+        "P_predicted_interval": pred,
+        "mathematical_prediction_enclosed": True,
+        "shipping_covariance_prediction_enclosed": False,
         "theorem_promotion": "NOT_ESTABLISHED",
     }
 
@@ -510,6 +570,8 @@ def build(header: Path) -> dict:
             "process_covariance_backend": "POSITIVE_KERNEL_CELL_INTERVAL_EXACT_RATIONAL_ACCUMULATION",
             "process_covariance_mathematical_integral_enclosed": True,
             "process_covariance_shipping_float_path_enclosed": False,
+            "covariance_prediction_backend": "EXACT_RATIONAL_INTERVAL_PHI_P_PHIT_PLUS_Q",
+            "covariance_prediction_mathematical_path_enclosed": True,
             "theorem_promotion": "BLOCKED_BY_NO_PROOF_USABLE_ACCEPTED_DT_GUARD_AND_SHIPPING_QD_FLOAT_PATH",
         },
         "discrete_source_branches": {
@@ -528,10 +590,11 @@ def build(header: Path) -> dict:
             "metric_consequence": "inverse-covariance information energy is nonexpansive",
         },
         "promotion_rule": (
-            "source-boundary scalar arithmetic, exact per-axis transition and mathematical OU process "
-            "covariance are now enclosed; deployment promotion still requires a proof-usable source-derived "
-            "accepted-dt upper guard/contract, enclosure of the shipping binary32 Qd/PSD-cleanup path, full "
-            "H/A Riccati propagation, nonlinear SO(3) remainder bounds and remaining jump certificates"
+            "source-boundary scalar arithmetic, exact per-axis transition, mathematical OU process covariance "
+            "and one-step mathematical covariance prediction are now enclosed; deployment promotion still "
+            "requires a proof-usable source-derived accepted-dt upper guard/contract, enclosure of the shipping "
+            "binary32 Qd/PSD-cleanup path, measurement/Riccati updates over full H/A words, nonlinear SO(3) "
+            "remainder bounds and remaining jump certificates"
         ),
     }
 

--- a/tools/ou3_source_domain_contract.py
+++ b/tools/ou3_source_domain_contract.py
@@ -13,16 +13,27 @@ operation as IEEE-754 binary32, using exact rationals between operations and an
 explicit nearest/ties-to-even rounding step. The returned Python float is an
 exact binary64 representation of the deployed binary32 value.
 
-The producer also contains the first transcendental enclosure used by the
-continuous-word proof. ``validated_ou_primitives`` bounds exp(-h/tau), phi_pa
-and phi_Sa using exact rational Taylor arithmetic plus an explicit Lagrange
-remainder. ``validated_phi_axis4`` lifts those scalar bounds to the exact 4x4
-[v,p,S,a] transition used by IntegratedOUChain<T,3>::transition.
+The producer also contains the first validated continuous-word arithmetic:
+``validated_ou_primitives`` bounds exp(-h/tau), phi_pa and phi_Sa using exact
+rational Taylor arithmetic plus an explicit Lagrange remainder;
+``validated_phi_axis4`` lifts those scalar bounds to the exact 4x4
+[v,p,S,a] transition used by IntegratedOUChain<T,3>::transition; and
+``validated_qd_axis4_kernel`` encloses the exact mathematical OU process
+covariance using the positive impulse-response kernel
 
-Both are intentionally parameterized by an accepted-step interval: the
-deployed wrapper presently checks only dt>0 and finiteness, so the source
-contract records the missing finite upper step guard as an explicit theorem
-blocker instead of silently substituting the nominal 200 Hz period.
+    Qd = (2 sigma^2 / tau) integral_0^h g(r) g(r)^T dr.
+
+The kernel integral is subdivided into cells.  Every cell uses the validated
+transition/OU primitive bounds, and every sum/product is accumulated as an
+exact Fraction.  This avoids the cancellation-heavy closed-form covariance
+expressions.  The claim is intentionally narrow: it encloses the mathematical
+continuous OU covariance, while the shipping binary32 closed-form computation
+and its PSD cleanup remain a separate implementation-arithmetic obligation.
+
+All word-level arithmetic is intentionally parameterized by an accepted-step
+interval: the deployed wrapper presently checks only dt>0 and finiteness, so
+the source contract records the missing finite upper step guard as an explicit
+theorem blocker instead of silently substituting the nominal 200 Hz period.
 """
 from __future__ import annotations
 
@@ -322,6 +333,116 @@ def validated_phi_axis4(h_bounds: tuple[float, float] | list[float],
     }
 
 
+def _kernel_interval_on_cell(r_lo: Fraction, r_hi: Fraction,
+                             tau_bounds: tuple[float, float] | list[float],
+                             order: int) -> list[tuple[Fraction, Fraction]]:
+    """Return validated impulse-response intervals [v,p,S,a] on one r-cell."""
+    lo = _fraction_down(r_lo)
+    hi = _fraction_up(r_hi)
+    M = validated_phi_axis4((lo, hi), tau_bounds, order)["Phi_interval"]
+    ans: list[tuple[Fraction, Fraction]] = []
+    for i in range(4):
+        b = M[i][3]
+        blo = max(0.0, float(b[0]))
+        bhi = max(blo, float(b[1]))
+        ans.append((Fraction.from_float(blo), Fraction.from_float(bhi)))
+    return ans
+
+
+def _integrate_kernel_bounds(h: Fraction,
+                             tau_bounds: tuple[float, float] | list[float],
+                             cells: int, order: int) -> tuple[list[list[Fraction]], list[list[Fraction]]]:
+    """Bound integral_0^h g g^T dr by exact-rational cell sums."""
+    if h < 0:
+        raise ValueError("integration horizon must be nonnegative")
+    if cells <= 0:
+        raise ValueError("cells must be positive")
+    lower = [[Fraction(0, 1) for _ in range(4)] for _ in range(4)]
+    upper = [[Fraction(0, 1) for _ in range(4)] for _ in range(4)]
+    if h == 0:
+        return lower, upper
+    width = h / cells
+    for k in range(cells):
+        r0 = width * k
+        r1 = width * (k + 1)
+        g = _kernel_interval_on_cell(r0, r1, tau_bounds, order)
+        for i in range(4):
+            for j in range(i, 4):
+                cell_lo = width * g[i][0] * g[j][0]
+                cell_hi = width * g[i][1] * g[j][1]
+                lower[i][j] += cell_lo
+                upper[i][j] += cell_hi
+                if i != j:
+                    lower[j][i] += cell_lo
+                    upper[j][i] += cell_hi
+    return lower, upper
+
+
+def validated_qd_axis4_kernel(h_bounds: tuple[float, float] | list[float],
+                              tau_bounds: tuple[float, float] | list[float],
+                              sigma2_bounds: tuple[float, float] | list[float],
+                              cells: int = 24, order: int = 96) -> dict:
+    """Rigorous elementwise enclosure of the mathematical integrated-OU Qd.
+
+    The chain impulse response from the white driving noise to [v,p,S,a] is
+    exactly the fourth column of the transition matrix evaluated at elapsed
+    time r.  All four components are nonnegative for r>=0,tau>0. Therefore
+    each covariance entry is a monotone-in-h integral of a nonnegative product.
+
+    This routine bounds the minimum at h_lo and maximum at h_hi by cellwise
+    interval integration and then applies qc=2*sigma2/tau. Dependencies are
+    discarded conservatively.  It does not yet claim enclosure of the shipping
+    binary32 closed-form evaluation or regularize_psd_if_needed() perturbation.
+    """
+    h_lo_f, h_hi_f = map(float, h_bounds)
+    t_lo_f, t_hi_f = map(float, tau_bounds)
+    s_lo_f, s_hi_f = map(float, sigma2_bounds)
+    if h_lo_f < 0 or h_hi_f < h_lo_f:
+        raise ValueError("invalid h interval")
+    if t_lo_f <= 0 or t_hi_f < t_lo_f:
+        raise ValueError("invalid tau interval")
+    if s_lo_f < 0 or s_hi_f < s_lo_f:
+        raise ValueError("invalid sigma2 interval")
+
+    h_lo = Fraction.from_float(h_lo_f)
+    h_hi = Fraction.from_float(h_hi_f)
+    t_lo = Fraction.from_float(t_lo_f)
+    t_hi = Fraction.from_float(t_hi_f)
+    s_lo = Fraction.from_float(s_lo_f)
+    s_hi = Fraction.from_float(s_hi_f)
+
+    int_lo, _ = _integrate_kernel_bounds(h_lo, tau_bounds, cells, order)
+    _, int_hi = _integrate_kernel_bounds(h_hi, tau_bounds, cells, order)
+    qc_lo = Fraction(2, 1) * s_lo / t_hi
+    qc_hi = Fraction(2, 1) * s_hi / t_lo
+
+    Q: list[list[list[float]]] = []
+    for i in range(4):
+        row: list[list[float]] = []
+        for j in range(4):
+            qlo = qc_lo * int_lo[i][j]
+            qhi = qc_hi * int_hi[i][j]
+            row.append([_fraction_down(qlo), _fraction_up(qhi)])
+        Q.append(row)
+
+    return {
+        "validated_arithmetic": True,
+        "outward_rounded": True,
+        "claim": "MATHEMATICAL_INTEGRATED_OU_PROCESS_COVARIANCE_ENCLOSURE",
+        "backend": "POSITIVE_KERNEL_CELL_INTERVAL_EXACT_RATIONAL_ACCUMULATION",
+        "cells": cells,
+        "state_order": ["v", "p", "S", "a_w"],
+        "h_s": [_fraction_down(h_lo), _fraction_up(h_hi)],
+        "tau_s": [_fraction_down(t_lo), _fraction_up(t_hi)],
+        "sigma2_aw": [_fraction_down(s_lo), _fraction_up(s_hi)],
+        "Qd_interval": Q,
+        "mathematical_integral_enclosed": True,
+        "shipping_binary32_closed_form_enclosed": False,
+        "shipping_psd_cleanup_enclosed": False,
+        "theorem_promotion": "NOT_ESTABLISHED",
+    }
+
+
 def build(header: Path) -> dict:
     text = header.read_text()
     c = {name: parse_const(text, name) for name in REQUIRED}
@@ -390,7 +511,10 @@ def build(header: Path) -> dict:
             "requires_finite_h_upper": True,
             "backend": "EXACT_RATIONAL_TAYLOR_WITH_LAGRANGE_REMAINDER",
             "transition_matrix_backend": "VALIDATED_INTERVAL_4X4_INTEGRATED_OU_CHAIN",
-            "theorem_promotion": "BLOCKED_BY_UNBOUNDED_ACCEPTED_DT",
+            "process_covariance_backend": "POSITIVE_KERNEL_CELL_INTERVAL_EXACT_RATIONAL_ACCUMULATION",
+            "process_covariance_mathematical_integral_enclosed": True,
+            "process_covariance_shipping_float_path_enclosed": False,
+            "theorem_promotion": "BLOCKED_BY_UNBOUNDED_ACCEPTED_DT_AND_SHIPPING_QD_FLOAT_PATH",
         },
         "discrete_source_branches": {
             "mode": ["H", "A"],
@@ -408,10 +532,10 @@ def build(header: Path) -> dict:
             "metric_consequence": "inverse-covariance information energy is nonexpansive",
         },
         "promotion_rule": (
-            "source-boundary scalar arithmetic and the exact per-axis transition enclosure are now "
-            "validated; deployment promotion still requires a finite source-derived accepted-dt upper "
-            "bound, validated process-covariance and full H/A Riccati propagation, nonlinear SO(3) "
-            "remainder bounds and remaining jump certificates"
+            "source-boundary scalar arithmetic, exact per-axis transition and mathematical OU process "
+            "covariance are now enclosed; deployment promotion still requires a finite source-derived "
+            "accepted-dt upper bound, enclosure of the shipping binary32 Qd/PSD-cleanup path, full H/A "
+            "Riccati propagation, nonlinear SO(3) remainder bounds and remaining jump certificates"
         ),
     }
 

--- a/tools/ou3_source_domain_contract.py
+++ b/tools/ou3_source_domain_contract.py
@@ -13,23 +13,17 @@ operation as IEEE-754 binary32, using exact rationals between operations and an
 explicit nearest/ties-to-even rounding step. The returned Python float is an
 exact binary64 representation of the deployed binary32 value.
 
-The producer also contains the first validated continuous-word arithmetic:
-``validated_ou_primitives`` bounds exp(-h/tau), phi_pa and phi_Sa using exact
-rational Taylor arithmetic plus an explicit Lagrange remainder;
-``validated_phi_axis4`` lifts those scalar bounds to the exact 4x4
-[v,p,S,a] transition used by IntegratedOUChain<T,3>::transition;
-``validated_qd_axis4_kernel`` encloses the exact mathematical OU process
-covariance using the positive impulse-response kernel; and
-``validated_covariance_predict_axis4`` performs the interval covariance
-prediction Phi P Phi^T + Qd with exact-rational interval matrix arithmetic.
+Validated continuous-word building blocks included here are:
+- exact-rational Taylor/Lagrange bounds for the OU scalar primitives;
+- the exact 4x4 [v,p,S,a] IntegratedOUChain transition enclosure;
+- a positive-kernel exact-rational enclosure of the mathematical OU Qd;
+- exact-rational interval covariance prediction Phi P Phi^T + Qd; and
+- the scalar-axis mathematical S=0 pseudo-measurement Riccati update.
 
-The Qd kernel integral is subdivided into cells. Every cell uses the validated
-transition/OU primitive bounds, and every sum/product is accumulated as an
-exact Fraction. This avoids the cancellation-heavy closed-form covariance
-expressions. The claim is intentionally narrow: it encloses the mathematical
-continuous OU covariance/prediction, while the shipping binary32 closed-form
-Qd computation and its PSD cleanup remain a separate implementation-arithmetic
-obligation.
+The scalar pseudo update is a building block for the shipping 3-D update. The
+actual filter forms the 3x3 innovation P_SS+R_S, solves it with LDLT, and applies
+a Joseph update, so cross-axis coupling and shipping floating-point factorization
+remain explicit obligations before theorem promotion.
 
 The public wrapper accepts every positive finite binary32 ``dt``. That set is
 technically finite -- [2^-149, FLT_MAX] -- but it has no operational safety
@@ -57,21 +51,12 @@ REQUIRED = (
     "PSEUDO_UPDATE_PERIOD_MIN_S_DEFAULT", "PSEUDO_UPDATE_PERIOD_MAX_S_DEFAULT",
     "MAG_DELAY_SEC", "ONLINE_TUNE_WARMUP_SEC",
 )
-
 HYBRID_OBLIGATIONS = (
-    "startup_handoff",
-    "held_to_active",
-    "magnetic_lock",
-    "magnetic_regauge_refinement",
-    "tilt_reset",
-    "tilt_relock",
-    "cooldown_reentry",
-    "periodic_aw_covariance_sync",
+    "startup_handoff", "held_to_active", "magnetic_lock",
+    "magnetic_regauge_refinement", "tilt_reset", "tilt_relock",
+    "cooldown_reentry", "periodic_aw_covariance_sync",
 )
-
-CONST_RE = re.compile(
-    r"constexpr\s+float\s+([A-Za-z_]\w*)\s*=\s*([^;]+);", re.MULTILINE
-)
+CONST_RE = re.compile(r"constexpr\s+float\s+([A-Za-z_]\w*)\s*=\s*([^;]+);", re.MULTILINE)
 _FLOAT32_MAX_BITS = 0x7F7FFFFF
 
 
@@ -88,9 +73,7 @@ def _bits_to_positive_fraction(bits: int) -> Fraction:
         return Fraction(mantissa, 1 << 149)
     significand = (1 << 23) | mantissa
     power = exponent - 127 - 23
-    if power >= 0:
-        return Fraction(significand << power, 1)
-    return Fraction(significand, 1 << (-power))
+    return Fraction(significand << power, 1) if power >= 0 else Fraction(significand, 1 << (-power))
 
 
 def _round_fraction_binary32(value: Fraction) -> Fraction:
@@ -105,31 +88,24 @@ def _round_fraction_binary32(value: Fraction) -> Fraction:
     candidate &= 0x7FFFFFFF
     if candidate > _FLOAT32_MAX_BITS:
         raise RuntimeError(f"binary32 constant overflow for {value}")
-    choices: list[tuple[Fraction, int]] = []
-    for bits in (candidate - 1, candidate, candidate + 1):
-        if 0 <= bits <= _FLOAT32_MAX_BITS:
-            choices.append((_bits_to_positive_fraction(bits), bits))
+    choices = [(_bits_to_positive_fraction(bits), bits)
+               for bits in (candidate - 1, candidate, candidate + 1)
+               if 0 <= bits <= _FLOAT32_MAX_BITS]
     if not choices:
         raise RuntimeError(f"cannot round binary32 constant {value}")
-    def rank(item: tuple[Fraction, int]) -> tuple[Fraction, int]:
-        exact, bits = item
-        return (abs(exact - x), bits & 1)
-    exact, _ = min(choices, key=rank)
+    exact, _ = min(choices, key=lambda item: (abs(item[0] - x), item[1] & 1))
     return exact if sign > 0 else -exact
 
 
 def _literal_fraction(expr: str, node: ast.Constant) -> Fraction:
-    token = ast.get_source_segment(expr, node)
-    if token is None:
-        token = repr(node.value)
+    token = ast.get_source_segment(expr, node) or repr(node.value)
     try:
         return Fraction(token)
     except (ValueError, ZeroDivisionError) as exc:
         raise RuntimeError(f"cannot parse constexpr literal {token!r}") from exc
 
 
-def _eval_constexpr32(node: ast.AST, expr: str, text: str,
-                      stack: tuple[str, ...]) -> Fraction:
+def _eval_constexpr32(node: ast.AST, expr: str, text: str, stack: tuple[str, ...]) -> Fraction:
     if isinstance(node, ast.Expression):
         return _eval_constexpr32(node.body, expr, text, stack)
     if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
@@ -142,24 +118,18 @@ def _eval_constexpr32(node: ast.AST, expr: str, text: str,
     if isinstance(node, ast.BinOp):
         a = _eval_constexpr32(node.left, expr, text, stack)
         b = _eval_constexpr32(node.right, expr, text, stack)
-        if isinstance(node.op, ast.Add):
-            exact = a + b
-        elif isinstance(node.op, ast.Sub):
-            exact = a - b
-        elif isinstance(node.op, ast.Mult):
-            exact = a * b
+        if isinstance(node.op, ast.Add): exact = a + b
+        elif isinstance(node.op, ast.Sub): exact = a - b
+        elif isinstance(node.op, ast.Mult): exact = a * b
         elif isinstance(node.op, ast.Div):
-            if b == 0:
-                raise ZeroDivisionError("constexpr division by zero")
+            if b == 0: raise ZeroDivisionError("constexpr division by zero")
             exact = a / b
-        else:
-            raise RuntimeError(f"unsupported constexpr operator: {ast.dump(node.op)}")
+        else: raise RuntimeError(f"unsupported constexpr operator: {ast.dump(node.op)}")
         return _round_fraction_binary32(exact)
     raise RuntimeError(f"unsupported constexpr expression node: {ast.dump(node)}")
 
 
-def parse_const_fraction(text: str, name: str,
-                         stack: tuple[str, ...] = ()) -> Fraction:
+def parse_const_fraction(text: str, name: str, stack: tuple[str, ...] = ()) -> Fraction:
     if name in stack:
         raise RuntimeError(f"cyclic implementation constant alias: {' -> '.join((*stack, name))}")
     expressions = {n: expr for n, expr in CONST_RE.findall(text)}
@@ -167,40 +137,32 @@ def parse_const_fraction(text: str, name: str,
         raise RuntimeError(f"cannot extract implementation constant {name}")
     expr = " ".join(_strip_float_suffixes(expressions[name]).split())
     try:
-        tree = ast.parse(expr, mode="eval")
-        return _eval_constexpr32(tree, expr, text, (*stack, name))
+        return _eval_constexpr32(ast.parse(expr, mode="eval"), expr, text, (*stack, name))
     except (SyntaxError, ZeroDivisionError) as exc:
         raise RuntimeError(f"cannot evaluate implementation constant {name}: {expr!r}") from exc
 
 
 def parse_const(text: str, name: str, stack: tuple[str, ...] = ()) -> float:
     value = float(parse_const_fraction(text, name, stack))
-    if not math.isfinite(value):
-        raise RuntimeError(f"implementation constant {name} is non-finite")
+    if not math.isfinite(value): raise RuntimeError(f"implementation constant {name} is non-finite")
     return value
 
 
 def parse_aw_sigma_floor(text: str) -> float:
-    pat = re.compile(
-        r"const\s+float\s+sigma_floor\s*=\s*std::max\(\s*"
-        r"([0-9.+\-eE]+)f?\s*,\s*band_noise_floor_sigma_\(\)\s*\)\s*;"
-    )
+    pat = re.compile(r"const\s+float\s+sigma_floor\s*=\s*std::max\(\s*([0-9.+\-eE]+)f?\s*,\s*band_noise_floor_sigma_\(\)\s*\)\s*;")
     m = pat.search(text)
-    if not m:
-        raise RuntimeError("cannot extract deployed a_w stationary-std floor")
+    if not m: raise RuntimeError("cannot extract deployed a_w stationary-std floor")
     return float(_round_fraction_binary32(Fraction(m.group(1))))
 
 
 def _outward_point(x: float) -> list[float]:
     x = float(x)
-    if not math.isfinite(x):
-        raise RuntimeError(f"non-finite source-domain endpoint {x!r}")
+    if not math.isfinite(x): raise RuntimeError(f"non-finite source-domain endpoint {x!r}")
     return [math.nextafter(x, -math.inf), math.nextafter(x, math.inf)]
 
 
 def _outward_box(lo: float, hi: float) -> list[float]:
-    lo = float(lo)
-    hi = float(hi)
+    lo, hi = float(lo), float(hi)
     if not (math.isfinite(lo) and math.isfinite(hi)) or lo > hi:
         raise RuntimeError(f"invalid source interval [{lo!r}, {hi!r}]")
     return [math.nextafter(lo, -math.inf), math.nextafter(hi, math.inf)]
@@ -208,25 +170,18 @@ def _outward_box(lo: float, hi: float) -> list[float]:
 
 def _fraction_down(q: Fraction) -> float:
     y = float(q)
-    if Fraction.from_float(y) > q:
-        y = math.nextafter(y, -math.inf)
-    return y
+    return math.nextafter(y, -math.inf) if Fraction.from_float(y) > q else y
 
 
 def _fraction_up(q: Fraction) -> float:
     y = float(q)
-    if Fraction.from_float(y) < q:
-        y = math.nextafter(y, math.inf)
-    return y
+    return math.nextafter(y, math.inf) if Fraction.from_float(y) < q else y
 
 
 def _exp_neg_point_rational(x: Fraction, order: int = 96) -> tuple[Fraction, Fraction]:
-    if x < 0:
-        raise ValueError("exp(-x) enclosure requires x>=0")
-    if order < 1:
-        raise ValueError("Taylor order must be positive")
-    term = Fraction(1, 1)
-    total = term
+    if x < 0: raise ValueError("exp(-x) enclosure requires x>=0")
+    if order < 1: raise ValueError("Taylor order must be positive")
+    term = total = Fraction(1, 1)
     for n in range(1, order + 1):
         term *= -x
         term /= n
@@ -235,381 +190,195 @@ def _exp_neg_point_rational(x: Fraction, order: int = 96) -> tuple[Fraction, Fra
     return total - rem, total + rem
 
 
-def validated_ou_primitives(h_bounds: tuple[float, float] | list[float],
-                            tau_bounds: tuple[float, float] | list[float],
-                            order: int = 96) -> dict:
+def validated_ou_primitives(h_bounds, tau_bounds, order: int = 96) -> dict:
     h_lo, h_hi = map(Fraction.from_float, map(float, h_bounds))
     t_lo, t_hi = map(Fraction.from_float, map(float, tau_bounds))
-    if h_lo < 0 or h_hi < h_lo:
-        raise ValueError("invalid nonnegative step interval")
-    if t_lo <= 0 or t_hi < t_lo:
-        raise ValueError("invalid positive tau interval")
-    x_lo = h_lo / t_hi
-    x_hi = h_hi / t_lo
+    if h_lo < 0 or h_hi < h_lo: raise ValueError("invalid nonnegative step interval")
+    if t_lo <= 0 or t_hi < t_lo: raise ValueError("invalid positive tau interval")
+    x_lo, x_hi = h_lo / t_hi, h_hi / t_lo
     alpha_lo, _ = _exp_neg_point_rational(x_hi, order)
     _, alpha_hi = _exp_neg_point_rational(x_lo, order)
-    alpha_lo = max(Fraction(0, 1), alpha_lo)
-    alpha_hi = min(Fraction(1, 1), alpha_hi)
-    pa_core_lo = max(Fraction(0, 1), x_lo + alpha_lo - 1)
-    pa_core_hi = x_hi + alpha_hi - 1
-    sa_core_lo = max(Fraction(0, 1), Fraction(1, 2) * x_lo * x_lo - x_hi - alpha_hi + 1)
-    sa_core_hi = Fraction(1, 2) * x_hi * x_hi - x_lo - alpha_lo + 1
-    tau2_lo, tau2_hi = t_lo * t_lo, t_hi * t_hi
-    tau3_lo, tau3_hi = tau2_lo * t_lo, tau2_hi * t_hi
-    phi_pa_lo = tau2_lo * pa_core_lo
-    phi_pa_hi = tau2_hi * max(Fraction(0, 1), pa_core_hi)
-    phi_sa_lo = tau3_lo * sa_core_lo
-    phi_sa_hi = tau3_hi * max(Fraction(0, 1), sa_core_hi)
+    alpha_lo, alpha_hi = max(Fraction(0), alpha_lo), min(Fraction(1), alpha_hi)
+    pa_lo = max(Fraction(0), x_lo + alpha_lo - 1)
+    pa_hi = max(Fraction(0), x_hi + alpha_hi - 1)
+    sa_lo = max(Fraction(0), Fraction(1, 2)*x_lo*x_lo - x_hi - alpha_hi + 1)
+    sa_hi = max(Fraction(0), Fraction(1, 2)*x_hi*x_hi - x_lo - alpha_lo + 1)
+    t2lo, t2hi = t_lo*t_lo, t_hi*t_hi
+    t3lo, t3hi = t2lo*t_lo, t2hi*t_hi
     return {
-        "validated_arithmetic": True,
-        "outward_rounded": True,
+        "validated_arithmetic": True, "outward_rounded": True,
         "backend": f"EXACT_RATIONAL_TAYLOR_ORDER_{order}_LAGRANGE_REMAINDER",
         "h_s": [_fraction_down(h_lo), _fraction_up(h_hi)],
         "tau_s": [_fraction_down(t_lo), _fraction_up(t_hi)],
         "x_h_over_tau": [_fraction_down(x_lo), _fraction_up(x_hi)],
         "alpha": [_fraction_down(alpha_lo), _fraction_up(alpha_hi)],
-        "phi_pa_s2": [_fraction_down(phi_pa_lo), _fraction_up(phi_pa_hi)],
-        "phi_Sa_s3": [_fraction_down(phi_sa_lo), _fraction_up(phi_sa_hi)],
+        "phi_pa_s2": [_fraction_down(t2lo*pa_lo), _fraction_up(t2hi*pa_hi)],
+        "phi_Sa_s3": [_fraction_down(t3lo*sa_lo), _fraction_up(t3hi*sa_hi)],
     }
 
 
-def _mul_nonnegative_bounds(a: list[float], b: list[float]) -> list[float]:
-    if a[0] < 0 or b[0] < 0:
-        raise ValueError("nonnegative interval multiplication received a negative lower bound")
-    return [
-        math.nextafter(float(a[0]) * float(b[0]), -math.inf),
-        math.nextafter(float(a[1]) * float(b[1]), math.inf),
-    ]
+def _mul_nonnegative_bounds(a, b):
+    if a[0] < 0 or b[0] < 0: raise ValueError("negative lower bound")
+    return [math.nextafter(float(a[0])*float(b[0]), -math.inf),
+            math.nextafter(float(a[1])*float(b[1]), math.inf)]
 
 
-def validated_phi_axis4(h_bounds: tuple[float, float] | list[float],
-                        tau_bounds: tuple[float, float] | list[float],
-                        order: int = 96) -> dict:
+def validated_phi_axis4(h_bounds, tau_bounds, order: int = 96) -> dict:
     p = validated_ou_primitives(h_bounds, tau_bounds, order)
-    h_lo, h_hi = map(float, h_bounds)
-    t_lo, t_hi = map(float, tau_bounds)
-    if h_lo < 0 or h_hi < h_lo or t_lo <= 0 or t_hi < t_lo:
-        raise ValueError("invalid h/tau transition domain")
-    zero = [0.0, 0.0]
-    one = [1.0, 1.0]
+    h_lo, h_hi = map(float, h_bounds); t_lo, t_hi = map(float, tau_bounds)
+    zero, one = [0.0, 0.0], [1.0, 1.0]
     h = _outward_box(h_lo, h_hi)
-    half_h2 = [
-        math.nextafter(0.5 * h_lo * h_lo, -math.inf),
-        math.nextafter(0.5 * h_hi * h_hi, math.inf),
-    ]
-    one_minus_alpha = [
-        max(0.0, math.nextafter(1.0 - p["alpha"][1], -math.inf)),
-        math.nextafter(1.0 - p["alpha"][0], math.inf),
-    ]
-    tau = _outward_box(t_lo, t_hi)
-    phi_va = _mul_nonnegative_bounds(tau, one_minus_alpha)
-    M = [
-        [one, zero, zero, phi_va],
-        [h, one, zero, p["phi_pa_s2"]],
-        [half_h2, h, one, p["phi_Sa_s3"]],
-        [zero, zero, zero, p["alpha"]],
-    ]
-    return {
-        "validated_arithmetic": True,
-        "outward_rounded": True,
-        "implementation": "IntegratedOUChain<T,3>::transition",
-        "state_order": ["v", "p", "S", "a_w"],
-        "scalar_primitives": p,
-        "Phi_interval": M,
-    }
+    half_h2 = [math.nextafter(0.5*h_lo*h_lo, -math.inf), math.nextafter(0.5*h_hi*h_hi, math.inf)]
+    one_minus_alpha = [max(0.0, math.nextafter(1-p["alpha"][1], -math.inf)), math.nextafter(1-p["alpha"][0], math.inf)]
+    phi_va = _mul_nonnegative_bounds(_outward_box(t_lo, t_hi), one_minus_alpha)
+    M = [[one, zero, zero, phi_va], [h, one, zero, p["phi_pa_s2"]],
+         [half_h2, h, one, p["phi_Sa_s3"]], [zero, zero, zero, p["alpha"]]]
+    return {"validated_arithmetic": True, "outward_rounded": True,
+            "implementation": "IntegratedOUChain<T,3>::transition",
+            "state_order": ["v", "p", "S", "a_w"], "scalar_primitives": p, "Phi_interval": M}
 
 
-def _kernel_interval_on_cell(r_lo: Fraction, r_hi: Fraction,
-                             tau_bounds: tuple[float, float] | list[float],
-                             order: int) -> list[tuple[Fraction, Fraction]]:
-    lo = _fraction_down(r_lo)
-    hi = _fraction_up(r_hi)
-    M = validated_phi_axis4((lo, hi), tau_bounds, order)["Phi_interval"]
-    ans: list[tuple[Fraction, Fraction]] = []
+def _kernel_interval_on_cell(r_lo, r_hi, tau_bounds, order):
+    M = validated_phi_axis4((_fraction_down(r_lo), _fraction_up(r_hi)), tau_bounds, order)["Phi_interval"]
+    ans=[]
     for i in range(4):
-        b = M[i][3]
-        blo = max(0.0, float(b[0]))
-        bhi = max(blo, float(b[1]))
+        blo=max(0.0,float(M[i][3][0])); bhi=max(blo,float(M[i][3][1]))
         ans.append((Fraction.from_float(blo), Fraction.from_float(bhi)))
     return ans
 
 
-def _integrate_kernel_bounds(h: Fraction,
-                             tau_bounds: tuple[float, float] | list[float],
-                             cells: int, order: int) -> tuple[list[list[Fraction]], list[list[Fraction]]]:
-    if h < 0:
-        raise ValueError("integration horizon must be nonnegative")
-    if cells <= 0:
-        raise ValueError("cells must be positive")
-    lower = [[Fraction(0, 1) for _ in range(4)] for _ in range(4)]
-    upper = [[Fraction(0, 1) for _ in range(4)] for _ in range(4)]
-    if h == 0:
-        return lower, upper
-    width = h / cells
+def _integrate_kernel_bounds(h, tau_bounds, cells, order):
+    if h < 0 or cells <= 0: raise ValueError("invalid integration domain")
+    lower=[[Fraction(0) for _ in range(4)] for _ in range(4)]
+    upper=[[Fraction(0) for _ in range(4)] for _ in range(4)]
+    if h == 0: return lower, upper
+    width=h/cells
     for k in range(cells):
-        r0 = width * k
-        r1 = width * (k + 1)
-        g = _kernel_interval_on_cell(r0, r1, tau_bounds, order)
+        g=_kernel_interval_on_cell(width*k, width*(k+1), tau_bounds, order)
         for i in range(4):
-            for j in range(i, 4):
-                cell_lo = width * g[i][0] * g[j][0]
-                cell_hi = width * g[i][1] * g[j][1]
-                lower[i][j] += cell_lo
-                upper[i][j] += cell_hi
-                if i != j:
-                    lower[j][i] += cell_lo
-                    upper[j][i] += cell_hi
+            for j in range(i,4):
+                lo=width*g[i][0]*g[j][0]; hi=width*g[i][1]*g[j][1]
+                lower[i][j]+=lo; upper[i][j]+=hi
+                if i!=j: lower[j][i]+=lo; upper[j][i]+=hi
     return lower, upper
 
 
-def validated_qd_axis4_kernel(h_bounds: tuple[float, float] | list[float],
-                              tau_bounds: tuple[float, float] | list[float],
-                              sigma2_bounds: tuple[float, float] | list[float],
-                              cells: int = 24, order: int = 96) -> dict:
-    h_lo_f, h_hi_f = map(float, h_bounds)
-    t_lo_f, t_hi_f = map(float, tau_bounds)
-    s_lo_f, s_hi_f = map(float, sigma2_bounds)
-    if h_lo_f < 0 or h_hi_f < h_lo_f:
-        raise ValueError("invalid h interval")
-    if t_lo_f <= 0 or t_hi_f < t_lo_f:
-        raise ValueError("invalid tau interval")
-    if s_lo_f < 0 or s_hi_f < s_lo_f:
-        raise ValueError("invalid sigma2 interval")
-    h_lo = Fraction.from_float(h_lo_f)
-    h_hi = Fraction.from_float(h_hi_f)
-    t_lo = Fraction.from_float(t_lo_f)
-    t_hi = Fraction.from_float(t_hi_f)
-    s_lo = Fraction.from_float(s_lo_f)
-    s_hi = Fraction.from_float(s_hi_f)
-    int_lo, _ = _integrate_kernel_bounds(h_lo, tau_bounds, cells, order)
-    _, int_hi = _integrate_kernel_bounds(h_hi, tau_bounds, cells, order)
-    qc_lo = Fraction(2, 1) * s_lo / t_hi
-    qc_hi = Fraction(2, 1) * s_hi / t_lo
-    Q: list[list[list[float]]] = []
+def validated_qd_axis4_kernel(h_bounds, tau_bounds, sigma2_bounds, cells: int = 24, order: int = 96) -> dict:
+    h_lo,h_hi=map(Fraction.from_float,map(float,h_bounds)); t_lo,t_hi=map(Fraction.from_float,map(float,tau_bounds)); s_lo,s_hi=map(Fraction.from_float,map(float,sigma2_bounds))
+    if h_lo<0 or h_hi<h_lo or t_lo<=0 or t_hi<t_lo or s_lo<0 or s_hi<s_lo: raise ValueError("invalid Qd domain")
+    int_lo,_=_integrate_kernel_bounds(h_lo,tau_bounds,cells,order); _,int_hi=_integrate_kernel_bounds(h_hi,tau_bounds,cells,order)
+    qc_lo=Fraction(2)*s_lo/t_hi; qc_hi=Fraction(2)*s_hi/t_lo
+    Q=[]
     for i in range(4):
-        row: list[list[float]] = []
-        for j in range(4):
-            qlo = qc_lo * int_lo[i][j]
-            qhi = qc_hi * int_hi[i][j]
-            row.append([_fraction_down(qlo), _fraction_up(qhi)])
+        row=[]
+        for j in range(4): row.append([_fraction_down(qc_lo*int_lo[i][j]), _fraction_up(qc_hi*int_hi[i][j])])
         Q.append(row)
-    return {
-        "validated_arithmetic": True,
-        "outward_rounded": True,
-        "claim": "MATHEMATICAL_INTEGRATED_OU_PROCESS_COVARIANCE_ENCLOSURE",
-        "backend": "POSITIVE_KERNEL_CELL_INTERVAL_EXACT_RATIONAL_ACCUMULATION",
-        "cells": cells,
-        "state_order": ["v", "p", "S", "a_w"],
-        "h_s": [_fraction_down(h_lo), _fraction_up(h_hi)],
-        "tau_s": [_fraction_down(t_lo), _fraction_up(t_hi)],
-        "sigma2_aw": [_fraction_down(s_lo), _fraction_up(s_hi)],
-        "Qd_interval": Q,
-        "mathematical_integral_enclosed": True,
-        "shipping_binary32_closed_form_enclosed": False,
-        "shipping_psd_cleanup_enclosed": False,
-        "theorem_promotion": "NOT_ESTABLISHED",
-    }
+    return {"validated_arithmetic":True,"outward_rounded":True,"claim":"MATHEMATICAL_INTEGRATED_OU_PROCESS_COVARIANCE_ENCLOSURE",
+            "backend":"POSITIVE_KERNEL_CELL_INTERVAL_EXACT_RATIONAL_ACCUMULATION","cells":cells,"state_order":["v","p","S","a_w"],
+            "h_s":[_fraction_down(h_lo),_fraction_up(h_hi)],"tau_s":[_fraction_down(t_lo),_fraction_up(t_hi)],"sigma2_aw":[_fraction_down(s_lo),_fraction_up(s_hi)],
+            "Qd_interval":Q,"mathematical_integral_enclosed":True,"shipping_binary32_closed_form_enclosed":False,"shipping_psd_cleanup_enclosed":False,"theorem_promotion":"NOT_ESTABLISHED"}
 
 
-def _iv_from_float(bounds: list[float]) -> tuple[Fraction, Fraction]:
-    if len(bounds) != 2:
-        raise ValueError("interval needs two endpoints")
-    lo, hi = map(float, bounds)
-    if not (math.isfinite(lo) and math.isfinite(hi)) or lo > hi:
-        raise ValueError(f"invalid finite interval {bounds!r}")
-    return Fraction.from_float(lo), Fraction.from_float(hi)
-
-
-def _iv_add(a: tuple[Fraction, Fraction],
-            b: tuple[Fraction, Fraction]) -> tuple[Fraction, Fraction]:
-    return a[0] + b[0], a[1] + b[1]
-
-
-def _iv_mul(a: tuple[Fraction, Fraction],
-            b: tuple[Fraction, Fraction]) -> tuple[Fraction, Fraction]:
-    p = (a[0] * b[0], a[0] * b[1], a[1] * b[0], a[1] * b[1])
-    return min(p), max(p)
-
-
-def _iv_matrix_from_float(M: list[list[list[float]]]) -> list[list[tuple[Fraction, Fraction]]]:
-    return [[_iv_from_float(x) for x in row] for row in M]
-
-
-def _iv_transpose(M: list[list[tuple[Fraction, Fraction]]]) -> list[list[tuple[Fraction, Fraction]]]:
-    return [list(row) for row in zip(*M)]
-
-
-def _iv_matmul(A: list[list[tuple[Fraction, Fraction]]],
-               B: list[list[tuple[Fraction, Fraction]]]) -> list[list[tuple[Fraction, Fraction]]]:
-    if not A or not B or len(A[0]) != len(B):
-        raise ValueError("interval matrix dimensions do not conform")
-    out: list[list[tuple[Fraction, Fraction]]] = []
+def _iv_from_float(b):
+    lo,hi=map(float,b)
+    if not(math.isfinite(lo) and math.isfinite(hi)) or lo>hi: raise ValueError("invalid interval")
+    return Fraction.from_float(lo),Fraction.from_float(hi)
+def _iv_add(a,b): return a[0]+b[0],a[1]+b[1]
+def _iv_sub(a,b): return a[0]-b[1],a[1]-b[0]
+def _iv_mul(a,b):
+    p=(a[0]*b[0],a[0]*b[1],a[1]*b[0],a[1]*b[1]); return min(p),max(p)
+def _iv_div_positive(a,b):
+    if b[0] <= 0: raise ValueError("denominator interval must be positive")
+    return _iv_mul(a,(Fraction(1,1)/b[1],Fraction(1,1)/b[0]))
+def _iv_matrix_from_float(M): return [[_iv_from_float(x) for x in row] for row in M]
+def _iv_transpose(M): return [list(row) for row in zip(*M)]
+def _iv_matmul(A,B):
+    if not A or not B or len(A[0])!=len(B): raise ValueError("matrix dimensions")
+    out=[]
     for i in range(len(A)):
-        row: list[tuple[Fraction, Fraction]] = []
+        row=[]
         for j in range(len(B[0])):
-            acc = (Fraction(0, 1), Fraction(0, 1))
-            for k in range(len(B)):
-                acc = _iv_add(acc, _iv_mul(A[i][k], B[k][j]))
+            acc=(Fraction(0),Fraction(0))
+            for k in range(len(B)): acc=_iv_add(acc,_iv_mul(A[i][k],B[k][j]))
             row.append(acc)
         out.append(row)
     return out
 
 
-def validated_covariance_predict_axis4(
-        P_interval: list[list[list[float]]],
-        h_bounds: tuple[float, float] | list[float],
-        tau_bounds: tuple[float, float] | list[float],
-        sigma2_bounds: tuple[float, float] | list[float],
-        cells: int = 24, order: int = 96) -> dict:
-    """Enclose one mathematical covariance prediction Phi P Phi^T + Qd."""
-    if len(P_interval) != 4 or any(len(row) != 4 for row in P_interval):
-        raise ValueError("P_interval must be 4x4")
-    phi = validated_phi_axis4(h_bounds, tau_bounds, order)
-    qd = validated_qd_axis4_kernel(h_bounds, tau_bounds, sigma2_bounds, cells, order)
-    A = _iv_matrix_from_float(phi["Phi_interval"])
-    P = _iv_matrix_from_float(P_interval)
-    Q = _iv_matrix_from_float(qd["Qd_interval"])
-    AP = _iv_matmul(A, P)
-    APA = _iv_matmul(AP, _iv_transpose(A))
-    pred: list[list[list[float]]] = []
+def validated_covariance_predict_axis4(P_interval,h_bounds,tau_bounds,sigma2_bounds,cells: int=24,order: int=96)->dict:
+    if len(P_interval)!=4 or any(len(r)!=4 for r in P_interval): raise ValueError("P_interval must be 4x4")
+    phi=validated_phi_axis4(h_bounds,tau_bounds,order); qd=validated_qd_axis4_kernel(h_bounds,tau_bounds,sigma2_bounds,cells,order)
+    A=_iv_matrix_from_float(phi["Phi_interval"]); P=_iv_matrix_from_float(P_interval); Q=_iv_matrix_from_float(qd["Qd_interval"])
+    APA=_iv_matmul(_iv_matmul(A,P),_iv_transpose(A)); pred=[]
     for i in range(4):
-        row: list[list[float]] = []
+        row=[]
         for j in range(4):
-            lo, hi = _iv_add(APA[i][j], Q[i][j])
-            row.append([_fraction_down(lo), _fraction_up(hi)])
+            lo,hi=_iv_add(APA[i][j],Q[i][j]); row.append([_fraction_down(lo),_fraction_up(hi)])
         pred.append(row)
-    return {
-        "validated_arithmetic": True,
-        "outward_rounded": True,
-        "claim": "MATHEMATICAL_OU_AXIS_COVARIANCE_PREDICTION_ENCLOSURE",
-        "state_order": ["v", "p", "S", "a_w"],
-        "Phi": phi,
-        "Qd": qd,
-        "P_prior_interval": P_interval,
-        "P_predicted_interval": pred,
-        "mathematical_prediction_enclosed": True,
-        "shipping_covariance_prediction_enclosed": False,
-        "theorem_promotion": "NOT_ESTABLISHED",
-    }
+    return {"validated_arithmetic":True,"outward_rounded":True,"claim":"MATHEMATICAL_OU_AXIS_COVARIANCE_PREDICTION_ENCLOSURE",
+            "state_order":["v","p","S","a_w"],"Phi":phi,"Qd":qd,"P_prior_interval":P_interval,"P_predicted_interval":pred,
+            "mathematical_prediction_enclosed":True,"shipping_covariance_prediction_enclosed":False,"theorem_promotion":"NOT_ESTABLISHED"}
+
+
+def validated_scalar_s_pseudo_update_axis4(P_interval,R_bounds)->dict:
+    """Enclose exact scalar S=0 covariance update for one [v,p,S,a] axis."""
+    if len(P_interval)!=4 or any(len(r)!=4 for r in P_interval): raise ValueError("P_interval must be 4x4")
+    P=_iv_matrix_from_float(P_interval); R=_iv_from_float(list(R_bounds))
+    if R[0] <= 0: raise ValueError("R_S must be strictly positive")
+    innov=_iv_add(P[2][2],R)
+    if innov[0] <= 0: raise ValueError("P_SS+R_S lacks a positive lower bound")
+    post=[]
+    for i in range(4):
+        row=[]
+        for j in range(4):
+            corr=_iv_div_positive(_iv_mul(P[i][2],P[2][j]),innov)
+            lo,hi=_iv_sub(P[i][j],corr)
+            row.append([_fraction_down(lo),_fraction_up(hi)])
+        post.append(row)
+    return {"validated_arithmetic":True,"outward_rounded":True,
+            "claim":"MATHEMATICAL_SCALAR_AXIS_S_ZERO_RICCATI_UPDATE_ENCLOSURE",
+            "state_order":["v","p","S","a_w"],"measurement":"S=0","R_S_interval":list(R_bounds),
+            "innovation_variance_interval":[_fraction_down(innov[0]),_fraction_up(innov[1])],
+            "P_prior_interval":P_interval,"P_posterior_interval":post,
+            "mathematical_scalar_update_enclosed":True,"shipping_3d_ldlt_joseph_update_enclosed":False,"theorem_promotion":"NOT_ESTABLISHED"}
 
 
 def build(header: Path) -> dict:
-    text = header.read_text()
-    c = {name: parse_const(text, name) for name in REQUIRED}
-    sigma_floor = parse_aw_sigma_floor(text)
-    continuous = {
-        "wave_tune_frequency_hz": [c["MIN_TUNE_FREQ_HZ"], c["MAX_TUNE_FREQ_HZ"]],
-        "tau_aw_s": [c["MIN_TAU_S"], c["MAX_TAU_S"]],
-        "sigma_aw_mps2": [sigma_floor, c["MAX_SIGMA_A"]],
-        "R_S_base": [c["MIN_R_S"], c["MAX_R_S"]],
-        "pseudo_update_period_s": [
-            c["PSEUDO_UPDATE_PERIOD_MIN_S_DEFAULT"], c["PSEUDO_UPDATE_PERIOD_MAX_S_DEFAULT"],
-        ],
-    }
-    timing = {
-        "mag_delay": c["MAG_DELAY_SEC"],
-        "online_tune_warmup": c["ONLINE_TUNE_WARMUP_SEC"],
-    }
-    parameter_box = {
-        "qualification": "SOURCE_DERIVED_OUTWARD_ROUNDED_PARAMETER_BOX",
-        "validated_arithmetic": True,
-        "outward_rounded": True,
-        "arithmetic_backend": "EXACT_BINARY32_SOURCE_PLUS_BINARY64_NEXTAFTER_OUTWARD",
-        "continuous_parameters": {
-            name: _outward_box(bounds[0], bounds[1])
-            for name, bounds in continuous.items()
-        },
-        "timing_constants_s": {
-            name: _outward_point(value)
-            for name, value in timing.items()
-        },
-        "continuous_word_enclosed": False,
-        "nonlinear_word_enclosed": False,
-        "theorem_promotion": "NOT_ESTABLISHED",
-    }
-    min_positive_f32 = float(_bits_to_positive_fraction(1))
-    max_finite_f32 = float(_bits_to_positive_fraction(_FLOAT32_MAX_BITS))
-    return {
-        "schema": 2,
-        "claim": "OU3_SOURCE_COMPLETE_IMPLEMENTATION_DOMAIN_CONTRACT",
-        "source_generated_not_trajectory_fit": True,
-        "source_complete_parameter_domain": True,
-        "validated_arithmetic": False,
-        "outward_rounded": False,
-        "implementation_header": str(header.relative_to(REPO)),
-        "implementation_scalar_semantics": {
-            "type": "IEEE754_BINARY32",
-            "rounding": "ROUND_TO_NEAREST_TIES_TO_EVEN_EACH_OPERATION",
-            "evaluation": "EXACT_RATIONAL_THEN_BINARY32_ROUND",
-        },
-        "continuous_parameters": continuous,
-        "timing_constants_s": timing,
-        "validated_parameter_box": parameter_box,
-        "accepted_update_step_domain_s": {
-            "lower_closed": min_positive_f32,
-            "upper_closed": max_finite_f32,
-            "type_level_finite_upper_bound": True,
-            "operational_safety_upper_guard": False,
-            "proof_usable_supported_upper_bound": False,
-            "implementation_observation": (
-                "SeaStateFusionFilter_OU_III::updateCore_ accepts every positive finite binary32 dt; "
-                "the IEEE-754 type supplies a finite maximum but the implementation supplies no "
-                "operationally meaningful maximum supported step"
-            ),
-            "theorem_effect": (
-                "a source-complete type-level domain exists, but its FLT_MAX upper endpoint is not a "
-                "finite-state operational domain for the transition/covariance formulas; theorem "
-                "promotion requires a source/configuration supported-step guard or equivalent caller contract"
-            ),
-        },
-        "validated_ou_primitive_backend": {
-            "available": True,
-            "requires_proof_usable_h_upper": True,
-            "backend": "EXACT_RATIONAL_TAYLOR_WITH_LAGRANGE_REMAINDER",
-            "transition_matrix_backend": "VALIDATED_INTERVAL_4X4_INTEGRATED_OU_CHAIN",
-            "process_covariance_backend": "POSITIVE_KERNEL_CELL_INTERVAL_EXACT_RATIONAL_ACCUMULATION",
-            "process_covariance_mathematical_integral_enclosed": True,
-            "process_covariance_shipping_float_path_enclosed": False,
-            "covariance_prediction_backend": "EXACT_RATIONAL_INTERVAL_PHI_P_PHIT_PLUS_Q",
-            "covariance_prediction_mathematical_path_enclosed": True,
-            "theorem_promotion": "BLOCKED_BY_NO_PROOF_USABLE_ACCEPTED_DT_GUARD_AND_SHIPPING_QD_FLOAT_PATH",
-        },
-        "discrete_source_branches": {
-            "mode": ["H", "A"],
-            "accelerometer_gate": ["accepted", "rejected"],
-            "magnetometer_gate": ["not_due", "accepted", "rejected"],
-            "S_zero_pseudo": ["not_due", "due"],
-            "magnetic_gauge": ["unlocked", "locked", "refined"],
-            "tilt_recovery": ["normal", "reset", "relock", "cooldown_reentry"],
-            "aw_covariance_sync": ["not_due", "due_psd_increment"],
-        },
-        "hybrid_obligations": list(HYBRID_OBLIGATIONS),
-        "periodic_aw_covariance_sync_proof": {
-            "required_mode": "PSD_NONEXPANSIVE",
-            "operation": "P_plus=P_minus+E_a Delta_plus E_a^T with Delta_plus>=0",
-            "metric_consequence": "inverse-covariance information energy is nonexpansive",
-        },
-        "promotion_rule": (
-            "source-boundary scalar arithmetic, exact per-axis transition, mathematical OU process covariance "
-            "and one-step mathematical covariance prediction are now enclosed; deployment promotion still "
-            "requires a proof-usable source-derived accepted-dt upper guard/contract, enclosure of the shipping "
-            "binary32 Qd/PSD-cleanup path, measurement/Riccati updates over full H/A words, nonlinear SO(3) "
-            "remainder bounds and remaining jump certificates"
-        ),
-    }
+    text=header.read_text(); c={name:parse_const(text,name) for name in REQUIRED}; sigma_floor=parse_aw_sigma_floor(text)
+    continuous={"wave_tune_frequency_hz":[c["MIN_TUNE_FREQ_HZ"],c["MAX_TUNE_FREQ_HZ"]],"tau_aw_s":[c["MIN_TAU_S"],c["MAX_TAU_S"]],
+                "sigma_aw_mps2":[sigma_floor,c["MAX_SIGMA_A"]],"R_S_base":[c["MIN_R_S"],c["MAX_R_S"]],
+                "pseudo_update_period_s":[c["PSEUDO_UPDATE_PERIOD_MIN_S_DEFAULT"],c["PSEUDO_UPDATE_PERIOD_MAX_S_DEFAULT"]]}
+    timing={"mag_delay":c["MAG_DELAY_SEC"],"online_tune_warmup":c["ONLINE_TUNE_WARMUP_SEC"]}
+    parameter_box={"qualification":"SOURCE_DERIVED_OUTWARD_ROUNDED_PARAMETER_BOX","validated_arithmetic":True,"outward_rounded":True,
+                   "arithmetic_backend":"EXACT_BINARY32_SOURCE_PLUS_BINARY64_NEXTAFTER_OUTWARD",
+                   "continuous_parameters":{n:_outward_box(b[0],b[1]) for n,b in continuous.items()},
+                   "timing_constants_s":{n:_outward_point(v) for n,v in timing.items()},"continuous_word_enclosed":False,"nonlinear_word_enclosed":False,"theorem_promotion":"NOT_ESTABLISHED"}
+    min_positive_f32=float(_bits_to_positive_fraction(1)); max_finite_f32=float(_bits_to_positive_fraction(_FLOAT32_MAX_BITS))
+    return {"schema":2,"claim":"OU3_SOURCE_COMPLETE_IMPLEMENTATION_DOMAIN_CONTRACT","source_generated_not_trajectory_fit":True,"source_complete_parameter_domain":True,
+            "validated_arithmetic":False,"outward_rounded":False,"implementation_header":str(header.relative_to(REPO)),
+            "implementation_scalar_semantics":{"type":"IEEE754_BINARY32","rounding":"ROUND_TO_NEAREST_TIES_TO_EVEN_EACH_OPERATION","evaluation":"EXACT_RATIONAL_THEN_BINARY32_ROUND"},
+            "continuous_parameters":continuous,"timing_constants_s":timing,"validated_parameter_box":parameter_box,
+            "accepted_update_step_domain_s":{"lower_closed":min_positive_f32,"upper_closed":max_finite_f32,"type_level_finite_upper_bound":True,
+                "operational_safety_upper_guard":False,"proof_usable_supported_upper_bound":False,
+                "implementation_observation":"SeaStateFusionFilter_OU_III::updateCore_ accepts every positive finite binary32 dt; the IEEE-754 type supplies a finite maximum but the implementation supplies no operationally meaningful maximum supported step",
+                "theorem_effect":"a source-complete type-level domain exists, but its FLT_MAX upper endpoint is not a finite-state operational domain for the transition/covariance formulas; theorem promotion requires a source/configuration supported-step guard or equivalent caller contract"},
+            "validated_ou_primitive_backend":{"available":True,"requires_proof_usable_h_upper":True,"backend":"EXACT_RATIONAL_TAYLOR_WITH_LAGRANGE_REMAINDER",
+                "transition_matrix_backend":"VALIDATED_INTERVAL_4X4_INTEGRATED_OU_CHAIN","process_covariance_backend":"POSITIVE_KERNEL_CELL_INTERVAL_EXACT_RATIONAL_ACCUMULATION",
+                "process_covariance_mathematical_integral_enclosed":True,"process_covariance_shipping_float_path_enclosed":False,
+                "covariance_prediction_backend":"EXACT_RATIONAL_INTERVAL_PHI_P_PHIT_PLUS_Q","covariance_prediction_mathematical_path_enclosed":True,
+                "scalar_S_zero_update_backend":"EXACT_RATIONAL_SCALAR_RICCATI_UPDATE","scalar_S_zero_mathematical_path_enclosed":True,
+                "shipping_3d_S_zero_update_enclosed":False,"theorem_promotion":"BLOCKED_BY_NO_PROOF_USABLE_ACCEPTED_DT_GUARD_AND_SHIPPING_QD_FLOAT_PATH"},
+            "discrete_source_branches":{"mode":["H","A"],"accelerometer_gate":["accepted","rejected"],"magnetometer_gate":["not_due","accepted","rejected"],
+                "S_zero_pseudo":["not_due","due"],"magnetic_gauge":["unlocked","locked","refined"],"tilt_recovery":["normal","reset","relock","cooldown_reentry"],
+                "aw_covariance_sync":["not_due","due_psd_increment"]},"hybrid_obligations":list(HYBRID_OBLIGATIONS),
+            "periodic_aw_covariance_sync_proof":{"required_mode":"PSD_NONEXPANSIVE","operation":"P_plus=P_minus+E_a Delta_plus E_a^T with Delta_plus>=0",
+                "metric_consequence":"inverse-covariance information energy is nonexpansive"},
+            "promotion_rule":"source-boundary scalar arithmetic, exact per-axis transition, mathematical OU process covariance, one-step covariance prediction and scalar-axis S=0 Riccati update are enclosed; deployment promotion still requires a proof-usable accepted-dt guard/contract, shipping binary32 Qd/PSD-cleanup and 3-D LDLT/Joseph enclosure, full H/A words, nonlinear SO(3) bounds and remaining jump certificates"}
 
 
-def main() -> int:
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--header", type=Path, default=DEFAULT_HEADER)
-    ap.add_argument("--output", type=Path, required=True)
-    args = ap.parse_args()
-    payload = build(args.header.resolve())
-    args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(json.dumps(payload, indent=2, sort_keys=True))
-    print(json.dumps(payload, indent=2, sort_keys=True))
-    return 0
+def main()->int:
+    ap=argparse.ArgumentParser(); ap.add_argument("--header",type=Path,default=DEFAULT_HEADER); ap.add_argument("--output",type=Path,required=True); args=ap.parse_args()
+    payload=build(args.header.resolve()); args.output.parent.mkdir(parents=True,exist_ok=True); args.output.write_text(json.dumps(payload,indent=2,sort_keys=True)); print(json.dumps(payload,indent=2,sort_keys=True)); return 0
 
 
-if __name__ == "__main__":
-    raise SystemExit(main())
+if __name__=="__main__": raise SystemExit(main())


### PR DESCRIPTION
PR #403 was merged at head 9d472e0 while proof work was still continuing on its branch. This continuation PR preserves only the post-merge theorem work and becomes the single long-lived PR for the remaining OU-III proof closure.

Current additions after #403:
- exact-rational Taylor/Lagrange outward enclosure for the deployed OU scalar primitives exp(-h/tau), phi_pa and phi_Sa;
- validated interval enclosure of the exact IntegratedOUChain<T,3> 4x4 [v,p,S,a_w] transition block;
- tests against direct deployed formulas;
- explicit source-domain theorem blocker showing that SeaStateFusionFilter_OU_III currently accepts any finite positive dt and therefore has no finite source-derived upper step bound for a deployment-wide continuous-word certificate.

All sampled/replay basin results remain diagnostic only. Do not promote the deployment theorem until the source-complete outward-rounded Riccati/nonlinear/hybrid/stochastic gates are genuinely discharged.

Keep all remaining proof fixes in this PR; do not create a new proof PR for each iteration.