### PR TITLE
Continue P5 with authoritative componentwise y/z perturbation

### DIFF
--- a/.github/workflows/ou3-p5-v48-authoritative-componentwise-yz-fast.yml
+++ b/.github/workflows/ou3-p5-v48-authoritative-componentwise-yz-fast.yml
@@ -11,6 +11,7 @@ on:
       - "tools/ou3_p5_sample1_v41_authoritative_split_signed_v45.py"
       - "tools/ou3_implementation_proof_manifest.py"
       - "tools/ou3_proof_operating_domain.json"
+      - "tools/ou3_interval.py"
       - "src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h"
       - "src/tuner/AccelVibrationGuard.h"
       - ".github/workflows/ou3-p5-v48-authoritative-componentwise-yz-fast.yml"
@@ -91,10 +92,12 @@ jobs:
               print(f"diagnostic={diagnostic}", file=gh)
       - name: "V48 rc=${{ steps.audit.outputs.rc }} status=${{ steps.audit.outputs.status }} parentq=${{ steps.audit.outputs.parentq }} refinedq=${{ steps.audit.outputs.refinedq }}"
         run: |
-          echo "productq=${{ steps.audit.outputs.productq }} geodesicq=${{ steps.audit.outputs.geodesicq }}"
-          echo "ey=${{ steps.audit.outputs.ey }} ez=${{ steps.audit.outputs.ez }} oldyz=${{ steps.audit.outputs.oldyz }}"
           echo "strict=${{ steps.audit.outputs.strict }} closed=${{ steps.audit.outputs.closed }}"
           echo "next=${{ steps.audit.outputs.next }}"
+      - name: "V48 q product=${{ steps.audit.outputs.productq }} geodesic=${{ steps.audit.outputs.geodesicq }}"
+        run: echo "q_target=8"
+      - name: "V48 caps ey=${{ steps.audit.outputs.ey }} ez=${{ steps.audit.outputs.ez }} oldyz=${{ steps.audit.outputs.oldyz }}"
+        run: echo "componentwise_yz=true"
       - name: "V48 diagnostic=${{ steps.audit.outputs.diagnostic }}"
         run: echo "producer_rc=${{ steps.audit.outputs.rc }}"
       - name: Fail closed on producer validation

--- a/.github/workflows/ou3-p5-v48-authoritative-componentwise-yz-fast.yml
+++ b/.github/workflows/ou3-p5-v48-authoritative-componentwise-yz-fast.yml
@@ -1,0 +1,71 @@
+name: ou3-p5-v48-authoritative-componentwise-yz-fast
+
+on:
+  push:
+    paths:
+      - "tools/ou3_p5_sample1_authoritative_componentwise_yz_v48.py"
+      - "tests/validation/test_ou3_p5_sample1_authoritative_componentwise_yz_v48.py"
+      - "tools/ou3_p5_sample1_directional_innovation_row_lift_v34.py"
+      - "tools/ou3_p5_sample1_first_psd_exact_joseph_components_v40.py"
+      - "tools/ou3_p5_sample1_v40_split_signed_first_survivor_v44.py"
+      - "tools/ou3_p5_sample1_v41_authoritative_split_signed_v45.py"
+      - ".github/workflows/ou3-p5-v48-authoritative-componentwise-yz-fast.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ou3-p5-v48-authoritative-componentwise-yz-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  v48-componentwise-yz:
+    name: P5 V48 authoritative componentwise yz
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - name: Compile V48 producer and test
+        run: |
+          python3 -m py_compile \
+            tools/ou3_p5_sample1_authoritative_componentwise_yz_v48.py \
+            tests/validation/test_ou3_p5_sample1_authoritative_componentwise_yz_v48.py
+      - name: Test V48 contract
+        working-directory: tests/validation
+        run: python3 -m unittest -v test_ou3_p5_sample1_authoritative_componentwise_yz_v48
+      - name: Run V48 authoritative componentwise-yz audit
+        id: audit
+        shell: bash
+        run: |
+          python3 tools/ou3_p5_sample1_authoritative_componentwise_yz_v48.py \
+            --source-pieces 4 --source-cell-index 0 \
+            --p-pieces 24 --tangent-pieces 24 --axial-pieces 24 \
+            --residual-x-pieces 6 --parallel-pieces 6 \
+            --output /tmp/p5_sample1_v48.json
+          python3 - "$GITHUB_OUTPUT" <<'PY'
+          import json, math, sys
+          with open('/tmp/p5_sample1_v48.json', encoding='utf-8') as fh:
+              d=json.load(fh)
+          def fmt(x):
+              try: y=float(x)
+              except (TypeError, ValueError): return 'na'
+              return f'{y:.12g}' if math.isfinite(y) else str(y)
+          caps=d.get('componentwise_yz_perturbation_detail') or {}
+          with open(sys.argv[1], 'a', encoding='utf-8') as gh:
+              print(f"status={d.get('P5_SAMPLE1_AUTHORITATIVE_COMPONENTWISE_YZ_V48')}", file=gh)
+              print(f"parentq={fmt(d.get('authoritative_parent_best_q_upper'))}", file=gh)
+              print(f"refinedq={fmt(d.get('authoritative_componentwise_best_q_upper'))}", file=gh)
+              print(f"productq={fmt(d.get('authoritative_componentwise_product_q_upper'))}", file=gh)
+              print(f"geodesicq={fmt(d.get('authoritative_componentwise_geodesic_q_upper'))}", file=gh)
+              print(f"ey={fmt(caps.get('theta_y_component_abs_upper_rad'))}", file=gh)
+              print(f"ez={fmt(caps.get('theta_z_component_abs_upper_rad'))}", file=gh)
+              print(f"oldyz={fmt(caps.get('V31_parent_yz_norm_upper_rad'))}", file=gh)
+              print(f"strict={d.get('at_least_one_yz_component_strictly_refined')}", file=gh)
+              print(f"closed={d.get('first_V41_survivor_closed_by_V48_componentwise_yz')}", file=gh)
+              print(f"next={d.get('next_obligation')}", file=gh)
+      - name: "V48 status=${{ steps.audit.outputs.status }} parentq=${{ steps.audit.outputs.parentq }} refinedq=${{ steps.audit.outputs.refinedq }} productq=${{ steps.audit.outputs.productq }} geodesicq=${{ steps.audit.outputs.geodesicq }}"
+        run: |
+          echo "ey=${{ steps.audit.outputs.ey }} ez=${{ steps.audit.outputs.ez }} oldyz=${{ steps.audit.outputs.oldyz }}"
+          echo "strict=${{ steps.audit.outputs.strict }} closed=${{ steps.audit.outputs.closed }}"
+          echo "next=${{ steps.audit.outputs.next }}"

--- a/.github/workflows/ou3-p5-v48-authoritative-componentwise-yz-fast.yml
+++ b/.github/workflows/ou3-p5-v48-authoritative-componentwise-yz-fast.yml
@@ -9,6 +9,10 @@ on:
       - "tools/ou3_p5_sample1_first_psd_exact_joseph_components_v40.py"
       - "tools/ou3_p5_sample1_v40_split_signed_first_survivor_v44.py"
       - "tools/ou3_p5_sample1_v41_authoritative_split_signed_v45.py"
+      - "tools/ou3_implementation_proof_manifest.py"
+      - "tools/ou3_proof_operating_domain.json"
+      - "src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h"
+      - "src/tuner/AccelVibrationGuard.h"
       - ".github/workflows/ou3-p5-v48-authoritative-componentwise-yz-fast.yml"
   workflow_dispatch:
 
@@ -26,11 +30,16 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-      - name: Compile V48 producer and test
+      - name: Compile V48 producer, manifest, and test
         run: |
           python3 -m py_compile \
+            tools/ou3_implementation_proof_manifest.py \
             tools/ou3_p5_sample1_authoritative_componentwise_yz_v48.py \
             tests/validation/test_ou3_p5_sample1_authoritative_componentwise_yz_v48.py
+      - name: Audit deployed proof manifest including vibration guard
+        run: |
+          python3 tools/ou3_implementation_proof_manifest.py \
+            --output /tmp/ou3_implementation_proof_manifest.json
       - name: Test V48 contract
         working-directory: tests/validation
         run: python3 -m unittest -v test_ou3_p5_sample1_authoritative_componentwise_yz_v48

--- a/.github/workflows/ou3-p5-v48-authoritative-componentwise-yz-fast.yml
+++ b/.github/workflows/ou3-p5-v48-authoritative-componentwise-yz-fast.yml
@@ -38,21 +38,36 @@ jobs:
         id: audit
         shell: bash
         run: |
+          set +e
           python3 tools/ou3_p5_sample1_authoritative_componentwise_yz_v48.py \
             --source-pieces 4 --source-cell-index 0 \
             --p-pieces 24 --tangent-pieces 24 --axial-pieces 24 \
             --residual-x-pieces 6 --parallel-pieces 6 \
-            --output /tmp/p5_sample1_v48.json
-          python3 - "$GITHUB_OUTPUT" <<'PY'
-          import json, math, sys
-          with open('/tmp/p5_sample1_v48.json', encoding='utf-8') as fh:
-              d=json.load(fh)
+            --output /tmp/p5_sample1_v48.json \
+            > /tmp/p5_sample1_v48.log 2>&1
+          rc=$?
+          set -e
+          cat /tmp/p5_sample1_v48.log
+          python3 - "$GITHUB_OUTPUT" "$rc" <<'PY'
+          import json, math, pathlib, sys
+          out, rc = sys.argv[1], int(sys.argv[2])
+          path = pathlib.Path('/tmp/p5_sample1_v48.json')
+          d = json.loads(path.read_text(encoding='utf-8')) if path.exists() else {}
+          log = pathlib.Path('/tmp/p5_sample1_v48.log').read_text(encoding='utf-8', errors='replace')
           def fmt(x):
               try: y=float(x)
               except (TypeError, ValueError): return 'na'
               return f'{y:.12g}' if math.isfinite(y) else str(y)
           caps=d.get('componentwise_yz_perturbation_detail') or {}
-          with open(sys.argv[1], 'a', encoding='utf-8') as gh:
+          failures=d.get('validation_failures') or d.get('failures') or []
+          if failures:
+              diagnostic=str(failures[0])
+          else:
+              lines=[x.strip() for x in log.splitlines() if x.strip()]
+              diagnostic=lines[-1] if lines else 'none'
+          diagnostic=' '.join(diagnostic.split())[:180]
+          with open(out, 'a', encoding='utf-8') as gh:
+              print(f"rc={rc}", file=gh)
               print(f"status={d.get('P5_SAMPLE1_AUTHORITATIVE_COMPONENTWISE_YZ_V48')}", file=gh)
               print(f"parentq={fmt(d.get('authoritative_parent_best_q_upper'))}", file=gh)
               print(f"refinedq={fmt(d.get('authoritative_componentwise_best_q_upper'))}", file=gh)
@@ -64,8 +79,15 @@ jobs:
               print(f"strict={d.get('at_least_one_yz_component_strictly_refined')}", file=gh)
               print(f"closed={d.get('first_V41_survivor_closed_by_V48_componentwise_yz')}", file=gh)
               print(f"next={d.get('next_obligation')}", file=gh)
-      - name: "V48 status=${{ steps.audit.outputs.status }} parentq=${{ steps.audit.outputs.parentq }} refinedq=${{ steps.audit.outputs.refinedq }} productq=${{ steps.audit.outputs.productq }} geodesicq=${{ steps.audit.outputs.geodesicq }}"
+              print(f"diagnostic={diagnostic}", file=gh)
+      - name: "V48 rc=${{ steps.audit.outputs.rc }} status=${{ steps.audit.outputs.status }} parentq=${{ steps.audit.outputs.parentq }} refinedq=${{ steps.audit.outputs.refinedq }}"
         run: |
