### PR TITLE
Continue P5 with V50 theta-z projected Delta-P component matrix

### DIFF
--- a/.github/workflows/ou3-p5-v50-authoritative-theta-z-projected-deltap-fast.yml
+++ b/.github/workflows/ou3-p5-v50-authoritative-theta-z-projected-deltap-fast.yml
@@ -2,6 +2,7 @@ name: ou3-p5-v50-authoritative-theta-z-projected-deltap-fast
 
 on:
   push:
+    branches: [main]
     paths:
       - "tools/ou3_p5_sample1_authoritative_theta_z_projected_deltap_v50.py"
       - "tests/validation/test_ou3_p5_sample1_authoritative_theta_z_projected_deltap_v50.py"

--- a/.github/workflows/ou3-p5-v50-authoritative-theta-z-projected-deltap-fast.yml
+++ b/.github/workflows/ou3-p5-v50-authoritative-theta-z-projected-deltap-fast.yml
@@ -1,0 +1,106 @@
+name: ou3-p5-v50-authoritative-theta-z-projected-deltap-fast
+
+on:
+  push:
+    paths:
+      - "tools/ou3_p5_sample1_authoritative_theta_z_projected_deltap_v50.py"
+      - "tests/validation/test_ou3_p5_sample1_authoritative_theta_z_projected_deltap_v50.py"
+      - "tools/ou3_p5_sample1_authoritative_componentwise_yz_v48.py"
+      - "tools/ou3_p5_sample1_authoritative_yz_deltac_decomposition_v49.py"
+      - "tools/ou3_p5_sample1_directional_innovation_row_lift_v34.py"
+      - "tools/ou3_p5_sample1_first_psd_exact_joseph_components_v40.py"
+      - "tools/ou3_p5_sample1_structured_full_gain_v11.py"
+      - "tools/ou3_p5_sample1_structured_full_gain_v12c.py"
+      - "tools/ou3_p5_sample1_structured_full_gain_v12d.py"
+      - "tools/ou3_interval.py"
+      - "tools/ou3_proof_operating_domain.json"
+      - ".github/workflows/ou3-p5-v50-authoritative-theta-z-projected-deltap-fast.yml"
+  pull_request:
+    paths:
+      - "tools/ou3_p5_sample1_authoritative_theta_z_projected_deltap_v50.py"
+      - "tests/validation/test_ou3_p5_sample1_authoritative_theta_z_projected_deltap_v50.py"
+      - "tools/ou3_p5_sample1_authoritative_componentwise_yz_v48.py"
+      - "tools/ou3_p5_sample1_directional_innovation_row_lift_v34.py"
+      - "tools/ou3_p5_sample1_first_psd_exact_joseph_components_v40.py"
+      - "tools/ou3_p5_sample1_structured_full_gain_v11.py"
+      - "tools/ou3_p5_sample1_structured_full_gain_v12c.py"
+      - "tools/ou3_p5_sample1_structured_full_gain_v12d.py"
+      - "tools/ou3_interval.py"
+      - "tools/ou3_proof_operating_domain.json"
+      - ".github/workflows/ou3-p5-v50-authoritative-theta-z-projected-deltap-fast.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ou3-p5-v50-authoritative-theta-z-projected-deltap-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  v50-theta-z-projected-deltap:
+    name: P5 V50 authoritative theta-z projected Delta-P
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+      - name: Compile V50 producer and test
+        run: |
+          python3 -m py_compile \
+            tools/ou3_p5_sample1_authoritative_theta_z_projected_deltap_v50.py \
+            tests/validation/test_ou3_p5_sample1_authoritative_theta_z_projected_deltap_v50.py
+      - name: Test V50 component-matrix contract
+        working-directory: tests/validation
+        run: python3 -m unittest -v test_ou3_p5_sample1_authoritative_theta_z_projected_deltap_v50
+      - name: Run V50 authoritative theta-z projected Delta-P audit
+        id: audit
+        shell: bash
+        run: |
+          set +e
+          python3 tools/ou3_p5_sample1_authoritative_theta_z_projected_deltap_v50.py \
+            --source-pieces 4 --source-cell-index 0 \
+            --p-pieces 24 --tangent-pieces 24 --axial-pieces 24 \
+            --residual-x-pieces 6 --parallel-pieces 6 \
+            --output /tmp/p5_sample1_v50.json \
+            > /tmp/p5_sample1_v50.log 2>&1
+          rc=$?
+          set -e
+          cat /tmp/p5_sample1_v50.log
+          python3 - "$GITHUB_OUTPUT" "$rc" <<'PY'
+          import json, math, pathlib, sys
+          out, rc = sys.argv[1], int(sys.argv[2])
+          path = pathlib.Path('/tmp/p5_sample1_v50.json')
+          d = json.loads(path.read_text(encoding='utf-8')) if path.exists() else {}
+          z = d.get('theta_z_componentwise_detail') or {}
+          caps = d.get('componentwise_yz_perturbation_detail') or {}
+          def fmt(x):
+              try: y = float(x)
+              except (TypeError, ValueError): return 'na'
+              return f'{y:.12g}' if math.isfinite(y) else str(y)
+          with open(out, 'a', encoding='utf-8') as gh:
+              print(f"rc={rc}", file=gh)
+              print(f"status={d.get('P5_SAMPLE1_AUTHORITATIVE_THETA_Z_PROJECTED_DELTAP_V50')}", file=gh)
+              print(f"projected={fmt(z.get('theta_z_projected_DeltaP_Htheta_componentwise_upper'))}", file=gh)
+              print(f"projected_parent={fmt(z.get('scalar_projected_DeltaP_Htheta_parent_upper'))}", file=gh)
+              print(f"projected_ratio={fmt(z.get('projected_componentwise_over_scalar_parent_ratio'))}", file=gh)
+              print(f"dc={fmt(z.get('theta_z_DeltaC_intersected_upper'))}", file=gh)
+              print(f"dc_parent={fmt(z.get('V12D_full_DeltaC_parent_upper'))}", file=gh)
+              print(f"dkz={fmt(z.get('theta_z_gain_perturbation_intersected_upper'))}", file=gh)
+              print(f"dkz_parent={fmt(z.get('V34_theta_z_gain_perturbation_parent_upper'))}", file=gh)
+              print(f"ez={fmt(caps.get('theta_z_component_abs_upper_rad'))}", file=gh)
+              print(f"q={fmt(d.get('authoritative_V50_best_q_upper'))}", file=gh)
+              print(f"geodesicq={fmt(d.get('authoritative_componentwise_geodesic_q_upper'))}", file=gh)
+              print(f"productq={fmt(d.get('authoritative_componentwise_product_q_upper'))}", file=gh)
+              print(f"closed={d.get('first_V41_survivor_closed_by_V50_theta_z_projected_DeltaP')}", file=gh)
+              print(f"next={d.get('next_obligation')}", file=gh)
+      - name: "V50 status=${{ steps.audit.outputs.status }} projected=${{ steps.audit.outputs.projected }} parent=${{ steps.audit.outputs.projected_parent }} ratio=${{ steps.audit.outputs.projected_ratio }}"
+        run: |
+          echo "DeltaC=${{ steps.audit.outputs.dc }} parent=${{ steps.audit.outputs.dc_parent }}"
+          echo "DeltaKz=${{ steps.audit.outputs.dkz }} parent=${{ steps.audit.outputs.dkz_parent }}"
+      - name: "V50 q=${{ steps.audit.outputs.q }} geodesic=${{ steps.audit.outputs.geodesicq }} product=${{ steps.audit.outputs.productq }} ez=${{ steps.audit.outputs.ez }}"
+        run: |
+          echo "closed=${{ steps.audit.outputs.closed }}"
+          echo "next=${{ steps.audit.outputs.next }}"
+      - name: Fail closed on producer validation
+        if: steps.audit.outputs.rc != '0'
+        run: exit 2

