### PR TITLE
doc(ou3): add a TikZ block diagram of the full OU-III filter structure

### DIFF
--- a/doc/kalman_ou_iii/kalman_ou-w3d.tex
+++ b/doc/kalman_ou_iii/kalman_ou-w3d.tex
@@ -12,6 +12,8 @@
 \interdisplaylinepenalty=2500
 \usepackage{pgf}
 \usepackage{pgfplots}
+\usepackage{tikz}
+\usetikzlibrary{arrows.meta,fit,backgrounds,positioning,calc}
 \usepackage{xcolor}
 \usepackage{float}
 \usepackage{mathrsfs}
@@ -237,6 +239,7 @@ extended Kalman filter, inertial navigation, IMU, marine Motion Reference Unit, 
 \input{w3d-intro.tex-part}
 \input{w3d-related-work-modern.tex-part}
 \input{w3d-nomenclature.tex-part}
+\input{w3d-architecture.tex-part}
 \input{w3d-state.tex-part}
 \input{w3d-meas.tex-part}
 \input{w3d-proc-cont.tex-part}

--- a/doc/kalman_ou_iii/w3d-architecture.tex-part
+++ b/doc/kalman_ou_iii/w3d-architecture.tex-part
@@ -1,0 +1,220 @@
+% =======================================================
+\section{Filter Architecture}
+\label{sec:architecture}
+
+Figure~\ref{fig:ou3-architecture} is the block diagram of the deployed OU--III
+estimator.  It is read top to bottom.  Above the dashed barrier is the
+measurement-only front end: a Mahony complementary observer, the levelled
+vertical-acceleration channel it feeds, the magnetic hard-iron tracker, the
+wave-period and acceleration-scale estimators, and the adaptation module that
+turns those two statistics into the OU schedule.  Below the barrier is the
+21-state quaternion MEKF of Eq.~\eqref{eq:nominal-state-vector}, whose
+recursion couples the attitude states, the OU-driven linear chain, and the
+residual accelerometer bias through three rank--3 correction channels.
+
+The barrier carries the structural property the stability argument relies on.
+Every edge that crosses it points downward: raw inertial and magnetic samples,
+the gated startup handoff of Sec.~\ref{sec:proxy-handoff}, the slewed hard-iron
+correction of Sec.~\ref{sec:mag-hi-apply}, and the staged parameter tuple
+$\vartheta_k=(\tau,\sigma_{aw},\vct r_S,T_S)$ of
+Eq.~\eqref{eq:adapt-one-sample-staging}.  No MEKF state, covariance, or
+innovation returns to the front end, so the schedule is an exogenous
+$\mathcal F_{k-1}$-measurable sequence rather than a feedback law, which is
+what makes the source-reachable schedule family of
+Sec.~\ref{sec:iss-source-family} finite and the certificates of
+Sec.~\ref{sec:adaptation} well posed.  The Mahony proxy is therefore not a
+redundant attitude solution retained for convenience: it exists so that
+levelling, hard-iron geometry, and the sea-state observables can be produced
+without closing a loop through the estimator they schedule.
+
+\begin{figure*}[t]
+\centering
+\resizebox{\textwidth}{!}{%
+\begin{tikzpicture}[
+  font=\scriptsize,
+  x=1cm, y=1cm,
+  blk/.style={draw, rounded corners=1.5pt, align=center, inner sep=3pt,
+              text width=26mm, minimum height=10mm, fill=white},
+  sens/.style={blk, fill=black!10, text width=23mm, minimum height=13mm},
+  front/.style={blk, fill=black!3, minimum height=11.5mm},
+  adapt/.style={blk, fill=black!7, text width=31mm, minimum height=11.5mm},
+  core/.style={blk, fill=black!5, minimum height=12mm},
+  stateb/.style={blk, fill=white, densely dashed, text width=27mm,
+                 minimum height=11mm},
+  outb/.style={blk, fill=black!10, text width=86mm, align=center,
+               minimum height=9mm, inner xsep=6pt},
+  grp/.style={draw=black!45, thin, rounded corners=4pt, inner sep=6pt},
+  sig/.style={-{Latex[length=1.9mm,width=1.4mm]}, semithick},
+  wire/.style={semithick},
+  sched/.style={-{Latex[length=1.9mm,width=1.4mm]}, semithick, dashed},
+  schedw/.style={semithick, dashed},
+  hand/.style={-{Latex[length=1.9mm,width=1.4mm]}, semithick,
+               dash pattern=on 4pt off 2pt on 1pt off 2pt},
+  handw/.style={semithick, dash pattern=on 4pt off 2pt on 1pt off 2pt},
+  lb/.style={font=\tiny, inner sep=1.2pt, fill=white},
+  glbl/.style={font=\scriptsize\itshape, inner sep=2pt},
+  jn/.style={circle, fill, inner sep=0pt, minimum size=2.2pt}
+]
+
+% ---------------- sensors ----------------
+\node[sens] (imu) at (0,0.45)
+  {IMU\\[1pt] $\vct\omega^B,\ \vct f^B,\ \vct m^B,\ T$};
+
+% ---------------- measurement-only front end ----------------
+\node[front] (proxy) at (3.4,1.35)
+  {Mahony proxy\\ Eq.~\eqref{eq:proxy-mahony}};
+\node[front] (hi) at (3.4,-0.75)
+  {Hard-iron bias tracker\\ ridge solve, Eq.~\eqref{eq:mag-ridge}};
+\node[front] (vacc) at (6.8,1.35)
+  {Vertical-acceleration\\ estimator, Eq.~\eqref{eq:proxy-vertical}};
+\node[front] (per) at (10.2,2.35)
+  {Wave-period estimator\\ Eq.~\eqref{eq:wave-band-period}};
+\node[front] (sig) at (10.2,0.35)
+  {$\sigma$ estimator: scaled band,\\ noise floor removed,
+   Eq.~\eqref{eq:sigma-noise-subtraction}};
+\node[adapt] (ad) at (15.2,1.35)
+  {Adaptation module\\ targets Eq.~\eqref{eq:tuner-targets},
+   EMA Eq.~\eqref{eq:adapt-ewma},\\ anisotropy
+   Eq.~\eqref{eq:adapt-rs-axis-ratios}};
+
+\begin{scope}[on background layer]
+  \node[grp, fit=(proxy)(hi)(vacc)(per)(sig)(ad)] (feblk) {};
+\end{scope}
+\node[glbl, anchor=south west] at ([yshift=2pt]feblk.north west)
+  {Measurement-only front end (exogenous)};
+
+% ---------------- core QMEKF ----------------
+\node[core] (tu) at (3.4,-4.10)
+  {Time update\\ $q$ propagation, $\matg\Phi$, $\matg Q_d$};
+\node[core] (au) at (6.8,-4.10)
+  {Accelerometer update\\ rank 3, Eq.~\eqref{eq:acc-meas-jacobians}};
+\node[core] (mu) at (10.2,-4.10)
+  {Magnetometer update\\ rank 3, Eq.~\eqref{eq:mag-meas-jacobian}};
+\node[core] (pu) at (13.6,-4.10)
+  {Integral pseudo-update\\ $\vct z_S=0$, Eq.~\eqref{eq:zero-pseudo}};
+\node[core] (rst) at (17.0,-4.10)
+  {Injection and MEKF reset\\ Eqs.~\eqref{eq:joseph-update},
+   \eqref{eq:mekf-reset-covariance}};
+
+\node[stateb] (att) at (4.5,-6.20)
+  {Attitude states\\ $\delta\vct\theta,\ \delta\vct b_g$};
+\node[stateb] (lin) at (10.2,-6.20)
+  {Linear OU chain\\ $\delta\vct v,\delta\vct p,\delta\vct S,\delta\vct a_w$};
+\node[stateb] (ba) at (15.3,-6.20)
+  {Residual accel.\ bias\\ $\delta\vct b_a$, OU with $\tau_b$};
+
+\begin{scope}[on background layer]
+  \node[grp, fit=(tu)(au)(mu)(pu)(rst)(att)(lin)(ba)] (coreblk) {};
+\end{scope}
+\node[glbl, anchor=north east] at ([yshift=-2pt]coreblk.south east)
+  {Core quaternion MEKF, 21 states};
+
+\node[outb] (out) at (10.2,-7.90)
+  {Reported outputs: attitude, heave and 3-D displacement $\hat{\vct p}$,
+   velocity $\hat{\vct v}$, period $\widehat T_z$, wave direction};
+
+% ---------------- measurement-only barrier ----------------
+\draw[densely dashed, black!60] (-1.9,-1.80) -- (18.9,-1.80);
+\node[glbl, anchor=north east, text width=35mm, align=right] at (18.9,-1.92)
+  {every edge crossing this line points downward; no MEKF state,
+   covariance, or innovation returns to the front end};
+
+% ---------------- front-end signal flow ----------------
+\draw[sig] (imu.east) -- (proxy.west);
+\draw[sig] (proxy.south) --
+  node[lb,right]{$\mat A_i$ yaw-stripped} (hi.north);
+\draw[sig] (proxy.east) -- node[lb,above]{$\hat q_P$ tilt} (vacc.west);
+
+\draw[wire] (imu.south) -- (0,-0.75);
+\draw[sig] (0,-0.75) -- node[lb,above]{$\vct m^B$ raw} (hi.west);
+
+\draw[wire] (vacc.east) -- node[lb,above]{$a^P_\uparrow$} (8.60,1.35);
+\node[jn] at (8.60,1.35) {};
+\draw[sig] (8.60,1.35) |- (per.west);
+\draw[sig] (8.60,1.35) |- (sig.west);
+\draw[sig] (per.south) -- node[lb,right]{$f_{\mathrm{tune}}$, lagged}
+  (sig.north);
+
+\draw[wire] (per.east) -- (11.85,2.35);
+\draw[wire] (sig.east) -- (11.85,0.35);
+\draw[wire] (11.85,2.35) -- (11.85,0.35);
+\node[jn] at (11.85,1.35) {};
+\draw[sig] (11.85,1.35) --
+  node[lb,above]{$\widehat T_z,\ \widehat\sigma_{a,B}$} (ad.west);
+
+% ---------------- hard-iron correction of the raw magnetic stream ----------
+\node[draw, circle, inner sep=1pt, minimum size=4.6mm] (sum) at (10.2,-2.62)
+  {\tiny$-$};
+\draw[sig] (hi.east) -- node[lb,above,pos=0.60]{$\hat{\vct b}_m$, 45 s slew}
+  (10.2,-0.75) -- (sum.north);
+
+% ---------------- raw sensor bus into the core ----------------
+\draw[wire] (0,-0.75) -- (0,-2.62) -- (sum.west);
+\node[jn] at (3.80,-2.62) {};
+\node[jn] at (6.80,-2.62) {};
+\draw[sig] (3.80,-2.62) -- node[lb,right,pos=0.35]{$\vct\omega^B$}
+  (3.80,-3.50);
+\draw[sig] (6.80,-2.62) -- node[lb,right,pos=0.35]{$\vct f^B,T$}
+  (6.80,-3.50);
+\draw[sig] (sum.south) -- node[lb,right,pos=0.10]{corrected $\vct m^B$}
+  (10.2,-3.50);
+
+% ---------------- staged OU schedule ----------------
+\draw[schedw] (ad.south) -- (15.2,-2.25);
+\draw[schedw] (15.2,-2.25) -- (3.00,-2.25);
+\node[jn] at (3.00,-2.25) {};
+\node[jn] at (14.4,-2.25) {};
+\draw[sched] (3.00,-2.25) -- node[lb,left,pos=0.45]{$\tau,\sigma_{aw}$}
+  (3.00,-3.50);
+\draw[sched] (14.4,-2.25) -- node[lb,left,pos=0.45]{$\vct r_S,T_S$}
+  (14.4,-3.50);
+\node[lb, anchor=south] at (6.00,-2.23)
+  {staged schedule $\vartheta_k=(\tau,\sigma_{aw},\vct r_S,T_S)$};
+
+% ---------------- gated startup handoff ----------------
+\draw[handw] (proxy.north west) -- (-1.50,1.85);
+\draw[hand] (-1.50,1.85) -- (-1.50,-4.10) -- (tu.west);
+\node[lb, anchor=west, align=left, text width=17mm] at (-1.42,-3.20)
+  {gated handoff, Sec.~\ref{sec:proxy-handoff}};
+
+% ---------------- core recursion ----------------
+\draw[sig] (tu) -- (au);
+\draw[sig] (au) -- (mu);
+\draw[sig] (mu) -- (pu);
+\draw[sig] (pu) -- (rst);
+
+\draw[wire] (tu.south) -- (3.40,-5.30);
+\draw[wire] (au.south) -- (6.80,-5.30);
+\draw[wire] (mu.south) -- (10.2,-5.30);
+\draw[wire] (pu.south) -- (13.6,-5.30);
+\draw[wire] (rst.south) -- (17.0,-5.30);
+\draw[wire] (3.40,-5.30) -- (17.0,-5.30);
+\node[jn] at (3.40,-5.30) {};
+\node[jn] at (6.80,-5.30) {};
+\node[jn] at (10.2,-5.30) {};
+\node[jn] at (13.6,-5.30) {};
+\node[jn] at (17.0,-5.30) {};
+\node[lb, anchor=south] at (5.10,-5.28)
+  {$\hat{\vct x},\ \mat P$ shared};
+\draw[sig] (4.50,-5.30) -- (att.north);
+\draw[sig] (10.2,-5.30) -- (lin.north);
+\draw[sig] (15.3,-5.30) -- (ba.north);
+
+% ---------------- outputs ----------------
+\draw[sig] (att.south) |- (out.west);
+\draw[sig] (lin.south) -- (out.north);
+\end{tikzpicture}}
+\caption{Deployed OU--III filter structure.  Solid edges carry signals, dashed
+edges the staged OU schedule, and the dash-dotted edge the one-time startup
+handoff.
+The measurement-only front end levels the specific force with a Mahony proxy,
+derives the vertical wave channel, tracks the magnetic hard-iron offset, and
+estimates the wave period and the band-limited acceleration scale; the
+adaptation module maps those two statistics to
+$\vartheta_k=(\tau,\sigma_{aw},\vct r_S,T_S)$.  The core quaternion MEKF
+propagates and corrects the 21 states of
+Eq.~\eqref{eq:nominal-state-vector} through three rank--3 channels followed by
+the MEKF reset.  Every edge crossing the barrier points downward, so the
+schedule is exogenous with respect to the recursion it configures.}
+\label{fig:ou3-architecture}
+\end{figure*}