+          echo "productq=${{ steps.audit.outputs.productq }} geodesicq=${{ steps.audit.outputs.geodesicq }}"
           echo "ey=${{ steps.audit.outputs.ey }} ez=${{ steps.audit.outputs.ez }} oldyz=${{ steps.audit.outputs.oldyz }}"
           echo "strict=${{ steps.audit.outputs.strict }} closed=${{ steps.audit.outputs.closed }}"
           echo "next=${{ steps.audit.outputs.next }}"
+      - name: "V48 diagnostic=${{ steps.audit.outputs.diagnostic }}"
+        run: echo "producer_rc=${{ steps.audit.outputs.rc }}"
+      - name: Fail closed on producer validation
+        if: steps.audit.outputs.rc != '0'
+        run: exit 2

--- a/.github/workflows/ou3-p5-v49-authoritative-yz-deltac-decomposition-fast.yml
+++ b/.github/workflows/ou3-p5-v49-authoritative-yz-deltac-decomposition-fast.yml
@@ -1,0 +1,79 @@
+name: ou3-p5-v49-authoritative-yz-deltac-decomposition-fast
+
+on:
+  push:
+    paths:
+      - "tools/ou3_p5_sample1_authoritative_yz_deltac_decomposition_v49.py"
+      - "tests/validation/test_ou3_p5_sample1_authoritative_yz_deltac_decomposition_v49.py"
+      - "tools/ou3_p5_sample1_authoritative_componentwise_yz_v48.py"
+      - "tools/ou3_p5_sample1_exact_theta_yz_gain_rows_lift_v33.py"
+      - "tools/ou3_p5_sample1_directional_innovation_row_lift_v34.py"
+      - "tools/ou3_p5_sample1_first_psd_exact_joseph_components_v40.py"
+      - "tools/ou3_interval.py"
+      - "tools/ou3_proof_operating_domain.json"
+      - ".github/workflows/ou3-p5-v49-authoritative-yz-deltac-decomposition-fast.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ou3-p5-v49-authoritative-yz-deltac-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  v49-yz-deltac-decomposition:
+    name: P5 V49 authoritative yz Delta-C decomposition
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - name: Compile V49 producer and test
+        run: |
+          python3 -m py_compile \
+            tools/ou3_p5_sample1_authoritative_yz_deltac_decomposition_v49.py \
+            tests/validation/test_ou3_p5_sample1_authoritative_yz_deltac_decomposition_v49.py
+      - name: Test V49 contract
+        working-directory: tests/validation
+        run: python3 -m unittest -v test_ou3_p5_sample1_authoritative_yz_deltac_decomposition_v49
+      - name: Run V49 authoritative yz Delta-C decomposition
+        id: audit
+        shell: bash
+        run: |
+          set +e
+          python3 tools/ou3_p5_sample1_authoritative_yz_deltac_decomposition_v49.py \
+            --source-pieces 4 --source-cell-index 0 \
+            --p-pieces 24 --tangent-pieces 24 --axial-pieces 24 \
+            --output /tmp/p5_sample1_v49.json \
+            > /tmp/p5_sample1_v49.log 2>&1
+          rc=$?
+          set -e
+          cat /tmp/p5_sample1_v49.log
+          python3 - "$GITHUB_OUTPUT" "$rc" <<'PY'
+          import json, math, pathlib, sys
+          out, rc = sys.argv[1], int(sys.argv[2])
+          path = pathlib.Path('/tmp/p5_sample1_v49.json')
+          d = json.loads(path.read_text(encoding='utf-8')) if path.exists() else {}
+          z = d.get('theta_z_DeltaC_term_decomposition') or {}
+          def fmt(x):
+              try: y=float(x)
+              except (TypeError, ValueError): return 'na'
+              return f'{y:.12g}' if math.isfinite(y) else str(y)
+          with open(out, 'a', encoding='utf-8') as gh:
+              print(f"rc={rc}", file=gh)
+              print(f"status={d.get('P5_SAMPLE1_AUTHORITATIVE_YZ_DELTAC_DECOMPOSITION_V49')}", file=gh)
+              print(f"dominant={z.get('dominant_term')}", file=gh)
+              print(f"fraction={fmt(z.get('dominant_fraction'))}", file=gh)
+              print(f"candidate={fmt(z.get('row_DeltaC_candidate_upper'))}", file=gh)
+              print(f"parent={fmt(z.get('V12D_full_DeltaC_parent_upper'))}", file=gh)
+              print(f"ratio={fmt(z.get('candidate_over_parent_ratio'))}", file=gh)
+              print(f"gain={fmt(z.get('gain_resolvent_candidate_upper'))}", file=gh)
+              print(f"next={d.get('next_obligation')}", file=gh)
+      - name: "V49 rc=${{ steps.audit.outputs.rc }} status=${{ steps.audit.outputs.status }} dominant=${{ steps.audit.outputs.dominant }} fraction=${{ steps.audit.outputs.fraction }}"
+        run: |
+          echo "candidate=${{ steps.audit.outputs.candidate }} parent=${{ steps.audit.outputs.parent }} ratio=${{ steps.audit.outputs.ratio }}"
+          echo "gain=${{ steps.audit.outputs.gain }}"
+          echo "next=${{ steps.audit.outputs.next }}"
+      - name: Fail closed on producer validation
+        if: steps.audit.outputs.rc != '0'
+        run: exit 2

--- a/tests/validation/test_ou3_p3_word_algebra.py
+++ b/tests/validation/test_ou3_p3_word_algebra.py
@@ -18,8 +18,20 @@ class Ou3P3WordAlgebraTests(unittest.TestCase):
         self.assertFalse(d["dimension_change_inside_word"])
         self.assertEqual(
             set(d["operation_classes"]),
-            {"prediction", "accepted_joseph", "rejected_or_not_due", "left_error_reset", "aw_covariance_sync"},
+            {
+                "vibration_guard_dormant",
+                "prediction",
+                "accepted_joseph",
+                "rejected_or_not_due",
+                "left_error_reset",
+                "aw_covariance_sync",
+            },
         )
+        guard = d["operation_classes"]["vibration_guard_dormant"]
+        self.assertEqual(guard["A"], "I")
+        self.assertEqual(guard["B"], "0")
+        self.assertFalse(guard["active_or_transitioning_guard_covered"])
+        self.assertTrue(guard["active_or_transitioning_guard_requires_separate_source_certificate"])
         self.assertTrue(d["covariance_decomposition_invariant"]["Omega_s_psd"])
         self.assertTrue(d["strict_margin_preservation"]["covers_every_operation_class"])
         self.assertFalse(d["strict_margin_preservation"]["one_step_contraction_assumed"])

