### PR TITLE
Fix the phase-B tilt re-lock contract that reddens main

### DIFF
--- a/tests/validation/test_ou_stability_phase_b.py
+++ b/tests/validation/test_ou_stability_phase_b.py
@@ -114,9 +114,25 @@ class OUIIIStabilityPhaseBContractTests(unittest.TestCase):
             "constexpr float TILT_RESET_DEG = 70.0f;",
             "constexpr float TILT_RESET_HOLD_SEC = 0.35f;",
             "constexpr float TILT_RESET_COOLDOWN_SEC = 3.0f;",
-            "initialize_from_acc_preserve_yaw(acc)",
         ):
             self.assertIn(token, src)
+
+        # The proof re-lock map rebuilds roll/pitch from the instantaneous
+        # accelerometer and preserves pre-reset Euler yaw.  Name the sample by
+        # the variable the surrounding update uses rather than by a literal
+        # argument, so front-end conditioning of the accelerometer stays free to
+        # rename it; what the proof needs is that the re-lock reads the same
+        # sample the MEKF measurement update consumed, not a different version
+        # of the accelerometer.
+        relock = re.search(
+            r"initialize_from_acc_preserve_yaw\(\s*([A-Za-z_]\w*)\s*\)", src
+        )
+        self.assertIsNotNone(relock, "Live tilt re-lock must preserve yaw")
+        measurement = re.search(
+            r"measurement_update_acc_only\(\s*([A-Za-z_]\w*)\s*,", src
+        )
+        self.assertIsNotNone(measurement, "MEKF must take an accelerometer update")
+        self.assertEqual(relock.group(1), measurement.group(1))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What is failing

`main` is red on one test out of 915, in the `ou-evidence / commit` job of the `build` workflow ([run 33225943931](https://github.com/bareboat-necessities/ocean-imu/actions/runs/33225943931)):

```
FAIL: test_source_tilt_relock_still_matches_proof
  (test_ou_stability_phase_b.OUIIIStabilityPhaseBContractTests)
AssertionError: 'initialize_from_acc_preserve_yaw(acc)' not found in ...
```

## Cause

The front-end vibration guard (#426, #428) introduced a single point where raw accelerometer samples enter the fusion filter — `const Eigen::Vector3f acc_in = accel_guard_.step(acc, dt);` in `src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h` — and rewired every downstream consumer to `acc_in`, the MEKF measurement update and the Live tilt re-lock among them.

The phase-B source contract still asserted the literal argument spelling `initialize_from_acc_preserve_yaw(acc)`, so it broke on a rename even though the behaviour it guards is intact.

## Change

The three trigger constants (`TILT_RESET_DEG`, `TILT_RESET_HOLD_SEC`, `TILT_RESET_COOLDOWN_SEC`) are still asserted verbatim. The call-site check now asserts the property the proof actually needs — `w3d-hybrid-stability.tex-part` §"Tilt re-lock jump" and `w3d-init.tex-part` §"Live re-lock boundary": roll/pitch are rebuilt from the instantaneous accelerometer the filter itself is using, and pre-reset Euler yaw is preserved.

Concretely, the test captures the argument passed to `initialize_from_acc_preserve_yaw` and requires it to be the same variable passed to `measurement_update_acc_only`, rather than pinning a name. Front-end conditioning stays free to rename the sample; wiring the re-lock to a *different* version of the accelerometer does not.

## Verification

The test still fails on real regressions rather than merely passing: feeding the re-lock a different accelerometer variable fails on the mismatch, and dropping `preserve_yaw` fails on the missing call.

A/B over the same four test modules, same invocation, 30 tests each:

| commit | failures |
| --- | --- |
| `daa3dc5` (current main) | 6 |
| this branch | 5 |

The one that disappears is `test_source_tilt_relock_still_matches_proof`. The other five are unchanged across both commits and are not touched by this diff:

- `test_ou_evidence_contract.test_committed_bundles_match_immutable_replay_provenance`
- `test_ou_legacy_law_cleanup.test_publication_tree_has_no_legacy_numerical_law_studies`
- `test_source_archive_provenance` ×3

Those five are the stale replay-provenance cluster: committed provenance has not caught up with the vibration-guard sources (`src/tuner/AccelVibrationGuard.h` is a new replay dependency, `SeaStateFusionFilter_OU_III.h` / `W3dSimCommon.*` / `kalman_ou_iii-sim.cpp` differ). Running `tools/ou_evidence_contract.py --auto` on a clean checkout of `daa3dc5` reproduces it byte-for-byte.

That cluster is downstream of this same test failure. The `ou-evidence / commit` job regenerates the evidence and then runs `make -C tests/validation test` as the gate before committing ("A failed consistency check must never mutate the target branch"). The phase-B failure aborted that job, so the refreshed provenance was never pushed. With this fix the gate passes, the fingerprints get recorded, and the regenerated evidence lands — which re-aligns provenance for branches and PRs too.

Until that full run happens on `main`, no branch or PR smoke run can go green: `make test` depends on `evidence-contract`, which aborts on the stale provenance before `unittest` ever runs. A dispatched smoke run on this branch ([33230903600](https://github.com/bareboat-necessities/ocean-imu/actions/runs/33230903600)) fails there for that reason, not on the test.

The branch `build` run is green: [33230690706](https://github.com/bareboat-necessities/ocean-imu/actions/runs/33230690706).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CA1zP2qgaPLuCoFgyjQMsB

---
_Generated by [Claude Code](https://claude.ai/code/session_01CA1zP2qgaPLuCoFgyjQMsB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated validation coverage to confirm that tilt re-locking and accelerometer measurement updates use the same accelerometer sample.
  * Preserved the proof that re-locking processes the sample consumed by the measurement update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->