### PR DESCRIPTION
The OU-III manuscript described the deployed estimator only in prose spread
across the observables, adaptation, startup, hard-iron and Kalman-update
sections, leaving no single place that shows how the pieces connect.

Add a "Filter Architecture" section between the nomenclature and the state
definition, carrying a full-width TikZ block diagram of the deployed signal
flow:

  - the measurement-only front end: Mahony proxy, vertical-acceleration
    estimator, hard-iron bias tracker, wave-period estimator, sigma estimator,
    and the adaptation module that stages (tau, sigma_aw, r_S, T_S);
  - the core 21-state quaternion MEKF: time update, the three rank-3
    correction channels including the integral pseudo-update, injection and
    MEKF reset, and the attitude / linear-OU-chain / residual-bias state
    blocks;
  - the measurement-only barrier, drawn so that every edge crossing it points
    downward, which is the one-way information flow the source-reachable
    schedule argument relies on.

Every block cites the equation that defines it, so the figure doubles as an
index into the rest of the paper.  Loads tikz plus the arrows.meta, fit,
backgrounds, positioning and calc libraries in the manuscript preamble.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QCKRkze94KvHeba9tfHxZv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Filter Architecture section to the OU–III estimator documentation.
  * Included a detailed diagram showing sensor inputs, measurement processing, adaptive scheduling, estimator recursion, and reported outputs.
  * Clarified the separation between measurement-only processing and the 21-state quaternion estimator core.
  * Documented the staged schedule handoff and the direction of information flow across the architecture boundary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->