### PR TITLE
Advance OU-III validated continuous-source enclosure

### DIFF
--- a/.github/workflows/ou3-proof-fast.yml
+++ b/.github/workflows/ou3-proof-fast.yml
@@ -46,7 +46,7 @@ jobs:
         working-directory: tests/validation
         run: python3 -m unittest -v test_ou3_source_domain_contract
 
-  # Proof-only: no wave replay, simulator build, plot generation, or document build.
+  # Focused proof-only job: no replay, simulator, plots, PDFs, or broad build.
   scalar-ou:
     name: validated scalar OU transition
     runs-on: ubuntu-24.04

--- a/.github/workflows/ou3-proof-fast.yml
+++ b/.github/workflows/ou3-proof-fast.yml
@@ -3,12 +3,20 @@ name: ou3-proof-fast
 on:
   pull_request:
     paths:
+      - "src/kalman_ou_common/KalmanOUCoreMath.h"
+      - "src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h"
+      - "tools/ou3_interval.py"
+      - "tools/ou3_validated_transcendentals.py"
+      - "tools/ou3_scalar_ou_enclosure.py"
+      - "tools/ou3_source_interval_box.py"
       - "tools/ou3_certificate_completion.py"
       - "tools/ou3_validate_enclosure.py"
       - "tools/ou3_deployment_gate.py"
       - "tools/ou3_hybrid_aw_sync_proof.py"
       - "tools/ou3_hybrid_contract.py"
       - "tools/ou3_source_domain_contract.py"
+      - "tests/validation/test_ou3_validated_transcendentals.py"
+      - "tests/validation/test_ou3_scalar_ou_enclosure.py"
       - "tests/validation/test_ou3_certificate_completion.py"
       - "tests/validation/test_ou3_validate_enclosure.py"
       - "tests/validation/test_ou3_deployment_gate.py"
@@ -37,6 +45,27 @@ jobs:
       - name: Test source-domain contract
         working-directory: tests/validation
         run: python3 -m unittest -v test_ou3_source_domain_contract
+
+  scalar-ou:
+    name: validated scalar OU transition
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - name: Compile interval and scalar OU producers
+        run: |
+          python3 -m py_compile \
+            tools/ou3_interval.py \
+            tools/ou3_validated_transcendentals.py \
+            tools/ou3_scalar_ou_enclosure.py \
+            tests/validation/test_ou3_validated_transcendentals.py \
+            tests/validation/test_ou3_scalar_ou_enclosure.py
+      - name: Test validated transcendental and scalar OU enclosures
+        working-directory: tests/validation
+        run: |
+          python3 -m unittest -v \
+            test_ou3_validated_transcendentals \
+            test_ou3_scalar_ou_enclosure
 
   enclosure:
     name: continuous and nonlinear enclosure arithmetic

--- a/.github/workflows/ou3-proof-fast.yml
+++ b/.github/workflows/ou3-proof-fast.yml
@@ -46,6 +46,7 @@ jobs:
         working-directory: tests/validation
         run: python3 -m unittest -v test_ou3_source_domain_contract
 
+  # Proof-only: no wave replay, simulator build, plot generation, or document build.
   scalar-ou:
     name: validated scalar OU transition
     runs-on: ubuntu-24.04

