### PR TITLE
Test the first-accel rotation gauge stages as they actually run

### DIFF
--- a/tests/validation/test_ou3_p5_first_accel_rotation_gauge.py
+++ b/tests/validation/test_ou3_p5_first_accel_rotation_gauge.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from pathlib import Path
 import unittest
@@ -5,61 +6,134 @@ import unittest
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "tools"))
 
+from ou3_interval import Interval, matrix_add, matrix_mul, matrix_transpose
 import ou3_p5_first_accel_rotation_gauge as G
+import ou3_p5_full_h_prefix_cells as FULL
+import ou3_p5_full_h_prefix_cells_v3 as FULL3
+
+# Captured at import, before any producer installs a replacement axis backend on
+# the module, so these tests exercise the V1 gate exactly as V1 wrote it no
+# matter which later stage has already run in the same process.
+V1_SCALAR_AXIS_STRUCTURE = G._scalar_axis_structure
+
+
+def _first_prefix_source_matrices():
+    FULL3._install_backend()
+    domain_path = Path(G.DEFAULT_DOMAIN).resolve()
+    domain = json.loads(domain_path.read_text(encoding="utf-8"))
+    src, _phase = G._source_phase_children(1)[0]
+    P0 = FULL._initial_covariance(src, domain_path)
+    F, Q, _Rstep = FULL._transition_and_Q(src, domain)
+    return P0, F, Q
+
+
+def _first_prefix_covariance():
+    """Predicted covariance of the first source/phase child, as build() forms it."""
+    P0, F, Q = _first_prefix_source_matrices()
+    return FULL._psd_tighten(matrix_add(matrix_mul(matrix_mul(F, P0), matrix_transpose(F)), Q))
+
+
+def _isotropic_first_prefix(pss: Interval, psa: Interval, paw: Interval):
+    P = FULL._zero(18, 18)
+    for ax in range(3):
+        P[12 + ax][12 + ax] = pss
+        P[12 + ax][15 + ax] = psa
+        P[15 + ax][12 + ax] = psa
+        P[15 + ax][15 + ax] = paw
+    return P
+
+
+class Ou3P5FirstAccelRotationGaugeSourceStructureTests(unittest.TestCase):
+    """The gauge's axis isotropy is a property of the source matrices."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.P0, cls.F, cls.Q = _first_prefix_source_matrices()
+
+    def test_first_prefix_source_matrices_are_exactly_axis_isotropic(self):
+        for M in (self.P0, self.F, self.Q):
+            for base in ((12, 12), (12, 15), (15, 15)):
+                first = M[base[0]][base[1]]
+                for ax in range(3):
+                    self.assertEqual(M[base[0] + ax][base[1] + ax], first)
+
+    def test_first_prefix_source_matrices_have_no_cross_axis_linear_entries(self):
+        for M in (self.P0, self.F, self.Q):
+            for ai in range(3):
+                for aj in range(3):
+                    if ai == aj:
+                        continue
+                    for a, b in ((12 + ai, 12 + aj), (12 + ai, 15 + aj), (15 + ai, 15 + aj)):
+                        self.assertEqual(M[a][b], Interval.point(0.0))
 
 
 class Ou3P5FirstAccelRotationGaugeTests(unittest.TestCase):
+    """V1 is retained as the historical stage that stops at its own gate.
+
+    Its structural requirements are correct but it compares the three
+    *interval representations* of numerically identical axis expressions, so
+    the generic 18x18 product's last-ulp widening stops it before it can
+    evaluate a single correction cell.  V2 relaxes that to an axis hull and V3
+    certifies the source sparsity; both are exercised by their own tests.
+    """
+
     @classmethod
     def setUpClass(cls):
-        cls.d = G.build(
-            source_pieces=2,
-            yaw_axis_face_pieces=4,
-            force_magnitude_pieces=4,
+        cls.Pp = _first_prefix_covariance()
+
+    def test_gate_stops_on_bit_identical_axis_interval_representations(self):
+        with self.assertRaisesRegex(RuntimeError, "lost axis symmetry"):
+            V1_SCALAR_AXIS_STRUCTURE(self.Pp)
+
+    def test_the_rejected_axis_representations_differ_only_by_arithmetic_noise(self):
+        for base in ((12, 12), (12, 15), (15, 15)):
+            axes = [self.Pp[base[0] + ax][base[1] + ax] for ax in range(3)]
+            scale = max(abs(x.lo) for x in axes) + max(abs(x.hi) for x in axes)
+            self.assertGreater(scale, 0.0)
+            for attr in ("lo", "hi"):
+                values = [getattr(x, attr) for x in axes]
+                self.assertLessEqual((max(values) - min(values)) / scale, 1e-12)
+
+    def test_gate_accepts_an_exactly_isotropic_first_prefix(self):
+        pss = Interval(1.0, 2.0)
+        psa = Interval(-0.5, 0.5)
+        paw = Interval(3.0, 4.0)
+        self.assertEqual(
+            V1_SCALAR_AXIS_STRUCTURE(_isotropic_first_prefix(pss, psa, paw)),
+            (pss, psa, paw),
         )
 
-    def test_stage_is_source_bound_and_does_not_change_filter_or_range(self):
-        d = self.d
-        self.assertEqual(G.validate(d), [])
-        self.assertTrue(d["source_generated_not_trajectory_fit"])
-        self.assertFalse(d["source_replay_used"])
-        self.assertFalse(d["filter_changed"])
-        self.assertEqual(d["deployed_correction_limit_rad"], 6.0)
-        self.assertFalse(d["deployed_correction_limit_increased"])
+    def test_gate_rejects_reachable_cross_axis_covariance(self):
+        P = _isotropic_first_prefix(Interval(1.0, 2.0), Interval(-0.5, 0.5), Interval(3.0, 4.0))
+        P[12][13] = Interval(0.25, 0.25)
+        with self.assertRaisesRegex(RuntimeError, "gained cross-axis terms"):
+            V1_SCALAR_AXIS_STRUCTURE(P)
 
-    def test_rotation_gauge_consumes_exact_first_prefix_structure(self):
-        d = self.d
-        self.assertTrue(d["rotation_gauge_sets_J_aw_to_identity"])
-        self.assertTrue(d["rotation_gauge_sets_specific_force_direction_to_e3"])
-        self.assertTrue(d["gauge_requires_first_prefix_theta_aw_cross_zero"])
-        self.assertTrue(d["gauge_requires_first_prefix_aw_axis_isotropy"])
-        self.assertTrue(d["first_prefix_source_structure_checked"])
-        self.assertTrue(d["attitude_seed_rank_one_yaw_axis_retained"])
-        self.assertTrue(d["yaw_axis_cube_face_cover_complete"])
-        self.assertTrue(d["pseudo_phase_coupled_to_tau_before_branching"])
+    def test_gate_rejects_nonzero_theta_aw_covariance(self):
+        P = _isotropic_first_prefix(Interval(1.0, 2.0), Interval(-0.5, 0.5), Interval(3.0, 4.0))
+        P[0][15] = Interval(0.0, 1e-9)
+        with self.assertRaisesRegex(RuntimeError, "theta/a_w covariance is not exactly zero"):
+            V1_SCALAR_AXIS_STRUCTURE(P)
 
-    def test_loose_innovation_inverse_fallback_is_retired_for_this_stage(self):
-        d = self.d
-        self.assertGreater(d["evaluated_child_count"], 0)
-        self.assertGreater(d["fixed_pivot_inverse_count"], 0)
-        self.assertEqual(d["spectral_fallback_inverse_count"], 0)
 
-    def test_first_stage_never_promotes_complete_word(self):
-        d = self.d
-        self.assertFalse(d["whole_word_promoted_here"])
-        self.assertFalse(d["N_H_words_set_here"])
-        if d["P5_FIRST_ACCEL_ROTATION_GAUGED_CERTIFICATE"] == "PASS":
-            self.assertTrue(d["all_first_accelerometer_children_inside_validated_correction_range"])
-            self.assertIsNone(d["first_unclosed_child"])
-            self.assertEqual(
-                d["next_obligation"],
-                "PROPAGATE_ROTATION_GAUGED_CHILDREN_THROUGH_ACCEL_JOSEPH_RESET_AND_LATER_PREFIXES",
-            )
-        else:
-            self.assertIsNotNone(d["first_unclosed_child"])
-            self.assertEqual(
-                d["next_obligation"],
-                "REFINE_FIRST_ACCEL_ATTITUDE_COVARIANCE_AND_EFFECTIVE_AW_DIRECTION_COUPLING",
-            )
+class Ou3P5FirstAccelRotationGaugeValidateTests(unittest.TestCase):
+    def test_validate_reports_a_surviving_spectral_fallback_as_an_obligation(self):
+        message = "rotation-gauged innovation still required loose spectral inverse fallback"
+        self.assertIn(message, G.validate({"spectral_fallback_inverse_count": 6160}))
+        self.assertNotIn(message, G.validate({"spectral_fallback_inverse_count": 0}))
+
+    def test_validate_keeps_the_stage_out_of_the_promotion_path(self):
+        d = {
+            "whole_word_promoted_here": True,
+            "N_H_words_set_here": True,
+            "deployed_correction_limit_increased": True,
+            "deployed_correction_limit_rad": 8.0,
+        }
+        failures = G.validate(d)
+        self.assertIn("whole_word_promoted_here is not false", failures)
+        self.assertIn("N_H_words_set_here is not false", failures)
+        self.assertIn("deployed_correction_limit_increased is not false", failures)
+        self.assertIn("deployed correction range changed", failures)
 
 
 if __name__ == "__main__":

--- a/tests/validation/test_ou3_p5_first_accel_rotation_gauge_v2.py
+++ b/tests/validation/test_ou3_p5_first_accel_rotation_gauge_v2.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from pathlib import Path
 import unittest
@@ -5,59 +6,119 @@ import unittest
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "tools"))
 
+from ou3_interval import Interval, matrix_add, matrix_mul, matrix_transpose
+import ou3_p5_first_accel_rotation_gauge as V1G
 import ou3_p5_first_accel_rotation_gauge_v2 as G
+import ou3_p5_full_h_prefix_cells as FULL
+import ou3_p5_full_h_prefix_cells_v3 as FULL3
+
+# Captured at import so the V1 gate stays available for comparison whatever
+# else has already installed a backend on the shared module.
+V1_SCALAR_AXIS_STRUCTURE = V1G._scalar_axis_structure
+HULLED = G._scalar_axis_structure_hulled
+
+
+def _first_prefix_covariance():
+    FULL3._install_backend()
+    domain_path = Path(G.DEFAULT_DOMAIN).resolve()
+    domain = json.loads(domain_path.read_text(encoding="utf-8"))
+    src, _phase = V1G._source_phase_children(1)[0]
+    P0 = FULL._initial_covariance(src, domain_path)
+    F, Q, _Rstep = FULL._transition_and_Q(src, domain)
+    return FULL._psd_tighten(matrix_add(matrix_mul(matrix_mul(F, P0), matrix_transpose(F)), Q))
+
+
+def _axis_split_first_prefix():
+    """Isotropic first prefix whose axis representations differ by one ulp."""
+    P = FULL._zero(18, 18)
+    for base, value in (((12, 12), 2500.01), ((12, 15), 1e-9), ((15, 15), 0.3)):
+        for ax in range(3):
+            lo = FULL.down(value) if ax else value
+            hi = FULL.up(value) if ax == 2 else value
+            P[base[0] + ax][base[1] + ax] = Interval(lo, hi)
+            if base == (12, 15):
+                P[base[1] + ax][base[0] + ax] = Interval(lo, hi)
+    return P
 
 
 class Ou3P5FirstAccelRotationGaugeV2Tests(unittest.TestCase):
+    """V2 relaxes V1's representation gate but keeps its structural gates.
+
+    V2 therefore clears the last-ulp axis widening that stopped V1 and then
+    stops on the cross-axis subnormal dust the generic 18x18 interval product
+    leaves around the exact structural zero.  V3 is the stage that certifies
+    that dust against the source sparsity and runs to a result.
+    """
+
     @classmethod
     def setUpClass(cls):
-        cls.d = G.build(
-            source_pieces=2,
-            yaw_axis_face_pieces=4,
-            force_magnitude_pieces=4,
-        )
+        cls.Pp = _first_prefix_covariance()
 
-    def test_v2_hulls_only_equivalent_axis_interval_representations(self):
-        d = self.d
-        self.assertEqual(G.validate(d), [])
-        self.assertTrue(d["axis_isotropic_source_intervals_hulled_across_equivalent_axes"])
-        self.assertFalse(d["bit_identical_axis_interval_endpoints_required"])
-        self.assertTrue(d["cross_axis_covariance_still_required_exact_zero"])
-        self.assertTrue(d["theta_aw_covariance_still_required_exact_zero"])
+    def test_hull_clears_the_axis_representation_gate_that_stopped_v1(self):
+        P = _axis_split_first_prefix()
+        with self.assertRaisesRegex(RuntimeError, "lost axis symmetry"):
+            V1_SCALAR_AXIS_STRUCTURE(P)
+        pss, psa, paw = HULLED(P)
+        for value, base in ((pss, (12, 12)), (psa, (12, 15)), (paw, (15, 15))):
+            for ax in range(3):
+                axis = P[base[0] + ax][base[1] + ax]
+                self.assertLessEqual(value.lo, axis.lo)
+                self.assertGreaterEqual(value.hi, axis.hi)
 
-    def test_source_and_deployed_range_contracts_remain_unchanged(self):
-        d = self.d
-        self.assertTrue(d["source_generated_not_trajectory_fit"])
-        self.assertFalse(d["source_replay_used"])
-        self.assertFalse(d["filter_changed"])
-        self.assertEqual(d["deployed_correction_limit_rad"], 6.0)
-        self.assertFalse(d["deployed_correction_limit_increased"])
-        self.assertTrue(d["rotation_gauge_sets_J_aw_to_identity"])
-        self.assertTrue(d["rotation_gauge_sets_specific_force_direction_to_e3"])
+    def test_hull_still_stops_on_first_prefix_cross_axis_interval_dust(self):
+        with self.assertRaisesRegex(RuntimeError, "gained cross-axis terms"):
+            HULLED(self.Pp)
 
-    def test_innovation_inverse_must_close_without_spectral_fallback(self):
-        d = self.d
-        self.assertGreater(d["evaluated_child_count"], 0)
-        self.assertGreater(d["fixed_pivot_inverse_count"], 0)
-        self.assertEqual(d["spectral_fallback_inverse_count"], 0)
+    def test_the_rejected_cross_axis_entries_are_subnormal_arithmetic_dust(self):
+        worst = 0.0
+        for ai in range(3):
+            for aj in range(3):
+                if ai == aj:
+                    continue
+                for a, b in ((12 + ai, 12 + aj), (12 + ai, 15 + aj), (15 + ai, 15 + aj)):
+                    z = self.Pp[a][b]
+                    self.assertLessEqual(z.lo, 0.0)
+                    self.assertGreaterEqual(z.hi, 0.0)
+                    worst = max(worst, z.abs_upper())
+        self.assertLess(worst, 1e-300)
 
-    def test_stage_remains_fail_closed_and_never_sets_NH(self):
-        d = self.d
-        self.assertFalse(d["whole_word_promoted_here"])
-        self.assertFalse(d["N_H_words_set_here"])
-        if d["P5_FIRST_ACCEL_ROTATION_GAUGED_CERTIFICATE"] == "PASS":
-            self.assertTrue(d["all_first_accelerometer_children_inside_validated_correction_range"])
-            self.assertIsNone(d["first_unclosed_child"])
-            self.assertEqual(
-                d["next_obligation"],
-                "PROPAGATE_ROTATION_GAUGED_CHILDREN_THROUGH_ACCEL_JOSEPH_RESET_AND_LATER_PREFIXES",
-            )
-        else:
-            self.assertIsNotNone(d["first_unclosed_child"])
-            self.assertEqual(
-                d["next_obligation"],
-                "REFINE_FIRST_ACCEL_ATTITUDE_COVARIANCE_AND_EFFECTIVE_AW_DIRECTION_COUPLING",
-            )
+    def test_hull_rejects_reachable_cross_axis_covariance(self):
+        P = _axis_split_first_prefix()
+        P[12][13] = Interval(0.25, 0.25)
+        with self.assertRaisesRegex(RuntimeError, "gained cross-axis terms"):
+            HULLED(P)
+
+    def test_hull_rejects_nonzero_theta_aw_covariance(self):
+        P = _axis_split_first_prefix()
+        P[0][15] = Interval(0.0, 1e-9)
+        with self.assertRaisesRegex(RuntimeError, "theta/a_w covariance is not exactly zero"):
+            HULLED(P)
+
+
+class Ou3P5FirstAccelRotationGaugeV2ContractTests(unittest.TestCase):
+    def test_v2_declares_its_own_schema_over_the_v1_stage(self):
+        self.assertEqual(G.SCHEMA, 2)
+        self.assertNotEqual(G.SCHEMA, V1G.SCHEMA)
+        self.assertEqual(G.DEFAULT_DOMAIN, V1G.DEFAULT_DOMAIN)
+
+    def test_validate_rejects_a_weakened_structural_contract(self):
+        d = {
+            "schema": G.SCHEMA,
+            "axis_isotropic_source_intervals_hulled_across_equivalent_axes": False,
+            "bit_identical_axis_interval_endpoints_required": True,
+            "cross_axis_covariance_still_required_exact_zero": False,
+            "theta_aw_covariance_still_required_exact_zero": False,
+        }
+        failures = G.validate(d)
+        self.assertIn("axis-equivalent interval hull is not active", failures)
+        self.assertIn("bit-identical interval endpoint gate remains active", failures)
+        self.assertIn("cross-axis zero structure was weakened", failures)
+        self.assertIn("theta/a_w zero structure was weakened", failures)
+
+    def test_validate_inherits_the_v1_stage_gates(self):
+        message = "rotation-gauged innovation still required loose spectral inverse fallback"
+        self.assertIn(message, G.validate({"spectral_fallback_inverse_count": 6160}))
+        self.assertIn("schema mismatch", G.validate({"schema": V1G.SCHEMA}))
 
 
 if __name__ == "__main__":

--- a/tests/validation/test_ou3_p5_first_accel_rotation_gauge_v3.py
+++ b/tests/validation/test_ou3_p5_first_accel_rotation_gauge_v3.py
@@ -7,8 +7,23 @@ sys.path.insert(0, str(ROOT / "tools"))
 
 import ou3_p5_first_accel_rotation_gauge_v3 as G
 
+SPECTRAL_FALLBACK_OBLIGATION = (
+    "rotation-gauged innovation still required loose spectral inverse fallback"
+)
+
 
 class Ou3P5FirstAccelRotationGaugeV3Tests(unittest.TestCase):
+    """V3 is the rotation-gauged stage that runs to a result.
+
+    It certifies the first-prefix source sparsity before the generic interval
+    product, so the subnormal dust that stopped V2 no longer masquerades as
+    reachable cross-axis covariance.  The stage still does not close: part of
+    the source cover leaves the innovation box too wide for a fixed-pivot
+    inverse and falls back on the deliberately loose S>=R enclosure.  That is
+    reported as the open subdivision target, which is what the structured-gain
+    and sample-1 stages downstream of here refine.
+    """
+
     @classmethod
     def setUpClass(cls):
         cls.d = G.build(
@@ -19,13 +34,15 @@ class Ou3P5FirstAccelRotationGaugeV3Tests(unittest.TestCase):
 
     def test_structural_zeros_are_source_certified_not_thresholded(self):
         d = self.d
-        self.assertEqual(G.validate(d), [])
         self.assertTrue(d["first_prefix_source_sparsity_certified_before_interval_product"])
         self.assertGreater(d["source_sparsity_cells_checked"], 0)
         self.assertFalse(d["structural_zero_canonicalization_uses_numeric_threshold"])
         self.assertFalse(d["cross_axis_interval_dust_treated_as_physical_covariance"])
         self.assertTrue(d["axis_equivalent_same_axis_intervals_hulled"])
         self.assertGreaterEqual(d["arithmetic_zero_dust_abs_upper_max"], 0.0)
+
+    def test_certified_dust_stays_far_below_any_reachable_covariance(self):
+        self.assertLess(self.d["arithmetic_zero_dust_abs_upper_max"], 1e-300)
 
     def test_source_and_deployed_range_contracts_remain_unchanged(self):
         d = self.d
@@ -37,21 +54,47 @@ class Ou3P5FirstAccelRotationGaugeV3Tests(unittest.TestCase):
         self.assertTrue(d["rotation_gauge_sets_J_aw_to_identity"])
         self.assertTrue(d["rotation_gauge_sets_specific_force_direction_to_e3"])
 
-    def test_innovation_inverse_must_close_without_spectral_fallback(self):
+    def test_source_sparsity_certificate_admits_the_whole_child_cover(self):
         d = self.d
         self.assertGreater(d["evaluated_child_count"], 0)
+        self.assertEqual(
+            d["evaluated_child_count"],
+            d["source_phase_cell_count"] * d["yaw_axis_cell_count"] * d["force_magnitude_cell_count"],
+        )
+        self.assertEqual(
+            d["fixed_pivot_inverse_count"] + d["spectral_fallback_inverse_count"],
+            d["evaluated_child_count"],
+        )
+
+    def test_spectral_fallback_is_the_only_outstanding_stage_obligation(self):
+        d = self.d
         self.assertGreater(d["fixed_pivot_inverse_count"], 0)
-        self.assertEqual(d["spectral_fallback_inverse_count"], 0)
+        self.assertGreater(d["spectral_fallback_inverse_count"], 0)
+        self.assertEqual(G.validate(d), [SPECTRAL_FALLBACK_OBLIGATION])
+
+    def test_stage_is_fail_closed_on_the_children_it_cannot_bound(self):
+        d = self.d
+        self.assertEqual(d["P5_FIRST_ACCEL_ROTATION_GAUGED_CERTIFICATE"], "NOT_ESTABLISHED")
+        self.assertFalse(d["all_first_accelerometer_children_inside_validated_correction_range"])
+        self.assertGreater(d["children_above_validated_correction_limit"], 0)
+        self.assertGreater(d["max_first_accelerometer_correction_norm_upper_rad"], 6.0)
+        self.assertEqual(
+            d["next_obligation"],
+            "REFINE_FIRST_ACCEL_ATTITUDE_COVARIANCE_AND_EFFECTIVE_AW_DIRECTION_COUPLING",
+        )
+
+    def test_nonclosure_carries_a_source_child_witness(self):
+        witness = self.d["first_unclosed_child"]
+        self.assertIsNotNone(witness)
+        self.assertEqual(witness["inverse_backend"], "SPD_S_GE_R_SPECTRAL_ENTRY_ENCLOSURE")
+        self.assertGreater(witness["correction_norm_upper_rad"], 6.0)
+        for key in ("tau_s", "sigma_aw_mps2", "R_S_filter_std", "pseudo_period_s"):
+            self.assertEqual(len(witness[key]), 2)
 
     def test_stage_never_promotes_complete_word(self):
         d = self.d
         self.assertFalse(d["whole_word_promoted_here"])
         self.assertFalse(d["N_H_words_set_here"])
-        if d["P5_FIRST_ACCEL_ROTATION_GAUGED_CERTIFICATE"] == "PASS":
-            self.assertTrue(d["all_first_accelerometer_children_inside_validated_correction_range"])
-            self.assertIsNone(d["first_unclosed_child"])
-        else:
-            self.assertIsNotNone(d["first_unclosed_child"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The three P5 first-accelerometer rotation-gauge stages arrived with tests
that asserted a closure none of them reaches, so prose validation went red
the moment the branch merged and the full suite ran them for the first time.
The producers are right and the tests were wrong.

V1 compares the three interval *representations* of numerically identical
axis expressions.  The generic 18x18 product widens them by one ulp, so V1
stops at "lost axis symmetry" before it evaluates a single correction cell
-- which is what V2's docstring says V1 does.  V2 hulls the axes and then
stops on the subnormal dust the natural extension leaves around the exact
structural zero, which is what V3's docstring says V2 does.  V3 certifies
the source sparsity first and does run: 7680 children, 1520 fixed-pivot and
6160 loose spectral-fallback inverses, 7600 over the deployed range, status
NOT_ESTABLISHED with next_obligation REFINE_FIRST_ACCEL_ATTITUDE_COVARIANCE
_AND_EFFECTIVE_AW_DIRECTION_COUPLING.  That refinement is the V4..V14D chain
already downstream of here, so demanding zero spectral fallbacks at this
stage asked the gauge to be its own successor.

V1's test also only got as far as it did because test_ou3_p5_first_accel
_exact_source sorts earlier and leaks RG3._install_backend's monkeypatch
onto the shared module; its outcome depended on test order.  The V1 and V2
gates are now exercised directly on the real first-prefix covariance with
the pristine gate captured at import, so the result is order independent,
and each gate is still shown to reject genuinely reachable cross-axis and
theta/a_w structure rather than only arithmetic noise.  V3 keeps its full
build and asserts the honest contract: fixed plus fallback covers the child
cover, the fallback is the sole outstanding validate() obligation, and the
nonclosure carries a spectral-fallback witness above the 6 rad range.

Dropping V1's and V2's builds-that-crash also takes about 155 seconds off
the suite.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y93jCAoXuXe7m4PaeLnG5F

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded validation coverage for rotation-gauge stages across multiple versions.
  * Added checks for axis isotropy, covariance constraints, representation differences, numerical noise, and subnormal cross-axis values.
  * Added coverage for spectral fallback obligations, fail-closed certificate states, and source-child witnesses.
  * Updated expectations to reflect that the stage does not promote when a spectral fallback remains required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->