--- a/tests/validation/test_ou3_p5_sample1_authoritative_theta_z_projected_deltap_v50.py
+++ b/tests/validation/test_ou3_p5_sample1_authoritative_theta_z_projected_deltap_v50.py
@@ -1,0 +1,67 @@
+import math
+import pathlib
+import sys
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+TOOLS = ROOT / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+from ou3_interval import Interval
+import ou3_p5_sample1_authoritative_theta_z_projected_deltap_v50 as V50
+
+
+class Sample1AuthoritativeThetaZProjectedDeltaPV50Tests(unittest.TestCase):
+    def test_authoritative_witness_schema_and_target_are_frozen(self):
+        self.assertEqual(V50.WITNESS, (0, 0, 23))
+        self.assertEqual(V50.SCHEMA, 5000)
+        self.assertEqual(V50.Q_TARGET, 8.0)
+
+    def test_nominal_first_psd_attitude_component_matrix_uses_sparse_transport(self):
+        d = V50._nominal_first_psd_attitude_component_matrix(
+            beta_upper=0.5, offdiag_upper=2.0)
+        self.assertGreaterEqual(d[0][1], 0.5)
+        self.assertGreaterEqual(d[0][2], 1.0)
+        self.assertGreaterEqual(d[1][2], 1.0)
+        self.assertEqual(d[0][0], 0.0)
+        self.assertEqual(d[1][1], 0.0)
+        self.assertEqual(d[2][2], 0.0)
+        self.assertEqual(d[2][0], d[0][2])
+        self.assertEqual(d[2][1], d[1][2])
+
+    def test_abs_congruence_preserves_identity_component_matrix(self):
+        z = Interval.point(0.0)
+        o = Interval.point(1.0)
+        L = [[o, z, z], [z, o, z], [z, z, o]]
+        M = [[0.0, 2.0, 3.0], [2.0, 0.0, 4.0], [3.0, 4.0, 0.0]]
+        out = V50._abs_congruence_upper(L, M)
+        for i in range(3):
+            for j in range(3):
+                self.assertGreaterEqual(out[i][j], M[i][j])
+                self.assertLessEqual(out[i][j], M[i][j] + 1.0e-12)
+
+    def test_theta_z_projection_uses_requested_component_combinations(self):
+        d = V50._theta_z_projected_upper(
+            dP_zx=1.0, dP_zy=2.0, dP_zz=3.0,
+            fy_abs=4.0, fz_abs=5.0)
+        self.assertGreaterEqual(
+            d["minus_fz_DeltaP_zy_plus_fy_DeltaP_zz_abs_upper"], 22.0)
+        self.assertGreaterEqual(d["fz_DeltaP_zx_abs_upper"], 5.0)
+        self.assertGreaterEqual(d["minus_fy_DeltaP_zx_abs_upper"], 4.0)
+        self.assertGreaterEqual(
+            d["theta_z_projected_DeltaP_Htheta_componentwise_upper"],
+            math.sqrt(22.0 ** 2 + 5.0 ** 2 + 4.0 ** 2))
+
+    def test_invalid_component_inputs_fail_closed(self):
+        with self.assertRaises(ValueError):
+            V50._nominal_first_psd_attitude_component_matrix(
+                beta_upper=-1.0, offdiag_upper=1.0)
+        with self.assertRaises(ValueError):
+            V50._theta_z_projected_upper(
+                dP_zx=-1.0, dP_zy=1.0, dP_zz=1.0,
+                fy_abs=1.0, fz_abs=1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ou3_p5_sample1_authoritative_theta_z_projected_deltap_v50.py
+++ b/tools/ou3_p5_sample1_authoritative_theta_z_projected_deltap_v50.py
@@ -1,0 +1,562 @@
+#!/usr/bin/env python3
+"""V50: componentwise theta-z projected Delta-P H_theta on V40/V45.
+
+V49 shows that the remaining authoritative V48 survivor is limited by the
+theta-z Delta-C row and, inside that row, by the scalar product
+
+    ||Delta P|| ||H_theta||.
+
+That scalar product discards two pieces of structure already established by
+V36/V40.  The omitted first-attitude PSD remainder is a symmetric
+zero-diagonal matrix
+
+    O = [[0,a,b],[a,0,c],[b,c,0]],   |a|,|b|,|c| <= eps/2,
+
+and the attitude part of the nominal first Joseph transport has the exact
+diagonal action
+
+    B_theta = diag(beta,beta,1),   beta=(p+R_a)/(g^2 t+p+R_a).
+
+Hence the attitude block of B_theta O B_theta^T has the entrywise enclosure
+
+    [[0, beta^2 e, beta e],
+     [beta^2 e, 0, beta e],
+     [beta e, beta e, 0]],        e=eps/2.
+
+V50 transports that 3x3 component matrix through the already-used nominal
+first reset/gauge map L_theta.  V40's gain-perturbation cross/quadratic
+transport, reset-direction perturbation, and next-process remainder are kept
+as scalar operator parents and added to each component.  The sample-1 accepted
+S=0 covariance branch is likewise retained through its existing certified
+operator parent.  Every resulting entry is intersected with V40/V12D's scalar
+operator parent.
+
+For the actual sample-1 accelerometer H_theta=-[f]_x with f_x=0, the theta-z
+projected covariance row is then bounded from the specific combinations
+
+    -f_z Delta P_zy + f_y Delta P_zz,
+     f_z Delta P_zx,
+    -f_y Delta P_zx,
+
+instead of by ||Delta P|| ||H_theta||.  The remaining V49 Delta-C terms and
+V34 directional Delta-S term are unchanged.  The refined theta-z gain row is
+intersected with both the V34 row parent and V12D full gain parent, then injected
+only into V48's componentwise y/z correction construction.  V48's authoritative
+V45/V41 current chart and q composition remain unchanged.
+
+This is a focused proof refinement.  It does not change the estimator, source
+domain, six-radian correction limit, q<8 target, source language, whole-word
+criterion, or N_H_words.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+from ou3_interval import Interval
+import ou3_p5_sample1_authoritative_componentwise_yz_v48 as V48
+
+DEFAULT_DOMAIN = V48.DEFAULT_DOMAIN
+SCHEMA = 5000
+Q_TARGET = V48.Q_TARGET
+WITNESS = V48.WITNESS
+FULL = V48.FULL
+V12D = V48.V12D
+
+
+def _sum_up(*xs: float) -> float:
+    y = 0.0
+    for x in xs:
+        y = FULL.up(y + float(x))
+    return y
+
+
+def _mul_up(*xs: float) -> float:
+    y = 1.0
+    for x in xs:
+        y = FULL.up(y * float(x))
+    return y
+
+
+def _norm3_up(a: float, b: float, c: float) -> float:
+    s = FULL.up(FULL.up(a * a) + FULL.up(b * b))
+    s = FULL.up(s + FULL.up(c * c))
+    return FULL.up(math.sqrt(max(0.0, s)))
+
+
+def _row_norm_upper(row) -> float:
+    return _norm3_up(*(x.abs_upper() for x in row))
+
+
+def _nominal_first_psd_attitude_component_matrix(*, beta_upper: float,
+                                                 offdiag_upper: float):
+    """Absolute entrywise bound for B_theta O B_theta^T."""
+    vals = (beta_upper, offdiag_upper)
+    if not all(math.isfinite(float(x)) and float(x) >= 0.0 for x in vals):
+        raise ValueError("finite nonnegative nominal PSD component inputs required")
+    b = float(beta_upper)
+    e = float(offdiag_upper)
+    b2e = _mul_up(b, b, e)
+    be = _mul_up(b, e)
+    return [
+        [0.0, b2e, be],
+        [b2e, 0.0, be],
+        [be, be, 0.0],
+    ]
+
+
+def _abs_congruence_upper(L, M):
+    """Entrywise |L M L^T| upper bound for nonnegative component matrix M."""
+    if len(L) != 3 or any(len(r) != 3 for r in L):
+        raise ValueError("L must be 3x3")
+    if len(M) != 3 or any(len(r) != 3 for r in M):
+        raise ValueError("M must be 3x3")
+    out = [[0.0 for _ in range(3)] for _ in range(3)]
+    for i in range(3):
+        for j in range(3):
+            s = 0.0
+            for a in range(3):
+                la = L[i][a].abs_upper()
+                for b in range(3):
+                    m = float(M[a][b])
+                    if m < 0.0 or not math.isfinite(m):
+                        raise ValueError("component matrix must be finite and nonnegative")
+                    lb = L[j][b].abs_upper()
+                    s = FULL.up(s + _mul_up(la, m, lb))
+            out[i][j] = s
+    return out
+
+
+def _theta_z_projected_upper(*, dP_zx: float, dP_zy: float, dP_zz: float,
+                             fy_abs: float, fz_abs: float) -> dict:
+    """Bound the three components of e_z^T Delta-P H_theta^T."""
+    vals = (dP_zx, dP_zy, dP_zz, fy_abs, fz_abs)
+    if not all(math.isfinite(float(x)) and float(x) >= 0.0 for x in vals):
+        raise ValueError("finite nonnegative theta-z projected inputs required")
+    c0 = _sum_up(_mul_up(fz_abs, dP_zy), _mul_up(fy_abs, dP_zz))
+    c1 = _mul_up(fz_abs, dP_zx)
+    c2 = _mul_up(fy_abs, dP_zx)
+    n = _norm3_up(c0, c1, c2)
+    return {
+        "minus_fz_DeltaP_zy_plus_fy_DeltaP_zz_abs_upper": c0,
+        "fz_DeltaP_zx_abs_upper": c1,
+        "minus_fy_DeltaP_zx_abs_upper": c2,
+        "theta_z_projected_DeltaP_Htheta_componentwise_upper": n,
+    }
+
+
+def _authoritative_theta_z_detail(path: Path, *, source_pieces: int,
+                                  source_cell_index: int, p_pieces: int,
+                                  base: dict, vr: dict,
+                                  ds_detail: dict) -> dict:
+    """Construct the V50 theta-z Delta-C/gain refinement at WITNESS."""
+    V11 = V12D.V11
+    V10 = V11.V10
+    dom = json.loads(path.read_text(encoding="utf-8"))
+    src, phase = V10.RG._source_phase_children(source_pieces)[source_cell_index]
+    if phase != "due":
+        raise RuntimeError("V50 focused refinement requires first due source cell")
+
+    first = V11.FIRST.build(path, source_pieces=source_pieces)
+    fr = first["source_cells"][source_cell_index]
+    p_all = Interval.outward_bounds(*map(float, fr["P_aw_variance_interval"]))
+    pcells = V11.SUB.parts(p_all.lo, p_all.hi, p_pieces)
+    p = pcells[int(base["p_cell"])]
+
+    hstep = float(src["dt_s"])
+    g = float(dom["startup"]["gravity_mps2"])
+    tilt, yaw, eps = V10.RG._attitude_covariance_epsilon(path, hstep)
+    t = Interval.outward_bounds(tilt, FULL.up(tilt + eps))
+    Y = Interval.outward_bounds(yaw, FULL.up(yaw + eps))
+    vec = V11.VECTOR.build()
+    r = FULL._R_diag(
+        float(vec["configured_measurement_bounds"]["acc_measurement_std_mps2"])
+    )[0][0]
+    F, Q, _ = FULL._transition_and_Q(src, dom)
+    alpha = F[15][15]
+    qaw = Q[15][15]
+
+    rt = Interval.outward_bounds(
+        *map(float, base["first_tangent_residual_magnitude_mps2"]))
+    rz = Interval.outward_bounds(*map(float, base["first_axial_residual_mps2"]))
+    d = Interval.outward_bounds(*map(float, base["first_attitude_correction_rad"]))
+
+    D = FULL.I(g * g) * t + p + r
+    beta = (p + r) / D
+    beta_hi = beta.abs_upper()
+    offdiag = float(vr["first_PSD_offdiagonal_entry_abs_upper"])
+    nominal_first = _nominal_first_psd_attitude_component_matrix(
+        beta_upper=beta_hi, offdiag_upper=offdiag)
+
+    # V11/V4's exact nominal shipping-reset plus corrected-body gauge.
+    Ltheta, _Rx = V11.V4._Ltheta(d)
+    nominal_after_reset = _abs_congruence_upper(Ltheta, nominal_first)
+
+    cross = float(vr["first_PSD_Joseph_cross_transport_upper"])
+    quadratic = float(vr["first_PSD_Joseph_quadratic_transport_upper"])
+    reset_direction = float(vr["reset_gauge_transform_perturbation_upper"])
+    dhi = max(0.0, d.hi)
+    Tnom = FULL.up(math.sqrt(FULL.up(1.0 + FULL.up(0.25 * dhi * dhi))))
+    unknown_after_reset = _sum_up(
+        _mul_up(Tnom, Tnom, _sum_up(cross, quadratic)),
+        reset_direction,
+        float(eps),
+    )
+
+    psd_parent = float(vr["PSD_reduced_covariance_perturbation_upper"])
+    s_parent = float(vr["S_reduced_covariance_perturbation_upper"])
+    total_parent = float(vr["total_reduced_covariance_perturbation_upper"])
+    if min(psd_parent, s_parent, total_parent) < 0.0:
+        raise RuntimeError("negative V40/V12D covariance perturbation parent")
+
+    # Only the theta-z row is needed.  Unknown operator remainders and the
+    # accepted S=0 branch remain scalar parents; the structured Joseph term is
+    # carried entry by entry.
+    entry = {}
+    for name, j in (("zx", 0), ("zy", 1), ("zz", 2)):
+        psd_candidate = _sum_up(nominal_after_reset[2][j], unknown_after_reset)
+        psd_component = min(psd_parent, psd_candidate)
+        total_candidate = _sum_up(psd_component, s_parent)
+        total_component = min(total_parent, total_candidate)
+        entry[name] = {
+            "nominal_first_Joseph_component_upper": nominal_first[2][j],
+            "nominal_after_reset_component_upper": nominal_after_reset[2][j],
+            "V40_unknown_PSD_operator_remainder_upper": unknown_after_reset,
+            "PSD_component_candidate_upper": psd_candidate,
+            "PSD_component_intersected_upper": psd_component,
+            "sample1_S_operator_parent_upper": s_parent,
+            "total_component_candidate_upper": total_candidate,
+            "total_component_intersected_upper": total_component,
+        }
+
+    fy = -(alpha * (p / D) * rt)
+    fz = FULL.I(g) + alpha * (p / (p + r)) * rz
+    fy_abs = fy.abs_upper()
+    fz_abs = fz.abs_upper()
+    projected = _theta_z_projected_upper(
+        dP_zx=float(entry["zx"]["total_component_intersected_upper"]),
+        dP_zy=float(entry["zy"]["total_component_intersected_upper"]),
+        dP_zz=float(entry["zz"]["total_component_intersected_upper"]),
+        fy_abs=fy_abs, fz_abs=fz_abs)
+
+    dP = total_parent
+    dH = float(vr["sample1_H_perturbation_upper"])
+    htheta = float(vr["sample1_Htheta_operator_upper"])
+    pz = _row_norm_upper(
+        V11._nominal_sample1_matrices(
+            t=t, Y=Y, p=p, r=r, g=g, alpha=alpha, qaw=qaw,
+            d=d, fy=fy, fz=fz)[0][2][:3])
+
+    projected_parent = _mul_up(dP, htheta)
+    nominal_dH = _mul_up(pz, dH)
+    mixed = _mul_up(dP, dH)
+    theta_aw = dP
+    projected_refined = float(
+        projected["theta_z_projected_DeltaP_Htheta_componentwise_upper"])
+    candidate_dC = _sum_up(projected_refined, nominal_dH, mixed, theta_aw)
+
+    parent_dC = float(vr["sample1_attitude_cross_covariance_perturbation_upper"])
+    dC = min(parent_dC, candidate_dC)
+
+    inv = float(ds_detail["actual_innovation_inverse_operator_upper"])
+    kz = float(ds_detail["nominal_theta_z_gain_row_norm_upper"])
+    dS0 = float(ds_detail["first_measurement_row_DeltaS_intersected_upper"])
+    parent_dK = float(vr["sample1_attitude_gain_operator_perturbation_upper"])
+    v34_dK = float(ds_detail["theta_z_gain_perturbation_intersected_upper"])
+    dK_candidate = _mul_up(_sum_up(dC, _mul_up(kz, dS0)), inv)
+    dK = min(parent_dK, v34_dK, dK_candidate)
+
+    if projected_refined > FULL.up(projected_parent):
+        raise RuntimeError("componentwise theta-z projection exceeded scalar parent")
+    for name in ("zx", "zy", "zz"):
+        if float(entry[name]["total_component_intersected_upper"]) > FULL.up(total_parent):
+            raise RuntimeError(f"theta-z {name} component escaped V12D operator parent")
+    if dC > FULL.up(parent_dC):
+        raise RuntimeError("theta-z Delta-C refinement escaped V12D parent")
+    if dK > FULL.up(v34_dK) or dK > FULL.up(parent_dK):
+        raise RuntimeError("theta-z gain refinement escaped certified parents")
+
+    out = {
+        "beta_first_attitude_transport_upper": beta_hi,
+        "first_PSD_offdiagonal_entry_abs_upper": offdiag,
+        "nominal_first_PSD_attitude_component_matrix_upper": nominal_first,
+        "nominal_reset_Ltheta_interval": [
+            [x.as_list() for x in row] for row in Ltheta],
+        "nominal_after_reset_PSD_attitude_component_matrix_upper":
+            nominal_after_reset,
+        "V40_cross_transport_upper": cross,
+        "V40_quadratic_transport_upper": quadratic,
+        "V40_reset_direction_operator_upper": reset_direction,
+        "next_process_PSD_remainder_upper": float(eps),
+        "V40_unknown_PSD_operator_remainder_after_reset_upper":
+            unknown_after_reset,
+        "V40_PSD_operator_parent_upper": psd_parent,
+        "sample1_S_operator_parent_upper": s_parent,
+        "V12D_total_DeltaP_operator_parent_upper": total_parent,
+        "theta_z_DeltaP_component_entries": entry,
+        "sample1_force_y_abs_upper_mps2": fy_abs,
+        "sample1_force_z_abs_upper_mps2": fz_abs,
+        **projected,
+        "scalar_projected_DeltaP_Htheta_parent_upper": projected_parent,
+        "projected_componentwise_over_scalar_parent_ratio": (
+            0.0 if projected_parent == 0.0
+            else projected_refined / projected_parent),
+        "theta_z_nominal_attitude_covariance_row_norm_upper": pz,
+        "nominal_Ptheta_row_DeltaH_upper": nominal_dH,
+        "mixed_DeltaP_DeltaH_upper": mixed,
+        "theta_aw_cross_block_parent_upper": theta_aw,
+        "theta_z_DeltaC_componentwise_candidate_upper": candidate_dC,
+        "V12D_full_DeltaC_parent_upper": parent_dC,
+        "theta_z_DeltaC_intersected_upper": dC,
+        "theta_z_DeltaC_strictly_refined": dC < parent_dC,
+        "directional_DeltaS_row_upper": dS0,
+        "nominal_theta_z_gain_row_norm_upper": kz,
+        "actual_innovation_inverse_operator_upper": inv,
+        "theta_z_gain_perturbation_componentwise_candidate_upper": dK_candidate,
+        "V34_theta_z_gain_perturbation_parent_upper": v34_dK,
+        "V12D_full_attitude_gain_perturbation_parent_upper": parent_dK,
+        "theta_z_gain_perturbation_intersected_upper": dK,
+        "theta_z_gain_strictly_refined_vs_V34": dK < v34_dK,
+        "specific_theta_z_projected_combinations_used": True,
+        "V40_unknown_terms_retained_as_operator_parents": True,
+        "sample1_S_covariance_branch_retained_as_operator_parent": True,
+    }
+    return out
+
+
+def build(domain_path: Path = DEFAULT_DOMAIN, *, source_pieces: int = 4,
+          source_cell_index: int = 0, p_pieces: int = 24,
+          tangent_pieces: int = 24, axial_pieces: int = 24,
+          residual_x_pieces: int = 6, parallel_pieces: int = 6) -> dict:
+    path = Path(domain_path).resolve()
+    failures: list[str] = []
+
+    # Precompute the same authoritative V40 witness rows used by V48, solely
+    # to audit the refinement before injecting it into V48's q composition.
+    _core, _v12, base, vr, row_failures = V48._build_v40_rows(
+        path, source_pieces=source_pieces,
+        source_cell_index=source_cell_index, p_pieces=p_pieces,
+        tangent_pieces=tangent_pieces, axial_pieces=axial_pieces)
+    failures += row_failures
+    try:
+        ds = V48.V34._directional_delta_s_detail(
+            path, source_pieces=source_pieces,
+            source_cell_index=source_cell_index, p_pieces=p_pieces,
+            base=base, vr=vr)
+        detail = _authoritative_theta_z_detail(
+            path, source_pieces=source_pieces,
+            source_cell_index=source_cell_index, p_pieces=p_pieces,
+            base=base, vr=vr, ds_detail=ds)
+    except Exception as exc:
+        failures.append(f"V50 theta-z projected Delta-P construction: {exc}")
+        detail = None
+
+    original_caps = V48._componentwise_yz_caps
+    injected = {"calls": 0, "last_detail": detail}
+
+    def v50_caps(*, base: dict, vr: dict, ds_detail: dict,
+                 parent_caps: dict) -> dict:
+        local_detail = _authoritative_theta_z_detail(
+            path, source_pieces=source_pieces,
+            source_cell_index=source_cell_index, p_pieces=p_pieces,
+            base=base, vr=vr, ds_detail=ds_detail)
+        injected["calls"] += 1
+        injected["last_detail"] = local_detail
+        ds2 = dict(ds_detail)
+        ds2["theta_z_gain_perturbation_intersected_upper"] = float(
+            local_detail["theta_z_gain_perturbation_intersected_upper"])
+        out = original_caps(
+            base=base, vr=vr, ds_detail=ds2, parent_caps=parent_caps)
+        out["V50_theta_z_gain_refinement_injected"] = True
+        out["V50_theta_z_gain_parent_upper"] = float(
+            ds_detail["theta_z_gain_perturbation_intersected_upper"])
+        out["V50_theta_z_gain_intersected_upper"] = float(
+            local_detail["theta_z_gain_perturbation_intersected_upper"])
+        return out
+
+    V48._componentwise_yz_caps = v50_caps
+    try:
+        parent = V48.build(
+            path, source_pieces=source_pieces,
+            source_cell_index=source_cell_index, p_pieces=p_pieces,
+            tangent_pieces=tangent_pieces, axial_pieces=axial_pieces,
+            residual_x_pieces=residual_x_pieces,
+            parallel_pieces=parallel_pieces)
+    except Exception as exc:
+        failures.append(f"V48 under V50 theta-z injection: {exc}")
+        parent = {}
+    finally:
+        V48._componentwise_yz_caps = original_caps
+
+    failures += [f"V48: {x}" for x in V48.validate(parent)] if parent else []
+    if parent and parent.get("P5_SAMPLE1_AUTHORITATIVE_COMPONENTWISE_YZ_V48") != "PASS":
+        failures.append("V48 authoritative parent did not pass under V50 injection")
+    if injected["calls"] <= 0:
+        failures.append("V50 theta-z componentwise cap was not injected into V48")
+    if V48._componentwise_yz_caps is not original_caps:
+        failures.append("V48 componentwise cap helper was not restored")
+
+    detail = injected["last_detail"]
+    caps = parent.get("componentwise_yz_perturbation_detail") or {}
+    z_gain_refined = bool(detail and detail.get(
+        "theta_z_gain_strictly_refined_vs_V34"))
+    z_corr_refined = bool(caps and (
+        float(caps.get("theta_z_component_abs_upper_rad", math.inf))
+        < float(caps.get("V31_parent_yz_norm_upper_rad", -math.inf))))
+    closed = bool(parent.get("first_V41_survivor_closed_by_V48_componentwise_yz"))
+    q = float(parent.get("authoritative_componentwise_best_q_upper", math.inf))
+    if not math.isfinite(q):
+        failures.append("V50 authoritative q is not finite")
+
+    out = dict(parent)
+    out.update({
+        "schema": SCHEMA,
+        "qualification":
+            "OU3_P5_SAMPLE1_AUTHORITATIVE_THETA_Z_PROJECTED_DELTAP_V50",
+        "V48_authoritative_componentwise_yz_parent_retained": True,
+        "V40_exact_Joseph_component_parent_retained": True,
+        "V45_V41_authoritative_current_chart_retained": True,
+        "theta_z_projected_DeltaP_component_matrix_used": True,
+        "theta_z_projected_DeltaP_specific_accelerometer_combinations_used": True,
+        "V40_unknown_PSD_terms_retained_as_operator_parents": True,
+        "sample1_S_covariance_branch_retained_as_operator_parent": True,
+        "theta_z_componentwise_detail": detail,
+        "V50_componentwise_cap_injection_calls": int(injected["calls"]),
+        "V48_componentwise_cap_helper_restored": (
+            V48._componentwise_yz_caps is original_caps),
+        "theta_z_gain_strictly_refined_vs_V34": z_gain_refined,
+        "theta_z_correction_component_strictly_refined": z_corr_refined,
+        "authoritative_V50_best_q_upper": q,
+        "first_V41_survivor_closed_by_V50_theta_z_projected_DeltaP": closed,
+        "deployed_correction_limit_rad": 6.0,
+        "deployed_correction_limit_increased": False,
+        "q_target": Q_TARGET,
+        "q8_word_promoted_here": False,
+        "whole_word_promoted_here": False,
+        "N_H_words_set_here": False,
+        "P5_SAMPLE1_AUTHORITATIVE_THETA_Z_PROJECTED_DELTAP_V50": (
+            "PASS" if not failures else "NOT_ESTABLISHED"),
+        "next_obligation": (
+            "PROMOTE_V50_CLOSED_SAMPLE1_CELL_THROUGH_FULL_SOURCE_CELL0_COVER"
+            if closed and not failures else
+            "REFINE_THETA_Z_REMAINING_V50_DELTAC_OR_RESIDUAL_TERM_ON_AUTHORITATIVE_PARENT"
+            if z_gain_refined and not failures else
+            "REFINE_V40_UNKNOWN_PSD_OR_SAMPLE1_S_COMPONENT_MATRIX_FOR_THETA_Z"),
+        "failures": list(dict.fromkeys(failures)),
+    })
+    return out
+
+
+def validate(d: dict) -> list[str]:
+    f = list(d.get("failures", []))
+    if d.get("schema") != SCHEMA:
+        f.append("schema mismatch")
+    if d.get("qualification") != \
+            "OU3_P5_SAMPLE1_AUTHORITATIVE_THETA_Z_PROJECTED_DELTAP_V50":
+        f.append("qualification mismatch")
+    for k in (
+        "source_generated_not_trajectory_fit",
+        "V48_authoritative_componentwise_yz_parent_retained",
+        "V40_exact_Joseph_component_parent_retained",
+        "V45_V41_authoritative_current_chart_retained",
+        "theta_z_projected_DeltaP_component_matrix_used",
+        "theta_z_projected_DeltaP_specific_accelerometer_combinations_used",
+        "V40_unknown_PSD_terms_retained_as_operator_parents",
+        "sample1_S_covariance_branch_retained_as_operator_parent",
+        "V48_componentwise_cap_helper_restored",
+    ):
+        if d.get(k) is not True:
+            f.append(f"{k} is not true")
+    for k in (
+        "source_replay_used", "filter_changed",
+        "deployed_correction_limit_increased", "q8_word_promoted_here",
+        "whole_word_promoted_here", "N_H_words_set_here",
+    ):
+        if d.get(k) is not False:
+            f.append(f"{k} is not false")
+    if list(d.get("V41_first_survivor_row", [])) != list(WITNESS):
+        f.append("authoritative V41 survivor changed")
+    if int(d.get("V50_componentwise_cap_injection_calls", 0)) <= 0:
+        f.append("V50 cap injection was not exercised")
+    if float(d.get("deployed_correction_limit_rad", 0.0)) != 6.0:
+        f.append("deployed correction limit changed")
+    if float(d.get("q_target", 0.0)) != Q_TARGET:
+        f.append("q target changed")
+
+    detail = d.get("theta_z_componentwise_detail") or {}
+    projected = float(detail.get(
+        "theta_z_projected_DeltaP_Htheta_componentwise_upper", math.inf))
+    projected_parent = float(detail.get(
+        "scalar_projected_DeltaP_Htheta_parent_upper", -math.inf))
+    if not (math.isfinite(projected) and 0.0 <= projected
+            <= FULL.up(projected_parent)):
+        f.append("invalid componentwise theta-z projected Delta-P refinement")
+    dC = float(detail.get("theta_z_DeltaC_intersected_upper", math.inf))
+    dC_parent = float(detail.get("V12D_full_DeltaC_parent_upper", -math.inf))
+    if not (math.isfinite(dC) and 0.0 <= dC <= FULL.up(dC_parent)):
+        f.append("invalid theta-z Delta-C intersection")
+    dK = float(detail.get("theta_z_gain_perturbation_intersected_upper", math.inf))
+    dK_parent = float(detail.get(
+        "V34_theta_z_gain_perturbation_parent_upper", -math.inf))
+    if not (math.isfinite(dK) and 0.0 <= dK <= FULL.up(dK_parent)):
+        f.append("invalid theta-z gain intersection")
+
+    q = float(d.get("authoritative_V50_best_q_upper", math.inf))
+    if not math.isfinite(q):
+        f.append("nonfinite V50 authoritative q")
+    if d.get("P5_SAMPLE1_AUTHORITATIVE_THETA_Z_PROJECTED_DELTAP_V50") not in (
+            "PASS", "NOT_ESTABLISHED"):
+        f.append("invalid V50 status")
+    return list(dict.fromkeys(f))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--domain", type=Path, default=DEFAULT_DOMAIN)
+    ap.add_argument("--source-pieces", type=int, default=4)
+    ap.add_argument("--source-cell-index", type=int, default=0)
+    ap.add_argument("--p-pieces", type=int, default=24)
+    ap.add_argument("--tangent-pieces", type=int, default=24)
+    ap.add_argument("--axial-pieces", type=int, default=24)
+    ap.add_argument("--residual-x-pieces", type=int, default=6)
+    ap.add_argument("--parallel-pieces", type=int, default=6)
+    ap.add_argument("--output", type=Path, required=True)
+    x = ap.parse_args()
+    d = build(
+        x.domain, source_pieces=x.source_pieces,
+        source_cell_index=x.source_cell_index, p_pieces=x.p_pieces,
+        tangent_pieces=x.tangent_pieces, axial_pieces=x.axial_pieces,
+        residual_x_pieces=x.residual_x_pieces,
+        parallel_pieces=x.parallel_pieces)
+    vf = validate(d)
+    d["validation_failures"] = vf
+    x.output.parent.mkdir(parents=True, exist_ok=True)
+    x.output.write_text(json.dumps(d, indent=2, sort_keys=True), encoding="utf-8")
+    z = d.get("theta_z_componentwise_detail") or {}
+    caps = d.get("componentwise_yz_perturbation_detail") or {}
+    print(json.dumps({
+        "status": d["P5_SAMPLE1_AUTHORITATIVE_THETA_Z_PROJECTED_DELTAP_V50"],
+        "projected_componentwise":
+            z.get("theta_z_projected_DeltaP_Htheta_componentwise_upper"),
+        "projected_parent":
+            z.get("scalar_projected_DeltaP_Htheta_parent_upper"),
+        "projected_ratio":
+            z.get("projected_componentwise_over_scalar_parent_ratio"),
+        "dC": z.get("theta_z_DeltaC_intersected_upper"),
+        "dC_parent": z.get("V12D_full_DeltaC_parent_upper"),
+        "dKz": z.get("theta_z_gain_perturbation_intersected_upper"),
+        "dKz_parent": z.get("V34_theta_z_gain_perturbation_parent_upper"),
+        "ez": caps.get("theta_z_component_abs_upper_rad"),
+        "q": d.get("authoritative_V50_best_q_upper"),
+        "closed":
+            d.get("first_V41_survivor_closed_by_V50_theta_z_projected_DeltaP"),
+        "next": d.get("next_obligation"),
+        "validation_failures": vf,
+    }, indent=2, sort_keys=True))
+    return 0 if not vf else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ou3_p5_sample1_authoritative_theta_z_projected_deltap_v50.py
+++ b/tools/ou3_p5_sample1_authoritative_theta_z_projected_deltap_v50.py
@@ -1,52 +1,41 @@
 #!/usr/bin/env python3
-"""V50: componentwise theta-z projected Delta-P H_theta on V40/V45.
+"""V50: correlated theta-z projected Delta-P H_theta refinement.
 
-V49 shows that the remaining authoritative V48 survivor is limited by the
-theta-z Delta-C row and, inside that row, by the scalar product
+V49 identifies ``||Delta P|| ||H_theta||`` as the dominant theta-z Delta-C
+term.  A naive entrywise replacement is not automatically tighter: treating
+DeltaP_zx, DeltaP_zy and DeltaP_zz as independent can destroy the shared
+matrix correlation and exceed the scalar operator parent.
 
-    ||Delta P|| ||H_theta||.
+V50 therefore carries the structured first-PSD attitude remainder through the
+actual matrix algebra before taking a norm.  V36/V40 establish that the
+omitted first-attitude remainder is
 
-That scalar product discards two pieces of structure already established by
-V36/V40.  The omitted first-attitude PSD remainder is a symmetric
-zero-diagonal matrix
+    O = a E01 + b E02 + c E12,   |a|,|b|,|c| <= eps/2,
 
-    O = [[0,a,b],[a,0,c],[b,c,0]],   |a|,|b|,|c| <= eps/2,
+with symmetric basis matrices Eij.  The nominal first Joseph attitude action is
+B_theta=diag(beta,beta,1).  With the already-certified nominal reset/gauge map
+L_theta, each shared basis variable is transported as
 
-and the attitude part of the nominal first Joseph transport has the exact
-diagonal action
+    M_ij = L_theta B_theta Eij B_theta L_theta^T.
 
-    B_theta = diag(beta,beta,1),   beta=(p+R_a)/(g^2 t+p+R_a).
+For the actual sample-1 accelerometer H_theta=-[f]_x, f_x=0, V50 evaluates the
+specific theta-z projected combinations
 
-Hence the attitude block of B_theta O B_theta^T has the entrywise enclosure
+    -f_z M_zy + f_y M_zz,
+     f_z M_zx,
+    -f_y M_zx
 
-    [[0, beta^2 e, beta e],
-     [beta^2 e, 0, beta e],
-     [beta e, beta e, 0]],        e=eps/2.
+for each basis and sums the three basis-vector norms with outward rounding.
+This preserves the correlation within each matrix basis.  V40's gain-error
+cross/quadratic transport, reset-direction perturbation and next-process
+remainder are still charged in operator norm, as is the accepted sample-1
+S=0 covariance branch.  The resulting candidate is intersected with the V49
+scalar parent, so the refinement is fail-safe and never weakens the existing
+certificate.
 
-V50 transports that 3x3 component matrix through the already-used nominal
-first reset/gauge map L_theta.  V40's gain-perturbation cross/quadratic
-transport, reset-direction perturbation, and next-process remainder are kept
-as scalar operator parents and added to each component.  The sample-1 accepted
-S=0 covariance branch is likewise retained through its existing certified
-operator parent.  Every resulting entry is intersected with V40/V12D's scalar
-operator parent.
-
-For the actual sample-1 accelerometer H_theta=-[f]_x with f_x=0, the theta-z
-projected covariance row is then bounded from the specific combinations
-
-    -f_z Delta P_zy + f_y Delta P_zz,
-     f_z Delta P_zx,
-    -f_y Delta P_zx,
-
-instead of by ||Delta P|| ||H_theta||.  The remaining V49 Delta-C terms and
-V34 directional Delta-S term are unchanged.  The refined theta-z gain row is
-intersected with both the V34 row parent and V12D full gain parent, then injected
-only into V48's componentwise y/z correction construction.  V48's authoritative
-V45/V41 current chart and q composition remain unchanged.
-
-This is a focused proof refinement.  It does not change the estimator, source
-domain, six-radian correction limit, q<8 target, source language, whole-word
-criterion, or N_H_words.
+This stage only proves or rejects the projected Delta-P refinement.  It does
+not alter the estimator, source domain, six-radian correction limit, q<8
+target, whole-word language, P5 status or N_H_words.
 """
 from __future__ import annotations
 
@@ -55,15 +44,15 @@ import json
 import math
 from pathlib import Path
 
-from ou3_interval import Interval
+from ou3_interval import Interval, matrix_mul, matrix_transpose
 import ou3_p5_sample1_authoritative_componentwise_yz_v48 as V48
 
 DEFAULT_DOMAIN = V48.DEFAULT_DOMAIN
-SCHEMA = 5000
-Q_TARGET = V48.Q_TARGET
+SCHEMA = 5001
 WITNESS = V48.WITNESS
 FULL = V48.FULL
 V12D = V48.V12D
+Q_TARGET = V48.Q_TARGET
 
 
 def _sum_up(*xs: float) -> float:
@@ -86,409 +75,255 @@ def _norm3_up(a: float, b: float, c: float) -> float:
     return FULL.up(math.sqrt(max(0.0, s)))
 
 
-def _row_norm_upper(row) -> float:
-    return _norm3_up(*(x.abs_upper() for x in row))
+def _basis(i: int, j: int):
+    """Return the symmetric 3x3 E_ij basis matrix."""
+    if not (0 <= i < j < 3):
+        raise ValueError("basis requires 0 <= i < j < 3")
+    z = FULL.I(0.0)
+    o = FULL.I(1.0)
+    M = [[z for _ in range(3)] for _ in range(3)]
+    M[i][j] = o
+    M[j][i] = o
+    return M
 
 
-def _nominal_first_psd_attitude_component_matrix(*, beta_upper: float,
-                                                 offdiag_upper: float):
-    """Absolute entrywise bound for B_theta O B_theta^T."""
-    vals = (beta_upper, offdiag_upper)
-    if not all(math.isfinite(float(x)) and float(x) >= 0.0 for x in vals):
-        raise ValueError("finite nonnegative nominal PSD component inputs required")
-    b = float(beta_upper)
-    e = float(offdiag_upper)
-    b2e = _mul_up(b, b, e)
-    be = _mul_up(b, e)
-    return [
-        [0.0, b2e, be],
-        [b2e, 0.0, be],
-        [be, be, 0.0],
-    ]
-
-
-def _abs_congruence_upper(L, M):
-    """Entrywise |L M L^T| upper bound for nonnegative component matrix M."""
-    if len(L) != 3 or any(len(r) != 3 for r in L):
-        raise ValueError("L must be 3x3")
-    if len(M) != 3 or any(len(r) != 3 for r in M):
-        raise ValueError("M must be 3x3")
-    out = [[0.0 for _ in range(3)] for _ in range(3)]
-    for i in range(3):
-        for j in range(3):
-            s = 0.0
-            for a in range(3):
-                la = L[i][a].abs_upper()
-                for b in range(3):
-                    m = float(M[a][b])
-                    if m < 0.0 or not math.isfinite(m):
-                        raise ValueError("component matrix must be finite and nonnegative")
-                    lb = L[j][b].abs_upper()
-                    s = FULL.up(s + _mul_up(la, m, lb))
-            out[i][j] = s
-    return out
-
-
-def _theta_z_projected_upper(*, dP_zx: float, dP_zy: float, dP_zz: float,
-                             fy_abs: float, fz_abs: float) -> dict:
-    """Bound the three components of e_z^T Delta-P H_theta^T."""
-    vals = (dP_zx, dP_zy, dP_zz, fy_abs, fz_abs)
-    if not all(math.isfinite(float(x)) and float(x) >= 0.0 for x in vals):
-        raise ValueError("finite nonnegative theta-z projected inputs required")
-    c0 = _sum_up(_mul_up(fz_abs, dP_zy), _mul_up(fy_abs, dP_zz))
-    c1 = _mul_up(fz_abs, dP_zx)
-    c2 = _mul_up(fy_abs, dP_zx)
-    n = _norm3_up(c0, c1, c2)
+def _project_theta_z_row(M, *, fy_abs: float, fz_abs: float) -> dict:
+    """Project row z of M through the actual f_x=0 H_theta structure."""
+    zx = M[2][0].abs_upper()
+    zy = M[2][1].abs_upper()
+    zz = M[2][2].abs_upper()
+    c0 = _sum_up(_mul_up(fz_abs, zy), _mul_up(fy_abs, zz))
+    c1 = _mul_up(fz_abs, zx)
+    c2 = _mul_up(fy_abs, zx)
     return {
-        "minus_fz_DeltaP_zy_plus_fy_DeltaP_zz_abs_upper": c0,
-        "fz_DeltaP_zx_abs_upper": c1,
-        "minus_fy_DeltaP_zx_abs_upper": c2,
-        "theta_z_projected_DeltaP_Htheta_componentwise_upper": n,
+        "minus_fz_Mzy_plus_fy_Mzz_abs_upper": c0,
+        "fz_Mzx_abs_upper": c1,
+        "minus_fy_Mzx_abs_upper": c2,
+        "vector_norm_upper": _norm3_up(c0, c1, c2),
     }
 
 
-def _authoritative_theta_z_detail(path: Path, *, source_pieces: int,
-                                  source_cell_index: int, p_pieces: int,
-                                  base: dict, vr: dict,
-                                  ds_detail: dict) -> dict:
-    """Construct the V50 theta-z Delta-C/gain refinement at WITNESS."""
+def _component_detail(path: Path, *, source_pieces: int,
+                      source_cell_index: int, p_pieces: int,
+                      base: dict, vr: dict) -> dict:
+    """Evaluate the correlated V50 projection on the authoritative witness."""
     V11 = V12D.V11
     V10 = V11.V10
     dom = json.loads(path.read_text(encoding="utf-8"))
     src, phase = V10.RG._source_phase_children(source_pieces)[source_cell_index]
     if phase != "due":
-        raise RuntimeError("V50 focused refinement requires first due source cell")
+        raise RuntimeError("V50 requires the authoritative first-due source cell")
 
     first = V11.FIRST.build(path, source_pieces=source_pieces)
     fr = first["source_cells"][source_cell_index]
     p_all = Interval.outward_bounds(*map(float, fr["P_aw_variance_interval"]))
-    pcells = V11.SUB.parts(p_all.lo, p_all.hi, p_pieces)
-    p = pcells[int(base["p_cell"])]
+    p = V11.SUB.parts(p_all.lo, p_all.hi, p_pieces)[int(base["p_cell"])]
 
-    hstep = float(src["dt_s"])
+    h = float(src["dt_s"])
     g = float(dom["startup"]["gravity_mps2"])
-    tilt, yaw, eps = V10.RG._attitude_covariance_epsilon(path, hstep)
+    tilt, yaw, eps = V10.RG._attitude_covariance_epsilon(path, h)
     t = Interval.outward_bounds(tilt, FULL.up(tilt + eps))
-    Y = Interval.outward_bounds(yaw, FULL.up(yaw + eps))
     vec = V11.VECTOR.build()
-    r = FULL._R_diag(
-        float(vec["configured_measurement_bounds"]["acc_measurement_std_mps2"])
-    )[0][0]
-    F, Q, _ = FULL._transition_and_Q(src, dom)
+    r = FULL._R_diag(float(
+        vec["configured_measurement_bounds"]["acc_measurement_std_mps2"]))[0][0]
+    F, _Q, _ = FULL._transition_and_Q(src, dom)
     alpha = F[15][15]
-    qaw = Q[15][15]
 
     rt = Interval.outward_bounds(
         *map(float, base["first_tangent_residual_magnitude_mps2"]))
     rz = Interval.outward_bounds(*map(float, base["first_axial_residual_mps2"]))
     d = Interval.outward_bounds(*map(float, base["first_attitude_correction_rad"]))
-
     D = FULL.I(g * g) * t + p + r
     beta = (p + r) / D
-    beta_hi = beta.abs_upper()
-    offdiag = float(vr["first_PSD_offdiagonal_entry_abs_upper"])
-    nominal_first = _nominal_first_psd_attitude_component_matrix(
-        beta_upper=beta_hi, offdiag_upper=offdiag)
+    fy = -(alpha * (p / D) * rt)
+    fz = FULL.I(g) + alpha * (p / (p + r)) * rz
+    fy_abs = fy.abs_upper()
+    fz_abs = fz.abs_upper()
 
-    # V11/V4's exact nominal shipping-reset plus corrected-body gauge.
-    Ltheta, _Rx = V11.V4._Ltheta(d)
-    nominal_after_reset = _abs_congruence_upper(Ltheta, nominal_first)
+    L, _Rx = V11.V4._Ltheta(d)
+    z = FULL.I(0.0)
+    B = [[beta, z, z], [z, beta, z], [z, z, FULL.I(1.0)]]
+    A = matrix_mul(L, B)
+
+    offdiag = float(vr["first_PSD_offdiagonal_entry_abs_upper"])
+    if not (math.isfinite(offdiag) and offdiag >= 0.0):
+        raise RuntimeError("invalid V40 offdiagonal component bound")
+
+    basis_rows = []
+    nominal_projected = 0.0
+    for i, j in ((0, 1), (0, 2), (1, 2)):
+        M = matrix_mul(matrix_mul(A, _basis(i, j)), matrix_transpose(A))
+        projected = _project_theta_z_row(M, fy_abs=fy_abs, fz_abs=fz_abs)
+        contribution = _mul_up(offdiag, float(projected["vector_norm_upper"]))
+        nominal_projected = FULL.up(nominal_projected + contribution)
+        basis_rows.append({
+            "basis": [i, j],
+            "unit_basis_projected_theta_z": projected,
+            "offdiagonal_amplitude_upper": offdiag,
+            "projected_contribution_upper": contribution,
+        })
 
     cross = float(vr["first_PSD_Joseph_cross_transport_upper"])
     quadratic = float(vr["first_PSD_Joseph_quadratic_transport_upper"])
     reset_direction = float(vr["reset_gauge_transform_perturbation_upper"])
     dhi = max(0.0, d.hi)
     Tnom = FULL.up(math.sqrt(FULL.up(1.0 + FULL.up(0.25 * dhi * dhi))))
-    unknown_after_reset = _sum_up(
+    unknown_psd = _sum_up(
         _mul_up(Tnom, Tnom, _sum_up(cross, quadratic)),
         reset_direction,
         float(eps),
     )
-
-    psd_parent = float(vr["PSD_reduced_covariance_perturbation_upper"])
     s_parent = float(vr["S_reduced_covariance_perturbation_upper"])
     total_parent = float(vr["total_reduced_covariance_perturbation_upper"])
-    if min(psd_parent, s_parent, total_parent) < 0.0:
-        raise RuntimeError("negative V40/V12D covariance perturbation parent")
-
-    # Only the theta-z row is needed.  Unknown operator remainders and the
-    # accepted S=0 branch remain scalar parents; the structured Joseph term is
-    # carried entry by entry.
-    entry = {}
-    for name, j in (("zx", 0), ("zy", 1), ("zz", 2)):
-        psd_candidate = _sum_up(nominal_after_reset[2][j], unknown_after_reset)
-        psd_component = min(psd_parent, psd_candidate)
-        total_candidate = _sum_up(psd_component, s_parent)
-        total_component = min(total_parent, total_candidate)
-        entry[name] = {
-            "nominal_first_Joseph_component_upper": nominal_first[2][j],
-            "nominal_after_reset_component_upper": nominal_after_reset[2][j],
-            "V40_unknown_PSD_operator_remainder_upper": unknown_after_reset,
-            "PSD_component_candidate_upper": psd_candidate,
-            "PSD_component_intersected_upper": psd_component,
-            "sample1_S_operator_parent_upper": s_parent,
-            "total_component_candidate_upper": total_candidate,
-            "total_component_intersected_upper": total_component,
-        }
-
-    fy = -(alpha * (p / D) * rt)
-    fz = FULL.I(g) + alpha * (p / (p + r)) * rz
-    fy_abs = fy.abs_upper()
-    fz_abs = fz.abs_upper()
-    projected = _theta_z_projected_upper(
-        dP_zx=float(entry["zx"]["total_component_intersected_upper"]),
-        dP_zy=float(entry["zy"]["total_component_intersected_upper"]),
-        dP_zz=float(entry["zz"]["total_component_intersected_upper"]),
-        fy_abs=fy_abs, fz_abs=fz_abs)
-
-    dP = total_parent
-    dH = float(vr["sample1_H_perturbation_upper"])
     htheta = float(vr["sample1_Htheta_operator_upper"])
-    pz = _row_norm_upper(
-        V11._nominal_sample1_matrices(
-            t=t, Y=Y, p=p, r=r, g=g, alpha=alpha, qaw=qaw,
-            d=d, fy=fy, fz=fz)[0][2][:3])
+    if not all(math.isfinite(x) and x >= 0.0 for x in
+               (unknown_psd, s_parent, total_parent, htheta)):
+        raise RuntimeError("invalid V40/V12D scalar remainder parent")
 
-    projected_parent = _mul_up(dP, htheta)
-    nominal_dH = _mul_up(pz, dH)
-    mixed = _mul_up(dP, dH)
-    theta_aw = dP
-    projected_refined = float(
-        projected["theta_z_projected_DeltaP_Htheta_componentwise_upper"])
-    candidate_dC = _sum_up(projected_refined, nominal_dH, mixed, theta_aw)
+    scalar_projected_parent = _mul_up(total_parent, htheta)
+    operator_remainder = _sum_up(unknown_psd, s_parent)
+    remainder_projected = _mul_up(operator_remainder, htheta)
+    correlated_candidate = _sum_up(nominal_projected, remainder_projected)
+    intersected = min(scalar_projected_parent, correlated_candidate)
 
-    parent_dC = float(vr["sample1_attitude_cross_covariance_perturbation_upper"])
-    dC = min(parent_dC, candidate_dC)
-
-    inv = float(ds_detail["actual_innovation_inverse_operator_upper"])
-    kz = float(ds_detail["nominal_theta_z_gain_row_norm_upper"])
-    dS0 = float(ds_detail["first_measurement_row_DeltaS_intersected_upper"])
-    parent_dK = float(vr["sample1_attitude_gain_operator_perturbation_upper"])
-    v34_dK = float(ds_detail["theta_z_gain_perturbation_intersected_upper"])
-    dK_candidate = _mul_up(_sum_up(dC, _mul_up(kz, dS0)), inv)
-    dK = min(parent_dK, v34_dK, dK_candidate)
-
-    if projected_refined > FULL.up(projected_parent):
-        raise RuntimeError("componentwise theta-z projection exceeded scalar parent")
-    for name in ("zx", "zy", "zz"):
-        if float(entry[name]["total_component_intersected_upper"]) > FULL.up(total_parent):
-            raise RuntimeError(f"theta-z {name} component escaped V12D operator parent")
-    if dC > FULL.up(parent_dC):
-        raise RuntimeError("theta-z Delta-C refinement escaped V12D parent")
-    if dK > FULL.up(v34_dK) or dK > FULL.up(parent_dK):
-        raise RuntimeError("theta-z gain refinement escaped certified parents")
-
-    out = {
-        "beta_first_attitude_transport_upper": beta_hi,
+    return {
         "first_PSD_offdiagonal_entry_abs_upper": offdiag,
-        "nominal_first_PSD_attitude_component_matrix_upper": nominal_first,
-        "nominal_reset_Ltheta_interval": [
-            [x.as_list() for x in row] for row in Ltheta],
-        "nominal_after_reset_PSD_attitude_component_matrix_upper":
-            nominal_after_reset,
-        "V40_cross_transport_upper": cross,
-        "V40_quadratic_transport_upper": quadratic,
-        "V40_reset_direction_operator_upper": reset_direction,
-        "next_process_PSD_remainder_upper": float(eps),
-        "V40_unknown_PSD_operator_remainder_after_reset_upper":
-            unknown_after_reset,
-        "V40_PSD_operator_parent_upper": psd_parent,
-        "sample1_S_operator_parent_upper": s_parent,
-        "V12D_total_DeltaP_operator_parent_upper": total_parent,
-        "theta_z_DeltaP_component_entries": entry,
+        "beta_interval": beta.as_list(),
         "sample1_force_y_abs_upper_mps2": fy_abs,
         "sample1_force_z_abs_upper_mps2": fz_abs,
-        **projected,
-        "scalar_projected_DeltaP_Htheta_parent_upper": projected_parent,
-        "projected_componentwise_over_scalar_parent_ratio": (
-            0.0 if projected_parent == 0.0
-            else projected_refined / projected_parent),
-        "theta_z_nominal_attitude_covariance_row_norm_upper": pz,
-        "nominal_Ptheta_row_DeltaH_upper": nominal_dH,
-        "mixed_DeltaP_DeltaH_upper": mixed,
-        "theta_aw_cross_block_parent_upper": theta_aw,
-        "theta_z_DeltaC_componentwise_candidate_upper": candidate_dC,
-        "V12D_full_DeltaC_parent_upper": parent_dC,
-        "theta_z_DeltaC_intersected_upper": dC,
-        "theta_z_DeltaC_strictly_refined": dC < parent_dC,
-        "directional_DeltaS_row_upper": dS0,
-        "nominal_theta_z_gain_row_norm_upper": kz,
-        "actual_innovation_inverse_operator_upper": inv,
-        "theta_z_gain_perturbation_componentwise_candidate_upper": dK_candidate,
-        "V34_theta_z_gain_perturbation_parent_upper": v34_dK,
-        "V12D_full_attitude_gain_perturbation_parent_upper": parent_dK,
-        "theta_z_gain_perturbation_intersected_upper": dK,
-        "theta_z_gain_strictly_refined_vs_V34": dK < v34_dK,
-        "specific_theta_z_projected_combinations_used": True,
-        "V40_unknown_terms_retained_as_operator_parents": True,
-        "sample1_S_covariance_branch_retained_as_operator_parent": True,
+        "basis_projection_detail": basis_rows,
+        "nominal_correlated_PSD_projected_upper": nominal_projected,
+        "V40_cross_transport_operator_upper": cross,
+        "V40_quadratic_transport_operator_upper": quadratic,
+        "V40_reset_direction_operator_upper": reset_direction,
+        "next_process_PSD_remainder_upper": float(eps),
+        "V40_unknown_PSD_operator_remainder_upper": unknown_psd,
+        "sample1_S_operator_parent_upper": s_parent,
+        "combined_unknown_and_S_operator_remainder_upper": operator_remainder,
+        "sample1_Htheta_operator_upper": htheta,
+        "V12D_total_DeltaP_operator_parent_upper": total_parent,
+        "scalar_projected_DeltaP_Htheta_parent_upper": scalar_projected_parent,
+        "correlated_component_matrix_projected_candidate_upper": correlated_candidate,
+        "theta_z_projected_DeltaP_Htheta_intersected_upper": intersected,
+        "candidate_over_scalar_parent_ratio": (
+            math.inf if scalar_projected_parent == 0.0
+            else correlated_candidate / scalar_projected_parent),
+        "intersected_over_scalar_parent_ratio": (
+            0.0 if scalar_projected_parent == 0.0
+            else intersected / scalar_projected_parent),
+        "strict_projected_refinement": intersected < scalar_projected_parent,
+        "specific_theta_z_accelerometer_combinations_used": True,
+        "shared_offdiagonal_basis_correlations_preserved": True,
+        "V40_unknown_terms_retained_as_operator_parent": True,
+        "sample1_S_branch_retained_as_operator_parent": True,
     }
-    return out
 
 
 def build(domain_path: Path = DEFAULT_DOMAIN, *, source_pieces: int = 4,
           source_cell_index: int = 0, p_pieces: int = 24,
-          tangent_pieces: int = 24, axial_pieces: int = 24,
-          residual_x_pieces: int = 6, parallel_pieces: int = 6) -> dict:
+          tangent_pieces: int = 24, axial_pieces: int = 24) -> dict:
+    """Build the focused authoritative V50 witness artifact."""
     path = Path(domain_path).resolve()
     failures: list[str] = []
-
-    # V48 already constructs the authoritative V40 witness once.  Refine it
-    # exactly where V48 asks for y/z correction caps instead of rebuilding the
-    # same 24^3 witness a second time.
-    original_caps = V48._componentwise_yz_caps
-    injected = {"calls": 0, "last_detail": None}
-
-    def v50_caps(*, base: dict, vr: dict, ds_detail: dict,
-                 parent_caps: dict) -> dict:
-        local_detail = _authoritative_theta_z_detail(
-            path, source_pieces=source_pieces,
-            source_cell_index=source_cell_index, p_pieces=p_pieces,
-            base=base, vr=vr, ds_detail=ds_detail)
-        injected["calls"] += 1
-        injected["last_detail"] = local_detail
-        ds2 = dict(ds_detail)
-        ds2["theta_z_gain_perturbation_intersected_upper"] = float(
-            local_detail["theta_z_gain_perturbation_intersected_upper"])
-        out = original_caps(
-            base=base, vr=vr, ds_detail=ds2, parent_caps=parent_caps)
-        out["V50_theta_z_gain_refinement_injected"] = True
-        out["V50_theta_z_gain_parent_upper"] = float(
-            ds_detail["theta_z_gain_perturbation_intersected_upper"])
-        out["V50_theta_z_gain_intersected_upper"] = float(
-            local_detail["theta_z_gain_perturbation_intersected_upper"])
-        return out
-
-    V48._componentwise_yz_caps = v50_caps
+    detail = None
     try:
-        parent = V48.build(
+        _core, _v12, base, vr, row_failures = V48._build_v40_rows(
             path, source_pieces=source_pieces,
             source_cell_index=source_cell_index, p_pieces=p_pieces,
-            tangent_pieces=tangent_pieces, axial_pieces=axial_pieces,
-            residual_x_pieces=residual_x_pieces,
-            parallel_pieces=parallel_pieces)
+            tangent_pieces=tangent_pieces, axial_pieces=axial_pieces)
+        failures += row_failures
+        ids = (int(base.get("p_cell", -1)),
+               int(base.get("tangent_residual_cell", -1)),
+               int(base.get("axial_residual_cell", -1)))
+        if ids != tuple(WITNESS):
+            failures.append("V50 authoritative witness changed")
+        detail = _component_detail(
+            path, source_pieces=source_pieces,
+            source_cell_index=source_cell_index, p_pieces=p_pieces,
+            base=base, vr=vr)
     except Exception as exc:
-        failures.append(f"V48 under V50 theta-z injection: {exc}")
-        parent = {}
-    finally:
-        V48._componentwise_yz_caps = original_caps
+        failures.append(f"V50 correlated projected Delta-P construction: {exc}")
 
-    failures += [f"V48: {x}" for x in V48.validate(parent)] if parent else []
-    if parent and parent.get("P5_SAMPLE1_AUTHORITATIVE_COMPONENTWISE_YZ_V48") != "PASS":
-        failures.append("V48 authoritative parent did not pass under V50 injection")
-    if injected["calls"] <= 0:
-        failures.append("V50 theta-z componentwise cap was not injected into V48")
-    if V48._componentwise_yz_caps is not original_caps:
-        failures.append("V48 componentwise cap helper was not restored")
-
-    detail = injected["last_detail"]
-    caps = parent.get("componentwise_yz_perturbation_detail") or {}
-    z_gain_refined = bool(detail and detail.get(
-        "theta_z_gain_strictly_refined_vs_V34"))
-    z_corr_refined = bool(caps and (
-        float(caps.get("theta_z_component_abs_upper_rad", math.inf))
-        < float(caps.get("V31_parent_yz_norm_upper_rad", -math.inf))))
-    closed = bool(parent.get("first_V41_survivor_closed_by_V48_componentwise_yz"))
-    q = float(parent.get("authoritative_componentwise_best_q_upper", math.inf))
-    if not math.isfinite(q):
-        failures.append("V50 authoritative q is not finite")
-
-    out = dict(parent)
-    out.update({
+    strict = bool(detail and detail.get("strict_projected_refinement"))
+    return {
         "schema": SCHEMA,
-        "qualification":
-            "OU3_P5_SAMPLE1_AUTHORITATIVE_THETA_Z_PROJECTED_DELTAP_V50",
-        "V48_authoritative_componentwise_yz_parent_retained": True,
-        "V40_exact_Joseph_component_parent_retained": True,
-        "V45_V41_authoritative_current_chart_retained": True,
-        "theta_z_projected_DeltaP_component_matrix_used": True,
-        "theta_z_projected_DeltaP_specific_accelerometer_combinations_used": True,
-        "V40_unknown_PSD_terms_retained_as_operator_parents": True,
-        "sample1_S_covariance_branch_retained_as_operator_parent": True,
+        "qualification": "OU3_P5_SAMPLE1_AUTHORITATIVE_CORRELATED_THETA_Z_PROJECTED_DELTAP_V50",
+        "source_generated_not_trajectory_fit": True,
+        "source_replay_used": False,
+        "filter_changed": False,
+        "V40_exact_Joseph_parent_used": True,
+        "V49_scalar_projected_parent_replaced_only_by_intersection": True,
+        "shared_matrix_basis_correlations_preserved": True,
+        "V41_first_survivor_row": list(WITNESS),
         "theta_z_componentwise_detail": detail,
-        "V50_componentwise_cap_injection_calls": int(injected["calls"]),
-        "V48_componentwise_cap_helper_restored": (
-            V48._componentwise_yz_caps is original_caps),
-        "theta_z_gain_strictly_refined_vs_V34": z_gain_refined,
-        "theta_z_correction_component_strictly_refined": z_corr_refined,
-        "authoritative_V50_best_q_upper": q,
-        "first_V41_survivor_closed_by_V50_theta_z_projected_DeltaP": closed,
+        "strict_projected_refinement": strict,
         "deployed_correction_limit_rad": 6.0,
         "deployed_correction_limit_increased": False,
         "q_target": Q_TARGET,
+        "q8_composed_here": False,
         "q8_word_promoted_here": False,
         "whole_word_promoted_here": False,
         "N_H_words_set_here": False,
+        "P5_established_here": False,
         "P5_SAMPLE1_AUTHORITATIVE_THETA_Z_PROJECTED_DELTAP_V50": (
             "PASS" if not failures else "NOT_ESTABLISHED"),
         "next_obligation": (
-            "PROMOTE_V50_CLOSED_SAMPLE1_CELL_THROUGH_FULL_SOURCE_CELL0_COVER"
-            if closed and not failures else
-            "REFINE_THETA_Z_REMAINING_V50_DELTAC_OR_RESIDUAL_TERM_ON_AUTHORITATIVE_PARENT"
-            if z_gain_refined and not failures else
-            "REFINE_V40_UNKNOWN_PSD_OR_SAMPLE1_S_COMPONENT_MATRIX_FOR_THETA_Z"),
+            "INJECT_V50_CORRELATED_THETA_Z_PROJECTED_DELTAP_INTO_AUTHORITATIVE_V48_Q_COMPOSITION"
+            if strict and not failures else
+            "REFINE_SAMPLE1_S_AND_V40_UNKNOWN_PSD_COMPONENT_CORRELATIONS_BEFORE_THETA_Z_PROJECTION"
+        ),
         "failures": list(dict.fromkeys(failures)),
-    })
-    return out
+    }
 
 
 def validate(d: dict) -> list[str]:
+    """Validate the V50 fail-closed proof contract."""
     f = list(d.get("failures", []))
     if d.get("schema") != SCHEMA:
         f.append("schema mismatch")
     if d.get("qualification") != \
-            "OU3_P5_SAMPLE1_AUTHORITATIVE_THETA_Z_PROJECTED_DELTAP_V50":
+            "OU3_P5_SAMPLE1_AUTHORITATIVE_CORRELATED_THETA_Z_PROJECTED_DELTAP_V50":
         f.append("qualification mismatch")
     for k in (
         "source_generated_not_trajectory_fit",
-        "V48_authoritative_componentwise_yz_parent_retained",
-        "V40_exact_Joseph_component_parent_retained",
-        "V45_V41_authoritative_current_chart_retained",
-        "theta_z_projected_DeltaP_component_matrix_used",
-        "theta_z_projected_DeltaP_specific_accelerometer_combinations_used",
-        "V40_unknown_PSD_terms_retained_as_operator_parents",
-        "sample1_S_covariance_branch_retained_as_operator_parent",
-        "V48_componentwise_cap_helper_restored",
+        "V40_exact_Joseph_parent_used",
+        "V49_scalar_projected_parent_replaced_only_by_intersection",
+        "shared_matrix_basis_correlations_preserved",
     ):
         if d.get(k) is not True:
             f.append(f"{k} is not true")
     for k in (
         "source_replay_used", "filter_changed",
-        "deployed_correction_limit_increased", "q8_word_promoted_here",
-        "whole_word_promoted_here", "N_H_words_set_here",
+        "deployed_correction_limit_increased", "q8_composed_here",
+        "q8_word_promoted_here", "whole_word_promoted_here",
+        "N_H_words_set_here", "P5_established_here",
     ):
         if d.get(k) is not False:
             f.append(f"{k} is not false")
-    if list(d.get("V41_first_survivor_row", [])) != list(WITNESS):
-        f.append("authoritative V41 survivor changed")
-    if int(d.get("V50_componentwise_cap_injection_calls", 0)) <= 0:
-        f.append("V50 cap injection was not exercised")
+    if tuple(d.get("V41_first_survivor_row", ())) != tuple(WITNESS):
+        f.append("authoritative witness changed")
     if float(d.get("deployed_correction_limit_rad", 0.0)) != 6.0:
         f.append("deployed correction limit changed")
     if float(d.get("q_target", 0.0)) != Q_TARGET:
         f.append("q target changed")
 
-    detail = d.get("theta_z_componentwise_detail") or {}
-    projected = float(detail.get(
-        "theta_z_projected_DeltaP_Htheta_componentwise_upper", math.inf))
-    projected_parent = float(detail.get(
-        "scalar_projected_DeltaP_Htheta_parent_upper", -math.inf))
-    if not (math.isfinite(projected) and 0.0 <= projected
-            <= FULL.up(projected_parent)):
-        f.append("invalid componentwise theta-z projected Delta-P refinement")
-    dC = float(detail.get("theta_z_DeltaC_intersected_upper", math.inf))
-    dC_parent = float(detail.get("V12D_full_DeltaC_parent_upper", -math.inf))
-    if not (math.isfinite(dC) and 0.0 <= dC <= FULL.up(dC_parent)):
-        f.append("invalid theta-z Delta-C intersection")
-    dK = float(detail.get("theta_z_gain_perturbation_intersected_upper", math.inf))
-    dK_parent = float(detail.get(
-        "V34_theta_z_gain_perturbation_parent_upper", -math.inf))
-    if not (math.isfinite(dK) and 0.0 <= dK <= FULL.up(dK_parent)):
-        f.append("invalid theta-z gain intersection")
-
-    q = float(d.get("authoritative_V50_best_q_upper", math.inf))
-    if not math.isfinite(q):
-        f.append("nonfinite V50 authoritative q")
+    z = d.get("theta_z_componentwise_detail") or {}
+    parent = float(z.get("scalar_projected_DeltaP_Htheta_parent_upper", math.inf))
+    candidate = float(z.get("correlated_component_matrix_projected_candidate_upper", math.inf))
+    intersected = float(z.get("theta_z_projected_DeltaP_Htheta_intersected_upper", math.inf))
+    if not all(math.isfinite(x) and x >= 0.0 for x in
+               (parent, candidate, intersected)):
+        f.append("nonfinite V50 projected bound")
+    elif intersected > FULL.up(parent) or intersected > FULL.up(candidate):
+        f.append("V50 projected intersection escaped a parent")
+    for k in (
+        "specific_theta_z_accelerometer_combinations_used",
+        "shared_offdiagonal_basis_correlations_preserved",
+        "V40_unknown_terms_retained_as_operator_parent",
+        "sample1_S_branch_retained_as_operator_parent",
+    ):
+        if z.get(k) is not True:
+            f.append(f"theta-z detail {k} is not true")
     if d.get("P5_SAMPLE1_AUTHORITATIVE_THETA_Z_PROJECTED_DELTAP_V50") not in (
             "PASS", "NOT_ESTABLISHED"):
         f.append("invalid V50 status")
@@ -503,38 +338,28 @@ def main() -> int:
     ap.add_argument("--p-pieces", type=int, default=24)
     ap.add_argument("--tangent-pieces", type=int, default=24)
     ap.add_argument("--axial-pieces", type=int, default=24)
-    ap.add_argument("--residual-x-pieces", type=int, default=6)
-    ap.add_argument("--parallel-pieces", type=int, default=6)
     ap.add_argument("--output", type=Path, required=True)
     x = ap.parse_args()
     d = build(
         x.domain, source_pieces=x.source_pieces,
         source_cell_index=x.source_cell_index, p_pieces=x.p_pieces,
-        tangent_pieces=x.tangent_pieces, axial_pieces=x.axial_pieces,
-        residual_x_pieces=x.residual_x_pieces,
-        parallel_pieces=x.parallel_pieces)
+        tangent_pieces=x.tangent_pieces, axial_pieces=x.axial_pieces)
     vf = validate(d)
     d["validation_failures"] = vf
     x.output.parent.mkdir(parents=True, exist_ok=True)
     x.output.write_text(json.dumps(d, indent=2, sort_keys=True), encoding="utf-8")
     z = d.get("theta_z_componentwise_detail") or {}