--- a/tests/validation/test_ou3_scalar_ou_enclosure.py
+++ b/tests/validation/test_ou3_scalar_ou_enclosure.py
@@ -1,0 +1,110 @@
+import importlib.util
+import math
+from pathlib import Path
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+spec = importlib.util.spec_from_file_location(
+    "ou3_scalar_ou_enclosure", ROOT / "tools" / "ou3_scalar_ou_enclosure.py"
+)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+def contains(bounds, value):
+    return float(bounds[0]) <= float(value) <= float(bounds[1])
+
+
+def direct_source_formula(h, tau):
+    x = h / tau
+    alpha = math.exp(-x)
+    em1 = math.expm1(-x)
+    if abs(x) < 1.0e-2:
+        x2 = x * x
+        x3 = x2 * x
+        x4 = x3 * x
+        x5 = x4 * x
+        pa = tau * tau * (0.5 * x2 - (1.0 / 6.0) * x3 + (1.0 / 24.0) * x4)
+        Sa = tau * tau * tau * (
+            (1.0 / 6.0) * x3 - (1.0 / 24.0) * x4 + (1.0 / 120.0) * x5
+        )
+    else:
+        pa = tau * tau * (x + em1)
+        Sa = tau * tau * tau * (0.5 * x * x - x - em1)
+    return x, alpha, em1, pa, Sa
+
+
+class ScalarOUEnclosureTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.payload = mod.build(mod.DEFAULT_HEADER.resolve(), cells_per_branch=24)
+
+    def test_generated_enclosure_validates_and_stays_unpromoted(self):
+        failures = mod.validate(self.payload)
+        self.assertEqual(failures, [])
+        self.assertTrue(self.payload["one_step_scalar_ou_enclosed"])
+        self.assertFalse(self.payload["deployment_timing_complete"])
+        self.assertFalse(self.payload["continuous_word_enclosed"])
+        self.assertFalse(self.payload["nonlinear_word_enclosed"])
+        self.assertEqual(self.payload["theorem_promotion"], "NOT_ESTABLISHED")
+
+    def test_nominal_source_schedule_is_inside_audited_transcendental_range(self):
+        x = self.payload["x_h_over_tau_source_box"]
+        self.assertGreater(x[0], 0.0)
+        self.assertLessEqual(x[1], mod.VT.MAX_ABS_ARGUMENT)
+        self.assertLessEqual(x[1], 0.26)
+
+    def test_source_tau_endpoints_and_branch_boundary_are_enclosed(self):
+        h = float(self.payload["nominal_imu_dt_source_value_s"])
+        tau_box = self.payload["tau_aw_source_box_s"]
+        samples = [
+            max(float(tau_box[0]), 0.02),
+            0.05,
+            0.2,
+            0.5,
+            1.0,
+            min(float(tau_box[1]), 12.0),
+        ]
+        for tau in samples:
+            with self.subTest(tau=tau):
+                x, alpha, em1, pa, Sa = direct_source_formula(h, tau)
+                candidates = [
+                    c for c in self.payload["cells"]
+                    if contains(c["x_h_over_tau"], x)
+                ]
+                self.assertTrue(candidates, f"no cell covers x={x} for tau={tau}")
+                self.assertTrue(
+                    any(
+                        contains(c["alpha"], alpha)
+                        and contains(c["em1"], em1)
+                        and contains(c["phi_pa_s2"], pa)
+                        and contains(c["phi_Sa_s3"], Sa)
+                        for c in candidates
+                    ),
+                    f"source formula not enclosed for tau={tau}, x={x}",
+                )
+
+    def test_global_bounds_contain_every_cell_and_keep_expected_signs(self):
+        g = self.payload["global_bounds"]
+        self.assertGreater(g["alpha"][0], 0.0)
+        self.assertLessEqual(g["alpha"][1], 1.0)
+        self.assertGreater(g["em1"][0], -1.0)
+        self.assertLess(g["em1"][1], 0.0)
+        self.assertGreaterEqual(g["phi_pa_s2"][0], 0.0)
+        self.assertGreaterEqual(g["phi_Sa_s3"][0], 0.0)
+        for c in self.payload["cells"]:
+            for key in ("alpha", "em1", "phi_pa_s2", "phi_Sa_s3"):
+                self.assertLessEqual(g[key][0], c[key][0])
+                self.assertGreaterEqual(g[key][1], c[key][1])
+
+    def test_result_names_external_dt_as_an_open_deployment_obligation(self):
+        msg = self.payload["deployment_timing_open_obligation"]
+        self.assertIn("updateTime", msg)
+        self.assertIn("dt", msg)
+        self.assertIn("admissible", msg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/validation/test_ou3_validated_transcendentals.py
+++ b/tests/validation/test_ou3_validated_transcendentals.py
@@ -1,0 +1,81 @@
+import importlib.util
+from decimal import Decimal, getcontext
+from pathlib import Path
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+spec = importlib.util.spec_from_file_location(
+    "ou3_validated_transcendentals",
+    ROOT / "tools" / "ou3_validated_transcendentals.py",
+)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+getcontext().prec = 90
+
+
+def dec(x: float) -> Decimal:
+    return Decimal.from_float(float(x))
+
+
+class ValidatedTranscendentalTests(unittest.TestCase):
+    def test_exp_and_expm1_enclose_high_precision_reference(self):
+        for x in (-0.5, -0.25, -0.01, -0.0004, 0.0, 0.01, 0.5):
+            with self.subTest(x=x):
+                exact_exp = dec(x).exp()
+                exact_em1 = exact_exp - Decimal(1)
+                E = mod.exp_point(x)
+                M = mod.expm1_point(x)
+                self.assertLessEqual(dec(E.lo), exact_exp)
+                self.assertGreaterEqual(dec(E.hi), exact_exp)
+                self.assertLessEqual(dec(M.lo), exact_em1)
+                self.assertGreaterEqual(dec(M.hi), exact_em1)
+
+    def test_ou_positive_kernels_avoid_expm1_cancellation(self):
+        for x in (0.0004, 0.01, 0.25, 0.5):
+            with self.subTest(x=x):
+                X = dec(x)
+                exp_neg = (-X).exp()
+                exact_pa = X + exp_neg - Decimal(1)
+                exact_Sa = X * X / Decimal(2) - X + Decimal(1) - exp_neg
+                pa = mod.ou_phi_pa_kernel_point(x)
+                Sa = mod.ou_phi_Sa_kernel_point(x)
+                self.assertLessEqual(dec(pa.lo), exact_pa)
+                self.assertGreaterEqual(dec(pa.hi), exact_pa)
+                self.assertLessEqual(dec(Sa.lo), exact_Sa)
+                self.assertGreaterEqual(dec(Sa.hi), exact_Sa)
+                self.assertGreaterEqual(pa.lo, 0.0)
+                self.assertGreaterEqual(Sa.lo, 0.0)
+
+    def test_interval_endpoints_use_monotonicity(self):
+        from ou3_interval import Interval
+
+        X = Interval(-0.25, -0.01)
+        E = mod.exp_interval(X)
+        self.assertLessEqual(dec(E.lo), dec(X.lo).exp())
+        self.assertGreaterEqual(dec(E.hi), dec(X.hi).exp())
+
+        K = mod.ou_phi_pa_kernel_interval(Interval(0.01, 0.25))
+        exact_lo = dec(0.01) + (-dec(0.01)).exp() - Decimal(1)
+        exact_hi = dec(0.25) + (-dec(0.25)).exp() - Decimal(1)
+        self.assertLessEqual(dec(K.lo), exact_lo)
+        self.assertGreaterEqual(dec(K.hi), exact_hi)
+
+    def test_audited_range_is_explicit(self):
+        with self.assertRaises(ValueError):
+            mod.exp_point(0.5000001)
+        with self.assertRaises(ValueError):
+            mod.expm1_point(-0.5000001)
+
+    def test_proof_module_does_not_call_libm_exp(self):
+        text = (ROOT / "tools" / "ou3_validated_transcendentals.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertNotIn("math.exp(", text)
+        self.assertNotIn("math.expm1(", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ou3_scalar_ou_enclosure.py
+++ b/tools/ou3_scalar_ou_enclosure.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Validated one-step scalar OU transition enclosure for OU-III.
+
+This is the next proof layer after ``ou3_source_interval_box.py``.  It consumes
+the source-derived outward-rounded tau box and encloses the scalar OU quantities
+used by ``KalmanOUCoreMath.h``:
+
+    x       = h / tau
+    alpha   = exp(-x)
+    em1     = expm1(-x)
+    phi_pa  = tau^2 (x + em1)
+    phi_Sa  = tau^3 (x^2/2 - x - em1)
+
+For x < 1e-2 the shipping implementation deliberately replaces the last two
+kernels by their finite Maclaurin polynomials.  The producer covers that branch
+separately and includes the threshold in both adjacent cells, so no branch
+boundary is lost to partition rounding.
+
+No replay, fitted extrema, Monte Carlo result, or ordinary libm transcendental
+is used in the enclosure.  Domain subdivision is only a dependency-reduction
+operation; every cell is widened with nextafter before it enters proof
+arithmetic.
+
+Important scope boundary
+------------------------
+``SeaStateFusionFilter_OU_III::updateTime`` accepts any positive finite caller
+``dt``.  The source currently has no deployment clamp around that external
+input.  This stage therefore certifies the *nominal 200 Hz source schedule*
+(``FREQ_SMOOTHER_DT``) only.  It intentionally reports
+``deployment_timing_complete = false`` and cannot promote the continuous word
+or theorem.  Closing a deployment theorem requires an explicit admissible IMU
+sample-period contract (or a shipping clamp) and then propagation through the
+full Riccati/measurement/reset word.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+from ou3_interval import Interval, hull
+import ou3_source_domain_contract as SOURCE
+import ou3_validated_transcendentals as VT
+
+REPO = Path(__file__).resolve().parents[1]
+DEFAULT_HEADER = SOURCE.DEFAULT_HEADER
+CORE_MATH = REPO / "src" / "kalman_ou_common" / "KalmanOUCoreMath.h"
+SCHEMA = 1
+BRANCH_X = 1.0e-2
+CELLS_PER_BRANCH = 64
+
+
+def _I(value: float) -> Interval:
+    value = float(value)
+    return Interval.outward_bounds(value, value)
+
+
+def _small_pa_kernel(x: Interval) -> Interval:
+    x2 = x.square()
+    x3 = x2 * x
+    x4 = x3 * x
+    return x2 * _I(0.5) - x3 * _I(1.0 / 6.0) + x4 * _I(1.0 / 24.0)
+
+
+def _small_Sa_kernel(x: Interval) -> Interval:
+    x2 = x.square()
+    x3 = x2 * x
+    x4 = x3 * x
+    x5 = x4 * x
+    return x3 * _I(1.0 / 6.0) - x4 * _I(1.0 / 24.0) + x5 * _I(1.0 / 120.0)
+
+
+def _geometric_edges(lo: float, hi: float, count: int) -> list[float]:
+    """Choose dependency-reduction cuts; cuts themselves are not proof bounds."""
+    if not (0.0 < lo < hi) or count < 1:
+        raise ValueError(f"bad geometric partition [{lo}, {hi}] / {count}")
+    ratio = (hi / lo) ** (1.0 / count)
+    edges = [lo]
+    value = lo
+    for _ in range(1, count):
+        value *= ratio
+        if not (edges[-1] < value < hi):
+            value = math.nextafter(edges[-1], math.inf)
+        edges.append(min(value, math.nextafter(hi, -math.inf)))
+    edges.append(hi)
+    # Guard against any accidental duplicate caused by extreme floating ratios.
+    for a, b in zip(edges, edges[1:]):
+        if not a < b:
+            raise RuntimeError("partition failed to make strictly increasing cuts")
+    return edges
+
+
+def _partition(lo: float, hi: float, count: int) -> list[Interval]:
+    if math.isclose(lo, hi, rel_tol=0.0, abs_tol=0.0):
+        return [Interval.outward_bounds(lo, hi)]
+    edges = _geometric_edges(lo, hi, count)
+    return [
+        Interval.outward_bounds(edges[i], edges[i + 1])
+        for i in range(len(edges) - 1)
+    ]
+
+
+def _cell(x: Interval, h: Interval, branch: str) -> dict:
+    if x.lo <= 0.0:
+        raise ValueError("h/tau cell must stay strictly positive")
+    if x.hi > VT.MAX_ABS_ARGUMENT:
+        raise ValueError(
+            f"h/tau={x.as_list()} exceeds audited transcendental range "
+            f"{VT.MAX_ABS_ARGUMENT}"
+        )
+
+    tau = h / x
+    alpha = VT.exp_interval(-x)
+    em1 = VT.expm1_interval(-x)
+
+    if branch == "small_x_polynomial":
+        pa_kernel = _small_pa_kernel(x)
+        Sa_kernel = _small_Sa_kernel(x)
+    elif branch == "expm1":
+        pa_kernel = VT.ou_phi_pa_kernel_interval(x)
+        Sa_kernel = VT.ou_phi_Sa_kernel_interval(x)
+    elif branch == "threshold_hull":
+        pa_kernel = hull(_small_pa_kernel(x), VT.ou_phi_pa_kernel_interval(x))
+        Sa_kernel = hull(_small_Sa_kernel(x), VT.ou_phi_Sa_kernel_interval(x))
+    else:
+        raise ValueError(f"unknown source branch {branch!r}")
+
+    tau2 = tau.square()
+    tau3 = tau2 * tau
+    phi_pa = tau2 * pa_kernel
+    phi_Sa = tau3 * Sa_kernel
+    return {
+        "branch": branch,
+        "x_h_over_tau": x.as_list(),
+        "tau_aw_s": tau.as_list(),
+        "alpha": alpha.as_list(),
+        "em1": em1.as_list(),
+        "phi_pa_s2": phi_pa.as_list(),
+        "phi_Sa_s3": phi_Sa.as_list(),
+    }
+
+
+def _as_interval(bounds: list[float]) -> Interval:
+    if not isinstance(bounds, list) or len(bounds) != 2:
+        raise ValueError(f"expected two interval endpoints, got {bounds!r}")
+    return Interval(float(bounds[0]), float(bounds[1]))
+
+
+def _hull_key(cells: list[dict], key: str) -> list[float]:
+    intervals = [_as_interval(c[key]) for c in cells]
+    return hull(*intervals).as_list()
+
+
+def build(
+    header: Path = DEFAULT_HEADER.resolve(), cells_per_branch: int = CELLS_PER_BRANCH
+) -> dict:
+    header = header.resolve()
+    source = SOURCE.build(header)
+    validated_box = source["validated_parameter_box"]
+    tau = _as_interval(validated_box["continuous_parameters"]["tau_aw_s"])
+
+    text = header.read_text(encoding="utf-8")
+    nominal_dt = SOURCE.parse_const(text, "FREQ_SMOOTHER_DT")
+    h = Interval.outward_bounds(nominal_dt, nominal_dt)
+    x_all = h / tau
+    if x_all.lo <= 0.0:
+        raise RuntimeError("source h/tau interval is not strictly positive")
+    if x_all.hi > VT.MAX_ABS_ARGUMENT:
+        raise RuntimeError(
+            f"source h/tau upper bound {x_all.hi} exceeds audited range "
+            f"{VT.MAX_ABS_ARGUMENT}"
+        )
+
+    cells: list[dict] = []
+    threshold = BRANCH_X
+
+    # The implementation uses the polynomial only for x < threshold.  The
+    # boundary is included in both sides conservatively; the tiny overlap is a
+    # proof feature, not a numerical special case.
+    if x_all.lo < threshold:
+        small_hi = min(x_all.hi, threshold)
+        if x_all.lo < small_hi:
+            small_cells = _partition(x_all.lo, small_hi, cells_per_branch)
+            for i, x in enumerate(small_cells):
+                branch = "small_x_polynomial"
+                if i == len(small_cells) - 1 and x.hi >= threshold:
+                    branch = "threshold_hull"
+                cells.append(_cell(x, h, branch))
+
+    if x_all.hi >= threshold:
+        large_lo = max(x_all.lo, threshold)
+        if large_lo < x_all.hi:
+            for x in _partition(large_lo, x_all.hi, cells_per_branch):
+                cells.append(_cell(x, h, "expm1"))
+        elif large_lo == x_all.hi:
+            cells.append(_cell(Interval.outward_bounds(large_lo, x_all.hi), h, "expm1"))
+
+    if not cells:
+        raise RuntimeError("source box produced no scalar OU cells")
+
+    return {
+        "schema": SCHEMA,
+        "qualification": "VALIDATED_NOMINAL_ONE_STEP_SCALAR_OU_ENCLOSURE",
+        "source_generated_not_trajectory_fit": True,
+        "validated_arithmetic": True,
+        "outward_rounded": True,
+        "transcendental_backend": (
+            "EXACT_RATIONAL_TAYLOR_REMAINDER_PLUS_BINARY64_NEXTAFTER_OUTWARD"
+        ),
+        "implementation_header": str(header.relative_to(REPO)),
+        "implementation_core_math": str(CORE_MATH.relative_to(REPO)),
+        "source_parameter_box_qualification": validated_box["qualification"],
+        "tau_aw_source_box_s": tau.as_list(),
+        "nominal_imu_dt_source_value_s": nominal_dt,
+        "nominal_imu_dt_box_s": h.as_list(),
+        "x_h_over_tau_source_box": x_all.as_list(),
+        "implementation_branch_threshold_x": threshold,
+        "cell_count": len(cells),
+        "cells_per_regular_branch": cells_per_branch,
+        "cells": cells,
+        "global_bounds": {
+            "alpha": _hull_key(cells, "alpha"),
+            "em1": _hull_key(cells, "em1"),
+            "phi_pa_s2": _hull_key(cells, "phi_pa_s2"),
+            "phi_Sa_s3": _hull_key(cells, "phi_Sa_s3"),
+        },
+        "one_step_scalar_ou_enclosed": True,
+        "deployment_timing_complete": False,
+        "deployment_timing_open_obligation": (
+            "updateTime(dt,...) accepts arbitrary positive finite caller dt; establish an "
+            "admissible deployment dt interval or enforce one in shipping code"
+        ),
+        "continuous_word_enclosed": False,
+        "nonlinear_word_enclosed": False,
+        "theorem_promotion": "NOT_ESTABLISHED",
+        "next_obligation": (
+            "bind an admissible deployment dt box, then propagate validated one-step "
+            "prediction/correction/reset matrices and Riccati covariance over complete H/A words"
+        ),
+    }
+
+
+def validate(payload: dict) -> list[str]:
+    failures: list[str] = []
+    if payload.get("schema") != SCHEMA:
+        failures.append("schema mismatch")
+    if payload.get("validated_arithmetic") is not True:
+        failures.append("validated arithmetic flag is not true")
+    if payload.get("outward_rounded") is not True:
+        failures.append("outward-rounded flag is not true")
+    if payload.get("one_step_scalar_ou_enclosed") is not True:
+        failures.append("one-step scalar OU enclosure is not marked complete")
+    if payload.get("deployment_timing_complete") is not False:
+        failures.append("this stage must not claim an unconstrained caller dt domain")
+    if payload.get("continuous_word_enclosed") is not False:
+        failures.append("scalar stage must not claim a complete continuous word")
+    if payload.get("nonlinear_word_enclosed") is not False:
+        failures.append("scalar stage must not claim a nonlinear word")
+    if payload.get("theorem_promotion") != "NOT_ESTABLISHED":
+        failures.append("scalar stage must not promote the theorem")
+
+    x = _as_interval(payload.get("x_h_over_tau_source_box", [math.nan, math.nan]))
+    if not (x.lo > 0.0 and x.hi <= VT.MAX_ABS_ARGUMENT):
+        failures.append("h/tau source box is outside the audited transcendental range")
+
+    cells = payload.get("cells")
+    if not isinstance(cells, list) or not cells:
+        failures.append("no proof cells")
+        return failures
+
+    # Every consecutive source-x cell must overlap or touch; first and last
+    # must cover the complete source x box.  This makes subdivision loss
+    # independently checkable from the generated artifact.
+    xs = [_as_interval(c["x_h_over_tau"]) for c in cells]
+    xs.sort(key=lambda I: (I.lo, I.hi))
+    if xs[0].lo > x.lo or xs[-1].hi < x.hi:
+        failures.append("proof cells do not cover source h/tau endpoints")
+    for a, b in zip(xs, xs[1:]):
+        if a.hi < b.lo:
+            failures.append(f"gap in h/tau proof cells: {a.hi} < {b.lo}")
+            break
+
+    g = payload.get("global_bounds", {})
+    for key in ("alpha", "em1", "phi_pa_s2", "phi_Sa_s3"):
+        try:
+            I = _as_interval(g[key])
+        except (KeyError, TypeError, ValueError):
+            failures.append(f"missing/invalid global interval {key}")
+            continue
+        for c in cells:
+            if not I.contains_interval(_as_interval(c[key])):
+                failures.append(f"global {key} does not contain a proof cell")
+                break
+
+    alpha = _as_interval(g["alpha"])
+    em1 = _as_interval(g["em1"])
+    pa = _as_interval(g["phi_pa_s2"])
+    Sa = _as_interval(g["phi_Sa_s3"])
+    if not (0.0 < alpha.lo <= alpha.hi <= 1.0):
+        failures.append("alpha enclosure violates 0 < alpha <= 1")
+    if not (-1.0 < em1.lo <= em1.hi < 0.0):
+        failures.append("em1 enclosure violates -1 < em1 < 0")
+    if pa.lo < 0.0 or Sa.lo < 0.0:
+        failures.append("OU integral coefficient enclosure is not nonnegative")
+    return failures
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--header", type=Path, default=DEFAULT_HEADER)
+    ap.add_argument("--cells-per-branch", type=int, default=CELLS_PER_BRANCH)
+    ap.add_argument("--output", type=Path, required=True)
+    args = ap.parse_args()
+
+    payload = build(args.header.resolve(), args.cells_per_branch)
+    failures = validate(payload)
+    payload["validation_pass"] = not failures
+    payload["validation_failures"] = failures
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    print(json.dumps({
+        "qualification": payload["qualification"],
+        "validation_pass": payload["validation_pass"],
+        "cell_count": payload["cell_count"],
+        "x_h_over_tau_source_box": payload["x_h_over_tau_source_box"],
+        "global_bounds": payload["global_bounds"],
+        "deployment_timing_complete": payload["deployment_timing_complete"],
+        "theorem_promotion": payload["theorem_promotion"],
+        "validation_failures": failures,
+    }, indent=2, sort_keys=True))
+    return 0 if not failures else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ou3_validated_transcendentals.py
+++ b/tools/ou3_validated_transcendentals.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Validated small-argument transcendental enclosures for OU-III proof work.
+
+The deployment proof must not promote bounds obtained from ordinary ``libm``
+round-to-nearest calls.  This module supplies the first transcendental layer on
+top of :mod:`ou3_interval` without using ``math.exp`` or ``math.expm1`` in any
+proof calculation.
+
+For |x| <= 1/2, exp(x) is enclosed by an exact-rational Taylor polynomial plus
+its Lagrange remainder.  The elementary bound exp(|x|) < 2 on this interval is
+sufficient: for 0 <= u <= 1/2,
+
+    exp(u) = 1 + u + sum_{n>=2} u^n/n!
+           <= 1 + 1/2 + sum_{n>=2} (1/2)^n < 2.
+
+Binary64 inputs are converted exactly to ``Fraction``.  Only after the exact
+rational lower/upper endpoints have been obtained are they converted back to
+binary64, with an explicit nextafter correction if round-to-nearest landed on
+the wrong side.  Thus the enclosure does not rely on platform transcendental
+accuracy.
+
+The range is intentionally narrow.  The current nominal 200 Hz OU-III one-step
+source box has h/tau <= 0.25.  Larger ranges require a separately audited range
+reduction rather than silently extending the trusted core.
+"""
+from __future__ import annotations
+
+from fractions import Fraction
+import math
+
+from ou3_interval import Interval
+
+MAX_ABS_ARGUMENT = 0.5
+DEFAULT_ORDER = 20
+
+
+def _down_fraction(q: Fraction) -> float:
+    """Greatest convenient binary64 lower enclosure of exact rational ``q``."""
+    f = float(q)
+    if not math.isfinite(f):
+        raise OverflowError(f"rational does not fit finite binary64: {q!r}")
+    if Fraction.from_float(f) > q:
+        f = math.nextafter(f, -math.inf)
+    return f
+
+
+def _up_fraction(q: Fraction) -> float:
+    """Smallest convenient binary64 upper enclosure of exact rational ``q``."""
+    f = float(q)
+    if not math.isfinite(f):
+        raise OverflowError(f"rational does not fit finite binary64: {q!r}")
+    if Fraction.from_float(f) < q:
+        f = math.nextafter(f, math.inf)
+    return f
+
+
+def _check_point(x: float) -> Fraction:
+    x = float(x)
+    if not math.isfinite(x) or abs(x) > MAX_ABS_ARGUMENT:
+        raise ValueError(
+            f"validated transcendental argument must be finite and |x| <= "
+            f"{MAX_ABS_ARGUMENT}, got {x!r}"
+        )
+    return Fraction.from_float(x)
+
+
+def _remainder_bound(x: Fraction, order: int) -> Fraction:
+    if order < 1:
+        raise ValueError("Taylor order must be positive")
+    # Lagrange remainder <= exp(|x|)|x|^(N+1)/(N+1)! and exp(|x|)<2.
+    return (
+        Fraction(2, 1)
+        * abs(x) ** (order + 1)
+        / Fraction(math.factorial(order + 1), 1)
+    )
+
+
+def exp_point(x: float, order: int = DEFAULT_ORDER) -> Interval:
+    """Outward enclosure of exp(x) for one binary64 point, without libm exp."""
+    q = _check_point(x)
+    term = Fraction(1, 1)
+    total = term
+    for n in range(1, order + 1):
+        term = term * q / Fraction(n, 1)
+        total += term
+    rem = _remainder_bound(q, order)
+    return Interval(_down_fraction(total - rem), _up_fraction(total + rem))
+
+
+def expm1_point(x: float, order: int = DEFAULT_ORDER) -> Interval:
+    """Outward enclosure of exp(x)-1 without cancellation or libm expm1."""
+    q = _check_point(x)
+    term = Fraction(1, 1)
+    total = Fraction(0, 1)
+    for n in range(1, order + 1):
+        term = term * q / Fraction(n, 1)
+        total += term
+    rem = _remainder_bound(q, order)
+    return Interval(_down_fraction(total - rem), _up_fraction(total + rem))
+
+
+def exp_interval(x: Interval, order: int = DEFAULT_ORDER) -> Interval:
+    """Outward enclosure of exp(X), using monotonicity at interval endpoints."""
+    _check_point(x.lo)
+    _check_point(x.hi)
+    lo = exp_point(x.lo, order).lo
+    hi = exp_point(x.hi, order).hi
+    return Interval(lo, hi)
+
+
+def expm1_interval(x: Interval, order: int = DEFAULT_ORDER) -> Interval:
+    """Outward enclosure of exp(X)-1, using monotonicity at endpoints."""
+    _check_point(x.lo)
+    _check_point(x.hi)
+    lo = expm1_point(x.lo, order).lo
+    hi = expm1_point(x.hi, order).hi
+    return Interval(lo, hi)
+
+
+def _positive_ou_kernel_point(
+    x: float, *, start_order: int, first_sign: int, order: int = DEFAULT_ORDER
+) -> Interval:
+    """Enclose a positive OU Taylor tail at one x in [0, 1/2]."""
+    q = _check_point(x)
+    if q < 0:
+        raise ValueError("OU kernel argument must be nonnegative")
+    total = Fraction(0, 1)
+    for n in range(start_order, order + 1):
+        sign = first_sign if (n - start_order) % 2 == 0 else -first_sign
+        total += Fraction(sign, 1) * q**n / Fraction(math.factorial(n), 1)
+    rem = _remainder_bound(q, order)
+    return Interval(_down_fraction(total - rem), _up_fraction(total + rem))
+
+
+def ou_phi_pa_kernel_point(x: float, order: int = DEFAULT_ORDER) -> Interval:
+    """Enclose x + exp(-x) - 1 for x in [0, 1/2]."""
+    # x + exp(-x) - 1 = x^2/2! - x^3/3! + ...
+    return _positive_ou_kernel_point(
+        x, start_order=2, first_sign=1, order=order
+    )
+
+
+def ou_phi_Sa_kernel_point(x: float, order: int = DEFAULT_ORDER) -> Interval:
+    """Enclose x^2/2 - x + 1 - exp(-x) for x in [0, 1/2]."""
+    # = x^3/3! - x^4/4! + ...
+    return _positive_ou_kernel_point(
+        x, start_order=3, first_sign=1, order=order
+    )
+
+
+def ou_phi_pa_kernel_interval(x: Interval, order: int = DEFAULT_ORDER) -> Interval:
+    """Enclose the monotone positive phi_pa kernel over X subset [0,1/2]."""
+    if x.lo < 0.0:
+        raise ValueError("OU kernel interval must be nonnegative")
+    # derivative 1-exp(-x) >= 0.
+    return Interval(
+        ou_phi_pa_kernel_point(x.lo, order).lo,
+        ou_phi_pa_kernel_point(x.hi, order).hi,
+    )
+
+
+def ou_phi_Sa_kernel_interval(x: Interval, order: int = DEFAULT_ORDER) -> Interval:
+    """Enclose the monotone positive phi_Sa kernel over X subset [0,1/2]."""
+    if x.lo < 0.0:
+        raise ValueError("OU kernel interval must be nonnegative")
+    # derivative x - 1 + exp(-x) = phi_pa kernel >= 0.
+    return Interval(
+        ou_phi_Sa_kernel_point(x.lo, order).lo,
+        ou_phi_Sa_kernel_point(x.hi, order).hi,
+    )


### PR DESCRIPTION
## Summary

Continue the OU-III stability certificate from the exact stopping point of #403 without rerunning completed replay estimates.

PR #403 closed the source-derived outward-rounded parameter box, but intentionally left `continuous_word_enclosed=false`, `nonlinear_word_enclosed=false`, and `theorem_promotion=NOT_ESTABLISHED`. This PR advances the next layer:

- add libm-independent validated `exp` / `expm1` enclosures using exact-rational Taylor sums plus a rigorous remainder and directed binary64 endpoint conversion;
- add validated positive OU kernels that avoid cancellation in `x + exp(-x) - 1` and `x^2/2 - x + 1 - exp(-x)`;
- propagate the source-derived tau box through the nominal one-step OU transition, including the implementation's `x < 1e-2` polynomial branch and the branch boundary;
- keep the result explicitly non-promotional: this is a one-step scalar enclosure, not yet a full H/A Riccati-word or nonlinear SO(3) certificate;
- expose a real remaining deployment-domain obligation: `updateTime(dt, ...)` accepts arbitrary positive finite caller `dt`, so the current source does not provide a complete deployment sample-period interval. The new producer certifies the shipping nominal 200 Hz schedule only and reports `deployment_timing_complete=false`;
- add focused proof-only unit CI. No wave replay, full validation study, plot build, document build, or full repository build is requested by this PR's proof job.

## Why this is new work

No H/A sampled-radius search, eight-sea replay, exact-map generation, or previously completed estimate is repeated. The new arithmetic starts exactly where #403 stopped: validated transcendental propagation beyond the already-completed source parameter box.

## Remaining proof obligations after this PR

1. Bind an admissible deployment `dt` interval (or enforce one in shipping code).
2. Propagate the validated one-step prediction/correction/reset and covariance recursion over complete source-reachable H/A words.
3. Establish strict continuous Riccati-injection/covariance/prefix-gain bounds.
4. Enclose the nonlinear SO(3) remainder and word-prefix safety.
5. Close remaining hybrid and stochastic bounds against those validated word enclosures.

This PR deliberately does not claim theorem closure before those steps are discharged.