### PR TITLE
paper: brace the lever-arm table's unit row so the article builds

### DIFF
--- a/doc/kalman_ou_iii/w3d-imu-lever-arm-results.tex-part
+++ b/doc/kalman_ou_iii/w3d-imu-lever-arm-results.tex-part
@@ -28,7 +28,7 @@ is therefore deterministic and recoverable rather than intrinsic OU--III error.
   \begin{tabular}{@{}rrrrr@{}}
     \toprule
     Offset & Max 3-D / CG & Max tilt / CG & Gyro model & Exact model \\
-    [cm] & unmodeled & unmodeled & max 3-D / CG & max 3-D / CG \\
+    {[cm]} & unmodeled & unmodeled & max 3-D / CG & max 3-D / CG \\
     \midrule
     10 & 1.006 (vertical) & 1.080 (athwartships) & 1.001 & 1.000 \\
     20 & 1.014 (vertical) & 1.548 (athwartships) & 1.002 & 1.000 \\

--- a/tests/validation/test_ou3_lever_arm_article.py
+++ b/tests/validation/test_ou3_lever_arm_article.py
@@ -118,6 +118,33 @@ class LeverArmCommittedEvidenceTests(unittest.TestCase):
         expected = mod.generate(load(SUMMARY), load(CUTOFF_SUMMARY))
         self.assertEqual(FRAGMENT.read_text(encoding="utf-8"), expected)
 
+    def test_no_row_opens_with_an_unbraced_bracket(self):
+        """A row after ``\\\\`` that opens with ``[`` is read as its optional
+        vertical-space argument, and LaTeX stops with "Missing number".  This
+        took down the published build once; braces are the fix, and this is
+        the check that keeps them there."""
+        for path in (FRAGMENT, DOC / "w3d-imu-lever-arm-study.tex-part"):
+            lines = path.read_text(encoding="utf-8").splitlines()
+            for previous, current in zip(lines, lines[1:]):
+                if not previous.rstrip().endswith(r"\\"):
+                    continue
+                with self.subTest(path=path.name, line=current):
+                    self.assertFalse(
+                        current.lstrip().startswith("["),
+                        f"{path.name}: row after a line break opens with an "
+                        f"unbraced bracket: {current.strip()!r}",
+                    )
+
+    def test_generator_braces_the_bracketed_unit_row(self):
+        """The same guard on the generator, so a regenerated fragment cannot
+        reintroduce it even before anything is committed."""
+        text = mod.generate(load(SUMMARY), load(CUTOFF_SUMMARY))
+        self.assertIn("{[cm]}", text)
+        lines = text.splitlines()
+        for previous, current in zip(lines, lines[1:]):
+            if previous.rstrip().endswith(r"\\"):
+                self.assertFalse(current.lstrip().startswith("["), current)
+
     def test_exact_model_returns_to_the_cg_baseline(self):
         """The section's central claim, checked against the numbers."""
         rows = load(SUMMARY)

--- a/tools/ou3_lever_arm_tex.py
+++ b/tools/ou3_lever_arm_tex.py
@@ -128,7 +128,10 @@ def generate(
         "  \\begin{tabular}{@{}rrrrr@{}}",
         "    \\toprule",
         "    Offset & Max 3-D / CG & Max tilt / CG & Gyro model & Exact model \\\\",
-        "    [cm] & unmodeled & unmodeled & max 3-D / CG & max 3-D / CG \\\\",
+        # The brace is load-bearing.  A row opening with an unbraced
+        # bracket is swallowed by the preceding \\ as its optional
+        # vertical-space argument, and LaTeX dies on "Missing number".
+        "    {[cm]} & unmodeled & unmodeled & max 3-D / CG & max 3-D / CG \\\\",
         "    \\midrule",
         *table_rows,
         "    \\bottomrule",


### PR DESCRIPTION
Fixes the `build (kalman_ou_iii)` failure on main introduced by #439.

## The break

The generated lever-arm table's second header row opened with an unbraced `[cm]`. TeX reads a bracket group immediately after `\\` as that line break's optional vertical-space argument, so it tried to parse `cm` as a dimension:

```
! Missing number, treated as zero.
l.31     [cm] & unmodeled & unmodeled & max 3-D / CG & max 3-D / CG \\
```

That is fatal, so `kalman_ou-w3d.pdf` was never produced.

## The fix

Brace the cell: `{[cm]}`.

## Verification

Checked with a real LaTeX run, not by reading:

- main's committed fragment reproduces the same `Missing number` error;
- the braced fragment compiles to a PDF;
- the whole lever-arm section — table, five figures, prose — compiles with **zero** errors under `IEEEtran`.

## Guards

Two regression tests, both confirmed to fail against the fragment that broke the build:

- one scans both lever-arm `.tex-part` files for a row opening with an unbraced bracket after a line break;
- one applies the same rule to freshly generated output, so a regeneration cannot reintroduce it before anything is committed.

## Note on how this reached main

The repo already runs `build (kalman_ou_iii)` on pull requests, and it would have caught this. On #439 that job was still in progress when the PR was merged. This one should wait for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScoWdQAuDcxXcNZXAmGjYR

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScoWdQAuDcxXcNZXAmGjYR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a LaTeX formatting issue in the IMU lever-arm results table that could cause compilation errors.
  * Ensured the `[cm]` unit displays correctly in generated and published table output.

* **Tests**
  * Added validation to prevent similar unbraced table-unit formatting issues in future outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->