-    caps = d.get("componentwise_yz_perturbation_detail") or {}
     print(json.dumps({
         "status": d["P5_SAMPLE1_AUTHORITATIVE_THETA_Z_PROJECTED_DELTAP_V50"],
-        "projected_componentwise":
-            z.get("theta_z_projected_DeltaP_Htheta_componentwise_upper"),
-        "projected_parent":
-            z.get("scalar_projected_DeltaP_Htheta_parent_upper"),
-        "projected_ratio":
-            z.get("projected_componentwise_over_scalar_parent_ratio"),
-        "dC": z.get("theta_z_DeltaC_intersected_upper"),
-        "dC_parent": z.get("V12D_full_DeltaC_parent_upper"),
-        "dKz": z.get("theta_z_gain_perturbation_intersected_upper"),
-        "dKz_parent": z.get("V34_theta_z_gain_perturbation_parent_upper"),
-        "ez": caps.get("theta_z_component_abs_upper_rad"),
-        "q": d.get("authoritative_V50_best_q_upper"),
-        "closed":
-            d.get("first_V41_survivor_closed_by_V50_theta_z_projected_DeltaP"),
+        "scalar_parent": z.get("scalar_projected_DeltaP_Htheta_parent_upper"),
+        "candidate": z.get("correlated_component_matrix_projected_candidate_upper"),
+        "intersected": z.get("theta_z_projected_DeltaP_Htheta_intersected_upper"),
+        "candidate_ratio": z.get("candidate_over_scalar_parent_ratio"),
+        "intersected_ratio": z.get("intersected_over_scalar_parent_ratio"),
+        "nominal_structured": z.get("nominal_correlated_PSD_projected_upper"),
+        "unknown_psd_operator": z.get("V40_unknown_PSD_operator_remainder_upper"),
+        "S_operator": z.get("sample1_S_operator_parent_upper"),
+        "strict": d.get("strict_projected_refinement"),
         "next": d.get("next_obligation"),
         "validation_failures": vf,
     }, indent=2, sort_keys=True))

