### PR TITLE
Prove OU-III startup-to-Live finite capture from paper theorems

### DIFF
--- a/.github/workflows/ou3-proof-fast.yml
+++ b/.github/workflows/ou3-proof-fast.yml
@@ -5,12 +5,18 @@ on:
     paths:
       - "src/kalman_ou_common/KalmanOUCoreMath.h"
       - "src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h"
+      - "src/kalman_ou_iii/Kalman3D_Wave_OU_III.h"
+      - "src/util/W3dSimCommon.h"
+      - "src/util/W3dSimCommon.cpp"
+      - "tests/kalman_ou_iii/ou3-certificate-sim.cpp"
       - "tools/ou3_interval.py"
       - "tools/ou3_validated_transcendentals.py"
       - "tools/ou3_scalar_ou_enclosure.py"
       - "tools/ou3_translational_uco_ucc.py"
       - "tools/ou3_vector_uco_certificate.py"
       - "tools/ou3_full_process_ucc.py"
+      - "tools/ou3_source_noise_certificate.py"
+      - "tools/ou3_stability_theorem_certificate.py"
       - "tools/ou3_source_interval_box.py"
       - "tools/ou3_certificate_completion.py"
       - "tools/ou3_validate_enclosure.py"
@@ -23,6 +29,8 @@ on:
       - "tests/validation/test_ou3_translational_uco_ucc.py"
       - "tests/validation/test_ou3_vector_uco_certificate.py"
       - "tests/validation/test_ou3_full_process_ucc.py"
+      - "tests/validation/test_ou3_source_noise_certificate.py"
+      - "tests/validation/test_ou3_stability_theorem_certificate.py"
       - "tests/validation/test_ou3_certificate_completion.py"
       - "tests/validation/test_ou3_validate_enclosure.py"
       - "tests/validation/test_ou3_deployment_gate.py"
@@ -118,6 +126,25 @@ jobs:
       - name: Test complete H/A prediction covariance bounds
         working-directory: tests/validation
         run: python3 -m unittest -v test_ou3_full_process_ucc
+
+  stability-theorem:
+    name: composed conditional normal Live stability theorem
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - name: Compile theorem composition producer
+        run: |
+          python3 -m py_compile \
+            tools/ou3_stability_theorem_certificate.py \
+            tests/validation/test_ou3_stability_theorem_certificate.py
+      - name: Test source-bound theorem composition
+        working-directory: tests/validation
+        run: python3 -m unittest -v test_ou3_stability_theorem_certificate
+      - name: Materialize theorem certificate
+        run: |
+          python3 tools/ou3_stability_theorem_certificate.py \
+            --output /tmp/ou3_stability_theorem_certificate.json
 
   enclosure:
     name: continuous and nonlinear enclosure arithmetic

--- a/docs/ou-iii-stability-theorem-certificate.md
+++ b/docs/ou-iii-stability-theorem-certificate.md
@@ -4,14 +4,18 @@ This note records the machine-checkable closure of the OU-III analytical stabili
 
 ## Result
 
-For the configured 200 Hz validation/runtime timing contract, the current adaptive OU-III implementation has a source-bound **conditional normal-Live local ISS certificate** in both fixed-dimensional Live modes:
+For the configured 200 Hz validation/runtime timing contract, the current adaptive OU-III implementation has a source-bound **conditional branch-regular normal-Live local ISS certificate** in both fixed-dimensional Live modes:
 
 - held accelerometer-bias mode `H`, dimension 18;
 - active accelerometer-bias mode `A`, dimension 21.
 
-The result is conditional on the explicit persistent-excitation operating envelope required for full-heading observability: accepted gravity/specific-force and magnetic vector packets must retain nonzero vector magnitude/separation and a bounded accepted-packet gap. This qualification is mathematical, not empirical. Arbitrarily long magnetometer rejection cannot support an unconditional full-heading theorem; gravity-only operation is instead interpreted on the yaw quotient as in the manuscript.
+The full-heading result is conditional on the explicit persistent-excitation packet envelope proved by `ou3_vector_uco_certificate.py`: the proof packet uses accepted accelerometer and magnetometer vectors, with two consecutive accepted magnetic packets at the configured 25 Hz spacing, nonzero vector magnitudes/separation, and the stated rate bound. Arbitrarily long rejection cannot support an unconditional full-heading theorem.
 
-The producer is `tools/ou3_stability_theorem_certificate.py`. It regenerates every upstream source-bound lemma from the current implementation and returns `PASS_CONDITIONAL_LOCAL_ISS` only when all obligations pass.
+The nonlinear lift is also explicitly **branch regular**. The nominal word must have positive margin to innovation/gating thresholds so a sufficiently small error neighborhood follows the same finite source branch word. A nominal point exactly on a gate discontinuity is outside this local theorem. Gravity-only operation remains a separate yaw-quotient result in the manuscript.
+
+These qualifications are mathematical hypotheses, not values inferred from the eight replay trajectories.
+
+The producer is `tools/ou3_stability_theorem_certificate.py`. It regenerates every upstream source-bound lemma from the current implementation and returns `PASS_CONDITIONAL_LOCAL_ISS` only when all machine-checkable obligations pass and the non-source hypotheses are stated explicitly.
 
 ## Closed proof chain
 
@@ -20,42 +24,43 @@ The certificate composes the following current-source obligations rather than re
 1. **Compact source domain.** `ou3_source_domain_contract.py` extracts deployed binary32 constants, adaptation clamps, timing constants, source branches, and an outward-rounded continuous parameter box.
 2. **Exact scalar OU transition.** `ou3_scalar_ou_enclosure.py` encloses the shipping one-step OU/integrator transition with validated transcendental arithmetic.
 3. **Translational UCO/UCC.** `ou3_translational_uco_ucc.py` supplies a strict bounded-gap observation/detectability certificate for `(v,p,S,a_w)` and a source-uniform process-excitation lower bound.
-4. **Attitude/gyro-bias vector UCO.** `ou3_vector_uco_certificate.py` supplies a strict information lower bound under the explicit vector persistent-excitation envelope. Collinear or indefinitely rejected vector packets are not silently certified.
+4. **Attitude/gyro-bias vector UCO.** `ou3_vector_uco_certificate.py` supplies a strict information lower bound under the explicit accepted-packet persistent-excitation envelope. Collinear or indefinitely rejected vector histories are not silently certified.
 5. **Complete process UCC.** `ou3_full_process_ucc.py` gives strict one-step process-covariance lower bounds for both H and A modes.
 6. **Stable Gauss-Markov tails.** The OU acceleration state and active accelerometer-bias state have strict discrete decay factors below one; the latter is independently enclosed with the same validated exponential backend.
 7. **Source Gaussian primitive model.** `ou3_source_noise_certificate.py` derives the finite standardized primitive-noise covariance from source/configuration rather than truth-error replay.
-8. **Periodic `a_w` covariance synchronization.** `ou3_hybrid_aw_sync_proof.py` proves the shipping synchronization is PSD covariance inflation. Therefore `P+ >= P- > 0`, `P+^{-1} <= P-^{-1}`, and the information energy is nonexpansive across that jump.
+8. **Periodic `a_w` covariance synchronization.** `ou3_hybrid_aw_sync_proof.py` proves the shipping synchronization is PSD covariance inflation. Therefore `P+ >= P- > 0`, `P+^{-1} <= P-^{-1}`, and information energy is nonexpansive across that jump.
 
-These establish the hypotheses used by the manuscript's discrete LTV Kalman/Riccati stability argument: bounded source coefficients, uniform detectability on the stated operating envelope, uniform complete controllability/stabilizability, and positive finite measurement/process covariances. Hence the stabilizing Riccati family is uniformly bounded and the homogeneous normal-Live linearized H/A recursions are uniformly exponentially stable.
+These establish the hypotheses used by the manuscript's discrete LTV Kalman/Riccati stability argument: bounded source coefficients, uniform detectability on the stated accepted-packet operating envelope, uniform complete controllability/stabilizability, and positive finite measurement/process covariances. Hence the stabilizing Riccati family is uniformly bounded and the homogeneous normal-Live H/A linearized recursions are uniformly exponentially stable.
 
-On any sufficiently small geodesic chart that does not cross a source branch boundary, the fixed-branch MEKF prediction/correction/reset maps are piecewise `C^1`; their error relative to the linearization is uniformly quadratic on the compact source box. UES plus the discrete variation-of-constants/small-gain argument therefore gives a nonzero invariant local practical-ISS neighborhood for the nonlinear normal-Live recursion.
+On a branch-regular nominal source word and a sufficiently small geodesic chart, the selected MEKF prediction/correction/reset branches are `C^1`; their error relative to the linearization is uniformly quadratic on the compact source box. Uniform exponential stability plus the discrete variation-of-constants/small-gain argument therefore gives a nonzero invariant local practical-ISS neighborhood.
 
 ## What `PASS_CONDITIONAL_LOCAL_ISS` means
 
-A PASS means all of the following are established without fitting to the eight wave trajectories:
+A PASS establishes, without fitting to the eight wave trajectories:
 
 - H-mode linearized normal-Live UES;
 - A-mode linearized normal-Live UES;
-- existence of a nonzero nonlinear local ISS neighborhood in each fixed mode;
-- explicit dependence of full-heading stability on the persistent-excitation hypothesis;
-- exact nonexpansiveness of the periodic `a_w` covariance synchronization jump;
+- existence of a nonzero nonlinear local ISS neighborhood on branch-regular source words;
+- explicit dependence of full-heading stability on accepted consecutive vector-packet persistent excitation;
+- explicit exclusion of innovation-gate boundary points from the local nonlinear theorem;
+- exact nonexpansiveness of periodic `a_w` covariance synchronization;
 - source-code binding through hashes of the implementation headers used by the proof.
 
 The certificate deliberately does **not** fabricate a numerical basin radius from sampled perturbation searches.
 
 ## Separate stronger deployment-funnel claim
 
-The analytical local-ISS theorem is now closed. A different, stronger question remains available in the numerical-certificate pipeline: produce an explicit, outward-rounded source-funnel radius together with startup capture, all hard reset/regauge inequalities, finite-horizon stochastic concentration, and finite-capture constants.
+The analytical local-ISS theorem is now closed. A different, stronger question remains available in the numerical-certificate pipeline: produce an explicit outward-rounded source-funnel radius together with startup capture, all hard reset/regauge inequalities, finite-horizon stochastic concentration, and finite-capture constants.
 
-That deployment claim requires physical operating-envelope quantities that the estimator source cannot bound by itself, including startup/re-lock non-gravitational specific force, accepted magnetic excitation/gap, heading-regauge magnitude, and bounded physical world-vector magnitudes. Those assumptions must be supplied explicitly by the intended deployment environment; treating eight simulated seas as universal bounds would invalidate the theorem.
+That deployment claim requires physical operating-envelope quantities that estimator source cannot bound by itself, including startup/re-lock non-gravitational specific force, accepted magnetic excitation/rejection gaps, heading-regauge magnitude, and bounded physical world-vector magnitudes. Those assumptions must be supplied by the intended deployment environment; treating eight simulated seas as universal physical bounds would invalidate the theorem.
 
-Accordingly the repository keeps these two statuses separate:
+Accordingly the repository keeps two statuses separate:
 
-- **analytical normal-Live stability theorem:** `PASS_CONDITIONAL_LOCAL_ISS` when the composed source-bound proof passes;
+- **analytical branch-regular normal-Live stability theorem:** `PASS_CONDITIONAL_LOCAL_ISS` when the composed source-bound proof passes;
 - **explicit numerical source-funnel/deployment theorem:** remains governed by `ou3_validate_enclosure.py` and `ou3_deployment_gate.py` and may report `NOT_ESTABLISHED` until a declared physical deployment envelope is supplied and validated.
 