--- a/tests/validation/test_ou3_p5_sample1_authoritative_componentwise_yz_v48.py
+++ b/tests/validation/test_ou3_p5_sample1_authoritative_componentwise_yz_v48.py
@@ -1,0 +1,84 @@
+import math
+import pathlib
+import sys
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+TOOLS = ROOT / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+from ou3_interval import Interval
+import ou3_p5_sample1_authoritative_componentwise_yz_v48 as V48
+
+
+class Sample1AuthoritativeComponentwiseYzV48Tests(unittest.TestCase):
+    def test_authoritative_witness_and_targets_are_frozen(self):
+        self.assertEqual(V48.WITNESS, (0, 0, 23))
+        self.assertEqual(V48.SCHEMA, 4800)
+        self.assertEqual(V48.Q_TARGET, 8.0)
+        self.assertAlmostEqual(V48.V45.V41_Q_POST, 8.344528951460543, places=12)
+
+    def test_componentwise_caps_do_not_duplicate_yz_radius(self):
+        base = {"sample1_full_residual_norm_upper_mps2": 3.0}
+        vr = {"total_residual_perturbation_upper_mps2": 0.2}
+        ds = {
+            "nominal_theta_y_gain_row_norm_upper": 2.0,
+            "nominal_theta_z_gain_row_norm_upper": 1.0,
+            "theta_y_gain_perturbation_intersected_upper": 0.5,
+            "theta_z_gain_perturbation_intersected_upper": 0.25,
+        }
+        parent = {
+            "x_correction_perturbation_abs_upper_rad": 0.1,
+            "yz_correction_perturbation_norm_upper_rad": 10.0,
+            "total_correction_perturbation_norm_upper_rad": 10.0,
+        }
+        d = V48._componentwise_yz_caps(
+            base=base, vr=vr, ds_detail=ds, parent_caps=parent)
+        self.assertAlmostEqual(d["theta_y_component_abs_upper_rad"], 2.0, places=12)
+        self.assertAlmostEqual(d["theta_z_component_abs_upper_rad"], 1.0, places=12)
+        self.assertLess(d["theta_z_component_abs_upper_rad"],
+                        d["theta_y_component_abs_upper_rad"])
+        self.assertGreaterEqual(
+            d["componentwise_yz_norm_upper_rad"],
+            max(d["theta_y_component_abs_upper_rad"],
+                d["theta_z_component_abs_upper_rad"]))
+        self.assertLessEqual(d["componentwise_yz_norm_upper_rad"], 10.0)
+        self.assertLessEqual(d["componentwise_total_norm_upper_rad"], 10.0)
+
+    def test_componentwise_caps_intersect_existing_v31_parents(self):
+        base = {"sample1_full_residual_norm_upper_mps2": 3.0}
+        vr = {"total_residual_perturbation_upper_mps2": 0.2}
+        ds = {
+            "nominal_theta_y_gain_row_norm_upper": 2.0,
+            "nominal_theta_z_gain_row_norm_upper": 1.0,
+            "theta_y_gain_perturbation_intersected_upper": 0.5,
+            "theta_z_gain_perturbation_intersected_upper": 0.25,
+        }
+        parent = {
+            "x_correction_perturbation_abs_upper_rad": 0.1,
+            "yz_correction_perturbation_norm_upper_rad": 0.3,
+            "total_correction_perturbation_norm_upper_rad": 0.4,
+        }
+        d = V48._componentwise_yz_caps(
+            base=base, vr=vr, ds_detail=ds, parent_caps=parent)
+        self.assertLessEqual(d["theta_y_component_abs_upper_rad"], 0.3)
+        self.assertLessEqual(d["theta_z_component_abs_upper_rad"], 0.3)
+        self.assertLessEqual(d["componentwise_yz_norm_upper_rad"], 0.3)
+        self.assertLessEqual(d["componentwise_total_norm_upper_rad"], 0.4)
+
+    def test_box_subset_is_componentwise(self):
+        parent = [Interval(-2.0, 2.0), Interval(-3.0, 3.0), Interval(-4.0, 4.0)]
+        child = [Interval(-1.0, 1.0), Interval(-2.0, 2.0), Interval(-3.0, 3.0)]
+        escaped = [Interval(-1.0, 1.0), Interval(-3.1, 2.0), Interval(-3.0, 3.0)]
+        self.assertTrue(V48._box_subset(child, parent))
+        self.assertFalse(V48._box_subset(escaped, parent))
+
+    def test_norm_helpers_are_conservative(self):
+        self.assertGreaterEqual(V48._norm2_up(3.0, 4.0), 5.0)
+        self.assertGreaterEqual(V48._norm3_up(1.0, 2.0, 2.0), 3.0)
+        self.assertTrue(math.isfinite(V48._norm3_up(1.0, 2.0, 2.0)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/validation/test_ou3_p5_sample1_authoritative_yz_deltac_decomposition_v49.py
+++ b/tests/validation/test_ou3_p5_sample1_authoritative_yz_deltac_decomposition_v49.py
@@ -1,0 +1,37 @@
+import math
+import pathlib
+import sys
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+TOOLS = ROOT / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import ou3_p5_sample1_authoritative_yz_deltac_decomposition_v49 as V49
+
+
+class Sample1AuthoritativeYzDeltaCDecompositionV49Tests(unittest.TestCase):
+    def test_authoritative_witness_and_schema_are_frozen(self):
+        self.assertEqual(V49.WITNESS, (0, 0, 23))
+        self.assertEqual(V49.SCHEMA, 4900)
+
+    def test_deltac_terms_are_outward_and_sum_to_candidate(self):
+        d = V49._deltac_terms(dP=2.0, dH=3.0, htheta=4.0, row_norm=5.0)
+        self.assertGreaterEqual(d["projected_DeltaP_Htheta_upper"], 8.0)
+        self.assertGreaterEqual(d["nominal_Ptheta_row_DeltaH_upper"], 15.0)
+        self.assertGreaterEqual(d["mixed_DeltaP_DeltaH_upper"], 6.0)
+        self.assertGreaterEqual(d["theta_aw_cross_block_parent_upper"], 2.0)
+        self.assertGreaterEqual(d["row_DeltaC_candidate_upper"], 31.0)
+        self.assertIn(d["dominant_term"], d)
+        self.assertTrue(math.isfinite(d["dominant_fraction"]))
+        self.assertGreaterEqual(d["dominant_fraction"], 0.0)
+        self.assertLessEqual(d["dominant_fraction"], 1.0)
+
+    def test_invalid_terms_fail_closed(self):
+        with self.assertRaises(ValueError):
+            V49._deltac_terms(dP=-1.0, dH=1.0, htheta=1.0, row_norm=1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ou3_implementation_proof_manifest.py
+++ b/tools/ou3_implementation_proof_manifest.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Source-derived manifest for the OU-III implementation stability proof.
 
-This is deliberately not a simulator manifest.  It binds the proof to the
+This is deliberately not a simulator manifest. It binds the proof to the
 shipping `SeaStateFusion_OU_III` wrapper and `Kalman3D_Wave_OU_III` operations
-that define startup, normal Live words, and hard hybrid events.  A source change
+that define startup, normal Live words, and hard hybrid events. A source change
 that removes or changes one of the required semantics invalidates the manifest
 instead of silently leaving the theorem attached to an older algorithm.
 """
@@ -27,10 +27,12 @@ SCHEMA = 3
 
 
 def sha256(path: Path) -> str:
+    """Return the SHA-256 digest of a source file bound into the manifest."""
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
 def one_float(text: str, pattern: str, label: str) -> float:
+    """Extract exactly one implementation scalar using a source-audit regex."""
     m = re.search(pattern, text, flags=re.MULTILINE | re.DOTALL)
     if not m:
         raise RuntimeError(f"cannot extract implementation value {label}")
@@ -38,11 +40,13 @@ def one_float(text: str, pattern: str, label: str) -> float:
 
 
 def require(text: str, marker: str, label: str) -> None:
+    """Fail closed unless a required shipping-source semantic marker exists."""
     if marker not in text:
         raise RuntimeError(f"missing implementation semantic marker {label}: {marker}")
 
 
 def build() -> dict:
+    """Build the source-bound implementation manifest for the proof chain."""
     w = WRAPPER.read_text(encoding="utf-8")
     k = MEKF.read_text(encoding="utf-8")
     c = CORE.read_text(encoding="utf-8")
@@ -96,6 +100,7 @@ def build() -> dict:
         "h_to_a_release": "mekf_->set_acc_bias_updates_enabled(true);",
         "mag_refinement_rewrites_heading": "impl_.mekf().set_quaternion_boat(q_new);",
         "mag_refinement_releases_bias_hold": "impl_.setAccBiasHold(false);",
+        "guard_armed_by_constructor": "setAccelVibrationGuard(ACC_VIBRATION_GUARD_HZ_DEFAULT,\n                               ACC_VIBRATION_GUARD_POLES_DEFAULT);",
         "guard_single_conditioned_feed": "const Eigen::Vector3f acc_in = accel_guard_.step(acc, dt);",
         "guard_conditioned_feed_reaches_proxy": "vertical_accel_comp_.update(dt, gyro, acc_in, g_std);",
         "guard_zero_weight_is_bit_exact_transparent": "if (weight_ <= 0.0f) return acc;",
@@ -184,6 +189,7 @@ def build() -> dict:
         ],
         "vibration_guard": {
             "armed_by_default": guard_hz > 0.0,
+            "constructor_arm_call_source_bound": True,
             "zero_engagement_is_bit_exact_transparent": True,
             "active_guard_changes_measurement_dynamics": True,
             "active_guard_requires_separate_source_certificate": True,
@@ -194,6 +200,7 @@ def build() -> dict:
 
 
 def validate(d: dict) -> list[str]:
+    """Validate source-binding and conservative vibration-guard proof scope."""
     failures: list[str] = []
     if d.get("schema") != SCHEMA:
         failures.append("schema mismatch")
@@ -230,6 +237,8 @@ def validate(d: dict) -> list[str]:
     vg = d.get("vibration_guard", {})
     if vg.get("armed_by_default") is not True:
         failures.append("vibration guard is not source-bound as armed by default")
+    if vg.get("constructor_arm_call_source_bound") is not True:
+        failures.append("vibration guard constructor arm call is not source bound")
     if vg.get("zero_engagement_is_bit_exact_transparent") is not True:
         failures.append("vibration guard zero-engagement transparency is not source certified")
     if vg.get("active_guard_requires_separate_source_certificate") is not True:
@@ -238,6 +247,7 @@ def validate(d: dict) -> list[str]:
 
 
 def main() -> int:
+    """Write the validated implementation manifest as a machine-readable artifact."""
     ap = argparse.ArgumentParser()
     ap.add_argument("--output", type=Path, required=True)
     args = ap.parse_args()

--- a/tools/ou3_implementation_proof_manifest.py
+++ b/tools/ou3_implementation_proof_manifest.py
@@ -22,7 +22,8 @@ REPO = Path(__file__).resolve().parents[1]
 WRAPPER = REPO / "src" / "kalman_ou_iii" / "SeaStateFusionFilter_OU_III.h"
 MEKF = REPO / "src" / "kalman_ou_iii" / "Kalman3D_Wave_OU_III.h"
 CORE = REPO / "src" / "kalman_ou_common" / "KalmanOUCoreMath.h"
-SCHEMA = 2
+GUARD = REPO / "src" / "tuner" / "AccelVibrationGuard.h"
+SCHEMA = 3
 
 
 def sha256(path: Path) -> str:
@@ -45,10 +46,17 @@ def build() -> dict:
     w = WRAPPER.read_text(encoding="utf-8")
     k = MEKF.read_text(encoding="utf-8")
     c = CORE.read_text(encoding="utf-8")
+    g = GUARD.read_text(encoding="utf-8")
 
     two_kp = SOURCE.parse_const(w, "STARTUP_PROXY_TWO_KP_DEFAULT")
     two_ki = SOURCE.parse_const(w, "STARTUP_PROXY_TWO_KI_DEFAULT")
     dt = SOURCE.parse_const(w, "FREQ_SMOOTHER_DT")
+    guard_hz = SOURCE.parse_const(w, "ACC_VIBRATION_GUARD_HZ_DEFAULT")
+    guard_poles = int(one_float(
+        w,
+        r"ACC_VIBRATION_GUARD_POLES_DEFAULT\s*=\s*([0-9]+)",
+        "ACC_VIBRATION_GUARD_POLES_DEFAULT"))
+    guard_engage_lo = SOURCE.parse_const(g, "kEngageLoDefault")
 
     cfg = {
         "proxy_startup_min_sec": one_float(w, r"proxy_startup_min_sec\s*=\s*([0-9.eE+-]+)f", "proxy_startup_min_sec"),
@@ -88,20 +96,24 @@ def build() -> dict:
         "h_to_a_release": "mekf_->set_acc_bias_updates_enabled(true);",
         "mag_refinement_rewrites_heading": "impl_.mekf().set_quaternion_boat(q_new);",
         "mag_refinement_releases_bias_hold": "impl_.setAccBiasHold(false);",
-        "live_tilt_relock_preserves_yaw": "mekf_->initialize_from_acc_preserve_yaw(acc);",
+        "guard_single_conditioned_feed": "const Eigen::Vector3f acc_in = accel_guard_.step(acc, dt);",
+        "guard_conditioned_feed_reaches_proxy": "vertical_accel_comp_.update(dt, gyro, acc_in, g_std);",
+        "guard_zero_weight_is_bit_exact_transparent": "if (weight_ <= 0.0f) return acc;",
+        "live_tilt_relock_preserves_yaw": "mekf_->initialize_from_acc_preserve_yaw(acc_in);",
         "periodic_aw_sync": "periodic_aw_cov_sync_tick_();",
         "full_s_update": "void applyIntegralZeroPseudoMeas();",
         "joseph_update": "joseph_update3_",
         "quaternion_injection": "applyQuaternionCorrectionFromErrorState();",
         "left_error_reset": "apply_error_state_reset_jacobian_",
-        "prediction_before_acc": "mekf_->time_update(gyro, dt);\n            mekf_->measurement_update_acc_only(acc, tempC);",
+        "prediction_before_acc": "mekf_->time_update(gyro, dt);\n            mekf_->measurement_update_acc_only(acc_in, tempC);",
         "S_due_inside_time_update": "applyIntegralZeroPseudoMeas();",
         "acc_injects_immediately": "last_acc_diag_.accepted = true;",
         "mag_injects_immediately": "last_mag_diag_.accepted = true;",
         "aw_psd_floor": "Pext.template block<3,3>(OFF_AW, OFF_AW) += Delta;",
     }
+    joined = w + "\n" + k + "\n" + c + "\n" + g
     for label, marker in semantic_markers.items():
-        require(w + "\n" + k + "\n" + c, marker, label)
+        require(joined, marker, label)
 
     if "static constexpr int NX = BASE_N + EXT_ADD;" not in k:
         raise RuntimeError("cannot bind MEKF state dimension expression")
@@ -116,9 +128,13 @@ def build() -> dict:
             str(WRAPPER.relative_to(REPO)): sha256(WRAPPER),
             str(MEKF.relative_to(REPO)): sha256(MEKF),
             str(CORE.relative_to(REPO)): sha256(CORE),
+            str(GUARD.relative_to(REPO)): sha256(GUARD),
         },
         "configured_runtime": {
             "imu_dt_s": dt,
+            "accel_vibration_guard_cutoff_hz_default": guard_hz,
+            "accel_vibration_guard_poles_default": guard_poles,
+            "accel_vibration_guard_engage_lo_mps2": guard_engage_lo,
             "scope": "configured nominal runtime; arbitrary caller dt is outside the quantitative theorem",
         },
         "state_coordinates": {
@@ -140,6 +156,7 @@ def build() -> dict:
         "mekf_defaults": mekf_defaults,
         "normal_live_update_order": [
             "commit_previous_tune",
+            "vibration_guard_conditioning",
             "prediction",
             "apply_pending_aw_covariance_psd_increment",
             "periodic_S_zero_when_due_then_immediate_quaternion_injection_and_left_error_reset",
@@ -163,7 +180,14 @@ def build() -> dict:
             "tilt_relock",
             "cooldown_reentry",
             "periodic_aw_covariance_sync",
+            "accelerometer_vibration_guard_engagement",
         ],
+        "vibration_guard": {
+            "armed_by_default": guard_hz > 0.0,
+            "zero_engagement_is_bit_exact_transparent": True,
+            "active_guard_changes_measurement_dynamics": True,
+            "active_guard_requires_separate_source_certificate": True,
+        },
         "semantic_markers": sorted(semantic_markers),
         "pass": True,
     }
@@ -194,13 +218,22 @@ def validate(d: dict) -> list[str]:
         failures.append("manifest incorrectly merges same-sample correction resets")
     order = d.get("normal_live_update_order", [])
     try:
+        ig = order.index("vibration_guard_conditioning")
+        ip = order.index("prediction")
         iS = order.index("periodic_S_zero_when_due_then_immediate_quaternion_injection_and_left_error_reset")
         ia = order.index("accelerometer_correction_or_rejection_then_immediate_quaternion_injection_and_left_error_reset_if_accepted")
     except ValueError:
-        failures.append("manifest lacks exact S/accelerometer correction ordering")
+        failures.append("manifest lacks exact guard/S/accelerometer ordering")
     else:
-        if not iS < ia:
-            failures.append("manifest places periodic S correction after accelerometer, contrary to time_update source")
+        if not ig < ip < iS < ia:
+            failures.append("manifest source ordering does not match deployed guard/prediction/S/accelerometer path")
+    vg = d.get("vibration_guard", {})
+    if vg.get("armed_by_default") is not True:
+        failures.append("vibration guard is not source-bound as armed by default")
+    if vg.get("zero_engagement_is_bit_exact_transparent") is not True:
+        failures.append("vibration guard zero-engagement transparency is not source certified")
+    if vg.get("active_guard_requires_separate_source_certificate") is not True:
+        failures.append("active vibration-guard source branch was silently treated as already certified")
     return failures
 
 
@@ -219,6 +252,7 @@ def main() -> int:
         "startup": out["startup"],
         "normal_live_update_order": out["normal_live_update_order"],
         "hybrid_events": out["hybrid_events"],
+        "vibration_guard": out["vibration_guard"],
         "validation_failures": failures,
     }, indent=2, sort_keys=True))
     return 0 if not failures else 2

--- a/tools/ou3_p3_word_algebra.py
+++ b/tools/ou3_p3_word_algebra.py
@@ -44,11 +44,13 @@ SCHEMA = 2
 
 # This order is copied from the source-derived implementation manifest.  It is
 # intentionally more detailed than the covariance operation classes below: the
-# S pseudo update happens inside time_update() before the accelerometer update,
-# and every accepted correction performs its quaternion injection/reset
-# immediately rather than through one shared end-of-sample reset.
+# vibration guard runs before prediction, the S pseudo update happens inside
+# time_update() before the accelerometer update, and every accepted correction
+# performs its quaternion injection/reset immediately rather than through one
+# shared end-of-sample reset.
 EXPECTED_ORDER = [
     "commit_previous_tune",
+    "vibration_guard_conditioning",
     "prediction",
     "apply_pending_aw_covariance_psd_increment",
     "periodic_S_zero_when_due_then_immediate_quaternion_injection_and_left_error_reset",
@@ -95,6 +97,11 @@ def build() -> dict:
     reset_policy = manifest.get("same_sample_reset_policy", {})
     if reset_policy.get("single_shared_end_of_sample_reset") is not False:
         failures.append("source manifest merged immediate correction resets")
+    vibration_guard = manifest.get("vibration_guard", {})
+    if vibration_guard.get("zero_engagement_is_bit_exact_transparent") is not True:
+        failures.append("P3 requires source-certified zero-engagement vibration-guard transparency")
+    if vibration_guard.get("active_guard_requires_separate_source_certificate") is not True:
+        failures.append("P3 must not absorb active vibration-guard dynamics into the dormant branch")
 
     # Bind the abstract affine-PSD operations to the exact shipping source.
     _require(k, "P_LL_new = F_LL * P_LL_old * F_LLᵀ + Q_LL", "linear prediction", failures)
@@ -107,6 +114,17 @@ def build() -> dict:
     _require(k, "evals(i) = std::max(T(0), evals(i));", "a_w increment PSD projection", failures)
 
     operations = {
+        "vibration_guard_dormant": {
+            "affine_map": "P+=P",
+            "A": "I",
+            "B": "0",
+            "B_psd": True,
+            "measurement_map": "acc_in=acc",
+            "scope": "zero-engagement bit-exact-transparent branch only",
+            "active_or_transitioning_guard_covered": False,
+            "active_or_transitioning_guard_requires_separate_source_certificate": True,
+            "source_bound": "implementation manifest vibration_guard zero-engagement contract",
+        },
         "prediction": {
             "affine_map": "P+=F P F^T+Q",
             "A": "F",
@@ -168,6 +186,8 @@ def build() -> dict:
         "fixed_dimensions": {"H": 18, "A": 21},
         "dimension_change_inside_word": False,
         "normal_live_update_order": EXPECTED_ORDER,
+        "vibration_guard_scope": "dormant_zero_engagement_bit_exact_transparent_only",
+        "active_vibration_guard_covered": False,
         "same_sample_reset_policy": "immediate_after_each_accepted_S_acc_mag_correction",
         "operation_classes": operations,
         "covariance_decomposition_invariant": {
@@ -211,16 +231,27 @@ def validate(d: dict) -> list[str]:
         failures.append("dimension change was admitted inside a P3 word")
     if d.get("normal_live_update_order") != EXPECTED_ORDER:
         failures.append("normal-Live order mismatch")
+    if d.get("vibration_guard_scope") != "dormant_zero_engagement_bit_exact_transparent_only":
+        failures.append("P3 vibration-guard scope is not the certified dormant branch")
+    if d.get("active_vibration_guard_covered") is not False:
+        failures.append("P3 incorrectly claims active vibration-guard coverage")
     if d.get("same_sample_reset_policy") != "immediate_after_each_accepted_S_acc_mag_correction":
         failures.append("same-sample reset order is not source-faithful")
 
     ops = d.get("operation_classes", {})
-    required = {"prediction", "accepted_joseph", "rejected_or_not_due", "left_error_reset", "aw_covariance_sync"}
+    required = {"vibration_guard_dormant", "prediction", "accepted_joseph", "rejected_or_not_due", "left_error_reset", "aw_covariance_sync"}
     if set(ops) != required:
         failures.append("P3 operation class coverage is incomplete")
     for name in required:
         if ops.get(name, {}).get("B_psd") is not True:
             failures.append(f"{name} additive covariance is not PSD")
+    guard_op = ops.get("vibration_guard_dormant", {})
+    if guard_op.get("A") != "I" or guard_op.get("B") != "0":
+        failures.append("dormant vibration guard is not represented as exact identity")
+    if guard_op.get("active_or_transitioning_guard_covered") is not False:
+        failures.append("active vibration guard was admitted into dormant identity class")
+    if guard_op.get("active_or_transitioning_guard_requires_separate_source_certificate") is not True:
+        failures.append("active vibration guard is not fail-closed as a separate source obligation")
 
     reset = d.get("reset", {})
     if reset.get("determinant_formula") != "1+||dtheta||^2/4":

--- a/tools/ou3_p4_exact_word_map.py
+++ b/tools/ou3_p4_exact_word_map.py
@@ -20,6 +20,12 @@ all attitude/non-attitude cross gains.  Rejected/not-due branches are identity
 corrections.  In A mode the source's accelerometer-bias ball projection follows
 every state injection and is retained as an exact convex projection operation.
 
+The deployed vibration guard precedes prediction.  This P4 semantic map covers
+only the source-certified zero-engagement branch, where the guard returns the
+accelerometer input bit-for-bit and is therefore the exact identity on the
+measurement/error state.  Active or transitioning guard dynamics are a separate
+source/hybrid obligation and are deliberately not absorbed into this word map.
+
 The numerical P4 enclosure backend consumes this semantic map together with
 validated covariance/gain/source-node boxes.  Keeping semantics in a separate
 source-bound producer prevents a later interval optimization from changing the
@@ -40,6 +46,7 @@ SCHEMA = 1
 
 EXPECTED_ORDER = [
     "commit_previous_tune",
+    "vibration_guard_conditioning",
     "prediction",
     "apply_pending_aw_covariance_psd_increment",
     "periodic_S_zero_when_due_then_immediate_quaternion_injection_and_left_error_reset",
@@ -63,6 +70,16 @@ def _mode(mode: str, dimension: int, coordinates: list[str]) -> dict:
                 "kind": "source_state_commit",
                 "state_map": "identity_on_error_state",
                 "covariance_map": "parameter_commit_only",
+            },
+            {
+                "name": "vibration_guard_conditioning",
+                "kind": "source_measurement_conditioning",
+                "certified_branch": "dormant_zero_engagement_bit_exact_transparent_only",
+                "measurement_map": "acc_in=acc",
+                "state_map": "identity",
+                "covariance_map": "identity",
+                "active_or_transitioning_guard_covered": False,
+                "active_or_transitioning_guard_requires_separate_source_certificate": True,
             },
             {
                 "name": "prediction",
@@ -143,6 +160,11 @@ def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
     reset = manifest.get("same_sample_reset_policy", {})
     if reset.get("single_shared_end_of_sample_reset") is not False:
         failures.append("same-sample reset policy is not source-faithful")
+    vibration_guard = manifest.get("vibration_guard", {})
+    if vibration_guard.get("zero_engagement_is_bit_exact_transparent") is not True:
+        failures.append("P4 requires source-certified zero-engagement vibration-guard transparency")
+    if vibration_guard.get("active_guard_requires_separate_source_certificate") is not True:
+        failures.append("P4 must keep active vibration-guard dynamics outside the dormant word map")
     dims = manifest["state_coordinates"]
     return {
         "schema": SCHEMA,
@@ -150,6 +172,8 @@ def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
         "source_generated_not_trajectory_fit": True,
         "joint_source_reachability_required": True,
         "shipping_operation_order": order,
+        "vibration_guard_scope": "dormant_zero_engagement_bit_exact_transparent_only",
+        "active_vibration_guard_covered": False,
         "H": _mode("H", dims["H_dimension"], dims["H"]),
         "A": _mode("A", dims["A_dimension"], dims["A"]),
         "source_word_horizon_s": words["word_contract"]["conditional_word_language"]["word_horizon_lower_s"],
@@ -174,8 +198,20 @@ def validate(d: dict) -> list[str]:
         failures.append("word map permits Cartesian edge mixing")
     if d.get("shipping_operation_order") != EXPECTED_ORDER:
         failures.append("shipping operation order mismatch")
+    if d.get("vibration_guard_scope") != "dormant_zero_engagement_bit_exact_transparent_only":
+        failures.append("P4 vibration-guard scope is not the certified dormant branch")
+    if d.get("active_vibration_guard_covered") is not False:
+        failures.append("P4 incorrectly claims active vibration-guard coverage")
     for mode in ("H", "A"):
         m = d.get(mode, {})
+        operators = {op.get("name"): op for op in m.get("operators", [])}
+        guard = operators.get("vibration_guard_conditioning", {})
+        if guard.get("measurement_map") != "acc_in=acc" or guard.get("state_map") != "identity":
+            failures.append(f"{mode}: dormant vibration guard is not exact identity")
+        if guard.get("active_or_transitioning_guard_covered") is not False:
+            failures.append(f"{mode}: active vibration guard admitted into dormant P4 map")
+        if guard.get("active_or_transitioning_guard_requires_separate_source_certificate") is not True:
+            failures.append(f"{mode}: active vibration guard is not fail-closed")
         cp = m.get("correction_policy", {})
         if cp.get("deployed_normalized_quaternion_map") is not True:
             failures.append(f"{mode}: deployed quaternion injection missing")

--- a/tools/ou3_p5_complete_word_transport.py
+++ b/tools/ou3_p5_complete_word_transport.py
@@ -19,6 +19,12 @@ Prediction retains the complete tangent H map and its exact finite-angle group
 defect.  Tuner staging changes future source parameters but is not silently
 turned into a state contraction.
 
+The deployed vibration guard also precedes prediction.  On the only branch
+covered by the present certificate, zero engagement is source-certified to be
+bit-exact transparent, so its transport is the identity.  Active or
+transitioning guard behavior is intentionally left outside this calculus as a
+separate source/hybrid obligation.
+
 The first-due S correction is also composed exactly.  Its coarse source-staged
 bound does not stay in the convenient |c|<1 diagnostic set, but the Cayley chart
 has no singularity there.  ``ou3_p5_first_s_exact_prefix`` therefore widens to a
@@ -66,6 +72,16 @@ def _operation_calculus() -> list[dict]:
             "state_map": "identity_on_error_state",
             "covariance_map": "source_parameter_commit_only",
             "nonlinear_budget": "none_at_commit; parameters remain jointly source correlated",
+        },
+        {
+            "operation": "vibration_guard_conditioning",
+            "state_map": "identity_on_error_state",
+            "measurement_map": "acc_in=acc",
+            "covariance_map": "identity",
+            "certified_branch": "dormant_zero_engagement_bit_exact_transparent_only",
+            "active_or_transitioning_guard_covered": False,
+            "active_or_transitioning_guard_requires_separate_source_certificate": True,
+            "nonlinear_budget": "none on certified dormant branch",
         },
         {
             "operation": "prediction",
@@ -141,6 +157,13 @@ def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
     source_ops = list(word["shipping_operation_order"])
     if calc_ops != source_ops:
         failures.append("exact transport calculus does not match shipping source operation order")
+    guard = next((row for row in calculus if row["operation"] == "vibration_guard_conditioning"), None)
+    if guard is None or guard.get("state_map") != "identity_on_error_state" or guard.get("measurement_map") != "acc_in=acc":
+        failures.append("dormant vibration guard is not exact identity in P5 transport calculus")
+    if guard is not None and guard.get("active_or_transitioning_guard_covered") is not False:
+        failures.append("P5 transport calculus incorrectly covers active vibration guard")
+    if guard is not None and guard.get("active_or_transitioning_guard_requires_separate_source_certificate") is not True:
+        failures.append("P5 transport calculus does not fail closed on active vibration guard")
 
     horizon = float(word["source_word_horizon_s"])
     bg_bound = float(p1["go_live"]["physical_coordinate_bounds"]["gyro_bias_error_norm_upper_rad_s"])
@@ -159,6 +182,8 @@ def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
         "source_generated_not_trajectory_fit": True,
         "source_replay_used": False,
         "filter_changed": False,
+        "vibration_guard_scope": "dormant_zero_engagement_bit_exact_transparent_only",
+        "active_vibration_guard_covered": False,
         "source_word_horizon_s": horizon,
         "source_operation_order": source_ops,
         "operation_transport_calculus": calculus,
@@ -230,6 +255,10 @@ def validate(d: dict) -> list[str]:
         failures.append("complete-word transport uses replay")
     if d.get("filter_changed") is not False:
         failures.append("complete-word transport changes filter")
+    if d.get("vibration_guard_scope") != "dormant_zero_engagement_bit_exact_transparent_only":
+        failures.append("complete-word transport vibration-guard scope changed")
+    if d.get("active_vibration_guard_covered") is not False:
+        failures.append("complete-word transport incorrectly covers active vibration guard")
     if d.get("all_source_operation_classes_bound_to_transport_calculus") is not True:
         failures.append("complete-word transport calculus misses a source operation")
     if d.get("reset_condition_number_multiplier_used") is not False:

--- a/tools/ou3_p5_sample1_authoritative_componentwise_yz_v48.py
+++ b/tools/ou3_p5_sample1_authoritative_componentwise_yz_v48.py
@@ -1,0 +1,464 @@
+#!/usr/bin/env python3
+"""V48: componentwise y/z correction perturbation on the V40/V45 parent.
+
+V41's complete source-cell-0 q<8 cover leaves the authoritative first survivor
+(p,t,a)=(0,0,23) at q=8.34452895146.  V42 and the later focused current-only
+subdivisions show that splitting the final current box again is not the useful
+next direction.  V33 also showed that a standalone theta-y/z Delta-C row bound
+can exceed the already certified V12D operator parent and therefore must fail
+closed.
+
+This stage keeps both lessons.  It executes V45's authoritative V41/V18B chart
+capture with V40's exact Joseph-component parent, retains V12D's full Delta-C
+parent for theta-y/z, and reuses V34's safe directional first-row Delta-S
+refinement for the exact sparse nominal rows
+
+    K_theta,y = [g_y, 0, 0],   K_theta,z = [g_z, 0, 0].
+
+Instead of duplicating one Euclidean yz perturbation radius onto both y and z,
+V48 carries separate component bounds
+
+    e_y <= |g_y| drho + ||Delta K_y|| (rho + drho),
+    e_z <= |g_z| drho + ||Delta K_z|| (rho + drho),
+
+intersects each with the existing V31 yz-norm parent, and only then reconstructs
+an aggregate yz/total radius for radial and axis-cone checks.  The resulting
+component box is intersected with V44's source-derived nominal correction and
+with V45's authoritative first parent before the unchanged V15/V16/V18 q<8
+composition is evaluated.
+
+This is a focused proof refinement, not a theorem promotion.  It changes no
+filter setting, source domain, six-radian correction limit, q<8 target, source
+language, whole-word criterion, or N_H state.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+from ou3_interval import Interval
+import ou3_p5_sample1_directional_innovation_row_lift_v34 as V34
+import ou3_p5_sample1_first_psd_exact_joseph_components_v40 as V40
+import ou3_p5_sample1_v40_split_signed_first_survivor_v44 as V44
+import ou3_p5_sample1_v41_authoritative_split_signed_v45 as V45
+
+DEFAULT_DOMAIN = V45.DEFAULT_DOMAIN
+SCHEMA = 4800
+Q_TARGET = 8.0
+WITNESS = V45.WITNESS
+FULL = V44.FULL
+V12D = V40.V12D
+
+
+def _I(pair):
+    """Return an outward-rounded interval from a serialized endpoint pair."""
+    return Interval.outward_bounds(*map(float, pair))
+
+
+def _sum_up(*xs: float) -> float:
+    """Sum nonnegative scalars with the proof backend's upward rounding."""
+    y = 0.0
+    for x in xs:
+        y = FULL.up(y + float(x))
+    return y
+
+
+def _norm2_up(a: float, b: float) -> float:
+    """Return an upward-rounded Euclidean norm of two nonnegative scalars."""
+    aa = FULL.up(float(a) * float(a))
+    bb = FULL.up(float(b) * float(b))
+    return FULL.up(math.sqrt(FULL.up(aa + bb)))
+
+
+def _norm3_up(a: float, b: float, c: float) -> float:
+    """Return an upward-rounded Euclidean norm of three nonnegative scalars."""
+    ab = _norm2_up(a, b)
+    return _norm2_up(ab, c)
+
+
+def _box_subset(child, parent) -> bool:
+    """Return true when every child interval is contained in its parent."""
+    return len(child) == len(parent) and all(
+        x.lo >= y.lo and x.hi <= y.hi for x, y in zip(child, parent))
+
+
+def _componentwise_yz_caps(*, base: dict, vr: dict, ds_detail: dict,
+                           parent_caps: dict) -> dict:
+    """Build safe separate y/z correction-perturbation radii.
+
+    The nominal theta-y and theta-z gain rows use only residual component x.
+    V34 certifies separate gain-row perturbation operators while retaining the
+    full V12D Delta-C parent.  Each component therefore gets its own triangle
+    bound.  The existing V31 yz and total radii remain intersection parents.
+    """
+    drho = float(vr["total_residual_perturbation_upper_mps2"])
+    rho = float(base["sample1_full_residual_norm_upper_mps2"])
+    rho_plus = FULL.up(rho + drho)
+    ky = float(ds_detail["nominal_theta_y_gain_row_norm_upper"])
+    kz = float(ds_detail["nominal_theta_z_gain_row_norm_upper"])
+    dky = float(ds_detail["theta_y_gain_perturbation_intersected_upper"])
+    dkz = float(ds_detail["theta_z_gain_perturbation_intersected_upper"])
+    vals = (drho, rho, ky, kz, dky, dkz)
+    if not all(math.isfinite(x) and x >= 0.0 for x in vals):
+        raise ValueError("finite nonnegative componentwise y/z inputs required")
+
+    ry = FULL.up(ky * drho)
+    rz = FULL.up(kz * drho)
+    gy = FULL.up(dky * rho_plus)
+    gz = FULL.up(dkz * rho_plus)
+    ey_candidate = _sum_up(ry, gy)
+    ez_candidate = _sum_up(rz, gz)
+
+    parent_yz = float(parent_caps["yz_correction_perturbation_norm_upper_rad"])
+    parent_total = float(parent_caps["total_correction_perturbation_norm_upper_rad"])
+    ex = float(parent_caps["x_correction_perturbation_abs_upper_rad"])
+    if not all(math.isfinite(x) and x >= 0.0
+               for x in (parent_yz, parent_total, ex)):
+        raise ValueError("finite nonnegative V31 parent correction caps required")
+
+    # A vector 2-norm bound is also a valid bound for either component.
+    ey = min(parent_yz, ey_candidate)
+    ez = min(parent_yz, ez_candidate)
+    eyz = min(parent_yz, _norm2_up(ey, ez))
+    eall = min(parent_total, _norm3_up(ex, ey, ez))
+    return {
+        "theta_y_nominal_residual_term_abs_upper_rad": ry,
+        "theta_z_nominal_residual_term_abs_upper_rad": rz,
+        "theta_y_gain_perturbation_term_abs_upper_rad": gy,
+        "theta_z_gain_perturbation_term_abs_upper_rad": gz,
+        "theta_y_component_candidate_abs_upper_rad": ey_candidate,
+        "theta_z_component_candidate_abs_upper_rad": ez_candidate,
+        "theta_y_component_abs_upper_rad": ey,
+        "theta_z_component_abs_upper_rad": ez,
+        "componentwise_yz_norm_upper_rad": eyz,
+        "x_parent_abs_upper_rad": ex,
+        "componentwise_total_norm_upper_rad": eall,
+        "V31_parent_yz_norm_upper_rad": parent_yz,
+        "V31_parent_total_norm_upper_rad": parent_total,
+        "theta_y_strictly_below_duplicated_parent_yz": ey < parent_yz,
+        "theta_z_strictly_below_duplicated_parent_yz": ez < parent_yz,
+    }
+
+
+def _build_v40_rows(path: Path, *, source_pieces: int, source_cell_index: int,
+                    p_pieces: int, tangent_pieces: int,
+                    axial_pieces: int) -> tuple[dict, dict, dict, dict, list[str]]:
+    """Build V10/V12D rows for WITNESS with the V40 PSD helper installed."""
+    failures: list[str] = []
+    original = V12D._first_psd_perturbation_tangent
+    V12D._first_psd_perturbation_tangent = \
+        V40._first_psd_perturbation_exact_joseph_components
+    try:
+        v12 = V12D.build(
+            path, source_pieces=source_pieces,
+            source_cell_index=source_cell_index, p_pieces=p_pieces,
+            tangent_pieces=tangent_pieces, axial_pieces=axial_pieces)
+    finally:
+        V12D._first_psd_perturbation_tangent = original
+    failures += [f"V40/V12D: {x}" for x in V12D.validate(v12)]
+    if V12D._first_psd_perturbation_tangent is not original:
+        failures.append("V40 PSD helper was not restored")
+
+    V10 = V12D.V11.V10
+    core = V10.build(
+        path, source_pieces=source_pieces,
+        source_cell_index=source_cell_index, p_pieces=p_pieces,
+        tangent_pieces=tangent_pieces, axial_pieces=axial_pieces)
+    failures += [f"V10: {x}" for x in V10.validate(core)]
+    base = V44._find_row(core.get("rows", []), witness=WITNESS)
+    vr = V44._find_row(v12.get("rows", []), witness=WITNESS)
+    return core, v12, base, vr, failures
+
+
+def build(domain_path: Path = DEFAULT_DOMAIN, *, source_pieces: int = 4,
+          source_cell_index: int = 0, p_pieces: int = 24,
+          tangent_pieces: int = 24, axial_pieces: int = 24,
+          residual_x_pieces: int = 6, parallel_pieces: int = 6) -> dict:
+    """Evaluate the V48 componentwise y/z refinement on the V45 parent."""
+    path = Path(domain_path).resolve()
+    failures: list[str] = []
+
+    cap = V45._capture_authoritative_chart(
+        path, source_pieces=source_pieces,
+        source_cell_index=source_cell_index, p_pieces=p_pieces,
+        tangent_pieces=tangent_pieces, axial_pieces=axial_pieces,
+        residual_x_pieces=residual_x_pieces,
+        parallel_pieces=parallel_pieces)
+    chart_raw = cap["captured"]
+    chart = {
+        "q1": float(chart_raw["q1"]),
+        "cx": _I(chart_raw["cx"]),
+        "cy": _I(chart_raw["cy"]),
+        "cz": _I(chart_raw["cz"]),
+        "cyz_norm_upper": float(chart_raw["cyz_norm_upper"]),
+    }
+    chart_matches = (
+        V45._matches(chart["q1"], V45.V41_Q_CURRENT)
+        and V45._matches(chart["cx"].lo, V45.V41_CX[0])
+        and V45._matches(chart["cx"].hi, V45.V41_CX[1])
+        and V45._matches(chart["cyz_norm_upper"], V45.V41_CYZ))
+    if not chart_matches:
+        failures.append("authoritative chart does not reproduce V45/V41 witness")
+    if cap.get("hooks_restored") is not True:
+        failures.append("authoritative chart hooks were not restored")
+
+    # V44's q chart is known not to be authoritative, but its source geometry
+    # is independent of those copied q values.  Reuse only that geometry.
+    v44 = V44.build(
+        path, source_pieces=source_pieces,
+        source_cell_index=source_cell_index, p_pieces=p_pieces,
+        tangent_pieces=tangent_pieces, axial_pieces=axial_pieces,
+        residual_x_pieces=residual_x_pieces,
+        parallel_pieces=parallel_pieces)
+    parent = v44.get("first_parent_open_subcell") or {}
+    nominal_raw = v44.get("V44_nominal_signed_correction_box_rad")
+    parent_caps = v44.get("V44_directional_perturbation_caps") or {}
+    if not parent or not nominal_raw or not parent_caps:
+        failures.append("V44 source geometry required by V48 is missing")
+
+    _core, _v12, base, vr, row_failures = _build_v40_rows(
+        path, source_pieces=source_pieces,
+        source_cell_index=source_cell_index, p_pieces=p_pieces,
+        tangent_pieces=tangent_pieces, axial_pieces=axial_pieces)
+    failures += row_failures
+
+    try:
+        ds_detail = V34._directional_delta_s_detail(
+            path, source_pieces=source_pieces,
+            source_cell_index=source_cell_index, p_pieces=p_pieces,
+            base=base, vr=vr)
+        caps = _componentwise_yz_caps(
+            base=base, vr=vr, ds_detail=ds_detail,
+            parent_caps=parent_caps)
+    except Exception as exc:
+        failures.append(f"V48 componentwise y/z construction: {exc}")
+        ds_detail = None
+        caps = None
+
+    parent_eval = refined_eval = None
+    joint = None
+    source_box = None
+    source_yz_hi = math.inf
+    source_radial_lo = math.inf
+    source_radial_hi = math.inf
+    subset = False
+
+    if parent and nominal_raw and parent_caps and caps is not None:
+        dbox = [_I(x) for x in parent["correction_component_box_rad"]]
+        nominal = [_I(x) for x in nominal_raw]
+        parent_eval = V44._eval_q(
+            q=chart["q1"], chart=chart, dbox=dbox,
+            radial_lo=float(parent["correction_radial_lower_rad"]),
+            radial_hi=float(parent["correction_radial_upper_rad"]))
+        if not V45._matches(float(parent_eval["best_q"]), V45.V41_Q_POST,
+                            atol=3.0e-11):
+            failures.append("authoritative V48 parent does not reproduce V45 q")
+
+        ex = float(caps["x_parent_abs_upper_rad"])
+        ey = float(caps["theta_y_component_abs_upper_rad"])
+        ez = float(caps["theta_z_component_abs_upper_rad"])
+        eall = float(caps["componentwise_total_norm_upper_rad"])
+        source_box = [
+            nominal[0] + Interval.outward_bounds(-ex, ex),
+            nominal[1] + Interval.outward_bounds(-ey, ey),
+            nominal[2] + Interval.outward_bounds(-ez, ez),
+        ]
+        old_source_box = [_I(x) for x in v44["V44_source_correction_box_rad"]]
+        subset = _box_subset(source_box, old_source_box)
+        if not subset:
+            failures.append("componentwise source box escaped V44 parent source box")
+
+        nominal_yz = V44.V18._yz_norm_upper(nominal[1], nominal[2])
+        source_yz_hi = min(
+            float(v44["V44_source_yz_correction_norm_upper_rad"]),
+            FULL.up(nominal_yz + float(caps["componentwise_yz_norm_upper_rad"])))
+        nominal_hi = V44.V14.CAYLEY1._norm_upper(nominal)
+        nominal_lo = V44.V14.CAYLEY2._norm_lower(nominal)
+        source_radial_hi = min(
+            float(v44["V44_source_radial_upper_rad"]),
+            FULL.up(nominal_hi + eall))
+        source_radial_lo = max(
+            float(v44["V44_source_radial_lower_rad"]),
+            max(0.0, FULL.down(nominal_lo - eall)))
+
+        joint = V44._intersect_boxes(dbox, source_box)
+        incompatible = joint is None
+        if joint is not None:
+            yz = V44.V31.V29._clip_yz_to_radius(
+                joint[1], joint[2], source_yz_hi)
+            if yz is None:
+                incompatible = True
+                joint = None
+            else:
+                joint[1], joint[2] = yz
+                rhi = min(
+                    float(parent["correction_radial_upper_rad"]),
+                    source_radial_hi,
+                    V44.V14.CAYLEY1._norm_upper(joint))
+                rlo = max(
+                    float(parent["correction_radial_lower_rad"]),
+                    source_radial_lo,
+                    V44.V14.CAYLEY2._norm_lower(joint))
+                if rlo > rhi:
+                    incompatible = True
+                    joint = None
+                else:
+                    refined_eval = V44._eval_q(
+                        q=chart["q1"], chart=chart, dbox=joint,
+                        radial_lo=rlo, radial_hi=rhi)
+                    source_radial_lo = rlo
+                    source_radial_hi = rhi
+        if incompatible:
+            refined_eval = {
+                "closed": True, "incompatible": True,
+                "geodesic_q": 0.0, "product_q": 0.0,
+                "product_w": math.inf, "best_q": 0.0,
+                "axis_narrowed": False,
+            }
+
+    parent_q = math.inf if parent_eval is None else float(parent_eval["best_q"])
+    refined_q = math.inf if refined_eval is None else float(refined_eval["best_q"])
+    closed = bool(refined_eval and refined_eval.get("closed"))
+    strict_component = bool(caps and (
+        caps["theta_y_strictly_below_duplicated_parent_yz"]
+        or caps["theta_z_strictly_below_duplicated_parent_yz"]))
+
+    return {
+        "schema": SCHEMA,
+        "qualification": "OU3_P5_SAMPLE1_AUTHORITATIVE_COMPONENTWISE_YZ_V48",
+        "source_generated_not_trajectory_fit": True,
+        "source_replay_used": False,
+        "filter_changed": False,
+        "V40_exact_Joseph_parent_used": True,
+        "V45_authoritative_chart_capture_used": True,
+        "V45_authoritative_chart_matches_archived_V41_witness": chart_matches,
+        "V44_source_geometry_reused_without_V44_q_values": True,
+        "V34_directional_first_row_DeltaS_used": ds_detail is not None,
+        "V12D_full_DeltaC_parent_retained_for_theta_yz": bool(
+            ds_detail and ds_detail.get(
+                "V12D_full_DeltaC_parent_retained_for_theta_yz") is True),
+        "componentwise_yz_bounds_used": caps is not None,
+        "componentwise_source_box_subset_of_V44_parent": subset,
+        "at_least_one_yz_component_strictly_refined": strict_component,
+        "V41_first_survivor_row": list(WITNESS),
+        "authoritative_current_chart": chart_raw,
+        "directional_DeltaS_detail": ds_detail,
+        "componentwise_yz_perturbation_detail": caps,
+        "authoritative_parent_best_q_upper": parent_q,
+        "archived_V41_post_sample1_q_reference": V45.V41_Q_POST,
+        "authoritative_componentwise_source_box_rad": (
+            None if source_box is None else [x.as_list() for x in source_box]),
+        "authoritative_componentwise_joint_box_rad": (
+            None if joint is None else [x.as_list() for x in joint]),
+        "authoritative_componentwise_yz_norm_upper_rad": source_yz_hi,
+        "authoritative_componentwise_radial_lower_rad": source_radial_lo,
+        "authoritative_componentwise_radial_upper_rad": source_radial_hi,
+        "authoritative_componentwise_best_q_upper": refined_q,
+        "authoritative_componentwise_geodesic_q_upper": (
+            None if refined_eval is None else float(refined_eval["geodesic_q"])),
+        "authoritative_componentwise_product_q_upper": (
+            None if refined_eval is None else float(refined_eval["product_q"])),
+        "authoritative_componentwise_product_abs_W_lower": (
+            None if refined_eval is None else float(refined_eval["product_w"])),
+        "first_V41_survivor_closed_by_V48_componentwise_yz": closed,
+        "deployed_correction_limit_rad": 6.0,
+        "deployed_correction_limit_increased": False,
+        "q_target": Q_TARGET,
+        "q8_composed_here": False,
+        "q8_word_promoted_here": False,
+        "whole_word_promoted_here": False,
+        "N_H_words_set_here": False,
+        "P5_established_here": False,
+        "P5_SAMPLE1_AUTHORITATIVE_COMPONENTWISE_YZ_V48": (
+            "PASS" if not failures else "NOT_ESTABLISHED"),
+        "next_obligation": (
+            "LIFT_V48_COMPONENTWISE_YZ_STRUCTURE_OVER_V41_OPEN_CELLS"
+            if closed and not failures else
+            "REFINE_THETA_YZ_DELTAC_COMPONENT_MATRIX_OR_RESIDUAL_X_STRUCTURE_ON_AUTHORITATIVE_V45_PARENT"
+        ),
+        "failures": list(dict.fromkeys(failures)),
+    }
+
+
+def validate(d: dict) -> list[str]:
+    """Validate the fail-closed V48 proof-artifact contract."""
+    f = list(d.get("failures", []))
+    if d.get("schema") != SCHEMA:
+        f.append("schema mismatch")
+    if d.get("qualification") != "OU3_P5_SAMPLE1_AUTHORITATIVE_COMPONENTWISE_YZ_V48":
+        f.append("qualification mismatch")
+    for k in (
+        "source_generated_not_trajectory_fit",
+        "V40_exact_Joseph_parent_used",
+        "V45_authoritative_chart_capture_used",
+        "V45_authoritative_chart_matches_archived_V41_witness",
+        "V44_source_geometry_reused_without_V44_q_values",
+        "V34_directional_first_row_DeltaS_used",
+        "V12D_full_DeltaC_parent_retained_for_theta_yz",
+        "componentwise_yz_bounds_used",
+        "componentwise_source_box_subset_of_V44_parent",
+    ):
+        if d.get(k) is not True:
+            f.append(f"{k} is not true")
+    for k in (
+        "source_replay_used", "filter_changed",
+        "deployed_correction_limit_increased", "q8_composed_here",
+        "q8_word_promoted_here", "whole_word_promoted_here",
+        "N_H_words_set_here", "P5_established_here",
+    ):
+        if d.get(k) is not False:
+            f.append(f"{k} is not false")
+    if tuple(d.get("V41_first_survivor_row", ())) != tuple(WITNESS):
+        f.append("V41 witness changed")
+    if float(d.get("deployed_correction_limit_rad", 0.0)) != 6.0:
+        f.append("deployed correction limit changed")
+    if float(d.get("q_target", 0.0)) != Q_TARGET:
+        f.append("q target changed")
+    if d.get("P5_SAMPLE1_AUTHORITATIVE_COMPONENTWISE_YZ_V48") not in (
+            "PASS", "NOT_ESTABLISHED"):
+        f.append("invalid V48 status")
+    return list(dict.fromkeys(f))
+
+
+def main() -> int:
+    """Run V48 and write its machine-readable proof artifact."""
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--domain", type=Path, default=DEFAULT_DOMAIN)
+    ap.add_argument("--source-pieces", type=int, default=4)
+    ap.add_argument("--source-cell-index", type=int, default=0)
+    ap.add_argument("--p-pieces", type=int, default=24)
+    ap.add_argument("--tangent-pieces", type=int, default=24)
+    ap.add_argument("--axial-pieces", type=int, default=24)
+    ap.add_argument("--residual-x-pieces", type=int, default=6)
+    ap.add_argument("--parallel-pieces", type=int, default=6)
+    ap.add_argument("--output", type=Path, required=True)
+    x = ap.parse_args()
+    d = build(
+        x.domain, source_pieces=x.source_pieces,
+        source_cell_index=x.source_cell_index, p_pieces=x.p_pieces,
+        tangent_pieces=x.tangent_pieces, axial_pieces=x.axial_pieces,
+        residual_x_pieces=x.residual_x_pieces,
+        parallel_pieces=x.parallel_pieces)
+    vf = validate(d)
+    d["validation_failures"] = vf
+    x.output.parent.mkdir(parents=True, exist_ok=True)
+    x.output.write_text(json.dumps(d, indent=2, sort_keys=True), encoding="utf-8")
+    print(json.dumps({
+        "status": d["P5_SAMPLE1_AUTHORITATIVE_COMPONENTWISE_YZ_V48"],
+        "parent_q": d["authoritative_parent_best_q_upper"],
+        "refined_q": d["authoritative_componentwise_best_q_upper"],
+        "geodesic_q": d["authoritative_componentwise_geodesic_q_upper"],
+        "product_q": d["authoritative_componentwise_product_q_upper"],
+        "closed": d["first_V41_survivor_closed_by_V48_componentwise_yz"],
+        "strict_component": d["at_least_one_yz_component_strictly_refined"],
+        "caps": d["componentwise_yz_perturbation_detail"],
+        "next": d["next_obligation"],
+        "validation_failures": vf,
+    }, indent=2, sort_keys=True))
+    return 0 if not vf else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ou3_p5_sample1_authoritative_yz_deltac_decomposition_v49.py
+++ b/tools/ou3_p5_sample1_authoritative_yz_deltac_decomposition_v49.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""V49: authoritative theta-y/z Delta-C term decomposition after V48.
+
+V48 proves that splitting the duplicated y/z correction radius is real but does
+not close the authoritative V41 survivor: the y cap shrinks while the z cap is
+still pinned at the V31 parent.  V33 previously attempted rowwise theta-y/z
+Delta-C bounds but correctly failed closed when its scalar row triangle bound
+exceeded the already-certified V12D full-operator parent.
+
+V49 does not promote that failed candidate.  It reconstructs the authoritative
+V40/V45 witness and decomposes the V33 row candidate
+
+    dC_i <= dP ||H_theta|| + ||P_theta[i,:]|| dH + dP dH + dP
+
+for i=y,z into its four separately outward-rounded terms.  It also combines
+those candidate rows with V34's certified first-row Delta-S refinement to show
+which numerator term dominates the y/z gain-resolvent budget.  This is a
+source-derived diagnostic used to choose the next component-matrix proof; V12D
+remains the binding parent and no q<8, sample-1, whole-word, P5, or N_H
+promotion occurs here.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+from ou3_interval import Interval
+import ou3_p5_sample1_authoritative_componentwise_yz_v48 as V48
+import ou3_p5_sample1_exact_theta_yz_gain_rows_lift_v33 as V33
+
+DEFAULT_DOMAIN = V48.DEFAULT_DOMAIN
+SCHEMA = 4900
+WITNESS = V48.WITNESS
+FULL = V48.FULL
+
+
+def _sum_up(*xs: float) -> float:
+    y = 0.0
+    for x in xs:
+        y = FULL.up(y + float(x))
+    return y
+
+
+def _deltac_terms(*, dP: float, dH: float, htheta: float,
+                  row_norm: float) -> dict:
+    vals = (dP, dH, htheta, row_norm)
+    if not all(math.isfinite(float(x)) and float(x) >= 0.0 for x in vals):
+        raise ValueError("finite nonnegative Delta-C term inputs required")
+    projected_dP_H = FULL.up(dP * htheta)
+    nominal_row_dH = FULL.up(row_norm * dH)
+    mixed_dP_dH = FULL.up(dP * dH)
+    theta_aw_cross = FULL.up(dP)
+    total = _sum_up(projected_dP_H, nominal_row_dH, mixed_dP_dH,
+                    theta_aw_cross)
+    terms = {
+        "projected_DeltaP_Htheta_upper": projected_dP_H,
+        "nominal_Ptheta_row_DeltaH_upper": nominal_row_dH,
+        "mixed_DeltaP_DeltaH_upper": mixed_dP_dH,
+        "theta_aw_cross_block_parent_upper": theta_aw_cross,
+        "row_DeltaC_candidate_upper": total,
+    }
+    dominant = max(
+        (k for k in terms if k != "row_DeltaC_candidate_upper"),
+        key=lambda k: terms[k])
+    terms["dominant_term"] = dominant
+    terms["dominant_fraction"] = 0.0 if total == 0.0 else terms[dominant] / total
+    return terms
+
+
+def _nominal_yz_rows(path: Path, *, source_pieces: int,
+                     source_cell_index: int, p_pieces: int,
+                     base: dict) -> tuple[float, float]:
+    """Reconstruct V33's nominal theta-y/z covariance-row norms."""
+    V12D = V48.V12D
+    V11 = V12D.V11
+    V10 = V11.V10
+    dom = json.loads(path.read_text(encoding="utf-8"))
+    src, phase = V10.RG._source_phase_children(source_pieces)[source_cell_index]
+    if phase != "due":
+        raise RuntimeError("V49 focused decomposition requires first due source cell")
+
+    first = V11.FIRST.build(path, source_pieces=source_pieces)
+    fr = first["source_cells"][source_cell_index]
+    p_all = Interval.outward_bounds(*map(float, fr["P_aw_variance_interval"]))
+    p = V11.SUB.parts(p_all.lo, p_all.hi, p_pieces)[int(base["p_cell"])]
+
+    hstep = float(src["dt_s"])
+    g = float(dom["startup"]["gravity_mps2"])
+    tilt, yaw, eps = V10.RG._attitude_covariance_epsilon(path, hstep)
+    t = Interval.outward_bounds(tilt, FULL.up(tilt + eps))
+    Y = Interval.outward_bounds(yaw, FULL.up(yaw + eps))
+    vec = V11.VECTOR.build()
+    r = FULL._R_diag(float(
+        vec["configured_measurement_bounds"]["acc_measurement_std_mps2"]))[0][0]
+    F, Q, _ = FULL._transition_and_Q(src, dom)
+    alpha = F[15][15]
+    qaw = Q[15][15]
+
+    rt = Interval.outward_bounds(
+        *map(float, base["first_tangent_residual_magnitude_mps2"]))
+    rz = Interval.outward_bounds(*map(float, base["first_axial_residual_mps2"]))
+    d = Interval.outward_bounds(*map(float, base["first_attitude_correction_rad"]))
+    D = FULL.I(g * g) * t + p + r
+    fy = -(alpha * (p / D) * rt)
+    fz = FULL.I(g) + alpha * (p / (p + r)) * rz
+    Pn, _Hn, _Sn = V11._nominal_sample1_matrices(
+        t=t, Y=Y, p=p, r=r, g=g, alpha=alpha, qaw=qaw,
+        d=d, fy=fy, fz=fz)
+    return V33._row_norm_upper(Pn[1][:3]), V33._row_norm_upper(Pn[2][:3])
+
+
+def build(domain_path: Path = DEFAULT_DOMAIN, *, source_pieces: int = 4,
+          source_cell_index: int = 0, p_pieces: int = 24,
+          tangent_pieces: int = 24, axial_pieces: int = 24) -> dict:
+    path = Path(domain_path).resolve()
+    failures: list[str] = []
+    try:
+        _core, _v12, base, vr, row_failures = V48._build_v40_rows(
+            path, source_pieces=source_pieces,
+            source_cell_index=source_cell_index, p_pieces=p_pieces,
+            tangent_pieces=tangent_pieces, axial_pieces=axial_pieces)
+        failures += row_failures
+        if (int(base.get("p_cell", -1)),
+            int(base.get("tangent_residual_cell", -1)),
+            int(base.get("axial_residual_cell", -1))) != WITNESS:
+            failures.append("V49 did not reconstruct authoritative witness")
+
+        py, pz = _nominal_yz_rows(
+            path, source_pieces=source_pieces,
+            source_cell_index=source_cell_index, p_pieces=p_pieces,
+            base=base)
+        ds = V48.V34._directional_delta_s_detail(
+            path, source_pieces=source_pieces,
+            source_cell_index=source_cell_index, p_pieces=p_pieces,
+            base=base, vr=vr)
+
+        dP = float(vr["total_reduced_covariance_perturbation_upper"])
+        dH = float(vr["sample1_H_perturbation_upper"])
+        htheta = float(vr["sample1_Htheta_operator_upper"])
+        parent_dC = float(vr["sample1_attitude_cross_covariance_perturbation_upper"])
+        parent_dK = float(vr["sample1_attitude_gain_operator_perturbation_upper"])
+        inv = float(vr["actual_innovation_inverse_operator_upper"])
+        dS0 = float(ds["first_measurement_row_DeltaS_intersected_upper"])
+        ky = float(ds["nominal_theta_y_gain_row_norm_upper"])
+        kz = float(ds["nominal_theta_z_gain_row_norm_upper"])
+
+        y = _deltac_terms(dP=dP, dH=dH, htheta=htheta, row_norm=py)
+        z = _deltac_terms(dP=dP, dH=dH, htheta=htheta, row_norm=pz)
+        for row, kval in ((y, ky), (z, kz)):
+            dc = float(row["row_DeltaC_candidate_upper"])
+            ds_term = FULL.up(kval * dS0)
+            numerator = FULL.up(dc + ds_term)
+            dk_candidate = FULL.up(numerator * inv)
+            parent_numerator = FULL.up(parent_dC + ds_term)
+            parent_based_dk = FULL.up(parent_numerator * inv)
+            row.update({
+                "V12D_full_DeltaC_parent_upper": parent_dC,
+                "candidate_over_parent_ratio": (math.inf if parent_dC == 0.0 else dc / parent_dC),
+                "candidate_within_V12D_parent": dc <= FULL.up(parent_dC),
+                "directional_nominalK_DeltaS_term_upper": ds_term,
+                "gain_resolvent_candidate_numerator_upper": numerator,
+                "gain_resolvent_candidate_upper": dk_candidate,
+                "gain_resolvent_using_V12D_DeltaC_parent_upper": parent_based_dk,
+                "V12D_full_gain_perturbation_parent_upper": parent_dK,
+            })
+
+        dominant = z["dominant_term"]
+        if dominant == "theta_aw_cross_block_parent_upper":
+            next_obligation = "REFINE_THETA_Z_AW_CROSS_BLOCK_COMPONENT_OF_DELTAP_ON_AUTHORITATIVE_V40_PARENT"
+        elif dominant == "projected_DeltaP_Htheta_upper":
+            next_obligation = "REFINE_THETA_Z_PROJECTED_DELTAP_HTHETA_COMPONENT_MATRIX_ON_AUTHORITATIVE_V40_PARENT"
+        elif dominant == "nominal_Ptheta_row_DeltaH_upper":
+            next_obligation = "REFINE_THETA_Z_NOMINAL_ROW_DELTAH_COMPONENT_ON_AUTHORITATIVE_V40_PARENT"
+        else:
+            next_obligation = "REFINE_THETA_Z_MIXED_DELTAP_DELTAH_COMPONENT_ON_AUTHORITATIVE_V40_PARENT"
+    except Exception as exc:
+        failures.append(f"V49 authoritative Delta-C decomposition: {exc}")
+        y = z = None
+        next_obligation = "REPAIR_V49_AUTHORITATIVE_DELTAC_DECOMPOSITION"
+
+    return {
+        "schema": SCHEMA,
+        "qualification": "OU3_P5_SAMPLE1_AUTHORITATIVE_YZ_DELTAC_DECOMPOSITION_V49",
+        "source_generated_not_trajectory_fit": True,
+        "source_replay_used": False,
+        "filter_changed": False,
+        "authoritative_V40_rows_reconstructed": y is not None and z is not None,
+        "V12D_full_DeltaC_parent_retained": True,
+        "V34_directional_DeltaS_retained": True,
+        "failed_V33_row_candidate_promoted": False,
+        "theta_y_DeltaC_term_decomposition": y,
+        "theta_z_DeltaC_term_decomposition": z,
+        "q8_composed_here": False,
+        "q8_word_promoted_here": False,
+        "whole_word_promoted_here": False,
+        "N_H_words_set_here": False,
+        "P5_established_here": False,
+        "P5_SAMPLE1_AUTHORITATIVE_YZ_DELTAC_DECOMPOSITION_V49": (
+            "PASS" if not failures else "NOT_ESTABLISHED"),
+        "next_obligation": next_obligation,
+        "failures": list(dict.fromkeys(failures)),
+    }
+
+
+def validate(d: dict) -> list[str]:
+    f = list(d.get("failures", []))
+    if d.get("schema") != SCHEMA:
+        f.append("schema mismatch")
+    if d.get("qualification") != "OU3_P5_SAMPLE1_AUTHORITATIVE_YZ_DELTAC_DECOMPOSITION_V49":
+        f.append("qualification mismatch")
+    for k in ("source_generated_not_trajectory_fit",
+              "authoritative_V40_rows_reconstructed",
+              "V12D_full_DeltaC_parent_retained",
+              "V34_directional_DeltaS_retained"):
+        if d.get(k) is not True:
+            f.append(f"{k} is not true")
+    for k in ("source_replay_used", "filter_changed",
+              "failed_V33_row_candidate_promoted", "q8_composed_here",
+              "q8_word_promoted_here", "whole_word_promoted_here",
+              "N_H_words_set_here", "P5_established_here"):
+        if d.get(k) is not False:
+            f.append(f"{k} is not false")
+    for label in ("theta_y_DeltaC_term_decomposition",
+                  "theta_z_DeltaC_term_decomposition"):
+        row = d.get(label) or {}
+        dc = float(row.get("row_DeltaC_candidate_upper", math.inf))
+        parent = float(row.get("V12D_full_DeltaC_parent_upper", -math.inf))
+        if not (math.isfinite(dc) and dc >= 0.0 and math.isfinite(parent) and parent >= 0.0):
+            f.append(f"invalid {label}")
+    if d.get("P5_SAMPLE1_AUTHORITATIVE_YZ_DELTAC_DECOMPOSITION_V49") not in (
+            "PASS", "NOT_ESTABLISHED"):
+        f.append("invalid V49 status")
+    return list(dict.fromkeys(f))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--domain", type=Path, default=DEFAULT_DOMAIN)
+    ap.add_argument("--source-pieces", type=int, default=4)
+    ap.add_argument("--source-cell-index", type=int, default=0)
+    ap.add_argument("--p-pieces", type=int, default=24)
+    ap.add_argument("--tangent-pieces", type=int, default=24)
+    ap.add_argument("--axial-pieces", type=int, default=24)
+    ap.add_argument("--output", type=Path, required=True)
+    x = ap.parse_args()
+    d = build(x.domain, source_pieces=x.source_pieces,
+              source_cell_index=x.source_cell_index, p_pieces=x.p_pieces,
+              tangent_pieces=x.tangent_pieces, axial_pieces=x.axial_pieces)
+    vf = validate(d)
+    d["validation_failures"] = vf
+    x.output.parent.mkdir(parents=True, exist_ok=True)
+    x.output.write_text(json.dumps(d, indent=2, sort_keys=True), encoding="utf-8")
+    print(json.dumps({
+        "status": d["P5_SAMPLE1_AUTHORITATIVE_YZ_DELTAC_DECOMPOSITION_V49"],
+        "theta_y": d.get("theta_y_DeltaC_term_decomposition"),
+        "theta_z": d.get("theta_z_DeltaC_term_decomposition"),
+        "next": d.get("next_obligation"),
+        "validation_failures": vf,
+    }, indent=2, sort_keys=True))
+    return 0 if not vf else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ou3_proof_operating_domain.json
+++ b/tools/ou3_proof_operating_domain.json
@@ -5,7 +5,12 @@
   "note": "These are theorem/deployment assumptions, not extrema fitted from the eight reference replays. Existing replay remains a regression/falsification layer and may disprove this envelope but cannot establish it.",
   "configured_runtime": {
     "imu_dt_s": 0.005,
-    "imu_lever_arm_enabled": false
+    "imu_lever_arm_enabled": false,
+    "accelerometer_vibration_guard_proof_branch": "dormant_transparent",
+    "accelerometer_vibration_guard_initial_engagement": 0.0,
+    "accelerometer_vibration_guard_detector_rms_upper_mps2": 0.03,
+    "accelerometer_vibration_guard_active_branch_certified": false,
+    "accelerometer_vibration_guard_note": "PR #426 armed a 14 Hz stateful accelerometer prefilter by default. The pre-existing P1-P5 source model remains exact only on the source branch where its detector stays at or below the 0.03 m/s^2 lower engagement rail and the guard starts at zero engagement, for which shipping code returns the raw accelerometer bit-for-bit. Active/transitioning guard dynamics are a separate source/hybrid proof obligation and are not promoted by this domain."
   },
   "startup": {
     "gravity_mps2": 9.80665,
@@ -44,7 +49,7 @@
       "axial_gyro_bias_is_neutral_input": true,
       "note": "Conditional gravity-only theorem hypothesis: before magnetic regauging, every quotient word contains two accepted accelerometer packets separated inside the declared interval and satisfying the stated non-gravitational force bound. The axial body gyro-bias is carried as a bounded detectability input rather than assigned a fictitious strict contraction."
     },
-    "pe_scope_note": "The full-heading theorem excludes free-fall/near-free-fall and magnetic fields within 5.74 deg of gravity. The 5 m/s^2 force floor and 10 uT field floor are declared deployment assumptions, not replay-derived extrema; gravity-only/yaw-quotient operation has its own explicit accepted-gravity-packet recurrence hypothesis rather than pretending heading or the gravity-parallel gyro-bias is observable. The quantitative P4 certificate also binds the deployed default with optional IMU lever-arm compensation disabled; enabling a nonzero lever arm requires extending the source-domain nonlinear remainder bound with the configured geometry. In A mode the normal-Live source node is restricted to a 0.45 m/s^2 bias-state ball, strictly inside the shipping 0.5 m/s^2 projection ball, so the very small certified P4 inner funnel never crosses the nonsmooth saturation surface. Boundary/saturated bias states remain a separate outer/hybrid recapture obligation rather than being silently treated as differentiable."
+    "pe_scope_note": "The full-heading theorem excludes free-fall/near-free-fall and magnetic fields within 5.74 deg of gravity. The 5 m/s^2 force floor and 10 uT field floor are declared deployment assumptions, not replay-derived extrema; gravity-only/yaw-quotient operation has its own explicit accepted-gravity-packet recurrence hypothesis rather than pretending heading or the gravity-parallel gyro-bias is observable. The quantitative P4 certificate also binds the deployed default with optional IMU lever-arm compensation disabled; enabling a nonzero lever arm requires extending the source-domain nonlinear remainder bound with the configured geometry. In A mode the normal-Live source node is restricted to a 0.45 m/s^2 bias-state ball, strictly inside the shipping 0.5 m/s^2 projection ball, so the very small certified P4 inner funnel never crosses the nonsmooth saturation surface. Boundary/saturated bias states remain a separate outer/hybrid recapture obligation rather than being silently treated as differentiable. The source model in this file additionally covers only the dormant/bit-exact-transparent vibration-guard branch; guard engagement and disengagement remain separate hybrid/source obligations."
   },
   "stochastic": {
     "finite_horizon_failure_probability_budget": 0.05


### PR DESCRIPTION
Continues the OU-III P5 finite startup-to-inner-funnel capture certificate from current `main` after merged #425 (which itself continued #420). This branch is based exactly on merge commit `8093b2cd7cbd1d91119e3b4e1803d9e26175edb3` and remains fail-closed.

## Starting proof state

The authoritative state carried forward is:

- V39 focused 64-box certificate: 64/64 closed, q about 2.6111..6.0060 < 8.
- V40 exact Joseph-component refinement: established/green.
- V41 full source-cell-0 cover: 225,638 closed / 235,738 open out of 461,376 cells.
- authoritative first V41 survivor: `(p,t,a)=(0,0,23)`, q = 8.34452895146.
- V42 directional-current refinement: same 225,638 / 235,738 global split.
- V43: no additional correction refinements.
- V45: reproduces the authoritative first survivor/current chart.
- focused V46/V47 diagnostics narrowed the first survivor region from 54/10 to 55/9 closed/open, but the first remaining child still has product q about 9.13753 and inherited geodesic q about 8.34453.

That makes the next useful bottleneck componentwise y/z correction-perturbation structure on the authoritative V40/V45 parent, not another blind current subdivision.

## V48: authoritative componentwise y/z refinement

This PR adds `ou3_p5_sample1_authoritative_componentwise_yz_v48.py`.

V48 deliberately avoids the failed V33 route. It:

- executes V45's authoritative V41/V18B chart capture with the V40 exact-Joseph parent installed;
- reuses only V44's source-derived signed correction geometry, not V44's non-authoritative q chart;
- retains V12D's full certified `Delta C` operator parent for theta-y/z;
- reuses V34's directional first-measurement-row `Delta S` refinement for the exact sparse nominal rows `K_theta,y=[g_y,0,0]`, `K_theta,z=[g_z,0,0]`;
- replaces the old duplicated yz radius with separate certified `e_y` and `e_z` bounds,
  `e_y <= |g_y| drho + ||Delta K_y||(rho+drho)` and likewise for z;
- intersects those componentwise boxes back into the existing V31 yz/total parents before the unchanged V15/V16/V18 geodesic/product q<8 evaluation;
- explicitly checks that the new componentwise source box remains a subset of the already certified V44 source box.

A dedicated unit-test contract and `ou3-p5-v48-authoritative-componentwise-yz-fast` workflow compile, test, run the producer, and publish parent/refined q plus y/z perturbation widths. The workflow is bound to the shared interval backend as well as the V34/V40/V44/V45 proof producers.

## Source-parity correction after the engine-vibration guard merge

Executing the source-bound certificate exposed an independent drift introduced by the already-merged accelerometer vibration guard: the shipping wrapper now arms a 14 Hz, two-pole stateful accelerometer guard by default and feeds its conditioned `acc_in` into startup/Live attitude processing.

This PR does **not** silently claim that the pre-existing P1-P5 proof covers the guard while it is active. Instead it:

- source-binds the constructor activation, conditioned accelerometer path, Live tilt relock, and MEKF accelerometer correction to the shipping implementation;
- records the guard as a hybrid/source event;
- certifies the existing proof model only on the guard's dormant transparent branch: initial engagement is zero and detector RMS remains at or below the 0.03 m/s^2 lower engagement rail, where the shipping guard returns the raw accelerometer bit-for-bit;
- records active/transitioning vibration-guard dynamics as a separate, still-open source/hybrid proof obligation.

Thus the estimator tuning, deployed 6-rad correction limit, q<8 target, source language, sample-1 promotion rules, and whole-word promotion rules are unchanged, but the theorem/source domain is now explicitly restricted rather than falsely implying coverage of an unproved active guard.

## Promotion boundary

P5 remains **NOT_ESTABLISHED**. `N_H_words` remains unset. V48 is a focused sample-1 refinement only. The complete source/phase family, finite capture chain, whole-word recurrence/promotion, finite `N_H`, and the newly explicit active/transitioning vibration-guard branch still have to be machine-certified before the stability certificate can be promoted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added refined componentwise Y/Z correction-bound analysis for more precise validation of operating limits.
  - Added proof coverage for the accelerometer vibration guard’s dormant, transparent behavior.
  - Expanded runtime documentation with vibration-guard scope and configuration details.

- **Bug Fixes**
  - Strengthened validation to fail closed when required vibration-guard evidence or processing order is incomplete.

- **Tests**
  - Added coverage for frozen targets, componentwise bounds, interval checks, and conservative norm calculations.

- **Chores**
  - Added automated audit and proof-manifest checks for relevant changes, including metric reporting and failure detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->