### PR TITLE
Stop the history cleanup from erasing live pull-request checks

### DIFF
--- a/.github/workflows/actions-history-cleanup.yml
+++ b/.github/workflows/actions-history-cleanup.yml
@@ -20,19 +20,29 @@ on:
         type: string
         default: '5000'
 
-# Cancelled and skipped runs carry no evidence: a cancelled run produced no
-# verdict and a skipped one never executed. They accumulate in the Actions
-# history and bury the runs that do carry results (success, failure,
+# Cancelled and skipped runs carry no verdict: a cancelled run was voided
+# before it finished and a skipped one never executed. They accumulate in the
+# Actions history and bury the runs that do carry results (success, failure,
 # timed_out, ...), which are the record this project relies on. This job
-# removes only that no-evidence residue and nothing else. Note that the API
-# deletes whole runs, not individual jobs, so a run is removed only when the
-# run's own conclusion is cancelled or skipped.
+# removes that residue and nothing else. Note that the API deletes whole runs,
+# not individual jobs, so a run is removed only when the run's own conclusion
+# is cancelled or skipped.
+#
+# Carrying no verdict is not the same as carrying nothing. A cancelled run is
+# the only evidence that its workflow was triggered at all, and deleting it
+# also removes its check from the pull request. Sweeping every cancelled run
+# therefore erased the newest one for branches under active development and
+# made a superseded run look like a workflow GitHub had never started - the
+# focused pull-request workflows appeared to be dropped at random while the
+# push workflows, which are cancelled less often, looked fine. The pass now
+# keeps the newest cancelled/skipped run of each workflow on each branch.
 #
 # This repository generates cancelled runs quickly: cancel-in-progress voids a
-# whole batch on every push. The pass is therefore parallel and the cap is set
-# well above a week's production rate, or the backlog never shrinks. Because
-# the pass runs weekly rather than hourly, anything it leaves behind waits a
-# week, so the cap has real headroom rather than a nominal one.
+# whole batch on every push, and pushes here land faster than the focused
+# workflows finish. The pass is therefore parallel and the cap is set well
+# above a week's production rate, or the backlog never shrinks. Because the
+# pass runs weekly rather than hourly, anything it leaves behind waits a week,
+# so the cap has real headroom rather than a nominal one.
 permissions:
   contents: read
 
@@ -97,19 +107,46 @@ jobs:
                 .workflow_runs[]
                 | select(.status == "completed")
                 | select(.conclusion == "cancelled" or .conclusion == "skipped")
-                | [.id, .conclusion, .updated_at, .name] | @tsv
+                | [.id, .conclusion, .updated_at, .name,
+                   .workflow_id, (.head_branch // "-"), .created_at] | @tsv
               ' >> "$candidates"
           done
 
-          # Apply the age window, exclude this very run, and cap the batch.
+          # Pagination can hand back the same run twice when runs finish
+          # mid-listing, and the newest-per-branch pass below must not see a
+          # run more than once.
+          sort -u "$candidates" -o "$candidates"
+
+          # A cancelled run carries no *result*, but it is still the record
+          # that the workflow was triggered. Deleting the newest one for a
+          # branch also removes its check from the pull request, so a run
+          # that was merely superseded by the next push becomes
+          # indistinguishable from a workflow that GitHub never started -
+          # which reads as CI silently dropping the focused pull-request
+          # workflows. This repository pushes far faster than those
+          # workflows run, so that is the common case, not a rare one.
+          #
+          # Keep the most recent cancelled/skipped run of each workflow on
+          # each branch and sweep everything behind it. That bounds what is
+          # retained at one run per workflow per branch while leaving every
+          # pull request able to show that its focused workflow did fire.
+          keep="$(mktemp)"
+          sort -t"$(printf '\t')" -k5,5 -k6,6 -k7,7r "$candidates" \
+            | awk -F'\t' '!seen[$5 FS $6]++ { print $1 }' > "$keep"
+
+          # Apply the age window, exclude this very run and the newest run
+          # per workflow and branch, and cap the batch.
           selected="$(mktemp)"
           awk -F'\t' -v cutoff="$cutoff" -v self="$SELF_RUN_ID" -v cap="$MAX_DELETIONS" '
-            $1 != self && $3 < cutoff && n < cap { print; n++ }
-          ' "$candidates" | sort -u > "$selected"
+            NR == FNR { keep[$1] = 1; next }
+            $1 != self && !($1 in keep) && $3 < cutoff && n < cap { print; n++ }
+          ' "$keep" "$candidates" > "$selected"
 
           total_candidates="$(wc -l < "$candidates" | tr -d ' ')"
+          total_kept="$(wc -l < "$keep" | tr -d ' ')"
           total_selected="$(wc -l < "$selected" | tr -d ' ')"
           echo "Cancelled/skipped runs found: $total_candidates"
+          echo "Newest per workflow/branch:   $total_kept (retained)"
           echo "Eligible for deletion now:    $total_selected"
 
           if [ "$total_selected" -eq 0 ]; then
@@ -118,6 +155,7 @@ jobs:
               echo "### Actions history cleanup"
               echo
               echo "- Cancelled/skipped runs found: \`$total_candidates\`"
+              echo "- Retained as newest per workflow/branch: \`$total_kept\`"
               echo "- Nothing eligible this pass"
             } >> "$GITHUB_STEP_SUMMARY"
             exit 0
@@ -134,6 +172,7 @@ jobs:
               echo "### Actions history cleanup (dry run)"
               echo
               echo "- Cancelled/skipped runs found: \`$total_candidates\`"
+              echo "- Retained as newest per workflow/branch: \`$total_kept\`"
               echo "- Would delete: \`$total_selected\`"
             } >> "$GITHUB_STEP_SUMMARY"
             exit 0
@@ -196,6 +235,7 @@ jobs:
             echo "### Actions history cleanup"
             echo
             echo "- Cancelled/skipped runs found: \`$total_candidates\`"
+            echo "- Retained as newest per workflow/branch: \`$total_kept\`"
             echo "- Eligible this pass: \`$total_selected\`"
             echo "- Deleted: \`$deleted\`"
             echo "- Left in place (state changed): \`$left\`"


### PR DESCRIPTION
The focused pull-request workflows were not being dropped by GitHub. They
ran, were cancelled by cancel-in-progress when the next push landed, and
were then permanently deleted by actions-history-cleanup. Deleting a run
also removes its check from the pull request, so a superseded run became
indistinguishable from one that never started.

The 14:47 UTC pass on 2026-08-26 deleted 539 runs in a single sweep,
including 102 ou3-p5-full-matrix-fast, 55 ou3-p5-rotation-gauge-fast,
28 ou3-p5-subdivision-fast, 6 ou3-p5-outer-fast, 5 ou3-proof-fast and
3 ou3-numerical-certificate. Pushes on an active branch land every one to
three minutes while those workflows take longer than that to finish, so
their newest run is usually cancelled and was the run being erased. The
push workflows survived because they are cancelled less often, which is
why the loss looked specific to the pull-request side.

Keep the most recent cancelled/skipped run of each workflow on each
branch and sweep only what is genuinely behind it. That bounds retention
at one run per workflow per branch and still clears the backlog, while
leaving every pull request able to show that its focused workflow fired.
Also dedupe the candidate listing, which can repeat a run across
pagination, and report the retained count in the step summary.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TA81r9fu51vznxfCuP286M