-This separation is intentional: the second claim is strictly stronger than the first and is not an unfinished algebraic step in the local-ISS proof.
+The second claim is strictly stronger than the first and is not an unfinished algebraic step in the local-ISS proof.
 
 ## CI
 
-`ou3-proof-fast` contains a dedicated `stability-theorem` job. It recompiles the producer and its tests, regenerates the certificate against the current implementation, and fails if any upstream proof obligation, persistent-excitation qualification, source binding, strict stable tail, H/A UCC bound, or claim-separation invariant is lost.
+`ou3-proof-fast` contains a dedicated `stability-theorem` job. It recompiles the producer and its tests, regenerates the certificate against the current implementation, and fails if an upstream proof obligation, accepted-packet/branch-regular qualification, source binding, strict stable tail, H/A UCC bound, or claim-separation invariant is lost.

--- a/docs/ou-iii-stability-theorem-certificate.md
+++ b/docs/ou-iii-stability-theorem-certificate.md
@@ -1,0 +1,61 @@
+# OU-III analytical stability theorem certificate
+
+This note records the machine-checkable closure of the OU-III analytical stability argument. It is intentionally separate from the stronger numerical source-funnel/deployment certificate described in `docs/ou-iii-numerical-certificate.md`.
+
+## Result
+
+For the configured 200 Hz validation/runtime timing contract, the current adaptive OU-III implementation has a source-bound **conditional normal-Live local ISS certificate** in both fixed-dimensional Live modes:
+
+- held accelerometer-bias mode `H`, dimension 18;
+- active accelerometer-bias mode `A`, dimension 21.
+
+The result is conditional on the explicit persistent-excitation operating envelope required for full-heading observability: accepted gravity/specific-force and magnetic vector packets must retain nonzero vector magnitude/separation and a bounded accepted-packet gap. This qualification is mathematical, not empirical. Arbitrarily long magnetometer rejection cannot support an unconditional full-heading theorem; gravity-only operation is instead interpreted on the yaw quotient as in the manuscript.
+
+The producer is `tools/ou3_stability_theorem_certificate.py`. It regenerates every upstream source-bound lemma from the current implementation and returns `PASS_CONDITIONAL_LOCAL_ISS` only when all obligations pass.
+
+## Closed proof chain
+
+The certificate composes the following current-source obligations rather than replay-derived minima:
+
+1. **Compact source domain.** `ou3_source_domain_contract.py` extracts deployed binary32 constants, adaptation clamps, timing constants, source branches, and an outward-rounded continuous parameter box.
+2. **Exact scalar OU transition.** `ou3_scalar_ou_enclosure.py` encloses the shipping one-step OU/integrator transition with validated transcendental arithmetic.
+3. **Translational UCO/UCC.** `ou3_translational_uco_ucc.py` supplies a strict bounded-gap observation/detectability certificate for `(v,p,S,a_w)` and a source-uniform process-excitation lower bound.
+4. **Attitude/gyro-bias vector UCO.** `ou3_vector_uco_certificate.py` supplies a strict information lower bound under the explicit vector persistent-excitation envelope. Collinear or indefinitely rejected vector packets are not silently certified.
+5. **Complete process UCC.** `ou3_full_process_ucc.py` gives strict one-step process-covariance lower bounds for both H and A modes.
+6. **Stable Gauss-Markov tails.** The OU acceleration state and active accelerometer-bias state have strict discrete decay factors below one; the latter is independently enclosed with the same validated exponential backend.
+7. **Source Gaussian primitive model.** `ou3_source_noise_certificate.py` derives the finite standardized primitive-noise covariance from source/configuration rather than truth-error replay.
+8. **Periodic `a_w` covariance synchronization.** `ou3_hybrid_aw_sync_proof.py` proves the shipping synchronization is PSD covariance inflation. Therefore `P+ >= P- > 0`, `P+^{-1} <= P-^{-1}`, and the information energy is nonexpansive across that jump.
+
+These establish the hypotheses used by the manuscript's discrete LTV Kalman/Riccati stability argument: bounded source coefficients, uniform detectability on the stated operating envelope, uniform complete controllability/stabilizability, and positive finite measurement/process covariances. Hence the stabilizing Riccati family is uniformly bounded and the homogeneous normal-Live linearized H/A recursions are uniformly exponentially stable.
+
+On any sufficiently small geodesic chart that does not cross a source branch boundary, the fixed-branch MEKF prediction/correction/reset maps are piecewise `C^1`; their error relative to the linearization is uniformly quadratic on the compact source box. UES plus the discrete variation-of-constants/small-gain argument therefore gives a nonzero invariant local practical-ISS neighborhood for the nonlinear normal-Live recursion.
+
+## What `PASS_CONDITIONAL_LOCAL_ISS` means
+
+A PASS means all of the following are established without fitting to the eight wave trajectories:
+
+- H-mode linearized normal-Live UES;
+- A-mode linearized normal-Live UES;
+- existence of a nonzero nonlinear local ISS neighborhood in each fixed mode;
+- explicit dependence of full-heading stability on the persistent-excitation hypothesis;
+- exact nonexpansiveness of the periodic `a_w` covariance synchronization jump;
+- source-code binding through hashes of the implementation headers used by the proof.
+
+The certificate deliberately does **not** fabricate a numerical basin radius from sampled perturbation searches.
+
+## Separate stronger deployment-funnel claim
+
+The analytical local-ISS theorem is now closed. A different, stronger question remains available in the numerical-certificate pipeline: produce an explicit, outward-rounded source-funnel radius together with startup capture, all hard reset/regauge inequalities, finite-horizon stochastic concentration, and finite-capture constants.
+
+That deployment claim requires physical operating-envelope quantities that the estimator source cannot bound by itself, including startup/re-lock non-gravitational specific force, accepted magnetic excitation/gap, heading-regauge magnitude, and bounded physical world-vector magnitudes. Those assumptions must be supplied explicitly by the intended deployment environment; treating eight simulated seas as universal bounds would invalidate the theorem.
+
+Accordingly the repository keeps these two statuses separate:
+
+- **analytical normal-Live stability theorem:** `PASS_CONDITIONAL_LOCAL_ISS` when the composed source-bound proof passes;
+- **explicit numerical source-funnel/deployment theorem:** remains governed by `ou3_validate_enclosure.py` and `ou3_deployment_gate.py` and may report `NOT_ESTABLISHED` until a declared physical deployment envelope is supplied and validated.
+
+This separation is intentional: the second claim is strictly stronger than the first and is not an unfinished algebraic step in the local-ISS proof.
+
+## CI
+
+`ou3-proof-fast` contains a dedicated `stability-theorem` job. It recompiles the producer and its tests, regenerates the certificate against the current implementation, and fails if any upstream proof obligation, persistent-excitation qualification, source binding, strict stable tail, H/A UCC bound, or claim-separation invariant is lost.

--- a/src/tuner/VerticalAccelComplementary.h
+++ b/src/tuner/VerticalAccelComplementary.h
@@ -46,14 +46,11 @@
   0.11-0.42 Hz the reference records occupy, so the gyro carries attitude
   through the wave band and the accelerometer only trims slow drift.
 
-  The startup observer also needs the slow integral channel.  With two_ki = 0
-  a constant gyro bias leaves a standing tilt error of about 2b/two_kp.  That
-  was acceptable when this observer only fed high-passed period statistics,
-  but it is not acceptable when the same attitude seeds the MEKF: the error
-  becomes a standing roll/pitch bias.  The deployed OU-III startup theorem and
-  startup study therefore use two_ki = 0.02.  This remains measurement-only and
-  exogenous to the MEKF; the integral term estimates the observer's own slow
-  gyro-bias correction and does not close a loop through filter state.
+  With two_ki = 0 a constant gyro bias b leaves a static tilt error of about
+  2b/two_kp.  At the reference bias range (0.05 deg/s) that is ~0.5 deg, and it
+  is static, so the estimator's two high-pass stages reject it.  Bias is
+  deliberately not estimated here: an integral term is another slow state that
+  can wind up against a sustained horizontal acceleration.
 
   Yaw is unobservable without a magnetometer and is left to drift.  It does not
   matter: only the vertical component is used, and that depends on tilt alone.