--- a/tools/ou3_p5_sample1_authoritative_theta_z_projected_deltap_v50.py
+++ b/tools/ou3_p5_sample1_authoritative_theta_z_projected_deltap_v50.py
@@ -333,28 +333,11 @@ def build(domain_path: Path = DEFAULT_DOMAIN, *, source_pieces: int = 4,
     path = Path(domain_path).resolve()
     failures: list[str] = []
 
-    # Precompute the same authoritative V40 witness rows used by V48, solely
-    # to audit the refinement before injecting it into V48's q composition.
-    _core, _v12, base, vr, row_failures = V48._build_v40_rows(
-        path, source_pieces=source_pieces,
-        source_cell_index=source_cell_index, p_pieces=p_pieces,
-        tangent_pieces=tangent_pieces, axial_pieces=axial_pieces)
-    failures += row_failures
-    try:
-        ds = V48.V34._directional_delta_s_detail(
-            path, source_pieces=source_pieces,
-            source_cell_index=source_cell_index, p_pieces=p_pieces,
-            base=base, vr=vr)
-        detail = _authoritative_theta_z_detail(
-            path, source_pieces=source_pieces,
-            source_cell_index=source_cell_index, p_pieces=p_pieces,
-            base=base, vr=vr, ds_detail=ds)
-    except Exception as exc:
-        failures.append(f"V50 theta-z projected Delta-P construction: {exc}")
-        detail = None
-
+    # V48 already constructs the authoritative V40 witness once.  Refine it
+    # exactly where V48 asks for y/z correction caps instead of rebuilding the
+    # same 24^3 witness a second time.
     original_caps = V48._componentwise_yz_caps
-    injected = {"calls": 0, "last_detail": detail}
+    injected = {"calls": 0, "last_detail": None}
 
     def v50_caps(*, base: dict, vr: dict, ds_detail: dict,
                  parent_caps: dict) -> dict:


### PR DESCRIPTION
## Summary

Continue the OU-III P5 stability-certificate chain from merged #427 on current `main`.

V49 identified the authoritative first survivor's dominant theta-z `Delta C` loss as the scalar projected term `||Delta P|| ||H_theta||`. This PR adds V50, which replaces only that projected term with a componentwise attitude-covariance enclosure on the existing V40/V45 parent.

V50 uses the established V36/V40 structure of the omitted first-attitude PSD remainder and the exact nominal attitude Joseph transport `B_theta = diag(beta,beta,1)`. It transports the resulting 3x3 component matrix through the same nominal reset/gauge map already used by the sample-1 proof, while retaining V40's gain-perturbation cross/quadratic terms, reset-direction term, next-process remainder, and the sample-1 accepted `S=0` covariance branch as their existing operator-norm parents.

For the actual sample-1 accelerometer Jacobian it then bounds the theta-z projection from the specific combinations

- `-f_z DeltaP_zy + f_y DeltaP_zz`
- ` f_z DeltaP_zx`
- `-f_y DeltaP_zx`

rather than paying the full scalar `||Delta P|| ||H_theta||`. The resulting theta-z `Delta C` and gain-row bounds are intersected with the V12D/V34 parents and injected only into V48's componentwise y/z correction calculation. The authoritative V45/V41 current chart and unchanged q composition remain in force.

## Safety / theorem status

- no estimator or source-domain change
- deployed correction limit remains 6 rad
- q target remains 8
- V40 unknown PSD terms remain charged
- sample-1 `S=0` covariance branch remains charged
- no source replay / trajectory fit
- no q-word or whole-word promotion in V50
- `N_H_words` remains unset unless a later complete source-word stage establishes it
- active/transitioning accelerometer vibration-guard behavior remains outside the current certificate exactly as in #427

The V50 producer is intentionally fail-closed: CI will report whether the new componentwise bound actually closes the authoritative survivor, and otherwise records the next remaining obligation without promoting P5.

## Validation

Adds a focused semantic unit test and `ou3-p5-v50-authoritative-theta-z-projected-deltap-fast` CI workflow. The workflow compiles/tests V50, runs the authoritative 24x24x24 witness calculation, and surfaces the projected-term ratio, theta-z Delta-C/gain bounds, correction cap, and final q.