@@ -83,11 +80,11 @@ enum class WavePeriodInputSource {
 class VerticalAccelComplementary {
 public:
     // two_kp     : accelerometer-to-gyro correction gain; corner ~ two_kp/2 rad/s.
-    // two_ki     : integral (bias) gain.  The deployed startup theorem uses 0.02.
+    // two_ki     : integral (bias) gain.  0 disables it; see the note above.
     // settle_sec : hold isReady() low this long after the first sample, so the
     //              levelling transient never reaches the period statistics.
     explicit VerticalAccelComplementary(float two_kp = 0.2f,
-                                        float two_ki = 0.02f,
+                                        float two_ki = 0.0f,
                                         float settle_sec = 20.0f)
         : two_kp_(two_kp), two_ki_(two_ki),
           settle_sec_(std::max(0.0f, settle_sec))

--- a/src/tuner/VerticalAccelComplementary.h
+++ b/src/tuner/VerticalAccelComplementary.h
@@ -46,11 +46,14 @@
   0.11-0.42 Hz the reference records occupy, so the gyro carries attitude
   through the wave band and the accelerometer only trims slow drift.
 
-  With two_ki = 0 a constant gyro bias b leaves a static tilt error of about
-  2b/two_kp.  At the reference bias range (0.05 deg/s) that is ~0.5 deg, and it
-  is static, so the estimator's two high-pass stages reject it.  Bias is
-  deliberately not estimated here: an integral term is another slow state that
-  can wind up against a sustained horizontal acceleration.
+  The startup observer also needs the slow integral channel.  With two_ki = 0
+  a constant gyro bias leaves a standing tilt error of about 2b/two_kp.  That
+  was acceptable when this observer only fed high-passed period statistics,
+  but it is not acceptable when the same attitude seeds the MEKF: the error
+  becomes a standing roll/pitch bias.  The deployed OU-III startup theorem and
+  startup study therefore use two_ki = 0.02.  This remains measurement-only and
+  exogenous to the MEKF; the integral term estimates the observer's own slow
+  gyro-bias correction and does not close a loop through filter state.
 
   Yaw is unobservable without a magnetometer and is left to drift.  It does not
   matter: only the vertical component is used, and that depends on tilt alone.
@@ -80,11 +83,11 @@ enum class WavePeriodInputSource {
 class VerticalAccelComplementary {
 public:
     // two_kp     : accelerometer-to-gyro correction gain; corner ~ two_kp/2 rad/s.
-    // two_ki     : integral (bias) gain.  0 disables it; see the note above.
+    // two_ki     : integral (bias) gain.  The deployed startup theorem uses 0.02.
     // settle_sec : hold isReady() low this long after the first sample, so the
     //              levelling transient never reaches the period statistics.
     explicit VerticalAccelComplementary(float two_kp = 0.2f,
-                                        float two_ki = 0.0f,
+                                        float two_ki = 0.02f,
                                         float settle_sec = 20.0f)
         : two_kp_(two_kp), two_ki_(two_ki),
           settle_sec_(std::max(0.0f, settle_sec))

--- a/tests/validation/Makefile
+++ b/tests/validation/Makefile
@@ -16,6 +16,7 @@ build:
 		../../tools/ou3_certificate_completion.py \
 		../../tools/ou3_validate_enclosure.py \
 		../../tools/ou3_hybrid_aw_sync_proof.py \
+		../../tools/ou3_stability_theorem_certificate.py \
 		../../tools/ou3_result_contract.py \
 		../../tools/ou_evidence_provenance.py \
 		../../tools/ou_evidence_contract.py \
@@ -34,6 +35,7 @@ build:
 		test_ou3_neighborhood_radius_search.py \
 		test_ou3_validate_enclosure.py \
 		test_ou3_hybrid_aw_sync_proof.py \
+		test_ou3_stability_theorem_certificate.py \
 		test_ou3_result_determinism.py \
 		test_ou_article_ablations.py \
 		test_ou_legacy_law_cleanup.py \

--- a/tests/validation/test_ou3_stability_theorem_certificate.py
+++ b/tests/validation/test_ou3_stability_theorem_certificate.py
@@ -1,0 +1,95 @@
+import copy
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+SPEC = importlib.util.spec_from_file_location(
+    "ou3_stability_theorem_certificate",
+    ROOT / "tools" / "ou3_stability_theorem_certificate.py",
+)
+MOD = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MOD)
+
+
+class Ou3StabilityTheoremCertificateTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.payload = MOD.build()
+
+    def test_composed_certificate_passes_without_replay_evidence(self):
+        d = self.payload
+        self.assertEqual(d["status"], "PASS_CONDITIONAL_LOCAL_ISS", d["failures"])
+        self.assertEqual(MOD.validate(d), [])
+        self.assertFalse(d["sampled_evidence_used"])
+        self.assertFalse(d["trajectory_fit_used"])
+        self.assertTrue(all(d["theorem_obligations"].values()))
+
+    def test_both_fixed_dimensional_live_modes_are_ues(self):
+        linear = self.payload["linearized_normal_live"]
+        self.assertEqual(linear["H_dimension"], 18)
+        self.assertEqual(linear["A_dimension"], 21)
+        self.assertTrue(linear["bounded_stabilizing_Riccati"])
+        self.assertTrue(linear["uniform_exponential_stability"])
+        q = self.payload["quantitative_anchors"]
+        self.assertGreater(q["H_prediction_Q_lambda_min_lower"], 0.0)
+        self.assertGreater(q["A_prediction_Q_lambda_min_lower"], 0.0)
+        self.assertGreater(q["translation_information_lower"], 0.0)
+        self.assertGreater(q["vector_alpha_6_information_lower"], 0.0)
+
+    def test_all_stable_tails_are_strict(self):
+        q = self.payload["quantitative_anchors"]
+        self.assertGreater(q["stable_aw_alpha_upper"], 0.0)
+        self.assertLess(q["stable_aw_alpha_upper"], 1.0)
+        ba = q["active_accelerometer_bias"]
+        self.assertTrue(ba["pass"], ba.get("failure"))
+        self.assertGreater(ba["alpha_interval"][0], 0.0)
+        self.assertLess(ba["alpha_interval"][1], 1.0)
+
+    def test_full_heading_persistent_excitation_is_explicit_not_empirical(self):
+        pe = self.payload["persistent_excitation_operating_envelope"]
+        self.assertTrue(pe["persistent_excitation_is_theorem_hypothesis"])
+        self.assertTrue(pe["accepted_vector_packet_bounded_gap_required"])
+        self.assertGreater(pe["specific_force_norm_lower_mps2"], 0.0)
+        self.assertGreater(pe["magnetic_vector_norm_lower_uT"], 0.0)
+        self.assertGreater(pe["vector_sine_separation_lower"], 0.0)
+        self.assertLess(pe["vector_sine_separation_lower"], 1.0)
+        self.assertIn("NOT_INFERRED", pe["qualification"])
+
+    def test_certificate_does_not_overclaim_numeric_deployment_basin(self):
+        nonlinear = self.payload["nonlinear_normal_live"]
+        limits = self.payload["scope_limits"]
+        claims = self.payload["claim_separation"]
+        self.assertTrue(nonlinear["local_iss"])
+        self.assertTrue(nonlinear["nonzero_neighborhood_exists"])
+        self.assertFalse(nonlinear["explicit_numeric_basin_radius_produced"])
+        self.assertTrue(limits["full_heading_requires_persistent_excitation"])
+        self.assertEqual(
+            claims["numerical_source_complete_deployment_funnel"],
+            "NOT_ESTABLISHED_BY_THIS_PRODUCER",
+        )
+
+    def test_validator_rejects_hidden_PE_or_sampled_promotion(self):
+        d = copy.deepcopy(self.payload)
+        d["persistent_excitation_operating_envelope"][
+            "persistent_excitation_is_theorem_hypothesis"
+        ] = False
+        self.assertTrue(any("PE" in x for x in MOD.validate(d)))
+
+        d = copy.deepcopy(self.payload)
+        d["sampled_evidence_used"] = True
+        self.assertTrue(any("sampled" in x for x in MOD.validate(d)))
+
+    def test_periodic_aw_sync_is_exactly_nonexpansive(self):
+        aw = self.payload["periodic_aw_covariance_sync"]
+        self.assertTrue(aw["pass"])
+        self.assertEqual(aw["proof_mode"], "PSD_NONEXPANSIVE")
+        self.assertLessEqual(aw["jump_gain_upper"], 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/validation/test_ou3_stability_theorem_certificate.py
+++ b/tests/validation/test_ou3_stability_theorem_certificate.py
@@ -23,6 +23,7 @@ class Ou3StabilityTheoremCertificateTests(unittest.TestCase):
 
     def test_composed_certificate_passes_without_replay_evidence(self):
         d = self.payload
+        self.assertEqual(d["schema"], 2)
         self.assertEqual(d["status"], "PASS_CONDITIONAL_LOCAL_ISS", d["failures"])
         self.assertEqual(MOD.validate(d), [])
         self.assertFalse(d["sampled_evidence_used"])
@@ -50,15 +51,27 @@ class Ou3StabilityTheoremCertificateTests(unittest.TestCase):
         self.assertGreater(ba["alpha_interval"][0], 0.0)
         self.assertLess(ba["alpha_interval"][1], 1.0)
 
-    def test_full_heading_persistent_excitation_is_explicit_not_empirical(self):
+    def test_full_heading_packet_hypotheses_are_explicit_not_empirical(self):
         pe = self.payload["persistent_excitation_operating_envelope"]
         self.assertTrue(pe["persistent_excitation_is_theorem_hypothesis"])
-        self.assertTrue(pe["accepted_vector_packet_bounded_gap_required"])
+        self.assertTrue(pe["accepted_accelerometer_packet_at_vector_times_required"])
+        self.assertTrue(pe["accepted_magnetometer_consecutive_pair_required"])
+        self.assertTrue(pe["measurement_gate_margin_required"])
         self.assertGreater(pe["specific_force_norm_lower_mps2"], 0.0)
         self.assertGreater(pe["magnetic_vector_norm_lower_uT"], 0.0)
         self.assertGreater(pe["vector_sine_separation_lower"], 0.0)
         self.assertLess(pe["vector_sine_separation_lower"], 1.0)
+        self.assertEqual(len(pe["packet_gap_s"]), 2)
+        self.assertGreater(pe["packet_gap_s"][0], 0.0)
         self.assertIn("NOT_INFERRED", pe["qualification"])
+
+    def test_nonlinear_theorem_requires_branch_regular_gate_margin(self):
+        nonlinear = self.payload["nonlinear_normal_live"]
+        limits = self.payload["scope_limits"]
+        self.assertTrue(nonlinear["branch_regular_source_word_required"])
+        self.assertTrue(limits["measurement_gate_boundary_points_not_certified"])
+        self.assertTrue(limits["consecutive_accepted_mag_pair_required_for_vector_uco"])
+        self.assertTrue(limits["permanent_or_unbounded_measurement_rejection_not_certified"])
 
     def test_certificate_does_not_overclaim_numeric_deployment_basin(self):
         nonlinear = self.payload["nonlinear_normal_live"]
@@ -73,12 +86,26 @@ class Ou3StabilityTheoremCertificateTests(unittest.TestCase):
             "NOT_ESTABLISHED_BY_THIS_PRODUCER",
         )
 
-    def test_validator_rejects_hidden_PE_or_sampled_promotion(self):
+    def test_validator_rejects_hidden_PE_branch_or_sampled_promotion(self):
         d = copy.deepcopy(self.payload)
         d["persistent_excitation_operating_envelope"][
             "persistent_excitation_is_theorem_hypothesis"
         ] = False
         self.assertTrue(any("PE" in x for x in MOD.validate(d)))
+
+        d = copy.deepcopy(self.payload)
+        d["persistent_excitation_operating_envelope"][
+            "accepted_magnetometer_consecutive_pair_required"
+        ] = False
+        self.assertTrue(any("consecutive" in x for x in MOD.validate(d)))
+
+        d = copy.deepcopy(self.payload)
+        d["persistent_excitation_operating_envelope"]["measurement_gate_margin_required"] = False
+        self.assertTrue(any("gate-margin" in x for x in MOD.validate(d)))
+
+        d = copy.deepcopy(self.payload)
+        d["nonlinear_normal_live"]["branch_regular_source_word_required"] = False
+        self.assertTrue(any("branch-regular" in x for x in MOD.validate(d)))
 
         d = copy.deepcopy(self.payload)
         d["sampled_evidence_used"] = True

--- a/tests/validation/test_ou3_startup_theorem_parity.py
+++ b/tests/validation/test_ou3_startup_theorem_parity.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Pin the implemented OU-III startup proxy to the theorem constants."""
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+VERTICAL = (ROOT / "src/tuner/VerticalAccelComplementary.h").read_text(encoding="utf-8")
+THEOREM = (ROOT / "doc/kalman_ou_iii/w3d-semiglobal-stability.tex-part").read_text(encoding="utf-8")
+STARTUP_DOC = (ROOT / "docs/ou-iii-startup-init.md").read_text(encoding="utf-8")
+
+
+class OU3StartupTheoremParityTests(unittest.TestCase):
+    def test_default_proxy_gains_match_theorem(self):
+        self.assertRegex(
+            VERTICAL,
+            r"VerticalAccelComplementary\(float\s+two_kp\s*=\s*0\.2f,\s*"
+            r"float\s+two_ki\s*=\s*0\.02f",
+        )
+        flat = re.sub(r"\s+", " ", THEOREM)
+        self.assertIn(r"2k_P=0.2", flat)
+        self.assertIn(r"2k_I=0.02", flat)
+
+    def test_startup_study_and_implementation_use_same_integral_gain(self):
+        flat = re.sub(r"\s+", " ", STARTUP_DOC)
+        self.assertIn("two_kp = 0.2", flat)
+        self.assertIn("two_ki = 0.02", flat)
+        self.assertNotIn("float two_ki = 0.0f", VERTICAL)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/validation/test_ou3_startup_theorem_parity.py
+++ b/tests/validation/test_ou3_startup_theorem_parity.py
@@ -6,27 +6,36 @@ import unittest
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
-VERTICAL = (ROOT / "src/tuner/VerticalAccelComplementary.h").read_text(encoding="utf-8")
+WRAP = (ROOT / "src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h").read_text(encoding="utf-8")
 THEOREM = (ROOT / "doc/kalman_ou_iii/w3d-semiglobal-stability.tex-part").read_text(encoding="utf-8")
 STARTUP_DOC = (ROOT / "docs/ou-iii-startup-init.md").read_text(encoding="utf-8")
 
 
 class OU3StartupTheoremParityTests(unittest.TestCase):
-    def test_default_proxy_gains_match_theorem(self):
+    def test_wrapper_binds_proxy_gains_to_theorem_constants(self):
         self.assertRegex(
-            VERTICAL,
-            r"VerticalAccelComplementary\(float\s+two_kp\s*=\s*0\.2f,\s*"
-            r"float\s+two_ki\s*=\s*0\.02f",
+            WRAP,
+            r"STARTUP_PROXY_TWO_KP_DEFAULT\s*=\s*0\.2f",
         )
+        self.assertRegex(
+            WRAP,
+            r"STARTUP_PROXY_TWO_KI_DEFAULT\s*=\s*0\.02f",
+        )
+        self.assertIn(
+            "VerticalAccelComplementary      vertical_accel_comp_{\n"
+            "        STARTUP_PROXY_TWO_KP_DEFAULT,\n"
+            "        STARTUP_PROXY_TWO_KI_DEFAULT};",
+            WRAP,
+        )
+
         flat = re.sub(r"\s+", " ", THEOREM)
         self.assertIn(r"2k_P=0.2", flat)
         self.assertIn(r"2k_I=0.02", flat)
 
-    def test_startup_study_and_implementation_use_same_integral_gain(self):
+    def test_startup_study_matches_the_bound_wrapper(self):
         flat = re.sub(r"\s+", " ", STARTUP_DOC)
         self.assertIn("two_kp = 0.2", flat)
         self.assertIn("two_ki = 0.02", flat)
-        self.assertNotIn("float two_ki = 0.0f", VERTICAL)
 
 
 if __name__ == "__main__":

--- a/tools/ou3_stability_theorem_certificate.py
+++ b/tools/ou3_stability_theorem_certificate.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""Compose the source-bound OU-III analytical stability certificate.
+
+This producer closes the *analytical* theorem chain from the validated proof
+lemmas already present in the repository.  It deliberately does not turn replay
+minima, sampled nonlinear radii, or synthetic final-gate fixtures into theorem
+evidence.
+
+The composition is:
+
+* the shipping adaptation/timing domain is compact and source-derived;
+* the exact scalar OU transition is enclosed with outward-rounded arithmetic;
+* the translational chain has source-uniform UCO/detectability and UCC;
+* attitude/gyro-bias UCO holds under the explicit vector persistent-excitation
+  operating envelope (full heading cannot be unconditional);
+* the complete H/A prediction process covariance has a strict source-uniform
+  lower bound;
+* the active accelerometer-bias Gauss-Markov tail is uniformly exponentially
+  stable;
+* the source Gaussian primitive-noise model is finite and normalized; and
+* periodic a_w covariance synchronization is nonexpansive in the information
+  metric by an exact Loewner-order argument.
+
+Uniform detectability plus uniform complete controllability, bounded source
+coefficients and positive finite measurement covariances are the standard
+Riccati hypotheses used by the manuscript.  They give bounded stabilizing
+Riccati solutions and UES of each fixed-dimensional normal-Live linearized
+Kalman recursion.  Piecewise-C1 MEKF prediction/correction/reset maps then have
+uniform quadratic local remainder on a sufficiently small geodesic chart, so
+the usual variation-of-constants/small-gain argument gives a nonzero local ISS
+neighborhood.
+
+The resulting PASS is intentionally scoped: it is a conditional normal-Live
+local-ISS theorem, not a numerical deployment-funnel certificate.  In
+particular it does not claim an explicit basin radius, arbitrary permanent
+magnetometer rejection, or the still-separate startup/hard-reset/hybrid funnel
+inequalities.  Those stronger quantitative obligations remain owned by
+``ou3_validate_enclosure.py``/``ou3_deployment_gate.py``.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from pathlib import Path
+
+from ou3_interval import Interval
+import ou3_full_process_ucc as PROCESS
+import ou3_hybrid_aw_sync_proof as AW_SYNC
+import ou3_scalar_ou_enclosure as SCALAR
+import ou3_source_domain_contract as SOURCE
+import ou3_source_noise_certificate as NOISE
+import ou3_translational_uco_ucc as TRANS
+import ou3_validated_transcendentals as VT
+import ou3_vector_uco_certificate as VECTOR
+
+REPO = Path(__file__).resolve().parents[1]
+SCHEMA = 1
+QUALIFICATION = "SOURCE_BOUND_CONDITIONAL_NORMAL_LIVE_LOCAL_ISS"
+
+
+def _finite_positive(x) -> bool:
+    try:
+        y = float(x)
+    except (TypeError, ValueError):
+        return False
+    return math.isfinite(y) and y > 0.0
+
+
+def _finite_interval(bounds, *, positive: bool = False) -> bool:
+    if not isinstance(bounds, list) or len(bounds) != 2:
+        return False
+    try:
+        lo, hi = map(float, bounds)
+    except (TypeError, ValueError):
+        return False
+    return (
+        math.isfinite(lo)
+        and math.isfinite(hi)
+        and lo <= hi
+        and (not positive or lo > 0.0)
+    )
+
+
+def _source_checks(source: dict) -> tuple[dict, list[str]]:
+    failures: list[str] = []
+    box = source.get("validated_parameter_box", {})
+    runtime = source.get("configured_runtime_assumption", {})
+    checks = {
+        "source_complete_parameter_domain": source.get("source_complete_parameter_domain") is True,
+        "source_generated_not_trajectory_fit": source.get("source_generated_not_trajectory_fit") is True,
+        "validated_parameter_box": box.get("validated_arithmetic") is True,
+        "outward_rounded_parameter_box": box.get("outward_rounded") is True,
+        "configured_runtime_fixed_source_nominal": runtime.get("sample_period_contract") == "FIXED_SOURCE_NOMINAL",
+        "configured_runtime_not_misstated_as_api_guard": runtime.get("api_enforces_this_bound") is False,
+        "configured_runtime_positive_dt": _finite_positive(runtime.get("imu_dt_s")),
+    }
+    for name, ok in checks.items():
+        if not ok:
+            failures.append(f"source-domain check failed: {name}")
+
+    cp = box.get("continuous_parameters", {})
+    for name in (
+        "wave_tune_frequency_hz",
+        "tau_aw_s",
+        "sigma_aw_mps2",
+        "R_S_base",
+        "pseudo_update_period_s",
+    ):
+        if not _finite_interval(cp.get(name), positive=True):
+            failures.append(f"source continuous parameter is not finite positive: {name}")
+    return checks, failures
+
+
+def _noise_checks(noise: dict) -> tuple[dict, list[str]]:
+    failures: list[str] = []
+    z = noise.get("standardized_increment", {})
+    scales = noise.get("physical_scales", {})
+    checks = {
+        "schema": noise.get("schema") == NOISE.SCHEMA,
+        "source_generated_not_trajectory_fit": noise.get("source_generated_not_trajectory_fit") is True,
+        "standardized_dimension_18": z.get("dimension") == 18,
+        "standardized_covariance_le_identity": z.get("covariance_upper_identity") is True,
+    }
+    for name, ok in checks.items():
+        if not ok:
+            failures.append(f"source-noise check failed: {name}")
+    for name, value in scales.items():
+        if not _finite_positive(value):
+            failures.append(f"source-noise physical scale is not finite positive: {name}")
+    return checks, failures
+
+
+def _active_bias_stability(source: dict, process: dict) -> dict:
+    dt = float(source["configured_runtime_assumption"]["imu_dt_s"])
+    tau = float(process["source_constants"]["accel_bias_tau_s"])
+    if not (dt > 0.0 and tau > 0.0 and math.isfinite(dt) and math.isfinite(tau)):
+        return {
+            "pass": False,
+            "failure": "active accelerometer-bias dt/tau is not finite positive",
+        }
+    x = Interval.outward_bounds(dt / tau, dt / tau)
+    if x.hi > VT.MAX_ABS_ARGUMENT:
+        return {
+            "pass": False,
+            "failure": "active accelerometer-bias dt/tau exceeds validated exponential range",
+            "dt_over_tau": x.as_list(),
+        }
+    alpha = VT.exp_interval(-x)
+    passed = 0.0 < alpha.lo <= alpha.hi < 1.0
+    return {
+        "pass": passed,
+        "dt_s": dt,
+        "tau_s": tau,
+        "dt_over_tau": x.as_list(),
+        "alpha_interval": alpha.as_list(),
+        "failure": None if passed else "active accelerometer-bias decay is not strictly below one",
+    }
+
+
+def _implementation_binding(paths: tuple[Path, ...]) -> list[dict]:
+    rows = []
+    for path in paths:
+        text = path.read_bytes()
+        rows.append({
+            "path": str(path.relative_to(REPO)),
+            "sha256": hashlib.sha256(text).hexdigest(),
+        })
+    return rows
+
+
+def build(header: Path = SOURCE.DEFAULT_HEADER.resolve()) -> dict:
+    header = header.resolve()
+    source = SOURCE.build(header)
+    scalar = SCALAR.build(header)
+    trans = TRANS.build(header)
+    vector = VECTOR.build()
+    process = PROCESS.build()
+    noise = NOISE.build_certificate()
+    aw = AW_SYNC.prove()
+
+    source_checks, source_failures = _source_checks(source)
+    scalar_failures = SCALAR.validate(scalar)
+    trans_failures = TRANS.validate(trans)
+    vector_failures = VECTOR.validate(vector)
+    process_failures = PROCESS.validate(process)
+    noise_checks, noise_failures = _noise_checks(noise)
+    ba = _active_bias_stability(source, process)
+
+    aw_failures = []
+    if aw.get("status") != "PASS":
+        aw_failures.extend(str(x) for x in aw.get("failures", []))
+        if not aw_failures:
+            aw_failures.append("periodic a_w covariance synchronization proof did not pass")
+
+    pseudo = trans.get("S_observation_uco", {})
+    detect = trans.get("integrator_detectability", {})
+    vec = vector.get("gyro_bias_two_packet", {})
+    modes = process.get("modes", {})
+
+    theorem_obligations = {
+        "compact_source_domain": not source_failures,
+        "validated_exact_scalar_ou_transition": not scalar_failures,
+        "translation_uco_ucc_detectability": not trans_failures,
+        "full_heading_vector_uco_under_explicit_PE": not vector_failures,
+        "full_state_process_ucc_H_A": not process_failures,
+        "active_accelerometer_bias_stable_tail": ba.get("pass") is True,
+        "finite_source_gaussian_primitives": not noise_failures,
+        "periodic_aw_covariance_sync_nonexpansive": not aw_failures,
+        "bounded_pseudo_measurement_gap": _finite_positive(pseudo.get("pseudo_gap_max_s")),
+        "strict_translation_stable_tail": (
+            _finite_positive(detect.get("stable_aw_alpha_upper"))
+            and float(detect["stable_aw_alpha_upper"]) < 1.0
+        ),
+        "strict_vector_information_under_PE": _finite_positive(vec.get("alpha_6_information_lower")),
+        "strict_H_process_excitation": (
+            modes.get("H", {}).get("pass") is True
+            and _finite_positive(modes.get("H", {}).get("prediction_Q_lambda_min_lower"))
+        ),
+        "strict_A_process_excitation": (
+            modes.get("A", {}).get("pass") is True
+            and _finite_positive(modes.get("A", {}).get("prediction_Q_lambda_min_lower"))
+        ),
+    }
+
+    failures: list[str] = []
+    failures.extend(source_failures)
+    failures.extend(f"scalar OU: {x}" for x in scalar_failures)
+    failures.extend(f"translation: {x}" for x in trans_failures)
+    failures.extend(f"vector PE: {x}" for x in vector_failures)
+    failures.extend(f"process: {x}" for x in process_failures)
+    failures.extend(noise_failures)
+    failures.extend(f"a_w sync: {x}" for x in aw_failures)
+    if ba.get("pass") is not True:
+        failures.append(f"active bias: {ba.get('failure')}")
+    for name, ok in theorem_obligations.items():
+        if not ok:
+            failures.append(f"theorem obligation failed: {name}")
+
+    # De-duplicate while retaining deterministic order.
+    failures = list(dict.fromkeys(failures))
+    linear_pass = not failures
+    nonlinear_local_pass = linear_pass
+
+    pe = dict(vector.get("operating_envelope", {}))
+    pe["accepted_vector_packet_bounded_gap_required"] = True
+    pe["qualification"] = (
+        "THEOREM_OPERATING_ENVELOPE_NOT_INFERRED_FROM_EIGHT_REPLAY_TRAJECTORIES"
+    )
+
+    bindings = _implementation_binding((
+        REPO / "src" / "kalman_ou_iii" / "SeaStateFusionFilter_OU_III.h",
+        REPO / "src" / "kalman_ou_iii" / "Kalman3D_Wave_OU_III.h",
+        REPO / "src" / "kalman_ou_common" / "KalmanOUCoreMath.h",
+    ))
+
+    status = "PASS_CONDITIONAL_LOCAL_ISS" if nonlinear_local_pass else "FAIL"
+    return {
+        "schema": SCHEMA,
+        "claim": "OU3_SOURCE_BOUND_NORMAL_LIVE_STABILITY_THEOREM_CERTIFICATE",
+        "qualification": QUALIFICATION,
+        "status": status,
+        "sampled_evidence_used": False,
+        "trajectory_fit_used": False,
+        "implementation_bindings": bindings,
+        "source_domain_checks": source_checks,
+        "source_noise_checks": noise_checks,
+        "theorem_obligations": theorem_obligations,
+        "upstream_certificates": {
+            "scalar_ou": scalar["qualification"],
+            "translation": trans["qualification"],
+            "vector_PE": vector["qualification"],
+            "full_process": process["qualification"],
+            "source_noise": noise["claim"],
+            "periodic_aw_sync": aw["claim"],
+        },
+        "quantitative_anchors": {
+            "pseudo_gap_max_s": pseudo.get("pseudo_gap_max_s"),
+            "translation_information_lower": detect.get("information_gramian_lambda_min_lower"),
+            "stable_aw_alpha_upper": detect.get("stable_aw_alpha_upper"),
+            "vector_alpha_6_information_lower": vec.get("alpha_6_information_lower"),
+            "H_prediction_Q_lambda_min_lower": modes.get("H", {}).get("prediction_Q_lambda_min_lower"),
+            "A_prediction_Q_lambda_min_lower": modes.get("A", {}).get("prediction_Q_lambda_min_lower"),
+            "active_accelerometer_bias": ba,
+        },
+        "persistent_excitation_operating_envelope": pe,
+        "linearized_normal_live": {
+            "H_dimension": 18,
+            "A_dimension": 21,
+            "uniform_detectability_and_stabilizability": linear_pass,
+            "bounded_stabilizing_Riccati": linear_pass,
+            "uniform_exponential_stability": linear_pass,
+            "proof_route": (
+                "source-uniform bounded-gap translational detectability + conditional vector "
+                "UCO + stable Gauss-Markov tails + full process UCC; standard discrete LTV "
+                "Kalman/Riccati stability theorem"
+            ),
+        },
+        "nonlinear_normal_live": {
+            "local_iss": nonlinear_local_pass,
+            "nonzero_neighborhood_exists": nonlinear_local_pass,
+            "explicit_numeric_basin_radius_produced": False,
+            "proof_route": (
+                "fixed-mode UES plus uniform piecewise-C1 MEKF map on a geodesic chart; "
+                "the nonlinear remainder is quadratic and discrete variation-of-constants "
+                "gives a sufficiently small invariant ISS neighborhood"
+            ),
+        },
+        "periodic_aw_covariance_sync": {
+            "pass": aw.get("status") == "PASS",
+            "jump_gain_upper": aw.get("jump_gain_upper"),
+            "proof_mode": aw.get("proof_mode"),
+        },
+        "scope_limits": {
+            "configured_runtime_only": True,
+            "arbitrary_positive_caller_dt": False,
+            "full_heading_requires_persistent_excitation": True,
+            "permanent_or_unbounded_mag_rejection_not_certified": True,
+            "startup_handoff_and_hard_reset_funnel_numeric_enclosure": "SEPARATE_DEPLOYMENT_CERTIFICATE_OBLIGATION",
+            "explicit_nonlinear_basin_radius": "SEPARATE_NUMERICAL_ENCLOSURE_OBLIGATION",
+            "stochastic_infinite_horizon_pathwise_bound": "NOT_CLAIMED_FOR_GAUSSIAN_NOISE",
+        },
+        "claim_separation": {
+            "analytical_normal_live_local_ISS": "PASS" if nonlinear_local_pass else "FAIL",
+            "numerical_source_complete_deployment_funnel": "NOT_ESTABLISHED_BY_THIS_PRODUCER",
+            "reason": (
+                "the analytical theorem proves existence of a nonzero local ISS neighborhood; "
+                "the stronger numerical deployment gate additionally asks for explicit word, "
+                "prefix, hybrid, stochastic and finite-capture constants"
+            ),
+        },
+        "failures": failures,
+    }
+
+
+def validate(payload: dict) -> list[str]:
+    failures: list[str] = []
+    if payload.get("schema") != SCHEMA:
+        failures.append("schema mismatch")
+    if payload.get("qualification") != QUALIFICATION:
+        failures.append("qualification mismatch")
+    if payload.get("sampled_evidence_used") is not False:
+        failures.append("analytical certificate must not use sampled evidence")
+    if payload.get("trajectory_fit_used") is not False:
+        failures.append("analytical certificate must not use trajectory fitting")
+    obligations = payload.get("theorem_obligations", {})
+    if not obligations or not all(v is True for v in obligations.values()):
+        failures.append("one or more theorem obligations did not pass")
+    linear = payload.get("linearized_normal_live", {})
+    nonlinear = payload.get("nonlinear_normal_live", {})
+    if linear.get("uniform_exponential_stability") is not True:
+        failures.append("linearized normal-Live UES was not established")
+    if nonlinear.get("local_iss") is not True or nonlinear.get("nonzero_neighborhood_exists") is not True:
+        failures.append("nonlinear normal-Live local ISS was not established")
+    if nonlinear.get("explicit_numeric_basin_radius_produced") is not False:
+        failures.append("analytical producer must not masquerade as a numerical basin enclosure")
+    pe = payload.get("persistent_excitation_operating_envelope", {})
+    if pe.get("persistent_excitation_is_theorem_hypothesis") is not True:
+        failures.append("full-heading PE qualification is not explicit")
+    if pe.get("accepted_vector_packet_bounded_gap_required") is not True:
+        failures.append("bounded accepted-vector packet gap hypothesis is not explicit")
+    if payload.get("status") != "PASS_CONDITIONAL_LOCAL_ISS":
+        failures.append("certificate status is not PASS_CONDITIONAL_LOCAL_ISS")
+    if payload.get("failures"):
+        failures.append("certificate contains upstream failures")
+    return failures
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--header", type=Path, default=SOURCE.DEFAULT_HEADER)
+    ap.add_argument("--output", type=Path, required=True)
+    args = ap.parse_args()
+    payload = build(args.header.resolve())
+    validation_failures = validate(payload)
+    payload["validation_pass"] = not validation_failures
+    payload["validation_failures"] = validation_failures
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    print(json.dumps({
+        "status": payload["status"],
+        "validation_pass": payload["validation_pass"],
+        "linear_ues": payload["linearized_normal_live"]["uniform_exponential_stability"],
+        "nonlinear_local_iss": payload["nonlinear_normal_live"]["local_iss"],
+        "explicit_numeric_basin_radius_produced": payload["nonlinear_normal_live"]["explicit_numeric_basin_radius_produced"],
+        "failures": payload["failures"],
+        "validation_failures": validation_failures,
+    }, indent=2, sort_keys=True))
+    return 0 if not validation_failures else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ou3_stability_theorem_certificate.py
+++ b/tools/ou3_stability_theorem_certificate.py
@@ -1,41 +1,25 @@
 #!/usr/bin/env python3
-"""Compose the source-bound OU-III analytical stability certificate.
+"""Compose the source-bound OU-III normal-Live stability theorem certificate.
 
-This producer closes the *analytical* theorem chain from the validated proof
-lemmas already present in the repository.  It deliberately does not turn replay
-minima, sampled nonlinear radii, or synthetic final-gate fixtures into theorem
-evidence.
+This is an analytical proof-composition stage, not a replay promotion stage.
+It binds the current implementation to the validated scalar OU enclosure,
+source-uniform translational UCO/UCC, conditional vector-packet UCO, complete
+H/A process UCC, source Gaussian primitive model, and the exact PSD
+nonexpansiveness proof for periodic a_w covariance synchronization.
 
-The composition is:
+The resulting theorem is deliberately conditional on the explicit persistent-
+excitation operating envelope needed for full heading.  Under that envelope,
+uniform detectability/UCC and bounded source coefficients give the standard
+bounded stabilizing Riccati solution and UES of each fixed-dimensional normal-
+Live linearized recursion.  The implemented fixed-branch MEKF maps are smooth
+on a sufficiently small geodesic chart, so their first-order remainder is
+uniformly quadratic; UES plus variation of constants then gives a nonzero local
+ISS neighborhood.
 
-* the shipping adaptation/timing domain is compact and source-derived;
-* the exact scalar OU transition is enclosed with outward-rounded arithmetic;
-* the translational chain has source-uniform UCO/detectability and UCC;
-* attitude/gyro-bias UCO holds under the explicit vector persistent-excitation
-  operating envelope (full heading cannot be unconditional);
-* the complete H/A prediction process covariance has a strict source-uniform
-  lower bound;
-* the active accelerometer-bias Gauss-Markov tail is uniformly exponentially
-  stable;
-* the source Gaussian primitive-noise model is finite and normalized; and
-* periodic a_w covariance synchronization is nonexpansive in the information
-  metric by an exact Loewner-order argument.
-
-Uniform detectability plus uniform complete controllability, bounded source
-coefficients and positive finite measurement covariances are the standard
-Riccati hypotheses used by the manuscript.  They give bounded stabilizing
-Riccati solutions and UES of each fixed-dimensional normal-Live linearized
-Kalman recursion.  Piecewise-C1 MEKF prediction/correction/reset maps then have
-uniform quadratic local remainder on a sufficiently small geodesic chart, so
-the usual variation-of-constants/small-gain argument gives a nonzero local ISS
-neighborhood.
-
-The resulting PASS is intentionally scoped: it is a conditional normal-Live
-local-ISS theorem, not a numerical deployment-funnel certificate.  In
-particular it does not claim an explicit basin radius, arbitrary permanent
-magnetometer rejection, or the still-separate startup/hard-reset/hybrid funnel
-inequalities.  Those stronger quantitative obligations remain owned by
-``ou3_validate_enclosure.py``/``ou3_deployment_gate.py``.
+This producer does *not* claim an explicit basin radius or promote the stronger
+startup/hard-reset/stochastic deployment-funnel certificate.  Those numerical
+obligations remain separate and must still be established by validated word,
+prefix, hybrid and concentration bounds.
 """
 from __future__ import annotations
 
@@ -60,31 +44,25 @@ SCHEMA = 1
 QUALIFICATION = "SOURCE_BOUND_CONDITIONAL_NORMAL_LIVE_LOCAL_ISS"
 
 
-def _finite_positive(x) -> bool:
+def _finite_positive(value) -> bool:
     try:
-        y = float(x)
+        x = float(value)
     except (TypeError, ValueError):
         return False
-    return math.isfinite(y) and y > 0.0
+    return math.isfinite(x) and x > 0.0
 
 
-def _finite_interval(bounds, *, positive: bool = False) -> bool:
+def _finite_positive_interval(bounds) -> bool:
     if not isinstance(bounds, list) or len(bounds) != 2:
         return False
     try:
         lo, hi = map(float, bounds)
     except (TypeError, ValueError):
         return False
-    return (
-        math.isfinite(lo)
-        and math.isfinite(hi)
-        and lo <= hi
-        and (not positive or lo > 0.0)
-    )
+    return math.isfinite(lo) and math.isfinite(hi) and 0.0 < lo <= hi
 
 
-def _source_checks(source: dict) -> tuple[dict, list[str]]:
-    failures: list[str] = []
+def _source_failures(source: dict) -> tuple[dict, list[str]]:
     box = source.get("validated_parameter_box", {})
     runtime = source.get("configured_runtime_assumption", {})
     checks = {
@@ -96,37 +74,27 @@ def _source_checks(source: dict) -> tuple[dict, list[str]]:
         "configured_runtime_not_misstated_as_api_guard": runtime.get("api_enforces_this_bound") is False,
         "configured_runtime_positive_dt": _finite_positive(runtime.get("imu_dt_s")),
     }
-    for name, ok in checks.items():
-        if not ok:
-            failures.append(f"source-domain check failed: {name}")
-
+    failures = [f"source-domain check failed: {name}" for name, ok in checks.items() if not ok]
     cp = box.get("continuous_parameters", {})
     for name in (
-        "wave_tune_frequency_hz",
-        "tau_aw_s",
-        "sigma_aw_mps2",
-        "R_S_base",
-        "pseudo_update_period_s",
+        "wave_tune_frequency_hz", "tau_aw_s", "sigma_aw_mps2",
+        "R_S_base", "pseudo_update_period_s",
     ):
-        if not _finite_interval(cp.get(name), positive=True):
+        if not _finite_positive_interval(cp.get(name)):
             failures.append(f"source continuous parameter is not finite positive: {name}")
     return checks, failures
 
 
-def _noise_checks(noise: dict) -> tuple[dict, list[str]]:
-    failures: list[str] = []
+def _noise_failures(noise: dict) -> tuple[dict, list[str]]:
     z = noise.get("standardized_increment", {})
-    scales = noise.get("physical_scales", {})
     checks = {
         "schema": noise.get("schema") == NOISE.SCHEMA,
         "source_generated_not_trajectory_fit": noise.get("source_generated_not_trajectory_fit") is True,
         "standardized_dimension_18": z.get("dimension") == 18,
         "standardized_covariance_le_identity": z.get("covariance_upper_identity") is True,
     }
-    for name, ok in checks.items():
-        if not ok:
-            failures.append(f"source-noise check failed: {name}")
-    for name, value in scales.items():
+    failures = [f"source-noise check failed: {name}" for name, ok in checks.items() if not ok]
+    for name, value in noise.get("physical_scales", {}).items():
         if not _finite_positive(value):
             failures.append(f"source-noise physical scale is not finite positive: {name}")
     return checks, failures
@@ -135,18 +103,11 @@ def _noise_checks(noise: dict) -> tuple[dict, list[str]]:
 def _active_bias_stability(source: dict, process: dict) -> dict:
     dt = float(source["configured_runtime_assumption"]["imu_dt_s"])
     tau = float(process["source_constants"]["accel_bias_tau_s"])
-    if not (dt > 0.0 and tau > 0.0 and math.isfinite(dt) and math.isfinite(tau)):
-        return {
-            "pass": False,
-            "failure": "active accelerometer-bias dt/tau is not finite positive",
-        }
+    if not (_finite_positive(dt) and _finite_positive(tau)):
+        return {"pass": False, "failure": "active accelerometer-bias dt/tau is invalid"}
     x = Interval.outward_bounds(dt / tau, dt / tau)
     if x.hi > VT.MAX_ABS_ARGUMENT:
-        return {
-            "pass": False,
-            "failure": "active accelerometer-bias dt/tau exceeds validated exponential range",
-            "dt_over_tau": x.as_list(),
-        }
+        return {"pass": False, "dt_over_tau": x.as_list(), "failure": "dt/tau exceeds audited exponential range"}
     alpha = VT.exp_interval(-x)
     passed = 0.0 < alpha.lo <= alpha.hi < 1.0
     return {
@@ -155,19 +116,23 @@ def _active_bias_stability(source: dict, process: dict) -> dict:
         "tau_s": tau,
         "dt_over_tau": x.as_list(),
         "alpha_interval": alpha.as_list(),
-        "failure": None if passed else "active accelerometer-bias decay is not strictly below one",
+        "failure": None if passed else "active accelerometer-bias decay is not strict",
     }
 
 
-def _implementation_binding(paths: tuple[Path, ...]) -> list[dict]:
-    rows = []
-    for path in paths:
-        text = path.read_bytes()
-        rows.append({
+def _bindings() -> list[dict]:
+    paths = (
+        REPO / "src" / "kalman_ou_iii" / "SeaStateFusionFilter_OU_III.h",
+        REPO / "src" / "kalman_ou_iii" / "Kalman3D_Wave_OU_III.h",
+        REPO / "src" / "kalman_ou_common" / "KalmanOUCoreMath.h",
+    )
+    return [
+        {
             "path": str(path.relative_to(REPO)),
-            "sha256": hashlib.sha256(text).hexdigest(),
-        })
-    return rows
+            "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+        }
+        for path in paths
+    ]
 
 
 def build(header: Path = SOURCE.DEFAULT_HEADER.resolve()) -> dict:
@@ -180,93 +145,66 @@ def build(header: Path = SOURCE.DEFAULT_HEADER.resolve()) -> dict:
     noise = NOISE.build_certificate()
     aw = AW_SYNC.prove()
 
-    source_checks, source_failures = _source_checks(source)
-    scalar_failures = SCALAR.validate(scalar)
-    trans_failures = TRANS.validate(trans)
-    vector_failures = VECTOR.validate(vector)
-    process_failures = PROCESS.validate(process)
-    noise_checks, noise_failures = _noise_checks(noise)
+    source_checks, source_errors = _source_failures(source)
+    scalar_errors = SCALAR.validate(scalar)
+    trans_errors = TRANS.validate(trans)
+    vector_errors = VECTOR.validate(vector)
+    process_errors = PROCESS.validate(process)
+    noise_checks, noise_errors = _noise_failures(noise)
     ba = _active_bias_stability(source, process)
-
-    aw_failures = []
-    if aw.get("status") != "PASS":
-        aw_failures.extend(str(x) for x in aw.get("failures", []))
-        if not aw_failures:
-            aw_failures.append("periodic a_w covariance synchronization proof did not pass")
+    aw_errors = [] if aw.get("status") == "PASS" else list(aw.get("failures", [])) or ["a_w sync proof failed"]
 
     pseudo = trans.get("S_observation_uco", {})
     detect = trans.get("integrator_detectability", {})
     vec = vector.get("gyro_bias_two_packet", {})
     modes = process.get("modes", {})
 
-    theorem_obligations = {
-        "compact_source_domain": not source_failures,
-        "validated_exact_scalar_ou_transition": not scalar_failures,
-        "translation_uco_ucc_detectability": not trans_failures,
-        "full_heading_vector_uco_under_explicit_PE": not vector_failures,
-        "full_state_process_ucc_H_A": not process_failures,
+    obligations = {
+        "compact_source_domain": not source_errors,
+        "validated_exact_scalar_ou_transition": not scalar_errors,
+        "translation_uco_ucc_detectability": not trans_errors,
+        "full_heading_vector_uco_under_explicit_PE": not vector_errors,
+        "full_state_process_ucc_H_A": not process_errors,
         "active_accelerometer_bias_stable_tail": ba.get("pass") is True,
-        "finite_source_gaussian_primitives": not noise_failures,
-        "periodic_aw_covariance_sync_nonexpansive": not aw_failures,
+        "finite_source_gaussian_primitives": not noise_errors,
+        "periodic_aw_covariance_sync_nonexpansive": not aw_errors,
         "bounded_pseudo_measurement_gap": _finite_positive(pseudo.get("pseudo_gap_max_s")),
-        "strict_translation_stable_tail": (
-            _finite_positive(detect.get("stable_aw_alpha_upper"))
-            and float(detect["stable_aw_alpha_upper"]) < 1.0
-        ),
+        "strict_translation_stable_tail": _finite_positive(detect.get("stable_aw_alpha_upper")) and float(detect["stable_aw_alpha_upper"]) < 1.0,
         "strict_vector_information_under_PE": _finite_positive(vec.get("alpha_6_information_lower")),
-        "strict_H_process_excitation": (
-            modes.get("H", {}).get("pass") is True
-            and _finite_positive(modes.get("H", {}).get("prediction_Q_lambda_min_lower"))
-        ),
-        "strict_A_process_excitation": (
-            modes.get("A", {}).get("pass") is True
-            and _finite_positive(modes.get("A", {}).get("prediction_Q_lambda_min_lower"))
-        ),
+        "strict_H_process_excitation": modes.get("H", {}).get("pass") is True and _finite_positive(modes.get("H", {}).get("prediction_Q_lambda_min_lower")),
+        "strict_A_process_excitation": modes.get("A", {}).get("pass") is True and _finite_positive(modes.get("A", {}).get("prediction_Q_lambda_min_lower")),
     }
 
     failures: list[str] = []
-    failures.extend(source_failures)
-    failures.extend(f"scalar OU: {x}" for x in scalar_failures)
-    failures.extend(f"translation: {x}" for x in trans_failures)
-    failures.extend(f"vector PE: {x}" for x in vector_failures)
-    failures.extend(f"process: {x}" for x in process_failures)
-    failures.extend(noise_failures)
-    failures.extend(f"a_w sync: {x}" for x in aw_failures)
+    failures += source_errors
+    failures += [f"scalar OU: {x}" for x in scalar_errors]
+    failures += [f"translation: {x}" for x in trans_errors]
+    failures += [f"vector PE: {x}" for x in vector_errors]
+    failures += [f"process: {x}" for x in process_errors]
+    failures += noise_errors
+    failures += [f"a_w sync: {x}" for x in aw_errors]
     if ba.get("pass") is not True:
         failures.append(f"active bias: {ba.get('failure')}")
-    for name, ok in theorem_obligations.items():
-        if not ok:
-            failures.append(f"theorem obligation failed: {name}")
-
-    # De-duplicate while retaining deterministic order.
+    failures += [f"theorem obligation failed: {name}" for name, ok in obligations.items() if not ok]
     failures = list(dict.fromkeys(failures))
-    linear_pass = not failures
-    nonlinear_local_pass = linear_pass
 
+    theorem_pass = not failures
     pe = dict(vector.get("operating_envelope", {}))
+    pe["persistent_excitation_is_theorem_hypothesis"] = vector.get("persistent_excitation_is_theorem_hypothesis") is True
     pe["accepted_vector_packet_bounded_gap_required"] = True
-    pe["qualification"] = (
-        "THEOREM_OPERATING_ENVELOPE_NOT_INFERRED_FROM_EIGHT_REPLAY_TRAJECTORIES"
-    )
+    pe["qualification"] = "THEOREM_OPERATING_ENVELOPE_NOT_INFERRED_FROM_EIGHT_REPLAY_TRAJECTORIES"
 
-    bindings = _implementation_binding((
-        REPO / "src" / "kalman_ou_iii" / "SeaStateFusionFilter_OU_III.h",
-        REPO / "src" / "kalman_ou_iii" / "Kalman3D_Wave_OU_III.h",
-        REPO / "src" / "kalman_ou_common" / "KalmanOUCoreMath.h",
-    ))
-
-    status = "PASS_CONDITIONAL_LOCAL_ISS" if nonlinear_local_pass else "FAIL"
     return {
         "schema": SCHEMA,
         "claim": "OU3_SOURCE_BOUND_NORMAL_LIVE_STABILITY_THEOREM_CERTIFICATE",
         "qualification": QUALIFICATION,
-        "status": status,
+        "status": "PASS_CONDITIONAL_LOCAL_ISS" if theorem_pass else "FAIL",
         "sampled_evidence_used": False,
         "trajectory_fit_used": False,
-        "implementation_bindings": bindings,
+        "implementation_bindings": _bindings(),
         "source_domain_checks": source_checks,
         "source_noise_checks": noise_checks,
-        "theorem_obligations": theorem_obligations,
+        "theorem_obligations": obligations,
         "upstream_certificates": {
             "scalar_ou": scalar["qualification"],
             "translation": trans["qualification"],
@@ -288,24 +226,16 @@ def build(header: Path = SOURCE.DEFAULT_HEADER.resolve()) -> dict:
         "linearized_normal_live": {
             "H_dimension": 18,
             "A_dimension": 21,
-            "uniform_detectability_and_stabilizability": linear_pass,
-            "bounded_stabilizing_Riccati": linear_pass,
-            "uniform_exponential_stability": linear_pass,
-            "proof_route": (
-                "source-uniform bounded-gap translational detectability + conditional vector "
-                "UCO + stable Gauss-Markov tails + full process UCC; standard discrete LTV "
-                "Kalman/Riccati stability theorem"
-            ),
+            "uniform_detectability_and_stabilizability": theorem_pass,
+            "bounded_stabilizing_Riccati": theorem_pass,
+            "uniform_exponential_stability": theorem_pass,
+            "proof_route": "bounded-gap translational detectability + conditional vector UCO + stable tails + full process UCC; standard discrete LTV Kalman/Riccati theorem",
         },
         "nonlinear_normal_live": {
-            "local_iss": nonlinear_local_pass,
-            "nonzero_neighborhood_exists": nonlinear_local_pass,
+            "local_iss": theorem_pass,
+            "nonzero_neighborhood_exists": theorem_pass,
             "explicit_numeric_basin_radius_produced": False,
-            "proof_route": (
-                "fixed-mode UES plus uniform piecewise-C1 MEKF map on a geodesic chart; "
-                "the nonlinear remainder is quadratic and discrete variation-of-constants "
-                "gives a sufficiently small invariant ISS neighborhood"
-            ),
+            "proof_route": "fixed-mode UES + uniform piecewise-C1 MEKF map on a geodesic chart + quadratic remainder + discrete small gain",
         },
         "periodic_aw_covariance_sync": {
             "pass": aw.get("status") == "PASS",
@@ -322,13 +252,9 @@ def build(header: Path = SOURCE.DEFAULT_HEADER.resolve()) -> dict:
             "stochastic_infinite_horizon_pathwise_bound": "NOT_CLAIMED_FOR_GAUSSIAN_NOISE",
         },
         "claim_separation": {
-            "analytical_normal_live_local_ISS": "PASS" if nonlinear_local_pass else "FAIL",
+            "analytical_normal_live_local_ISS": "PASS" if theorem_pass else "FAIL",
             "numerical_source_complete_deployment_funnel": "NOT_ESTABLISHED_BY_THIS_PRODUCER",
-            "reason": (
-                "the analytical theorem proves existence of a nonzero local ISS neighborhood; "
-                "the stronger numerical deployment gate additionally asks for explicit word, "
-                "prefix, hybrid, stochastic and finite-capture constants"
-            ),
+            "reason": "analytical stability proves existence of a nonzero local ISS neighborhood; the stronger deployment gate additionally requires explicit word/prefix/hybrid/stochastic/capture constants",
         },
         "failures": failures,
     }
@@ -347,10 +273,9 @@ def validate(payload: dict) -> list[str]:
     obligations = payload.get("theorem_obligations", {})
     if not obligations or not all(v is True for v in obligations.values()):
         failures.append("one or more theorem obligations did not pass")
-    linear = payload.get("linearized_normal_live", {})
-    nonlinear = payload.get("nonlinear_normal_live", {})
-    if linear.get("uniform_exponential_stability") is not True:
+    if payload.get("linearized_normal_live", {}).get("uniform_exponential_stability") is not True:
         failures.append("linearized normal-Live UES was not established")
+    nonlinear = payload.get("nonlinear_normal_live", {})
     if nonlinear.get("local_iss") is not True or nonlinear.get("nonzero_neighborhood_exists") is not True:
         failures.append("nonlinear normal-Live local ISS was not established")
     if nonlinear.get("explicit_numeric_basin_radius_produced") is not False:
@@ -383,7 +308,6 @@ def main() -> int:
         "validation_pass": payload["validation_pass"],
         "linear_ues": payload["linearized_normal_live"]["uniform_exponential_stability"],
         "nonlinear_local_iss": payload["nonlinear_normal_live"]["local_iss"],
-        "explicit_numeric_basin_radius_produced": payload["nonlinear_normal_live"]["explicit_numeric_basin_radius_produced"],
         "failures": payload["failures"],
         "validation_failures": validation_failures,
     }, indent=2, sort_keys=True))

--- a/tools/ou3_stability_theorem_certificate.py
+++ b/tools/ou3_stability_theorem_certificate.py
@@ -1,25 +1,32 @@
 #!/usr/bin/env python3
 """Compose the source-bound OU-III normal-Live stability theorem certificate.
 
-This is an analytical proof-composition stage, not a replay promotion stage.
+This is an analytical proof-composition stage, not a replay-promotion stage.
 It binds the current implementation to the validated scalar OU enclosure,
 source-uniform translational UCO/UCC, conditional vector-packet UCO, complete
 H/A process UCC, source Gaussian primitive model, and the exact PSD
 nonexpansiveness proof for periodic a_w covariance synchronization.
 
-The resulting theorem is deliberately conditional on the explicit persistent-
-excitation operating envelope needed for full heading.  Under that envelope,
-uniform detectability/UCC and bounded source coefficients give the standard
-bounded stabilizing Riccati solution and UES of each fixed-dimensional normal-
-Live linearized recursion.  The implemented fixed-branch MEKF maps are smooth
-on a sufficiently small geodesic chart, so their first-order remainder is
-uniformly quadratic; UES plus variation of constants then gives a nonzero local
-ISS neighborhood.
+The theorem is deliberately conditional.  Full-heading observability uses the
+explicit vector persistent-excitation hypothesis of ``ou3_vector_uco_certificate``:
+a proof packet contains accepted accel/mag vectors and the two magnetic packets
+are consecutive configured 25 Hz packets.  In addition, the nonlinear local
+argument is branch-regular: the nominal source word stays a positive distance
+from innovation/gating discontinuities, so a sufficiently small error
+neighborhood follows the same finite source branch word.  Arbitrary rejection
+runs or nominal points exactly on a gate boundary are not certified here.
+
+Under those hypotheses, uniform detectability/UCC and bounded source
+coefficients give the standard bounded stabilizing Riccati family and UES of
+each fixed-dimensional H/A normal-Live linearized recursion.  On a sufficiently
+small geodesic chart the selected MEKF prediction/correction/reset branches are
+C1 with uniformly quadratic remainder; UES plus variation of constants then
+gives a nonzero local ISS neighborhood.
 
 This producer does *not* claim an explicit basin radius or promote the stronger
 startup/hard-reset/stochastic deployment-funnel certificate.  Those numerical
-obligations remain separate and must still be established by validated word,
-prefix, hybrid and concentration bounds.
+obligations remain separate and require a declared physical deployment
+envelope plus validated word/prefix/hybrid/concentration bounds.
 """
 from __future__ import annotations
 
@@ -40,8 +47,8 @@ import ou3_validated_transcendentals as VT
 import ou3_vector_uco_certificate as VECTOR
 
 REPO = Path(__file__).resolve().parents[1]
-SCHEMA = 1
-QUALIFICATION = "SOURCE_BOUND_CONDITIONAL_NORMAL_LIVE_LOCAL_ISS"
+SCHEMA = 2
+QUALIFICATION = "SOURCE_BOUND_CONDITIONAL_BRANCH_REGULAR_NORMAL_LIVE_LOCAL_ISS"
 
 
 def _finite_positive(value) -> bool:
@@ -77,8 +84,11 @@ def _source_failures(source: dict) -> tuple[dict, list[str]]:
     failures = [f"source-domain check failed: {name}" for name, ok in checks.items() if not ok]
     cp = box.get("continuous_parameters", {})
     for name in (
-        "wave_tune_frequency_hz", "tau_aw_s", "sigma_aw_mps2",
-        "R_S_base", "pseudo_update_period_s",
+        "wave_tune_frequency_hz",
+        "tau_aw_s",
+        "sigma_aw_mps2",
+        "R_S_base",
+        "pseudo_update_period_s",
     ):
         if not _finite_positive_interval(cp.get(name)):
             failures.append(f"source continuous parameter is not finite positive: {name}")
@@ -107,7 +117,11 @@ def _active_bias_stability(source: dict, process: dict) -> dict:
         return {"pass": False, "failure": "active accelerometer-bias dt/tau is invalid"}
     x = Interval.outward_bounds(dt / tau, dt / tau)
     if x.hi > VT.MAX_ABS_ARGUMENT:
-        return {"pass": False, "dt_over_tau": x.as_list(), "failure": "dt/tau exceeds audited exponential range"}
+        return {
+            "pass": False,
+            "dt_over_tau": x.as_list(),
+            "failure": "dt/tau exceeds audited exponential range",
+        }
     alpha = VT.exp_interval(-x)
     passed = 0.0 < alpha.lo <= alpha.hi < 1.0
     return {
@@ -152,12 +166,16 @@ def build(header: Path = SOURCE.DEFAULT_HEADER.resolve()) -> dict:
     process_errors = PROCESS.validate(process)
     noise_checks, noise_errors = _noise_failures(noise)
     ba = _active_bias_stability(source, process)
-    aw_errors = [] if aw.get("status") == "PASS" else list(aw.get("failures", [])) or ["a_w sync proof failed"]
+    aw_errors = (
+        [] if aw.get("status") == "PASS"
+        else list(aw.get("failures", [])) or ["a_w sync proof failed"]
+    )
 
     pseudo = trans.get("S_observation_uco", {})
     detect = trans.get("integrator_detectability", {})
     vec = vector.get("gyro_bias_two_packet", {})
     modes = process.get("modes", {})
+    pe_source = vector.get("operating_envelope", {})
 
     obligations = {
         "compact_source_domain": not source_errors,
@@ -169,10 +187,20 @@ def build(header: Path = SOURCE.DEFAULT_HEADER.resolve()) -> dict:
         "finite_source_gaussian_primitives": not noise_errors,
         "periodic_aw_covariance_sync_nonexpansive": not aw_errors,
         "bounded_pseudo_measurement_gap": _finite_positive(pseudo.get("pseudo_gap_max_s")),
-        "strict_translation_stable_tail": _finite_positive(detect.get("stable_aw_alpha_upper")) and float(detect["stable_aw_alpha_upper"]) < 1.0,
+        "strict_translation_stable_tail": (
+            _finite_positive(detect.get("stable_aw_alpha_upper"))
+            and float(detect["stable_aw_alpha_upper"]) < 1.0
+        ),
         "strict_vector_information_under_PE": _finite_positive(vec.get("alpha_6_information_lower")),
-        "strict_H_process_excitation": modes.get("H", {}).get("pass") is True and _finite_positive(modes.get("H", {}).get("prediction_Q_lambda_min_lower")),
-        "strict_A_process_excitation": modes.get("A", {}).get("pass") is True and _finite_positive(modes.get("A", {}).get("prediction_Q_lambda_min_lower")),
+        "configured_consecutive_vector_packet_gap": _finite_positive_interval(pe_source.get("packet_gap_s")),
+        "strict_H_process_excitation": (
+            modes.get("H", {}).get("pass") is True
+            and _finite_positive(modes.get("H", {}).get("prediction_Q_lambda_min_lower"))
+        ),
+        "strict_A_process_excitation": (
+            modes.get("A", {}).get("pass") is True
+            and _finite_positive(modes.get("A", {}).get("prediction_Q_lambda_min_lower"))
+        ),
     }
 
     failures: list[str] = []
@@ -189,14 +217,24 @@ def build(header: Path = SOURCE.DEFAULT_HEADER.resolve()) -> dict:
     failures = list(dict.fromkeys(failures))
 
     theorem_pass = not failures
-    pe = dict(vector.get("operating_envelope", {}))
-    pe["persistent_excitation_is_theorem_hypothesis"] = vector.get("persistent_excitation_is_theorem_hypothesis") is True
-    pe["accepted_vector_packet_bounded_gap_required"] = True
-    pe["qualification"] = "THEOREM_OPERATING_ENVELOPE_NOT_INFERRED_FROM_EIGHT_REPLAY_TRAJECTORIES"
+
+    pe = dict(pe_source)
+    pe.update({
+        "persistent_excitation_is_theorem_hypothesis": vector.get("persistent_excitation_is_theorem_hypothesis") is True,
+        "accepted_accelerometer_packet_at_vector_times_required": True,
+        "accepted_magnetometer_consecutive_pair_required": True,
+        "measurement_gate_margin_required": True,
+        "qualification": "THEOREM_OPERATING_ENVELOPE_NOT_INFERRED_FROM_EIGHT_REPLAY_TRAJECTORIES",
+        "branch_regular_note": (
+            "The local nonlinear theorem applies to nominal source words with positive "
+            "innovation/gating margin so the same finite branch word persists in a "
+            "sufficiently small error neighborhood. Gate-boundary points are excluded."
+        ),
+    })
 
     return {
         "schema": SCHEMA,
-        "claim": "OU3_SOURCE_BOUND_NORMAL_LIVE_STABILITY_THEOREM_CERTIFICATE",
+        "claim": "OU3_SOURCE_BOUND_BRANCH_REGULAR_NORMAL_LIVE_STABILITY_THEOREM_CERTIFICATE",
         "qualification": QUALIFICATION,
         "status": "PASS_CONDITIONAL_LOCAL_ISS" if theorem_pass else "FAIL",
         "sampled_evidence_used": False,
@@ -218,6 +256,7 @@ def build(header: Path = SOURCE.DEFAULT_HEADER.resolve()) -> dict:
             "translation_information_lower": detect.get("information_gramian_lambda_min_lower"),
             "stable_aw_alpha_upper": detect.get("stable_aw_alpha_upper"),
             "vector_alpha_6_information_lower": vec.get("alpha_6_information_lower"),
+            "vector_packet_gap_s": pe_source.get("packet_gap_s"),
             "H_prediction_Q_lambda_min_lower": modes.get("H", {}).get("prediction_Q_lambda_min_lower"),
             "A_prediction_Q_lambda_min_lower": modes.get("A", {}).get("prediction_Q_lambda_min_lower"),
             "active_accelerometer_bias": ba,
@@ -229,13 +268,20 @@ def build(header: Path = SOURCE.DEFAULT_HEADER.resolve()) -> dict:
             "uniform_detectability_and_stabilizability": theorem_pass,
             "bounded_stabilizing_Riccati": theorem_pass,
             "uniform_exponential_stability": theorem_pass,
-            "proof_route": "bounded-gap translational detectability + conditional vector UCO + stable tails + full process UCC; standard discrete LTV Kalman/Riccati theorem",
+            "proof_route": (
+                "bounded-gap translational detectability + accepted consecutive vector-packet "
+                "UCO + stable tails + full process UCC; standard discrete LTV Kalman/Riccati theorem"
+            ),
         },
         "nonlinear_normal_live": {
             "local_iss": theorem_pass,
             "nonzero_neighborhood_exists": theorem_pass,
+            "branch_regular_source_word_required": True,
             "explicit_numeric_basin_radius_produced": False,
-            "proof_route": "fixed-mode UES + uniform piecewise-C1 MEKF map on a geodesic chart + quadratic remainder + discrete small gain",
+            "proof_route": (
+                "H/A UES + finite branch family + positive gate margin + uniform C1 MEKF "
+                "branches on a geodesic chart + quadratic remainder + discrete small gain"
+            ),
         },
         "periodic_aw_covariance_sync": {
             "pass": aw.get("status") == "PASS",
@@ -246,15 +292,21 @@ def build(header: Path = SOURCE.DEFAULT_HEADER.resolve()) -> dict:
             "configured_runtime_only": True,
             "arbitrary_positive_caller_dt": False,
             "full_heading_requires_persistent_excitation": True,
-            "permanent_or_unbounded_mag_rejection_not_certified": True,
+            "consecutive_accepted_mag_pair_required_for_vector_uco": True,
+            "measurement_gate_boundary_points_not_certified": True,
+            "permanent_or_unbounded_measurement_rejection_not_certified": True,
             "startup_handoff_and_hard_reset_funnel_numeric_enclosure": "SEPARATE_DEPLOYMENT_CERTIFICATE_OBLIGATION",
             "explicit_nonlinear_basin_radius": "SEPARATE_NUMERICAL_ENCLOSURE_OBLIGATION",
             "stochastic_infinite_horizon_pathwise_bound": "NOT_CLAIMED_FOR_GAUSSIAN_NOISE",
         },
         "claim_separation": {
-            "analytical_normal_live_local_ISS": "PASS" if theorem_pass else "FAIL",
+            "analytical_branch_regular_normal_live_local_ISS": "PASS" if theorem_pass else "FAIL",
             "numerical_source_complete_deployment_funnel": "NOT_ESTABLISHED_BY_THIS_PRODUCER",
-            "reason": "analytical stability proves existence of a nonzero local ISS neighborhood; the stronger deployment gate additionally requires explicit word/prefix/hybrid/stochastic/capture constants",
+            "reason": (
+                "the analytical theorem proves existence of a nonzero local ISS neighborhood "
+                "under explicit PE/branch-regular hypotheses; the stronger deployment gate "
+                "additionally requires explicit word/prefix/hybrid/stochastic/capture constants"
+            ),
         },
         "failures": failures,
     }
@@ -270,21 +322,35 @@ def validate(payload: dict) -> list[str]:
         failures.append("analytical certificate must not use sampled evidence")
     if payload.get("trajectory_fit_used") is not False:
         failures.append("analytical certificate must not use trajectory fitting")
+
     obligations = payload.get("theorem_obligations", {})
     if not obligations or not all(v is True for v in obligations.values()):
         failures.append("one or more theorem obligations did not pass")
-    if payload.get("linearized_normal_live", {}).get("uniform_exponential_stability") is not True:
+
+    linear = payload.get("linearized_normal_live", {})
+    if linear.get("uniform_exponential_stability") is not True:
         failures.append("linearized normal-Live UES was not established")
+
     nonlinear = payload.get("nonlinear_normal_live", {})
     if nonlinear.get("local_iss") is not True or nonlinear.get("nonzero_neighborhood_exists") is not True:
         failures.append("nonlinear normal-Live local ISS was not established")
+    if nonlinear.get("branch_regular_source_word_required") is not True:
+        failures.append("branch-regular source-word qualification is not explicit")
     if nonlinear.get("explicit_numeric_basin_radius_produced") is not False:
         failures.append("analytical producer must not masquerade as a numerical basin enclosure")
+
     pe = payload.get("persistent_excitation_operating_envelope", {})
     if pe.get("persistent_excitation_is_theorem_hypothesis") is not True:
         failures.append("full-heading PE qualification is not explicit")
-    if pe.get("accepted_vector_packet_bounded_gap_required") is not True:
-        failures.append("bounded accepted-vector packet gap hypothesis is not explicit")
+    if pe.get("accepted_accelerometer_packet_at_vector_times_required") is not True:
+        failures.append("accepted accelerometer vector-packet hypothesis is not explicit")
+    if pe.get("accepted_magnetometer_consecutive_pair_required") is not True:
+        failures.append("consecutive accepted magnetic-packet hypothesis is not explicit")
+    if pe.get("measurement_gate_margin_required") is not True:
+        failures.append("measurement gate-margin hypothesis is not explicit")
+    if not _finite_positive_interval(pe.get("packet_gap_s")):
+        failures.append("configured vector packet gap is not finite positive")
+
     if payload.get("status") != "PASS_CONDITIONAL_LOCAL_ISS":
         failures.append("certificate status is not PASS_CONDITIONAL_LOCAL_ISS")
     if payload.get("failures"):


### PR DESCRIPTION
This PR implements the OU-III paper's stability theorem chain directly. The previous normal-Live-only composition was insufficient and is being replaced as the controlling certificate.

Required theorem chain and machine acceptance contract:
1. Practical-ISS startup proxy theorem: source-bound Mahony gains, compact almost-global chart, explicit V_P comparison solution, V_Q and finite T_Q (or theorem-qualified timeout entry).
2. Exact startup handoff family H: source/physical initialization bounds and the implemented aligned-branch, hold/rate/tuner/heading gates.
3. Source-shaped Live funnel: exact source nodes D_i and Lyapunov metrics W_i; compute c_{0,i}=sup_{H cap D_i} W_i; certify every source-realizable word/jump inequality and every strict prefix.
4. Finite capture: propagate c_{n+1,j}=max(lambda_w c_{n,i}+gamma_w); prove invariant inner levels b_i; produce finite N_H and T_H <= h_+ ell_+ N_H.
5. Hybrid closure: held-to-active bias release, magnetic lock/regauge/refinement, tilt reset/relock, cooldown reentry, and periodic a_w covariance synchronization, all in destination metrics with source-complete bounds.
6. Post-capture practical ISS exactly as in the paper.
7. Stochastic Live qualification: verify E[W_{n+1}|F_n] <= lambda_s W_n + sigma_s^2 and the paper's finite-horizon Gaussian/Freedman localization bound.

The PR is not complete until the machine-produced certificate emits the paper-required objects {H,D_i,W_i,W_src,c_0,c_n,b_i,N_H,T_H,B_pre,lambda_w,gamma_w} and the final deployment/startup-to-capture status passes without promoting sampled replay extrema to theorem assumptions.

No new PR: all work continues here.