### PR TITLE
P3/P4: widen the linear and nonlinear margins, then prove the P5 route cannot reach the handoff

### DIFF
--- a/.github/workflows/ou3-p5-full-matrix-fast.yml
+++ b/.github/workflows/ou3-p5-full-matrix-fast.yml
@@ -49,7 +49,7 @@ jobs:
   full-matrix-prefix:
     name: P5 full 18x18 H prefix cells
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v6
       - name: Compile full-matrix prefix producers

--- a/.github/workflows/ou3-p5-outer-fast.yml
+++ b/.github/workflows/ou3-p5-outer-fast.yml
@@ -13,7 +13,9 @@ on:
       - "tools/ou3_startup_stability_certificate.py"
       - "tools/ou3_p4_exact_word_map.py"
       - "tools/ou3_p4_group_algebra.py"
+      - "tools/ou3_p4_metric_defect_transport.py"
       - "tools/ou3_p4_nonlinear_word_certificate.py"
+      - "tools/ou3_p4_p5_route_ceiling_certificate.py"
       - "tools/ou3_p5_startup_capture_certificate.py"
       - "tools/ou3_p5_outer_h_word_certificate.py"
       - "tools/ou3_p5_go_live_covariance_stage.py"
@@ -76,6 +78,7 @@ jobs:
       - name: Compile P5 outer-H producers
         run: |
           python3 -m py_compile \
+            tools/ou3_p4_p5_route_ceiling_certificate.py \
             tools/ou3_p5_startup_capture_certificate.py \
             tools/ou3_p5_outer_h_word_certificate.py \
             tools/ou3_p5_go_live_covariance_stage.py \

--- a/.github/workflows/ou3-p5-outer-fast.yml
+++ b/.github/workflows/ou3-p5-outer-fast.yml
@@ -68,7 +68,7 @@ jobs:
   p5-outer:
     name: P5 source-staged outer-H bridge
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - name: Install numerical dependency

--- a/.github/workflows/ou3-proof-fast.yml
+++ b/.github/workflows/ou3-proof-fast.yml
@@ -35,7 +35,9 @@ on:
       - "tools/ou3_p4_group_algebra.py"
       - "tools/ou3_p4_exact_word_map.py"
       - "tools/ou3_p4_node_metrics.py"
+      - "tools/ou3_p4_metric_defect_transport.py"
       - "tools/ou3_p4_nonlinear_word_certificate.py"
+      - "tools/ou3_p4_p5_route_ceiling_certificate.py"
       - "tools/ou3_p5_startup_capture_certificate.py"
       - "tools/ou3_p5_outer_h_word_certificate.py"
       - "tools/ou3_proof_operating_domain.json"
@@ -62,7 +64,9 @@ on:
       - "tests/validation/test_ou3_explicit_information_word_certificate.py"
       - "tests/validation/test_ou3_p4_group_algebra.py"
       - "tests/validation/test_ou3_p4_word_map_and_metrics.py"
+      - "tests/validation/test_ou3_p4_metric_defect_transport.py"
       - "tests/validation/test_ou3_p4_nonlinear_word_certificate.py"
+      - "tests/validation/test_ou3_p4_p5_route_ceiling.py"
       - "tests/validation/test_ou3_p5_startup_capture_certificate.py"
       - "tests/validation/test_ou3_p5_outer_h_word_certificate.py"
       - "tests/validation/test_ou_stability_source_path_widening.py"
@@ -224,10 +228,14 @@ jobs:
             tools/ou3_p4_group_algebra.py \
             tools/ou3_p4_exact_word_map.py \
             tools/ou3_p4_node_metrics.py \
+            tools/ou3_p4_metric_defect_transport.py \
             tools/ou3_p4_nonlinear_word_certificate.py \
+            tools/ou3_p4_p5_route_ceiling_certificate.py \
             tests/validation/test_ou3_p4_group_algebra.py \
             tests/validation/test_ou3_p4_word_map_and_metrics.py \
+            tests/validation/test_ou3_p4_metric_defect_transport.py \
             tests/validation/test_ou3_p4_nonlinear_word_certificate.py \
+            tests/validation/test_ou3_p4_p5_route_ceiling.py \
             tests/validation/test_ou_stability_source_path_widening.py
       - name: Test exact P4 algebra, source map, metric and publication contract
         working-directory: tests/validation
@@ -235,7 +243,9 @@ jobs:
           python3 -m unittest -v \
             test_ou3_p4_group_algebra \
             test_ou3_p4_word_map_and_metrics \
+            test_ou3_p4_metric_defect_transport \
             test_ou3_p4_nonlinear_word_certificate \
+            test_ou3_p4_p5_route_ceiling \
             test_ou_stability_source_path_widening
       - name: Emit exact nonlinear P4 certificate and numerical margins
         run: |
@@ -247,6 +257,18 @@ jobs:
           for m in ('H','A'):
               r=p['modes'][m]
               print(f"P4_NUMERICAL {m} W_star={r['certified_level_W']:.17e} mu_W_lower={r['mu_W_lower']:.17e} gap_lower={r['endpoint_relative_W_decrease_lower']:.17e} prefix_norm={r['prefix_canonical_error_norm_upper']:.17e}")
+              print(f"P4_DEFECT_ROUTE {m} route={r['transported_word_defect_route']} B={r['transported_word_defect_B_upper']:.17e} B_isotropic={r['transported_word_defect_B_isotropic_upper']:.17e}")
+          PY
+      - name: Emit the P4/P5 uniform transported-defect route ceiling
+        run: |
+          python3 tools/ou3_p4_p5_route_ceiling_certificate.py --output /tmp/ou3_p4_p5_route_ceiling_certificate.json
+          python3 - <<'PY'
+          import json
+          c=json.load(open('/tmp/ou3_p4_p5_route_ceiling_certificate.json'))
+          print('P4_P5_UNIFORM_TRANSPORT_ROUTE_CEILING:',c['P4_P5_UNIFORM_TRANSPORT_ROUTE_CEILING'])
+          for m in ('H','A'):
+              r=c['modes'][m]
+              print(f"ROUTE_CEILING {m} now={r['certified_attitude_capture_radius_now']:.17e} ceiling={r['route_ceiling_absolute']:.17e} largest_handoff={r['largest_bounded_P1_handoff_cayley_norm']:.17e} shortfall={r['shortfall_factor_ceiling_vs_largest_handoff']:.6e}")
           PY
 
   p5-capture-identification:
@@ -263,6 +285,7 @@ jobs:
       - name: Compile P5 outer-H and capture certificates
         run: |
           python3 -m py_compile \
+            tools/ou3_p4_p5_route_ceiling_certificate.py \
             tools/ou3_p5_startup_capture_certificate.py \
             tools/ou3_p5_outer_h_word_certificate.py \
             tests/validation/test_ou3_p5_startup_capture_certificate.py \

--- a/.github/workflows/ou3-proof-fast.yml
+++ b/.github/workflows/ou3-proof-fast.yml
@@ -35,6 +35,7 @@ on:
       - "tools/ou3_p4_group_algebra.py"
       - "tools/ou3_p4_exact_word_map.py"
       - "tools/ou3_p4_node_metrics.py"
+      - "tools/ou3_p3_word_noise_accumulation.py"
       - "tools/ou3_p4_metric_defect_transport.py"
       - "tools/ou3_p4_nonlinear_word_certificate.py"
       - "tools/ou3_p4_p5_route_ceiling_certificate.py"
@@ -64,6 +65,7 @@ on:
       - "tests/validation/test_ou3_explicit_information_word_certificate.py"
       - "tests/validation/test_ou3_p4_group_algebra.py"
       - "tests/validation/test_ou3_p4_word_map_and_metrics.py"
+      - "tests/validation/test_ou3_p3_word_noise_accumulation.py"
       - "tests/validation/test_ou3_p4_metric_defect_transport.py"
       - "tests/validation/test_ou3_p4_nonlinear_word_certificate.py"
       - "tests/validation/test_ou3_p4_p5_route_ceiling.py"
@@ -175,7 +177,7 @@ jobs:
   enclosure:
     name: source-reachable matrix P3 and enclosure arithmetic
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - name: Install numerical dependency
@@ -189,12 +191,15 @@ jobs:
             tools/ou3_validated_kalman_interval.py \
             tools/ou3_source_reachable_matrix_p3.py \
             tools/ou3_source_reachable_matrix_p3_factored.py \
+            tools/ou3_source_reachable_matrix_p3_direct.py \
+            tools/ou3_p3_word_noise_accumulation.py \
             tools/ou3_p3_word_algebra.py \
             tools/ou3_explicit_information_word_certificate.py \
             tools/ou3_certificate_completion.py \
             tools/ou3_information_enclosure_contract.py \
             tools/ou3_validate_enclosure.py \
             tests/validation/test_ou3_validated_kalman_interval.py \
+            tests/validation/test_ou3_p3_word_noise_accumulation.py \
             tests/validation/test_ou3_p3_word_algebra.py \
             tests/validation/test_ou3_explicit_information_word_certificate.py \
             tests/validation/test_ou3_certificate_completion.py \
@@ -205,6 +210,7 @@ jobs:
           python3 -m unittest -v \
             test_ou3_validated_kalman_interval \
             test_ou3_p3_word_algebra \
+            test_ou3_p3_word_noise_accumulation \
             test_ou3_explicit_information_word_certificate \
             test_ou3_certificate_completion \
             test_ou3_validate_enclosure
@@ -215,7 +221,7 @@ jobs:
     name: exact Cayley nonlinear H A source-word P4
     needs: enclosure
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - name: Install numerical dependency
@@ -275,7 +281,7 @@ jobs:
     name: P5 outer-H word and startup capture gate
     needs: [startup-proof, p4-nonlinear]
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - name: Install numerical dependency
@@ -317,7 +323,7 @@ jobs:
   composition:
     name: stochastic capture and final composition arithmetic
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - name: Install numerical dependency

--- a/docs/ou-iii-implementation-stability-proof-plan.md
+++ b/docs/ou-iii-implementation-stability-proof-plan.md
@@ -116,6 +116,37 @@ hence the exact source-uniform worst prefix information gain is `1.0` rather tha
 
 The final producer `tools/ou3_explicit_information_word_certificate.py` emits `P3_IMPLEMENTATION_WORD_CERTIFICATE=PASS` only when the direct H/A interval inequalities, optimized four-S qualification, current source-word language, exact Live-operation algebra, reset nonsingularity, branch coverage, and unit prefix-information bound all validate together.
 
+#### `Omega_word` is the word's injected noise, not one IMU step
+
+The endpoint inequality is `Omega_word - delta Sigma_upper >> 0`, and `Sigma_upper` is a word-horizon covariance. The backend was comparing it against a single 5 ms `Q`. That is a valid lower bound -- the word contains at least one prediction -- but on the `S` channel the two differ by `(T/h)^7`, and it is what held `delta` at `3.79233618771658e-35`.
+
+`tools/ou3_p3_word_noise_accumulation.py` and the direct backend supply the accumulated floor from the shipping recursion itself. Over `N` pure prediction steps the source injects exactly
+
+`Omega_N = sum_{k<N} Phi^k Q (Phi^k)'`,
+
+which obeys the exact doubling identity `Omega_2m = Phi^m Omega_m Phi^m' + Omega_m`. That identity carries the `(theta, gyro-bias)` block. The translation block does not need it: for the integrated-OU chain the same sum is exactly `Q(N h)`, and scaled by `diag(sigma T, sigma T^2, sigma T^3, sigma)` the chain depends only on `X = T/tau`, so the analytic family the certificate already validates supplies the accumulated floor when it is read at the word horizon instead of at one step. `N` comes from a *lower* bound on the word's step count, so the floor stays a lower bound while `Sigma_upper` stays an upper bound at the horizon upper.
+
+Three further corrections were needed before that could be used.
+
+1. **The measurement information is block structured.** The word's Joseph updates shrink the injected floor, bounded conservatively by `(Omega^-1 + H' R^-1 H)^-1`. One scalar information bound collapses the comparison: the accelerometer's information lives in the `a_w` coordinate and is four orders above the attitude information, and no shipping update measures the gyro bias at all. Charging the `a_w` figure against the bias coordinate erased the entire accumulated bias floor.
+2. **The attitude propagation factor does not belong to the bias row.** `Sigma_upper` propagates the post-observation `(theta, bias)` bound to the word endpoint through `Phi = [[I,-T I],[0,I]]`. Only the attitude row integrates the bias over the word, so only it pays `2(1+T^2)`; the bias row propagates as itself plus its own random walk. Sharing one value inflated the binding channel by twenty-two times.
+3. **The exact-series tail factor was a literal `2.0`.** That is `exp(lambda x)` at `lambda x < ln 2`, which held for the per-step read and expires the moment the same family is read at a word horizon. It now carries `exp(lambda x.hi)`, which also tightens the per-step read slightly.
+
+The comparison itself is then normalised rather than certified in the congruence basis. Forming the posterior explicitly breaks down once the word assimilates real information -- `Omega (I + D Omega)^-1` cancels the measured directions almost exactly and no interval enclosure of it stays definite past a sixty-four step horizon -- and the information form `Omega^-1 + D <= (1/delta) Sigma^-1` fails in the rational congruence basis for the opposite reason: `Sigma^-1` there is assembled from a diagonal spanning thirteen decades and is not certifiably definite at all. Normalising `Sigma` to the identity with the diagonal `G = Sigma^{1/2}` leaves
+
+`lambda_max( G (Omega_word^-1 + D) G ) <= 1/delta`,
+
+an upper bound on one symmetric matrix. `Omega^-1` is read in the congruence basis, where it is well conditioned, and transported back by the exact rational `C`.
+
+The congruence certifies only on a narrow `X` cell, so each source cell is refined -- 128 sub-cells at the full word horizon, fewer for short ones -- and the margin is the minimum over its sub-cells. Every admissible horizon is scanned and the best kept: the trade is not monotone, because a longer horizon injects more noise but also assimilates more information, and `N = 1` reproduces the single-step comparison, so the scan can only improve on it. Each block keeps its own better route, since bundling would let a capped translation horizon discard an attitude floor that still carries the full word.
+
+The binding source cell moves from `tau` at its ceiling to `tau` in `[1.4837, 1.7226]` s, and the certified margin becomes
+
+- H: `delta >= 2.29539973862766885e-20` (translation `2.295399738627669e-20`, attitude/gyro-bias `1.602057713637565e-16`), against `2.1495791638793494e-34` for the single-step comparison;
+- A: `delta >= 2.29539973862766885e-20` (same limiting block, active-bias block `1.3919202799031725e-15`).
+
+That is fourteen and a half decades above the retired single-step floor, and it is what lifts the P4 level below.
+
 **PASS:** strict source-uniform H and A information contraction with explicit positive endpoint margins and an exact finite prefix information-gain bound. P4 consumes this information-word geometry directly through the exact Cayley lift below.
 
 ### P4 — Exact nonlinear SO(3) word certificate — COMPLETE
@@ -144,12 +175,13 @@ The nonlinear layer supplies one number: an upper bound `B` on `||r_word||_M / W
 
 Both gains bound the same quantity, so the producer keeps `min(B_isotropic, B_metric)` and the refinement can never widen the certificate. The structured route binds, taking `B` from `8.26237725542113e+34` to `2.19808143397921e+09`.
 
-The final validated CI certificate reports:
+The final validated CI certificate reports, for both H and A:
 
-- H: `W_* = 4.65099776131798868e-90`, `mu_W >= 1.89616809385829038e-35`, endpoint relative decrease `>= 1.89616809385829092e-35`, prefix canonical norm `<= 4.31323440648337294e-45`, certified attitude Cayley radius `<= 5.58190376455273201e-47`;
-- A: `W_* = 4.65099773925429715e-90`, `mu_W >= 1.89616808936071053e-35`, endpoint relative decrease `>= 1.89616808936071107e-35`, prefix canonical norm `<= 4.31323439625267857e-45`, certified attitude Cayley radius `<= 5.58190375131284112e-47`.
+- `W_* = 2.74835136346049263e-62`, `mu_W >= 1.14769986931383397e-20`, endpoint relative decrease `>= 1.14769986931383427e-20`, prefix canonical norm `<= 3.31563047606966924e-31`, certified attitude Cayley radius `<= 2.90423979800536192e-32`.
 
-That is fifty-one decades of `W_*` above the retired isotropic envelope (`3.29172575174270652e-141`), and it is still not a practical basin. The reason is no longer the defect constant: with `B` fixed, `sqrt(W_*) = delta/(8B)` is capped by the P3 word endpoint margin `delta = 3.79233618771658e-35`. Strict positivity is stored directly, so the proof never forms `1 - delta/2` when binary64 would round that quantity back to one.
+That is seventy-nine decades of `W_*` above the retired isotropic envelope (`3.29172575174270652e-141`): fifty-one from the structured transport that took `B` from `9.570736e+32` to `1.73074152502409096e+10`, and twenty-eight more from the P3 word-noise floor that took `delta` from `3.79233618771658e-35` to `2.29539973862766885e-20`. Strict positivity is stored directly, so the proof never forms `1 - delta/2` when binary64 would round that quantity back to one.
+
+It is still not a practical basin, and by the ceiling below it cannot become one on this route.
 
 #### The route, not its constants, is now the binding obstruction
 
@@ -159,7 +191,7 @@ That is fifty-one decades of `W_*` above the retired isotropic envelope (`3.2917
 
 `a_t` cancels. The ceiling does not depend on the covariance bound, on the metric normalization, or on any constant the search has been sharpening. At `delta = 1` and with no prefix overshoot at all it is `4.95049504950495e-03` rad; at the shipping prefix factor it is `1.23762376237624e-03` rad. The bounded P1 handoff nodes are `0.2721648148683776` and `0.5947333355555983` rad, so the route is short by at least a factor of `120` even at its own theoretical maximum, and the word would have to inject fewer than `1.69` accepted attitude corrections per second for it ever to reach the handoff.
 
-This is a ceiling on the proof route, not on the filter. It retires further sharpening of `kappa`, of the covariance enclosure, or of `delta` as a P5 direction: the ceiling is independent of all three.
+This is a ceiling on the proof route, not on the filter. It retires further sharpening of `kappa`, of the covariance enclosure, or of `delta` as a P5 direction: the ceiling is independent of all three. The two widenings recorded above are the direct evidence -- together they moved the reported radius by thirty-nine decades, from `5.73735631780239850e-71` to `2.90423979800536192e-32`, and moved the ceiling not at all.
 
 **PASS:** `P4_EXACT_NONLINEAR_WORD_CERTIFICATE=PASS` for both H and A with explicit positive `W_*`, positive `mu_W`, exact source-operation semantics, complete branch coverage, and prefix/chart safety. The level remains a theorem seed, and the route ceiling proves it cannot be promoted to the P1 handoff radius without the structural change named in P5.
 

--- a/docs/ou-iii-implementation-stability-proof-plan.md
+++ b/docs/ou-iii-implementation-stability-proof-plan.md
@@ -132,16 +132,38 @@ The validated word map follows the shipping order exactly: prediction; a due `S=
 
 P3's exact prefix information gain upper bound of `1.0` transports source-uniform quadratic nonlinear defects through arbitrary admissible accepted/rejected/not-due placements, so P4 covers the complete source branch family without enumerating an exponential list of rejection strings. The prefix bootstrap proves the certified Cayley norm is below one, hence `theta < 1 < pi`, and proves every accepted correction remains below `1e-2`, fixing the exact deployed quaternion branch throughout the inner funnel. In A mode the certified prefix also stays strictly inside the shipping accelerometer-bias projection ball, so the exact projection branch is the smooth identity-interior branch there; the nonsmooth projection surface is not silently linearized.
 
+#### Metric-consistent structured defect transport
+
+The nonlinear layer supplies one number: an upper bound `B` on `||r_word||_M / W_0`. The original route obtained it by leaving the metric -- `||z||_2 <= sqrt(W/m_-)` and `||r||_M <= sqrt(m_+) ||r||_2` -- and by bounding the gain isotropically as `||K|| <= sqrt(Sigma_max/R_min)`. That pays the full `sqrt(cond(Sigma))` of a covariance whose diagonal upper bounds span thirty-four decades, and it charges attitude-driven defects against the translation block that carries the whole spread.
+
+`tools/ou3_p4_metric_defect_transport.py` supplies the structured replacement. Three exact facts, each stated against the same source-derived P3/process bounds the certificate already consumes:
+
+1. **Gain transport.** For the shipping gain `K = P H^T S^-1` write `A = R^-1/2 H P^1/2`. Then `P^-1/2 K = A^T (A A^T + I)^-1 R^-1/2` and `||A^T (A A^T + I)^-1|| = max_i sigma_i/(1+sigma_i^2) <= 1/2`, so every residual defect satisfies `||K q||_M <= sqrt(s) ||q|| / (2 sqrt(lambda_min R))`. The node metric uses `Sigma_KF(g) >= P`, so the same bound holds there.
+2. **Chart transport.** Marginalising the exact quadratic form gives `min_xi [c;xi]^T Sigma^-1 [c;xi] = c^T (Sigma_cc)^-1 c`, hence `||c||^2 <= lambda_max(Sigma_cc) W / s`. The P3 covariance upper is a Loewner diagonal dominator, so the marginal block maximum bounds it. The exact word defects are quadratic in the attitude, gyro-bias and `a_w` coordinates only; the translation block never enters them.
+3. **Attitude-injection cost.** The quaternion injection remainder is supported on the attitude coordinates, so it is charged on the conditional attitude covariance. Every source node is post-prediction, where `Sigma >= Q` gives `(Sigma^-1)_tt <= I/(rho_att q_theta)`, or is reached from one by at most three in-sample corrections, each adding at most `||H_theta||^2/lambda_min(R)` in the exact information form `P+^-1 = P^-1 + H^T R^-1 H`.
+
+Both gains bound the same quantity, so the producer keeps `min(B_isotropic, B_metric)` and the refinement can never widen the certificate. The structured route binds, taking `B` from `8.26237725542113e+34` to `2.19808143397921e+09`.
+
 The final validated CI certificate reports:
 
-- H: `W_* = 3.29172575174270652e-141`, `mu_W >= 1.89616809385829038e-35`, endpoint relative decrease `>= 1.89616809385829092e-35`, prefix canonical norm `<= 1.14747126356047970e-70`;
-- A: `W_* = 3.29172573612719601e-141`, `mu_W >= 1.89616808936071053e-35`, endpoint relative decrease `>= 1.89616808936071107e-35`, prefix canonical norm `<= 1.14747126083875398e-70`.
+- H: `W_* = 4.65099776131798868e-90`, `mu_W >= 1.89616809385829038e-35`, endpoint relative decrease `>= 1.89616809385829092e-35`, prefix canonical norm `<= 4.31323440648337294e-45`, certified attitude Cayley radius `<= 5.58190376455273201e-47`;
+- A: `W_* = 4.65099773925429715e-90`, `mu_W >= 1.89616808936071053e-35`, endpoint relative decrease `>= 1.89616808936071107e-35`, prefix canonical norm `<= 4.31323439625267857e-45`, certified attitude Cayley radius `<= 5.58190375131284112e-47`.
 
-The tiny levels are theorem seeds, not practical-basin claims. Strict positivity is stored directly, so the proof never forms `1 - delta/2` when binary64 would round that quantity back to one. Source-node subdivision may later enlarge `W_*`, but it is only a widening of this same certificate route, not a fallback theorem.
+That is fifty-one decades of `W_*` above the retired isotropic envelope (`3.29172575174270652e-141`), and it is still not a practical basin. The reason is no longer the defect constant: with `B` fixed, `sqrt(W_*) = delta/(8B)` is capped by the P3 word endpoint margin `delta = 3.79233618771658e-35`. Strict positivity is stored directly, so the proof never forms `1 - delta/2` when binary64 would round that quantity back to one.
 
-**PASS:** `P4_EXACT_NONLINEAR_WORD_CERTIFICATE=PASS` for both H and A with explicit positive `W_*`, positive `mu_W`, exact source-operation semantics, complete branch coverage, and prefix/chart safety. P5 must now bridge the P1 handoff family to this inner H seed.
+#### The route, not its constants, is now the binding obstruction
 
-### P5 — Initialization-to-inner-funnel finite capture — OUTER ALGEBRA CLOSED, LATER PREFIX ENCLOSURE PENDING
+`tools/ou3_p4_p5_route_ceiling_certificate.py` closes the question of how far this accounting can go. The certified attitude radius of a level is exactly `theta(W) = a_t sqrt(W)` with `a_t = sqrt(Sigma_tt_upper/s)`. Under four hypotheses the shipping producer satisfies -- `delta <= 1` because `Omega_word <= Sigma`; the word must cover the all-accepted branch, so the injecting-operation count is at least the sample count; the exact Cayley cross term `0.5 d x c` is not slack; and the uniform accepted-injection bound is `a_t sqrt(W)`, which is the exact supremum of the attitude part of `K H z` on the metric ball -- an attitude-supported defect costs at least `1/a_t` in the metric, so
+
+`kappa >= 0.5 a_t`, `B >= F N 0.5 a_t`, `theta_capture <= delta / (F N)`.
+
+`a_t` cancels. The ceiling does not depend on the covariance bound, on the metric normalization, or on any constant the search has been sharpening. At `delta = 1` and with no prefix overshoot at all it is `4.95049504950495e-03` rad; at the shipping prefix factor it is `1.23762376237624e-03` rad. The bounded P1 handoff nodes are `0.2721648148683776` and `0.5947333355555983` rad, so the route is short by at least a factor of `120` even at its own theoretical maximum, and the word would have to inject fewer than `1.69` accepted attitude corrections per second for it ever to reach the handoff.
+
+This is a ceiling on the proof route, not on the filter. It retires further sharpening of `kappa`, of the covariance enclosure, or of `delta` as a P5 direction: the ceiling is independent of all three.
+
+**PASS:** `P4_EXACT_NONLINEAR_WORD_CERTIFICATE=PASS` for both H and A with explicit positive `W_*`, positive `mu_W`, exact source-operation semantics, complete branch coverage, and prefix/chart safety. The level remains a theorem seed, and the route ceiling proves it cannot be promoted to the P1 handoff radius without the structural change named in P5.
+
+### P5 — Initialization-to-inner-funnel finite capture — UNIFORM-TRANSPORT ROUTE PROVED INSUFFICIENT, MATCHED ROUTE REQUIRED
 
 The original composition audit correctly found that the useful P1 handoff family lies far outside the microscopic P4 inner seed. That result remains a guard against illegally extrapolating the P4 local recurrence, but it is no longer the current P5 obstruction. The outer bridge has since progressed through the source-staged startup covariance, first-`S`, large-angle geometry, quotient correction, and exact transport layers.
 
@@ -370,7 +392,63 @@ None of V51, V52, V53 or V54 composes `q<8`, promotes sample 1 or P5, or sets
 
 The independent implementation-stability composition gate continues to consume P5 directly. The older generic affine deployment-capture arithmetic is not accepted as a substitute.
 
-**PASS criterion for closing P5:** every certified normal or timeout handoff lies in a validated outer H capture funnel; every source-word prefix stays safe; the outer recurrence reaches `W_*` in a finite machine-certified number of H words/time. The current certificate does **not** yet satisfy this criterion.
+#### The uniform transported-defect route cannot close P5
+
+Every P5 attempt so far, including the whole V1..V54 sample-1 line, sharpens a
+constant inside one accounting:
+
+`||r_word||_M <= B W_0`, `B = F N kappa`, strict decrease requires `sqrt(W_0) <= delta/(2B)`.
+
+`tools/ou3_p4_p5_route_ceiling_certificate.py` bounds what that accounting can
+report, before any constant in it is chosen. Because the certified attitude
+radius of a level is exactly `theta(W) = a_t sqrt(W)` and an attitude-supported
+defect costs at least `1/a_t` in the metric, the chart scale `a_t` cancels and
+
+`theta_capture <= delta / (F N)`.
+
+With `delta <= 1` and `N` at least the word's sample count, the ceiling is
+`4.95049504950495e-03` rad with no prefix overshoot and `1.23762376237624e-03`
+rad at the shipping prefix factor. The bounded P1 handoff nodes are
+`0.2721648148683776` rad (normal gauged) and `0.5947333355555983` rad (timeout
+gauged). The route is therefore short by at least a factor of `120`, and would
+need the source word to inject fewer than `1.69` accepted attitude corrections
+per second before it could reach the handoff at all.
+
+The ceiling is independent of `kappa`, of the covariance enclosure, of the metric
+normalization and of `delta`. Retightening any of them -- including the
+fifty-one-decade metric-consistent widening of `B` recorded in P4 above -- moves
+the reported radius but not the ceiling. The `Delta S`, `Delta C`, `dP` and
+componentwise-split search directions of V42..V54 are constants of exactly this
+kind, so that line is retired here rather than continued.
+
+#### What a closing P5 route must change
+
+The failure is structural and localised: the accounting compares a defect that is
+*fast* (attitude, refreshed every accepted vector correction) against a margin
+that is *slow* (`delta`, rate-limited by the gyro-bias channel of the same word),
+and then accumulates the defect `N` times with no credit for the contraction
+happening in between. Three changes follow, and all three are needed:
+
+1. **Match each defect to its own operation.** For an accepted correction the
+   exact information identity gives `W - W+ = ||H z||^2_{s S^-1}` on the same
+   step that injects the defect. Charging the injected defect against that step's
+   own decrease removes both the `N`-fold accumulation and the dependence on the
+   whole-word `delta`.
+2. **Carry a directional or block margin.** The attitude channel must not be
+   rate-limited by the slowest source channel of the word. This means a block
+   Lyapunov function with a small-gain coupling constant, not one scalar `delta`
+   over the full 18/21-state box.
+3. **Replace the Cayley quadratic remainder on the attitude channel with an
+   exact finite-angle sector contraction** of the deployed correction. The
+   quadratic remainder is what forces the basin to shrink like `delta/(F N)`;
+   the finite-angle statement is what makes a radius of order `0.3` rad
+   expressible at all. `tools/ou3_p5_large_angle_sector_certificate.py` is the
+   existing entry point for that geometry.
+
+Until those land, `N_H_words` stays unset -- now for a proved reason rather than
+a pending computation.
+
+**PASS criterion for closing P5:** every certified normal or timeout handoff lies in a validated outer H capture funnel; every source-word prefix stays safe; the outer recurrence reaches `W_*` in a finite machine-certified number of H words/time. The current certificate does **not** yet satisfy this criterion, and the route ceiling above proves the present accounting never can.
 
 ### P6 — Prove every implemented hybrid jump
 

--- a/tests/validation/Makefile
+++ b/tests/validation/Makefile
@@ -28,7 +28,9 @@ build:
 		../../tools/ou3_p4_group_algebra.py \
 		../../tools/ou3_p4_exact_word_map.py \
 		../../tools/ou3_p4_node_metrics.py \
+		../../tools/ou3_p4_metric_defect_transport.py \
 		../../tools/ou3_p4_nonlinear_word_certificate.py \
+		../../tools/ou3_p4_p5_route_ceiling_certificate.py \
 		../../tools/ou3_p5_startup_capture_certificate.py \
 		../../tools/ou3_p5_outer_h_word_certificate.py \
 		../../tools/ou3_p5_go_live_covariance_stage.py \
@@ -75,7 +77,9 @@ build:
 		test_ou3_explicit_information_word_certificate.py \
 		test_ou3_p4_group_algebra.py \
 		test_ou3_p4_word_map_and_metrics.py \
+		test_ou3_p4_metric_defect_transport.py \
 		test_ou3_p4_nonlinear_word_certificate.py \
+		test_ou3_p4_p5_route_ceiling.py \
 		test_ou3_p5_startup_capture_certificate.py \
 		test_ou3_p5_outer_h_word_certificate.py \
 		test_ou3_p5_go_live_covariance_stage.py \

--- a/tests/validation/Makefile
+++ b/tests/validation/Makefile
@@ -28,6 +28,7 @@ build:
 		../../tools/ou3_p4_group_algebra.py \
 		../../tools/ou3_p4_exact_word_map.py \
 		../../tools/ou3_p4_node_metrics.py \
+		../../tools/ou3_p3_word_noise_accumulation.py \
 		../../tools/ou3_p4_metric_defect_transport.py \
 		../../tools/ou3_p4_nonlinear_word_certificate.py \
 		../../tools/ou3_p4_p5_route_ceiling_certificate.py \
@@ -77,6 +78,7 @@ build:
 		test_ou3_explicit_information_word_certificate.py \
 		test_ou3_p4_group_algebra.py \
 		test_ou3_p4_word_map_and_metrics.py \
+		test_ou3_p3_word_noise_accumulation.py \
 		test_ou3_p4_metric_defect_transport.py \
 		test_ou3_p4_nonlinear_word_certificate.py \
 		test_ou3_p4_p5_route_ceiling.py \

--- a/tests/validation/test_ou3_p3_word_noise_accumulation.py
+++ b/tests/validation/test_ou3_p3_word_noise_accumulation.py
@@ -1,0 +1,149 @@
+from pathlib import Path
+import math
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+
+import ou3_p3_word_noise_accumulation as WORDNOISE
+import ou3_source_reachable_matrix_p3_direct as DIRECT
+from ou3_interval import Interval, symmetric_positive_definite_ldlt
+
+
+def _point(value):
+    return Interval.outward_bounds(float(value), float(value))
+
+
+def _identity(n):
+    return [[_point(1.0 if i == j else 0.0) for j in range(n)] for i in range(n)]
+
+
+class Ou3P3WordNoiseAccumulationTests(unittest.TestCase):
+    def test_doubling_reproduces_the_explicit_prediction_sum(self):
+        # Omega_N = sum_k Phi^k Q (Phi^k)'.  Check the doubling identity against
+        # the sum written out term by term.
+        Phi = [[_point(1.0), _point(-0.25)], [_point(0.0), _point(1.0)]]
+        Q = [[_point(2.0), _point(0.5)], [_point(0.5), _point(3.0)]]
+        for doublings in range(4):
+            got = WORDNOISE.accumulate_word_noise(Q, Phi, doublings)
+            power = _identity(2)
+            total = [[_point(0.0), _point(0.0)], [_point(0.0), _point(0.0)]]
+            for _ in range(2 ** doublings):
+                term = [
+                    [
+                        sum(
+                            (power[i][a] * Q[a][b] * power[j][b] for a in range(2) for b in range(2)),
+                            _point(0.0),
+                        )
+                        for j in range(2)
+                    ]
+                    for i in range(2)
+                ]
+                total = [[total[i][j] + term[i][j] for j in range(2)] for i in range(2)]
+                power = [
+                    [sum((power[i][a] * Phi[a][j] for a in range(2)), _point(0.0)) for j in range(2)]
+                    for i in range(2)
+                ]
+            for i in range(2):
+                for j in range(2):
+                    self.assertAlmostEqual(
+                        0.5 * (got[i][j].lo + got[i][j].hi),
+                        0.5 * (total[i][j].lo + total[i][j].hi),
+                        delta=1.0e-9,
+                    )
+
+    def test_accumulation_is_monotone_in_the_horizon(self):
+        Phi = [[_point(1.0), _point(-0.1)], [_point(0.0), _point(1.0)]]
+        Q = [[_point(1.0), _point(0.0)], [_point(0.0), _point(1.0)]]
+        previous = None
+        for doublings in range(5):
+            got = WORDNOISE.accumulate_word_noise(Q, Phi, doublings)
+            trace = got[0][0].lo + got[1][1].lo
+            if previous is not None:
+                self.assertGreater(trace, previous)
+            previous = trace
+
+    def test_rebalancing_keeps_the_recursion_definite(self):
+        # Without rebalancing the S row grows like N^7 and the a_w row like N,
+        # so the enclosure loses definiteness long before the word horizon.
+        Phi = [
+            [_point(1.0), _point(0.0), _point(0.0), _point(1.0)],
+            [_point(1.0), _point(1.0), _point(0.0), _point(0.5)],
+            [_point(0.5), _point(1.0), _point(1.0), _point(1.0 / 6.0)],
+            [_point(0.0), _point(0.0), _point(0.0), _point(0.999)],
+        ]
+        Q = [[Interval.outward_bounds(0.0, 0.0) for _ in range(4)] for _ in range(4)]
+        for i in range(4):
+            Q[i][i] = Interval.outward_bounds(1.0, 1.0000001)
+        raw = WORDNOISE.accumulate_word_noise(Q, Phi, 9)
+        balanced = WORDNOISE.accumulate_word_noise(Q, Phi, 9, [0.5, 0.25, 0.125, 1.0])
+        raw_spread = max(abs(raw[i][i].hi) for i in range(4)) / min(
+            abs(raw[i][i].lo) for i in range(4)
+        )
+        balanced_spread = max(abs(balanced[i][i].hi) for i in range(4)) / min(
+            abs(balanced[i][i].lo) for i in range(4)
+        )
+        self.assertGreater(raw_spread, 1.0e6)
+        self.assertLess(balanced_spread, 1.0e4)
+
+    def test_measurement_posterior_never_exceeds_the_prior_floor(self):
+        Omega = [[_point(2.0), _point(0.3)], [_point(0.3), _point(1.0)]]
+        post = WORDNOISE.measurement_posterior(Omega, [0.0, 0.0])
+        for i in range(2):
+            for j in range(2):
+                self.assertAlmostEqual(post[i][j].lo, Omega[i][j].lo, delta=1.0e-12)
+        shrunk = WORDNOISE.measurement_posterior(Omega, [5.0, 5.0])
+        for i in range(2):
+            self.assertLess(shrunk[i][i].hi, Omega[i][i].lo)
+            self.assertGreater(shrunk[i][i].lo, 0.0)
+
+    def test_word_step_count_uses_a_lower_bound_on_the_horizon(self):
+        self.assertEqual(WORDNOISE.word_step_doublings(1.0, 0.005), 7)
+        self.assertEqual(WORDNOISE.word_step_doublings(3.14, 0.005), 9)
+        with self.assertRaises(RuntimeError):
+            WORDNOISE.word_step_doublings(0.001, 0.005)
+
+    def test_attitude_bias_floor_is_positive_and_bias_keeps_its_accumulation(self):
+        # No shipping update measures the gyro bias directly, so the bias
+        # coordinate must keep the whole accumulated floor while the attitude
+        # coordinate is shrunk by the vector information.
+        block = WORDNOISE.attitude_bias_word_noise(0.9999, 1.0e-4, 9, 0.066)
+        self.assertTrue(symmetric_positive_definite_ldlt(block)[0])
+        self.assertGreater(block[1][1].lo, 400.0)
+        self.assertLess(block[0][0].hi, block[1][1].lo)
+        self.assertGreater(block[0][0].lo, 0.0)
+
+    def test_normalised_sigma_margin_agrees_with_the_explicit_posterior(self):
+        # (Omega^-1 + D)^-1 >= delta Sigma  and  lambda_max(G (Omega^-1 + D) G) <= 1/delta
+        # with G = Sigma^{1/2} are the same statement.  The second is the one
+        # that survives a strongly measured word, because it never forms the
+        # posterior and never tests definiteness of a near-singular Sigma^-1.
+        from ou3_interval_linear_algebra import matrix_inverse_gauss_jordan
+        Omega = [
+            [_point(0.80), _point(0.10), _point(0.02), _point(0.01)],
+            [_point(0.10), _point(0.50), _point(0.03), _point(0.00)],
+            [_point(0.02), _point(0.03), _point(0.40), _point(0.05)],
+            [_point(0.01), _point(0.00), _point(0.05), _point(0.60)],
+        ]
+        sigma_diag = [40.0, 90.0, 25.0, 10.0]
+        info = [0.0, 0.0, 2.0, 7.0]
+        Sigma = [[_point(sigma_diag[i] if i == j else 0.0) for j in range(4)] for i in range(4)]
+        post = WORDNOISE.measurement_posterior(Omega, info)
+        explicit = DIRECT._certified_generalized_delta(post, Sigma, 1.0e-18)
+
+        inverse = matrix_inverse_gauss_jordan([list(r) for r in Omega])
+        sigma_root = [math.sqrt(v) for v in sigma_diag]
+        normalised = DIRECT._word_translation_block_margin(
+            inverse, sigma_root, [info[i] * sigma_diag[i] for i in range(4)]
+        )
+        self.assertGreater(explicit, 0.0)
+        self.assertGreater(normalised, 0.0)
+        # The normalised route bounds lambda_max by Gershgorin, so it can only
+        # under-report, and on a 4x4 by at most the row count.
+        self.assertLessEqual(normalised, explicit * (1.0 + 1.0e-9))
+        self.assertGreater(normalised, explicit / 4.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/validation/test_ou3_p4_metric_defect_transport.py
+++ b/tests/validation/test_ou3_p4_metric_defect_transport.py
@@ -1,0 +1,117 @@
+from pathlib import Path
+import math
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+
+import ou3_p4_metric_defect_transport as TRANSPORT
+import ou3_p4_nonlinear_word_certificate as P4
+
+
+class Ou3P4MetricDefectTransportTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.d = P4.build()
+
+    def test_certificate_keeps_the_smaller_of_the_two_valid_defect_gains(self):
+        for mode in ("H", "A"):
+            m = self.d["modes"][mode]
+            iso = m["transported_word_defect_B_isotropic_upper"]
+            met = m["transported_word_defect_B_metric_consistent_upper"]
+            chosen = m["transported_word_defect_B_upper"]
+            self.assertGreater(iso, 0.0)
+            self.assertGreater(met, 0.0)
+            self.assertEqual(chosen, min(iso, met))
+            self.assertEqual(
+                m["transported_word_defect_route"],
+                "METRIC_CONSISTENT_STRUCTURED_DEFECT_TRANSPORT"
+                if met <= iso
+                else "ISOTROPIC_EUCLIDEAN_DEFECT_ENVELOPE",
+            )
+
+    def test_structured_transport_is_the_binding_route_and_widens_the_level(self):
+        for mode in ("H", "A"):
+            m = self.d["modes"][mode]
+            self.assertEqual(
+                m["transported_word_defect_route"],
+                "METRIC_CONSISTENT_STRUCTURED_DEFECT_TRANSPORT",
+            )
+            # The structured route must stay far below the isotropic envelope it
+            # replaces; a regression that silently reverts it is caught here.
+            self.assertLess(
+                m["transported_word_defect_B_metric_consistent_upper"],
+                1.0e-20 * m["transported_word_defect_B_isotropic_upper"],
+            )
+            # The isotropic route certified 3.3e-141; the structured one must stay
+            # many decades above that without ever reaching a practical level.
+            self.assertGreater(m["certified_level_W"], 1.0e-100)
+            self.assertLess(m["certified_level_W"], 1.0e-40)
+
+    def test_defect_inputs_exclude_the_translation_block(self):
+        for mode in ("H", "A"):
+            m = self.d["modes"][mode]
+            # The nonlinear defects are quadratic in attitude, gyro bias and a_w
+            # only.  The translation diagonals carry the whole covariance spread
+            # and must not enter the chart scale.
+            self.assertGreaterEqual(
+                m["Sigma_defect_input_block_upper"], m["Sigma_attitude_block_upper"]
+            )
+            self.assertLess(m["Sigma_defect_input_block_upper"], m["Sigma_lambda_max_upper"])
+            t = m["metric_consistent_defect_transport"]
+            self.assertLess(t["attitude_chart_scale"], 1.0)
+            self.assertAlmostEqual(
+                t["attitude_chart_scale"],
+                math.sqrt(m["Sigma_attitude_block_upper"] / m["Sigma_lambda_max_upper"]),
+                delta=1.0e-12,
+            )
+
+    def test_gain_transport_uses_the_half_bound_not_the_isotropic_gain_norm(self):
+        for mode in ("H", "A"):
+            m = self.d["modes"][mode]
+            t = m["metric_consistent_defect_transport"]
+            rmin = m["measurement_bounds"]["all_correction_R_lambda_min_lower"]
+            s = m["Sigma_lambda_max_upper"]
+            self.assertAlmostEqual(
+                t["gain_metric_transport_upper"],
+                math.sqrt(s) / (2.0 * math.sqrt(rmin)),
+                delta=1.0e-6 * t["gain_metric_transport_upper"],
+            )
+            # sqrt(s)/(2 sqrt(Rmin)) must beat the retired sqrt(m_+)*||K|| chain.
+            self.assertLess(
+                t["gain_metric_transport_upper"],
+                math.sqrt(m["metric_lambda_max_upper"]) * m["full_gain_norm_upper"],
+            )
+
+    def test_module_validates_and_closes_its_own_prefix_bootstrap(self):
+        for mode in ("H", "A"):
+            t = self.d["modes"][mode]["metric_consistent_defect_transport"]
+            self.assertEqual(TRANSPORT.validate(t), [])
+            self.assertLessEqual(t["prefix_metric_norm_upper"], t["design_metric_radius"])
+            self.assertLess(t["prefix_attitude_cayley_norm_upper"], 1.0)
+            self.assertGreater(t["certified_level_W"], 0.0)
+
+    def test_module_fails_closed_on_a_non_positive_source_bound(self):
+        base = dict(self.d["modes"]["H"]["metric_consistent_defect_transport"])
+        inputs = {
+            "metric_scale": self.d["modes"]["H"]["Sigma_lambda_max_upper"],
+            "word_endpoint_delta_lower": 0.0,
+            "correction_R_lambda_min_lower": 1.0,
+            "Sigma_attitude_upper": 1.0,
+            "Sigma_gyro_bias_upper": 1.0,
+            "Sigma_defect_input_upper": 1.0,
+            "rho_attitude_scaled_lower": 1.0,
+            "Q_theta_diagonal_lower": 1.0,
+            "H_attitude_norm_upper": 1.0,
+            "vector_residual_quadratic_constant_upper": 1.0,
+            "prediction_increment_gain_upper": 1.0,
+            "state_operation_count_upper": 1.0,
+        }
+        with self.assertRaises(RuntimeError):
+            TRANSPORT.build(inputs)
+        self.assertGreater(base["certified_level_W"], 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/validation/test_ou3_p4_p5_route_ceiling.py
+++ b/tests/validation/test_ou3_p4_p5_route_ceiling.py
@@ -58,7 +58,9 @@ class Ou3P4P5RouteCeilingTests(unittest.TestCase):
                 m["certified_attitude_capture_radius_now"],
                 m["route_ceiling_at_shipping_prefix_factor"],
             )
-            self.assertGreater(m["shortfall_factor_now_vs_largest_handoff"], 1.0e30)
+            # A floor, not a pin: tightening P3 or P4 raises the reported
+            # radius and must not churn the obstruction test.
+            self.assertGreater(m["shortfall_factor_now_vs_largest_handoff"], 1.0e20)
 
     def test_breakeven_shows_the_word_structure_is_the_binding_hypothesis(self):
         for mode in ("H", "A"):

--- a/tests/validation/test_ou3_p4_p5_route_ceiling.py
+++ b/tests/validation/test_ou3_p4_p5_route_ceiling.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+import math
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+
+import ou3_p4_p5_route_ceiling_certificate as CEILING
+
+
+class Ou3P4P5RouteCeilingTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.d = CEILING.build()
+
+    def test_route_ceiling_validates_and_reports_the_obstruction(self):
+        d = self.d
+        self.assertEqual(CEILING.validate(d), [])
+        self.assertEqual(d["P4_P5_UNIFORM_TRANSPORT_ROUTE_CEILING"], "BELOW_P1_HANDOFF")
+        self.assertTrue(d["ceiling_is_about_the_proof_route_not_the_filter"])
+        self.assertFalse(d["source_replay_used"])
+        self.assertEqual(set(d["modes"]), {"H", "A"})
+
+    def test_ceiling_is_below_every_bounded_P1_handoff_node(self):
+        for mode in ("H", "A"):
+            m = self.d["modes"][mode]
+            self.assertFalse(m["route_can_reach_P1_handoff"])
+            self.assertLess(m["route_ceiling_absolute"], m["smallest_bounded_P1_handoff_cayley_norm"])
+            self.assertLess(m["route_ceiling_at_shipping_prefix_factor"], m["route_ceiling_absolute"])
+            self.assertGreater(m["shortfall_factor_ceiling_vs_largest_handoff"], 50.0)
+            self.assertGreater(m["shortfall_factor_ceiling_vs_smallest_handoff"], 20.0)
+
+    def test_ceiling_matches_delta_over_prefix_factor_times_injections(self):
+        for mode in ("H", "A"):
+            m = self.d["modes"][mode]
+            n = m["word_samples_upper"]
+            self.assertAlmostEqual(m["route_ceiling_absolute"], 1.0 / n, delta=1.0e-12)
+            self.assertAlmostEqual(
+                m["route_ceiling_at_shipping_prefix_factor"],
+                1.0 / (m["prefix_W_factor_upper"] * n),
+                delta=1.0e-12,
+            )
+
+    def test_ceiling_does_not_depend_on_the_covariance_or_metric_scale(self):
+        # theta_capture <= delta/(F N eps) has no a_t in it: the attitude chart
+        # scale cancels, so no covariance retightening can move the ceiling.
+        self.assertTrue(self.d["attitude_chart_scale_cancels_from_the_ceiling"])
+        h, a = self.d["modes"]["H"], self.d["modes"]["A"]
+        self.assertNotAlmostEqual(h["attitude_chart_scale"], 0.0)
+        self.assertAlmostEqual(h["route_ceiling_absolute"], a["route_ceiling_absolute"], delta=1.0e-15)
+
+    def test_current_radius_is_inside_its_own_ceiling_and_far_below_it(self):
+        for mode in ("H", "A"):
+            m = self.d["modes"][mode]
+            self.assertGreater(m["certified_attitude_capture_radius_now"], 0.0)
+            self.assertLess(
+                m["certified_attitude_capture_radius_now"],
+                m["route_ceiling_at_shipping_prefix_factor"],
+            )
+            self.assertGreater(m["shortfall_factor_now_vs_largest_handoff"], 1.0e30)
+
+    def test_breakeven_shows_the_word_structure_is_the_binding_hypothesis(self):
+        for mode in ("H", "A"):
+            m = self.d["modes"][mode]
+            # A word would have to inject fewer than two accepted attitude
+            # corrections per second for the route to ever reach the handoff.
+            self.assertLess(m["breakeven_injecting_operations_per_word"], 2.0)
+            self.assertLess(m["word_samples_upper"] / 10.0,
+                            m["state_operation_count_upper"])
+            self.assertLess(m["breakeven_injection_fraction_at_source_word"], 0.01)
+
+    def test_required_structural_change_retires_the_kappa_search(self):
+        d = self.d
+        joined = " ".join(d["required_structural_change"])
+        self.assertIn("information decrease of the same", joined)
+        self.assertIn("finite-angle sector", joined)
+        self.assertIn("kappa", d["retired_search_direction"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/validation/test_ou3_p5_startup_capture_certificate.py
+++ b/tests/validation/test_ou3_p5_startup_capture_certificate.py
@@ -55,11 +55,13 @@ class Ou3P5StartupCaptureCertificateTests(unittest.TestCase):
         weak = d["weakest_axis_witness"]
         self.assertEqual(weak["group"], "b_g")
         self.assertAlmostEqual(weak["axis_witness_W_lower"], 1.0e-4, delta=1.0e-18)
-        self.assertGreater(weak["W_lower_over_strict_decrease_threshold"], 1.0e135)
+        # Floors express "many orders", not a pinned value: a legitimate P4
+        # widening shrinks these ratios and must not churn the obstruction test.
+        self.assertGreater(weak["W_lower_over_strict_decrease_threshold"], 1.0e40)
         strong = d["largest_axis_witness"]
         self.assertEqual(strong["group"], "S")
         self.assertAlmostEqual(strong["axis_witness_W_lower"], 9.0e4, delta=1.0e-8)
-        self.assertGreater(strong["W_lower_over_strict_decrease_threshold"], 1.0e144)
+        self.assertGreater(strong["W_lower_over_strict_decrease_threshold"], 1.0e50)
 
     def test_gauged_handoffs_use_composed_full_attitude_not_tilt_only(self):
         b = self.d["outer_bridge_requirements"]
@@ -82,10 +84,32 @@ class Ou3P5StartupCaptureCertificateTests(unittest.TestCase):
         self.assertIn("YAW_QUOTIENT", b["timeout_ungauged_required_route"])
         self.assertIn("yaw-quotient", " ".join(b["required_proof_structure"]))
 
+    def test_N_H_words_is_unset_for_a_proved_route_ceiling_not_a_pending_count(self):
+        d = self.d
+        self.assertIsNone(d["N_H_words"])
+        self.assertEqual(
+            d["N_H_words_unset_reason"],
+            "PROVED_UNIFORM_TRANSPORT_ROUTE_CEILING_BELOW_P1_HANDOFF",
+        )
+        rc = d["route_ceiling"]
+        self.assertEqual(rc["status"], "BELOW_P1_HANDOFF")
+        b = d["outer_bridge_requirements"]
+        self.assertTrue(b["obstruction_is_the_route_not_its_constants"])
+        self.assertFalse(b["uniform_transport_route_can_ever_reach_P1_handoff"])
+        self.assertLess(
+            b["uniform_transport_route_ceiling_rad"],
+            b["timeout_gauged_full_attitude_cayley_norm_upper"],
+        )
+        self.assertLess(
+            b["uniform_transport_route_ceiling_rad"],
+            b["normal_gauged_full_attitude_cayley_norm_upper"],
+        )
+        self.assertGreater(b["uniform_transport_route_ceiling_shortfall_vs_largest_handoff"], 50.0)
+
     def test_unchanged_isotropic_P4_recurrence_is_not_outer_bridge(self):
         b = self.d["outer_bridge_requirements"]
-        self.assertGreater(b["uniform_B_reduction_factor_needed_at_weakest_witness"], 1.0e67)
-        self.assertGreater(b["uniform_B_reduction_factor_needed_at_largest_witness"], 1.0e72)
+        self.assertGreater(b["uniform_B_reduction_factor_needed_at_weakest_witness"], 1.0e20)
+        self.assertGreater(b["uniform_B_reduction_factor_needed_at_largest_witness"], 1.0e25)
         self.assertIn("Simply enlarging q_design", b["interpretation"])
         self.assertIn("staged outer-H bridge", self.d["required_next_certificate"])
 

--- a/tests/validation/test_ou3_p5_startup_capture_certificate.py
+++ b/tests/validation/test_ou3_p5_startup_capture_certificate.py
@@ -75,8 +75,10 @@ class Ou3P5StartupCaptureCertificateTests(unittest.TestCase):
         self.assertGreater(timeout, normal)
         self.assertTrue(b["normal_gauged_inside_current_promoted_cayley_norm_limit"])
         self.assertTrue(b["timeout_gauged_inside_current_promoted_cayley_norm_limit"])
-        self.assertGreater(b["normal_gauged_over_current_P4_design_radius_factor"], 1.0e11)
-        self.assertGreater(b["timeout_gauged_over_current_P4_design_radius_factor"], 5.0e11)
+        # Floors, not pins: a tighter covariance enclosure raises the P4
+        # design radius and must not churn the obstruction test.
+        self.assertGreater(b["normal_gauged_over_current_P4_design_radius_factor"], 1.0e8)
+        self.assertGreater(b["timeout_gauged_over_current_P4_design_radius_factor"], 1.0e8)
 
     def test_ungauged_timeout_has_no_fake_full_heading_radius(self):
         b = self.d["outer_bridge_requirements"]

--- a/tools/ou3_p3_word_noise_accumulation.py
+++ b/tools/ou3_p3_word_noise_accumulation.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Word-accumulated injected-noise floor for the source-reachable P3 comparison.
+
+P3 certifies the generalized endpoint inequality
+
+    Omega_word - delta * Sigma_upper  >>  0,
+
+where ``Omega_word`` is the process noise the deployed recursion injects over a
+whole source word and ``Sigma_upper`` bounds the covariance at the word
+endpoint.  The direct backend used a valid but extremely weak lower bound for
+``Omega_word``: the *single* IMU step's ``Q``.  Because ``Sigma_upper`` is a
+word-horizon quantity, that compares a 5 ms noise injection against a 3.1 s
+covariance -- a ratio of ``(T/h)^7`` on the ``S`` channel alone, and it is what
+held the P3 margin at ``3.8e-35``.
+
+For pure prediction the source runs ``P <- Phi P Phi' + Q`` each step, so after
+``N`` steps the injected floor is
+
+    Omega_N = sum_{k=0}^{N-1} Phi^k Q (Phi^k)',
+
+which obeys the exact doubling identity
+
+    Omega_{2m} = Phi^m Omega_m (Phi^m)' + Omega_m,   Phi^{2m} = Phi^m Phi^m.
+
+That identity is what this module supplies, for the (theta, gyro-bias) block.
+The translation block does not need it: for the integrated-OU chain the same sum
+is exactly ``Q(N h)`` -- the same analytic family the certificate already
+validates, read at the word horizon rather than at one step -- so the direct
+backend evaluates it there instead, with no recursion and no interval growth.
+
+``N`` is taken from a *lower* bound on the word's step count, so the accumulated
+matrix stays a lower bound on what the word actually injects while
+``Sigma_upper`` stays an upper bound at the word's horizon upper.
+
+The word's measurement updates shrink that floor.  For the Joseph update with
+any implemented gain,
+
+    (I-KH) Omega (I-KH)' + K R K'  >=  (Omega^-1 + H' R^-1 H)^-1,
+
+so assimilating every admissible measurement of the word with the optimal gain
+is a conservative lower comparison.  With an information upper bound ``D`` the
+posterior floor is ``(Omega^-1 + D)^-1 = Omega (I + D Omega)^-1``, computed here
+in that closed form for the small, well-conditioned attitude block.
+
+``D`` is kept *block structured*.  A single scalar bound is what makes the
+attitude/gyro-bias comparison collapse: the accelerometer's information lives in
+the ``a_w`` coordinate and is worth four orders more than the attitude
+information, and the gyro bias receives no direct measurement information at
+all.  Charging the ``a_w`` figure against the bias coordinate erases the whole
+accumulated bias floor.
+
+Everything is outward rounded.  Every routine returns a lower comparison for the
+same quantity the parent bounds, so a consumer takes the better of the two and
+can never be widened by this module.
+"""
+from __future__ import annotations
+
+import math
+
+from ou3_interval import (
+    Interval,
+    matrix_add,
+    matrix_identity,
+    matrix_mul,
+    matrix_transpose,
+)
+from ou3_interval_linear_algebra import matrix_inverse_gauss_jordan, matrix_symmetric_hull
+
+SCHEMA = 1
+
+def down(x: float) -> float:
+    return math.nextafter(float(x), -math.inf)
+
+
+def up(x: float) -> float:
+    return math.nextafter(float(x), math.inf)
+
+
+def _I(x: float) -> Interval:
+    return Interval.outward_bounds(float(x), float(x))
+
+
+def _diagonal(values: list[float]):
+    n = len(values)
+    return [[_I(values[i]) if i == j else _I(0.0) for j in range(n)] for i in range(n)]
+
+
+def accumulate_word_noise(Q, Phi, doublings: int, rebalance=None):
+    """``sum_{k<2^doublings} Phi^k Q (Phi^k)'`` by the exact doubling identity.
+
+    Held in the raw comparison scaling the accumulated matrix spans fourteen
+    decades after nine doublings -- the ``S`` row grows like ``N^7`` while the
+    ``a_w`` row grows like ``N`` -- and interval arithmetic loses the
+    correlation long before that: a relative input width of ``1e-6`` already
+    leaves the enclosure indefinite.
+
+    ``rebalance`` fixes that by carrying the recursion in the scaling of the
+    *current* horizon.  With ``J = diag(f)`` mapping the ``T`` scaling to the
+    ``2T`` scaling, the same exact identity reads
+
+        Omega_{k+1} = (J Psi_k) Omega_k (J Psi_k)' + J Omega_k J',
+        Psi_{k+1}   = J Psi_k Psi_k J^-1,
+
+    and both stay order one at every level.  For the ``[v,p,S,a_w]`` chain
+    ``f = (1/2, 1/4, 1/8, 1)`` -- exact binary fractions, so the rebalancing is
+    rounding-free.  Pass ``None`` to keep the raw recursion.
+    """
+    if doublings < 0:
+        raise ValueError("doubling count must be non-negative")
+    Omega = matrix_symmetric_hull(Q)
+    A = [list(row) for row in Phi]
+    if rebalance is None:
+        for _ in range(doublings):
+            Omega = matrix_symmetric_hull(
+                matrix_add(matrix_mul(matrix_mul(A, Omega), matrix_transpose(A)), Omega)
+            )
+            A = matrix_mul(A, A)
+        return Omega
+    if len(rebalance) != len(Omega) or any(not (v > 0.0) for v in rebalance):
+        raise ValueError("rebalancing factors must be positive and match the matrix order")
+    J = _diagonal(list(rebalance))
+    Jinv = _diagonal([1.0 / v for v in rebalance])
+    for _ in range(doublings):
+        JA = matrix_mul(J, A)
+        JAt = matrix_transpose(JA)
+        carried = matrix_mul(matrix_mul(J, Omega), matrix_transpose(J))
+        Omega = matrix_symmetric_hull(
+            matrix_add(matrix_mul(matrix_mul(JA, Omega), JAt), carried)
+        )
+        A = matrix_mul(matrix_mul(JA, A), Jinv)
+    return Omega
+
+
+def measurement_posterior(Omega, information: list[float]):
+    """Lower comparison ``(Omega^-1 + D)^-1 = Omega (I + D Omega)^-1``, ``D=diag(d)``.
+
+    ``information`` must be an upper bound on the measurement information the
+    word can assimilate in these coordinates; a larger ``D`` only lowers the
+    result, so an over-estimate stays conservative.
+    """
+    n = len(Omega)
+    if len(information) != n:
+        raise ValueError("information vector does not match matrix order")
+    if any(d < 0.0 or not math.isfinite(d) for d in information):
+        raise ValueError("measurement information must be finite non-negative")
+    D = [[_I(information[i]) if i == j else _I(0.0) for j in range(n)] for i in range(n)]
+    M = matrix_add(matrix_identity(n), matrix_mul(D, Omega))
+    Minv = matrix_inverse_gauss_jordan(M)
+    return matrix_symmetric_hull(matrix_mul(Omega, Minv))
+
+
+def word_step_doublings(word_horizon_lower_s: float, dt_s: float) -> int:
+    """Largest ``k`` with ``2^k`` prediction steps certainly inside the word."""
+    if not (word_horizon_lower_s > 0.0 and dt_s > 0.0):
+        raise ValueError("positive word horizon and step required")
+    steps = math.floor(down(word_horizon_lower_s / up(dt_s)))
+    if steps < 1:
+        raise RuntimeError("source word does not certainly contain one prediction step")
+    return int(math.floor(math.log2(steps)))
+
+
+def attitude_bias_word_noise(rho_attitude: float, coupling_per_step: float,
+                             doublings: int, attitude_information: float):
+    """Accumulated (theta, gyro-bias) noise floor for one axis, scaled and posterior.
+
+    In the comparison scaling ``diag(sqrt q_theta, sqrt q_bias)`` the source
+    attitude/bias prediction is ``[[1, -c],[0, 1]]`` with
+    ``c = h sqrt(q_bias/q_theta)``, and the scaled one-step process matrix
+    dominates ``rho_attitude I`` -- the same scaled comparison the parent
+    certificate already uses.  Only the attitude coordinate receives measurement
+    information; the gyro bias is never measured directly.
+    """
+    if not (0.0 < rho_attitude <= 1.0):
+        raise ValueError("scaled attitude/bias process floor must lie in (0,1]")
+    Phi = [[_I(1.0), _I(-abs(coupling_per_step))], [_I(0.0), _I(1.0)]]
+    Q = [[_I(rho_attitude), _I(0.0)], [_I(0.0), _I(rho_attitude)]]
+    Omega = accumulate_word_noise(Q, Phi, doublings)
+    return measurement_posterior(Omega, [attitude_information, 0.0])

--- a/tools/ou3_p4_metric_defect_transport.py
+++ b/tools/ou3_p4_metric_defect_transport.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Metric-consistent transported-defect gain for the OU-III P4 nonlinear word.
+
+P4 bounds the exact nonlinear source word by its P3 homogeneous tangent map plus
+an exact defect, and needs one number: an upper bound ``B`` on
+
+    ||r_word||_{M_end} / W_0,
+
+where ``M_g = s_m Sigma_KF(g)^-1`` is the mode metric and ``W_0`` the entry
+level.  The original route obtains ``B`` by leaving the metric entirely:
+
+    ||z||_2 <= sqrt(W/m_-),  ||r||_M <= sqrt(m_+) ||r||_2,
+
+with ``m_- = s/Sigma_max`` and ``m_+ = s/Sigma_min``.  That pays the full
+``sqrt(cond(Sigma))`` of an 18/21-state covariance whose entries range over
+thirty-four decades, and it bounds the gain by the isotropic
+``||K|| <= sqrt(Sigma_max/R_min)``.  Both steps are avoidable: the defects of the
+shipping word are *structured*, and the metric that measures them is the source
+covariance itself.
+
+This module supplies the structured replacement.  Three exact facts are used,
+each stated against the same source-derived P3/process bounds P4 already
+consumes.
+
+1.  **Gain transport (the injected correction defect never leaves the metric).**
+    For the shipping gain ``K = P H^T S^-1``, ``S = H P H^T + R``, write
+    ``A = R^-1/2 H P^1/2``.  Then
+
+        P^-1/2 K = P^1/2 H^T S^-1 = A^T (A A^T + I)^-1 R^-1/2,
+
+    and ``||A^T (A A^T + I)^-1||_2 = max_i sigma_i/(1+sigma_i^2) <= 1/2``.  Hence
+    for every residual defect ``q``
+
+        ||K q||_M <= sqrt(s) ||q||_2 / (2 sqrt(lambda_min(R))).
+
+    The node metric uses ``Sigma_KF(g) >= P``, so ``Sigma^-1 <= P^-1`` and the
+    same bound holds for the metric actually used.
+
+2.  **Chart transport (the defect inputs are marginal, not global).**
+    Marginalising the exact quadratic form,
+
+        min_xi [c;xi]^T Sigma^-1 [c;xi] = c^T (Sigma_cc)^-1 c,
+
+    so for any coordinate block ``c`` of the state,
+
+        ||c||^2 <= lambda_max(Sigma_cc) W / s.
+
+    The P3 covariance upper is a Loewner diagonal dominator, so
+    ``lambda_max(Sigma_cc)`` is bounded by the largest diagonal upper on that
+    block.  The nonlinear defects of the shipping word are quadratic in the
+    attitude, gyro-bias and ``a_w`` coordinates only; the translation block --
+    which carries the whole thirty-four-decade spread -- never enters them.
+
+3.  **Attitude-injection cost (an attitude-supported defect is charged on the
+    conditional attitude covariance).**  The quaternion injection remainder is
+    supported on the attitude coordinates, so its metric cost is
+    ``sqrt(s lambda_max((Sigma^-1)_theta,theta))``.  Every source node is either
+    a post-prediction node, where ``Sigma >= Q`` and therefore
+    ``(Sigma^-1)_tt <= (Q^-1)_tt <= I/(rho_att q_theta)``, or a node reached from
+    one by at most ``n_corr`` corrections inside the same sample, each adding at
+    most ``||H_theta||^2/lambda_min(R)`` of attitude information in the exact
+    information form ``P+^-1 = P^-1 + H^T R^-1 H``.
+
+Everything below is outward rounded.  The module returns an upper bound on the
+same ``B`` the parent route bounds, so the consumer takes the minimum of the two
+and can never be widened by this refinement.
+"""
+from __future__ import annotations
+
+import math
+
+SCHEMA = 1
+
+# Exact Cayley composition c (+) d = (c + d + 0.5 d x c)/(1 - d.c/4).
+CAYLEY_CROSS_COEFF = 0.5
+CAYLEY_DENOMINATOR_COEFF = 0.25
+# Deployed normalized polynomial quaternion branch, same constant as the parent.
+SOURCE_SERIES_CAYLEY_CUBIC_COEFF = 0.085
+# Prefix bootstrap factor shared with the parent route (W_s <= 4 W_0).
+PREFIX_BOOTSTRAP_W_FACTOR = 4.0
+# Corrections applied inside one IMU sample after its prediction: S, accel, mag.
+MAX_CORRECTIONS_PER_SAMPLE = 3
+# Largest accepted attitude injection kept inside the deployed series branch.
+MAX_DESIGN_INJECTION_NORM = 5.0e-3
+
+
+def down(x: float) -> float:
+    return math.nextafter(float(x), -math.inf)
+
+
+def up(x: float) -> float:
+    return math.nextafter(float(x), math.inf)
+
+
+def add_up(a: float, b: float) -> float:
+    return up(float(a) + float(b))
+
+
+def mul_up(a: float, b: float) -> float:
+    return up(float(a) * float(b))
+
+
+def div_up(a: float, b: float) -> float:
+    if not b > 0.0:
+        raise ValueError("positive denominator required")
+    return up(float(a) / float(b))
+
+
+def sqrt_up(x: float) -> float:
+    if x < 0.0:
+        raise ValueError("sqrt of negative")
+    r = math.sqrt(float(x))
+    # One outward step is enough: math.sqrt is correctly rounded.
+    return up(r)
+
+
+def _block_upper(diag_upper: list[float], indices: range | list[int]) -> float:
+    vals = [float(diag_upper[i]) for i in indices]
+    if not vals or not all(math.isfinite(v) and v > 0.0 for v in vals):
+        raise RuntimeError("covariance diagonal upper block is not finite positive")
+    return up(max(vals))
+
+
+def _composition_defect_upper(c_max: float, d_max: float) -> float:
+    """Exact Cayley/quaternion composition remainder above the additive map.
+
+    ``c_max`` bounds the current Cayley norm and ``d_max`` the injected
+    correction norm.  The homogeneous reference is ``c + d``; everything else is
+    defect.
+    """
+    if not d_max < MAX_DESIGN_INJECTION_NORM:
+        raise RuntimeError(f"injection radius leaves the deployed series branch: {d_max}")
+    dot_max = mul_up(d_max, c_max)
+    denom_lower = down(1.0 - up(CAYLEY_DENOMINATOR_COEFF * dot_max))
+    if not denom_lower > 0.99:
+        raise RuntimeError("Cayley product denominator is not safely positive")
+    cross = div_up(mul_up(CAYLEY_CROSS_COEFF, dot_max), denom_lower)
+    numerator_norm = add_up(add_up(c_max, d_max), mul_up(CAYLEY_CROSS_COEFF, dot_max))
+    denom_effect = div_up(
+        mul_up(numerator_norm, mul_up(CAYLEY_DENOMINATOR_COEFF, dot_max)), denom_lower
+    )
+    cubic = mul_up(SOURCE_SERIES_CAYLEY_CUBIC_COEFF, mul_up(d_max, mul_up(d_max, d_max)))
+    return add_up(cross, add_up(denom_effect, cubic))
+
+
+def _gain_at_radius(inputs: dict, w: float) -> dict:
+    """Transported word-defect gain B_metric valid on the metric ball ||z||_M<=w."""
+    s = float(inputs["metric_scale"])
+    sqrt_s = sqrt_up(s)
+    rmin = float(inputs["correction_R_lambda_min_lower"])
+    sqrt_rmin = math.sqrt(rmin)
+    if not sqrt_rmin > 0.0:
+        raise RuntimeError("measurement noise floor is not positive")
+
+    a_theta = sqrt_up(div_up(inputs["Sigma_attitude_upper"], s))
+    a_bias = sqrt_up(div_up(inputs["Sigma_gyro_bias_upper"], s))
+    a_input = sqrt_up(div_up(inputs["Sigma_defect_input_upper"], s))
+
+    # Fact 1: metric cost of a defect injected through the shipping gain.
+    gain_transport = div_up(sqrt_s, up(2.0 * sqrt_rmin))
+    # Fact 3: metric cost of a defect supported on the attitude coordinates.
+    attitude_information_upper = add_up(
+        div_up(1.0, down(inputs["rho_attitude_scaled_lower"] * inputs["Q_theta_diagonal_lower"])),
+        div_up(
+            mul_up(float(MAX_CORRECTIONS_PER_SAMPLE), mul_up(inputs["H_attitude_norm_upper"],
+                                                             inputs["H_attitude_norm_upper"])),
+            rmin,
+        ),
+    )
+    attitude_transport = sqrt_up(mul_up(s, attitude_information_upper))
+
+    # Fact 2: the defect inputs live on the attitude/bias/a_w marginal block.
+    c_max = mul_up(a_theta, w)
+    input_max = mul_up(a_input, w)
+
+    # Accepted vector correction: residual remainder pushed through the gain.
+    residual_defect = mul_up(inputs["vector_residual_quadratic_constant_upper"],
+                             mul_up(input_max, input_max))
+    corr_state_defect = mul_up(gain_transport, residual_defect)
+
+    # The same correction's exact attitude injection magnitude.  The linear part
+    # is P^1/2 A^T (A A^T + I)^-1 A P^-1/2 z, whose attitude rows are bounded by
+    # sqrt(lambda_max(Sigma_tt)) since ||A^T (A A^T+I)^-1 A|| <= 1.
+    inject_linear = mul_up(a_theta, w)
+    inject_nonlinear = mul_up(mul_up(a_theta, sqrt_s),
+                              div_up(residual_defect, up(2.0 * sqrt_rmin)))
+    inject_max = add_up(inject_linear, inject_nonlinear)
+    corr_inject_defect = mul_up(attitude_transport,
+                                _composition_defect_upper(c_max, inject_max))
+    correction_defect = add_up(corr_state_defect, corr_inject_defect)
+
+    # Prediction: the only nonlinearity is the attitude composition with the
+    # propagated increment, whose norm is the gyro-bias error over one sample.
+    pred_increment = mul_up(inputs["prediction_increment_gain_upper"], mul_up(a_bias, w))
+    prediction_defect = mul_up(attitude_transport,
+                               _composition_defect_upper(c_max, pred_increment))
+
+    per_operation = max(correction_defect, prediction_defect)
+    if not (math.isfinite(per_operation) and per_operation > 0.0):
+        raise RuntimeError("metric-consistent operation defect is not finite positive")
+
+    # ||r||_M <= per_operation, and per_operation is at least quadratic in w, so
+    # dividing by w^2 gives a valid coefficient on the whole ball of radius w.
+    kappa = div_up(per_operation, down(w * w))
+    B = mul_up(PREFIX_BOOTSTRAP_W_FACTOR,
+               mul_up(float(inputs["state_operation_count_upper"]), kappa))
+    return {
+        "design_metric_radius": w,
+        "attitude_chart_scale": a_theta,
+        "gyro_bias_chart_scale": a_bias,
+        "defect_input_chart_scale": a_input,
+        "gain_metric_transport_upper": gain_transport,
+        "attitude_conditional_information_upper": attitude_information_upper,
+        "attitude_metric_transport_upper": attitude_transport,
+        "accepted_injection_norm_upper": inject_max,
+        "correction_state_defect_upper": corr_state_defect,
+        "correction_injection_defect_upper": corr_inject_defect,
+        "prediction_defect_upper": prediction_defect,
+        "per_operation_metric_defect_upper": per_operation,
+        "metric_defect_coefficient_kappa_upper": kappa,
+        "transported_word_defect_B_upper": B,
+    }
+
+
+def build(inputs: dict) -> dict:
+    """Largest certified metric level for the metric-consistent transport route.
+
+    ``inputs`` carries only source-derived P3/process/domain numbers.  The design
+    radius is searched over a fixed decreasing ladder; a radius is admissible
+    only when the level it certifies closes its own prefix bootstrap inside it.
+    """
+    delta = float(inputs["word_endpoint_delta_lower"])
+    if not delta > 0.0:
+        raise RuntimeError("P3 endpoint margin is not positive")
+
+    best = None
+    ladder = []
+    exponent = -2
+    while exponent >= -160:
+        ladder.append(10.0 ** exponent)
+        exponent -= 2
+    for w in ladder:
+        try:
+            g = _gain_at_radius(inputs, w)
+        except RuntimeError:
+            continue
+        B = float(g["transported_word_defect_B_upper"])
+        sqrt_W = down(delta / up(8.0 * B))
+        W = down(sqrt_W * sqrt_W)
+        prefix = mul_up(sqrt_up(PREFIX_BOOTSTRAP_W_FACTOR), sqrt_W)
+        if not (W > 0.0 and prefix <= w):
+            continue
+        if best is None or W > best["certified_level_W"]:
+            best = dict(g)
+            best["certified_level_sqrt_W"] = sqrt_W
+            best["certified_level_W"] = W
+            best["prefix_metric_norm_upper"] = prefix
+    if best is None:
+        raise RuntimeError("metric-consistent transport route found no admissible design radius")
+
+    best["schema"] = SCHEMA
+    best["route"] = "METRIC_CONSISTENT_STRUCTURED_DEFECT_TRANSPORT"
+    best["prefix_attitude_cayley_norm_upper"] = mul_up(
+        best["attitude_chart_scale"], best["prefix_metric_norm_upper"]
+    )
+    best["prefix_defect_input_norm_upper"] = mul_up(
+        best["defect_input_chart_scale"], best["prefix_metric_norm_upper"]
+    )
+    best["exact_facts_used"] = [
+        "P^1/2 H^T S^-1 = A^T (A A^T + I)^-1 R^-1/2 with spectral norm <= 1/(2 sqrt(lambda_min R))",
+        "min_xi [c;xi]^T Sigma^-1 [c;xi] = c^T (Sigma_cc)^-1 c",
+        "Sigma >= Q at every post-prediction node, plus at most three in-sample corrections",
+    ]
+    return best
+
+
+def validate(d: dict) -> list[str]:
+    failures: list[str] = []
+    if d.get("schema") != SCHEMA:
+        failures.append("metric defect transport schema mismatch")
+    for key in ("certified_level_W", "certified_level_sqrt_W",
+                "transported_word_defect_B_upper", "metric_defect_coefficient_kappa_upper"):
+        v = d.get(key)
+        if not (isinstance(v, (int, float)) and math.isfinite(float(v)) and float(v) > 0.0):
+            failures.append(f"metric defect transport {key} is not finite positive")
+    if not float(d.get("prefix_metric_norm_upper", math.inf)) <= float(
+        d.get("design_metric_radius", 0.0)
+    ):
+        failures.append("metric defect transport prefix bootstrap did not close")
+    if not float(d.get("prefix_attitude_cayley_norm_upper", math.inf)) < 1.0:
+        failures.append("metric defect transport prefix leaves the Cayley chart")
+    return failures

--- a/tools/ou3_p4_nonlinear_word_certificate.py
+++ b/tools/ou3_p4_nonlinear_word_certificate.py
@@ -60,7 +60,9 @@ from pathlib import Path
 import ou3_explicit_information_word_certificate as P3
 import ou3_implementation_proof_manifest as MANIFEST
 import ou3_p4_exact_word_map as WORDMAP
+import ou3_full_process_ucc as PROCESS
 import ou3_p4_group_algebra as GROUP
+import ou3_p4_metric_defect_transport as TRANSPORT
 import ou3_p4_node_metrics as METRIC
 import ou3_source_domain_contract as SOURCE
 import ou3_vector_uco_certificate as VECTOR
@@ -255,6 +257,31 @@ def _mode_certificate(mode: str, p3: dict, metric: dict, wordmap: dict,
     Cvec = max(Cvec_acc, Cvec_mag)
     Cinput = mul_up(Kmax, Cvec)
 
+    # Structured inputs for the metric-consistent transport route.  The P3
+    # covariance upper is a Loewner diagonal dominator, so a block maximum over
+    # its diagonal bounds lambda_max of that marginal block.
+    diag_upper = [float(v) for v in row["matrix_comparison"]["Sigma_diagonal_upper"]]
+    if len(diag_upper) != int(row["dimension"]):
+        raise RuntimeError(f"{mode}: P3 covariance diagonal upper does not match mode dimension")
+    sigma_attitude_upper = TRANSPORT._block_upper(diag_upper, range(0, 3))
+    sigma_gyro_bias_upper = TRANSPORT._block_upper(diag_upper, range(3, 6))
+    sigma_aw_upper = TRANSPORT._block_upper(diag_upper, range(15, 18))
+    # The exact word defects are quadratic in the attitude, gyro-bias and a_w
+    # coordinates only; the translation block never enters them.
+    sigma_defect_input_upper = up(max(sigma_attitude_upper, sigma_gyro_bias_upper, sigma_aw_upper))
+    proc = PROCESS.build()
+    pf = PROCESS.validate(proc)
+    if pf:
+        raise RuntimeError(f"{mode}: process certificate failed: {pf}")
+    ab = proc["attitude_gyro_bias"]
+    q_theta_lower = float(ab["theta_diagonal_lower"])
+    q_bias_lower = float(ab["gyro_bias_diagonal_lower"])
+    cross_upper = float(ab["cross_norm_upper"])
+    rho_attitude = down(1.0 - div_up(cross_upper, down(math.sqrt(q_theta_lower * q_bias_lower))))
+    if not rho_attitude > 0.0:
+        raise RuntimeError(f"{mode}: scaled attitude/bias process comparison lost positivity")
+    H_attitude = up(max(fmax, magmax))
+
     q_design = min(1.0e-6, div_down(0.002, mul_up(2.0, max(Lcorr, 1.0))))
     if not q_design > 0.0:
         raise RuntimeError(f"{mode}: failed to obtain positive nonlinear design radius")
@@ -275,12 +302,38 @@ def _mode_certificate(mode: str, p3: dict, metric: dict, wordmap: dict,
     samples = int(p3["source_word_binding"]["word_samples_upper_at_configured_dt"])
     operation_count = MAX_STATE_OPERATIONS_PER_IMU_SAMPLE * samples
 
-    B = mul_up(PREFIX_BOOTSTRAP_W_FACTOR, float(operation_count))
-    B = mul_up(B, sqrt_mmax)
-    B = mul_up(B, Coperation)
-    B = div_up(B, mmin)
-    if not (math.isfinite(B) and B > 0.0):
+    B_isotropic = mul_up(PREFIX_BOOTSTRAP_W_FACTOR, float(operation_count))
+    B_isotropic = mul_up(B_isotropic, sqrt_mmax)
+    B_isotropic = mul_up(B_isotropic, Coperation)
+    B_isotropic = div_up(B_isotropic, mmin)
+    if not (math.isfinite(B_isotropic) and B_isotropic > 0.0):
         raise RuntimeError(f"{mode}: nonlinear word defect gain is not finite positive")
+
+    # Metric-consistent structured transport of the same word defect.  Both are
+    # upper bounds on ||r_word||_M/W_0, so the certificate keeps the smaller one
+    # and can never be widened by the refinement.
+    transport = TRANSPORT.build({
+        "metric_scale": metric_scale,
+        "word_endpoint_delta_lower": delta,
+        "correction_R_lambda_min_lower": rmin,
+        "Sigma_attitude_upper": sigma_attitude_upper,
+        "Sigma_gyro_bias_upper": sigma_gyro_bias_upper,
+        "Sigma_defect_input_upper": sigma_defect_input_upper,
+        "rho_attitude_scaled_lower": rho_attitude,
+        "Q_theta_diagonal_lower": q_theta_lower,
+        "H_attitude_norm_upper": H_attitude,
+        "vector_residual_quadratic_constant_upper": Cvec,
+        "prediction_increment_gain_upper": Lpred,
+        "state_operation_count_upper": operation_count,
+    })
+    transport_failures = TRANSPORT.validate(transport)
+    if transport_failures:
+        raise RuntimeError(f"{mode}: metric defect transport failed: {transport_failures}")
+    B_metric = float(transport["transported_word_defect_B_upper"])
+    if B_metric <= B_isotropic:
+        B, defect_route = B_metric, "METRIC_CONSISTENT_STRUCTURED_DEFECT_TRANSPORT"
+    else:
+        B, defect_route = B_isotropic, "ISOTROPIC_EUCLIDEAN_DEFECT_ENVELOPE"
 
     sqrt_W_star = div_down(delta, mul_up(8.0, B))
     W_star = mul_down(sqrt_W_star, sqrt_W_star)
@@ -354,6 +407,15 @@ def _mode_certificate(mode: str, p3: dict, metric: dict, wordmap: dict,
         "word_samples_upper": samples,
         "state_operation_count_upper": operation_count,
         "transported_word_defect_B_upper": B,
+        "transported_word_defect_B_isotropic_upper": B_isotropic,
+        "transported_word_defect_B_metric_consistent_upper": B_metric,
+        "transported_word_defect_route": defect_route,
+        "metric_consistent_defect_transport": transport,
+        "Sigma_attitude_block_upper": sigma_attitude_upper,
+        "Sigma_defect_input_block_upper": sigma_defect_input_upper,
+        "certified_attitude_cayley_radius_upper": mul_up(
+            transport["attitude_chart_scale"], mul_up(2.0, sqrt_W_star)
+        ),
         "nonlinear_sqrt_budget_fraction_of_delta_upper": nonlinear_sqrt_fraction,
         "certified_level_W": W_star,
         "certified_level_sqrt_W": sqrt_W_star,

--- a/tools/ou3_p4_p5_route_ceiling_certificate.py
+++ b/tools/ou3_p4_p5_route_ceiling_certificate.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Route ceiling for the OU-III P4/P5 uniform transported-defect bridge.
+
+P4 certifies an inner level ``W_*`` and P5 must show the P1 handoff family lies
+in the P4 strict-decrease domain.  Both use one accounting:
+
+    ||r_word||_M <= B W_0,   B = F N kappa,
+    strict decrease requires   sqrt(W_0) <= delta / (2 B),
+
+with ``F`` the prefix bootstrap factor, ``N`` the number of defect-injecting
+source operations in the word, ``kappa`` the uniform per-operation metric defect
+coefficient and ``delta`` the P3 word endpoint margin.  Sharpening the
+*constants* of that accounting has been the whole P5 search so far.  This
+certificate asks the prior question: what is the largest attitude capture radius
+the accounting itself can ever report, granting every input its most favourable
+admissible value?
+
+The certified attitude radius of a level ``W`` is exactly
+
+    theta(W) = sup{ ||c|| : W_g(z) <= W } = sqrt(lambda_max(Sigma_tt) W / s)
+             = a_t sqrt(W),      a_t = sqrt(Sigma_tt_upper / s).
+
+Four properties of the accounting are then used, each stated as an explicit
+hypothesis and each satisfied by the shipping P4 producer:
+
+  H1  ``delta <= 1``.  The margin is defined by ``Omega_word >= delta Sigma``
+      and the covariance contains its own injected noise, so ``Omega <= Sigma``.
+
+  H2  The word must cover the branch in which every attempted vector correction
+      is accepted, so ``N`` is at least the number of IMU samples in the word.
+
+  H3  The exact Cayley composition is ``c (+) d = (c+d+0.5 d x c)/(1-d.c/4)``.
+      Its homogeneous reference is ``c+d``, so any uniform defect bound is at
+      least ``0.5 sup||d|| sup||c||`` -- the cross term is exact, not a slack
+      estimate, and is maximal at ``d`` orthogonal to ``c``.
+
+  H4  The uniform accepted-injection bound is at least ``eps a_t sqrt(W)``.  The
+      shipping producer has ``eps = 1``: the exact supremum of the attitude part
+      of ``K H z`` over the metric ball is ``a_t sqrt(W)``, because
+      ``||A^T (A A^T + I)^-1 A|| -> 1`` and ``||E_t^T P^{1/2}|| = sqrt(lambda_max(P_tt))``.
+
+Under H1-H4, an attitude-supported defect costs at least
+``sqrt(s lambda_max((Sigma^-1)_tt)) >= sqrt(s/lambda_max(Sigma_tt)) = 1/a_t`` in
+the metric, so
+
+    kappa >= (1/a_t) * 0.5 * eps a_t^2 = 0.5 eps a_t,
+    B     >= F N 0.5 eps a_t,
+    theta_capture = a_t delta/(2B) <= delta / (F N eps).
+
+``a_t`` cancels: the ceiling is independent of how tight the covariance bound
+is, of the metric normalization, and of every constant the search has been
+sharpening.  With ``delta <= 1`` it depends only on the word's operation count
+and on the injection hypothesis.
+
+This is a ceiling on the *proof route*, not a property of the filter.  It says
+the uniform transported-defect accounting cannot report the P1 handoff radius,
+so P5 cannot close on it and no further sharpening of ``kappa`` can change that.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+import ou3_p4_nonlinear_word_certificate as P4
+import ou3_p5_heading_handoff_contract as HEADING
+
+REPO = Path(__file__).resolve().parents[1]
+DEFAULT_DOMAIN = REPO / "tools" / "ou3_proof_operating_domain.json"
+SCHEMA = 1
+
+# Ceiling values of the accounting inputs.  H1: Omega <= Sigma.
+MAX_ADMISSIBLE_DELTA = 1.0
+# H4 at the shipping producer.  Kept explicit so the ceiling can be re-read at a
+# weaker injection hypothesis without editing the derivation.
+SHIPPING_INJECTION_FRACTION = 1.0
+# Most generous prefix accounting: no overshoot at all (the shipping route pays 4).
+MOST_GENEROUS_PREFIX_FACTOR = 1.0
+# Exact Cayley cross-term coefficient.  Not adjustable.
+CAYLEY_CROSS_COEFF = 0.5
+
+
+def down(x: float) -> float:
+    return math.nextafter(float(x), -math.inf)
+
+
+def up(x: float) -> float:
+    return math.nextafter(float(x), math.inf)
+
+
+def _ceiling(delta: float, prefix_factor: float, injections: float,
+             injection_fraction: float) -> float:
+    """theta_capture <= delta / (F N eps).  Rounded upward: it is a ceiling."""
+    denom = down(down(prefix_factor * injections) * injection_fraction)
+    if not denom > 0.0:
+        raise RuntimeError("route ceiling denominator is not positive")
+    return up(delta / denom)
+
+
+def _handoff_rows(heading: dict) -> list[dict]:
+    rows = []
+    for key, label in (
+        ("gauged_quality_handoff", "normal_gauged"),
+        ("gauged_timeout_subbranch", "timeout_gauged"),
+    ):
+        node = heading[key]
+        rows.append({
+            "handoff_branch": label,
+            "full_attitude_cayley_norm_upper": float(node["full_attitude_cayley_norm_upper"]),
+        })
+    ung = heading.get("ungauged_timeout_subbranch", {})
+    rows.append({
+        "handoff_branch": "timeout_ungauged_yaw_quotient",
+        "full_attitude_cayley_norm_upper": None,
+        "full_heading_bound_available": bool(ung.get("full_heading_cayley_bound_available", False)),
+    })
+    return rows
+
+
+def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
+    domain_path = Path(domain_path).resolve()
+    p4 = P4.build(domain_path)
+    p4f = P4.validate(p4)
+    heading = HEADING.build()
+    hf = HEADING.validate(heading)
+    failures = [f"P4: {x}" for x in p4f] + [f"heading: {x}" for x in hf]
+
+    handoffs = _handoff_rows(heading)
+    bounded = [r for r in handoffs if r["full_attitude_cayley_norm_upper"] is not None]
+    largest = max(r["full_attitude_cayley_norm_upper"] for r in bounded)
+    smallest = min(r["full_attitude_cayley_norm_upper"] for r in bounded)
+
+    modes = {}
+    for mode in ("H", "A"):
+        row = p4.get("modes", {}).get(mode)
+        if not row:
+            failures.append(f"{mode}: P4 mode certificate missing")
+            continue
+        delta = float(row["word_endpoint_relative_Riccati_injection_margin_lower"])
+        B = float(row["transported_word_defect_B_upper"])
+        samples = float(row["word_samples_upper"])
+        operations = float(row["state_operation_count_upper"])
+        a_theta = float(row["metric_consistent_defect_transport"]["attitude_chart_scale"])
+        prefix_factor = float(row["prefix_W_factor_upper"])
+
+        # What the shipping certificate reports today.
+        sqrt_capture = down(delta / up(2.0 * B))
+        theta_now = up(a_theta * sqrt_capture)
+
+        # Ceiling of the same accounting at the shipping word structure and
+        # prefix factor, with delta at its maximum admissible value.
+        ceiling_shipping = _ceiling(MAX_ADMISSIBLE_DELTA, prefix_factor, samples,
+                                    SHIPPING_INJECTION_FRACTION)
+        # Ceiling after also granting a perfect prefix accounting.
+        ceiling_absolute = _ceiling(MAX_ADMISSIBLE_DELTA, MOST_GENEROUS_PREFIX_FACTOR,
+                                    samples, SHIPPING_INJECTION_FRACTION)
+        # Ceiling at the certificate's own delta, everything else ideal.
+        ceiling_at_source_delta = _ceiling(delta, MOST_GENEROUS_PREFIX_FACTOR, samples,
+                                           SHIPPING_INJECTION_FRACTION)
+
+        # What each hypothesis would have to become for the route to reach the
+        # largest bounded P1 handoff node.
+        breakeven_injections = down(MAX_ADMISSIBLE_DELTA / up(largest * MOST_GENEROUS_PREFIX_FACTOR))
+        breakeven_injection_fraction = down(
+            MAX_ADMISSIBLE_DELTA / up(largest * MOST_GENEROUS_PREFIX_FACTOR * samples)
+        )
+
+        reaches = ceiling_absolute >= largest
+        modes[mode] = {
+            "mode": mode,
+            "word_samples_upper": samples,
+            "state_operation_count_upper": operations,
+            "prefix_W_factor_upper": prefix_factor,
+            "attitude_chart_scale": a_theta,
+            "P3_word_endpoint_delta_lower": delta,
+            "transported_word_defect_B_upper": B,
+            "certified_attitude_capture_radius_now": theta_now,
+            "route_ceiling_at_shipping_prefix_factor": ceiling_shipping,
+            "route_ceiling_absolute": ceiling_absolute,
+            "route_ceiling_at_source_delta": ceiling_at_source_delta,
+            "largest_bounded_P1_handoff_cayley_norm": largest,
+            "smallest_bounded_P1_handoff_cayley_norm": smallest,
+            "shortfall_factor_now_vs_largest_handoff": up(largest / theta_now) if theta_now > 0.0 else math.inf,
+            "shortfall_factor_ceiling_vs_largest_handoff": up(largest / ceiling_absolute),
+            "shortfall_factor_ceiling_vs_smallest_handoff": up(smallest / ceiling_absolute),
+            "breakeven_injecting_operations_per_word": breakeven_injections,
+            "breakeven_injection_fraction_at_source_word": breakeven_injection_fraction,
+            "route_can_reach_P1_handoff": reaches,
+        }
+        if reaches:
+            failures.append(
+                f"{mode}: route ceiling unexpectedly covers the P1 handoff; the "
+                "obstruction statement must be re-derived before it is published"
+            )
+
+    blocked = bool(modes) and all(m["route_can_reach_P1_handoff"] is False for m in modes.values())
+    return {
+        "schema": SCHEMA,
+        "qualification": "UNIFORM_TRANSPORTED_DEFECT_ROUTE_CEILING_FOR_P4_INNER_LEVEL_AND_P5_CAPTURE",
+        "claim": "P5_CANNOT_CLOSE_ON_THE_UNIFORM_TRANSPORTED_DEFECT_ACCOUNTING",
+        "source_generated_not_trajectory_fit": True,
+        "outward_rounded": True,
+        "source_replay_used": False,
+        "ceiling_is_about_the_proof_route_not_the_filter": True,
+        "ceiling_formula": "theta_capture <= delta / (prefix_factor * injecting_operations * injection_fraction)",
+        "attitude_chart_scale_cancels_from_the_ceiling": True,
+        "hypotheses": {
+            "H1_delta_at_most_one": "Omega_word <= Sigma, so the relative Riccati injection margin is at most 1",
+            "H2_injecting_operations_at_least_word_samples": "the word language admits the all-accepted branch, so the uniform bound must cover one accepted vector correction per sample",
+            "H3_exact_Cayley_cross_term": "c (+) d = (c+d+0.5 d x c)/(1-d.c/4); 0.5 sup||d|| sup||c|| is exact, not slack",
+            "H4_injection_at_least_eps_a_theta_sqrt_W": "sup of the attitude part of K H z over the metric ball is a_t sqrt(W); the shipping producer uses eps=1",
+        },
+        "P1_handoff_family": handoffs,
+        "modes": modes,
+        "P4_P5_UNIFORM_TRANSPORT_ROUTE_CEILING": "BELOW_P1_HANDOFF" if blocked else "NOT_ESTABLISHED",
+        "required_structural_change": [
+            "match each injected defect against the information decrease of the same "
+            "operation instead of against the whole-word endpoint margin delta",
+            "carry a directional or block margin so the attitude channel is not "
+            "rate-limited by the slowest source channel of the word",
+            "replace the Cayley quadratic remainder on the attitude channel by an "
+            "exact finite-angle sector contraction of the deployed correction",
+        ],
+        "retired_search_direction": "further sharpening of the uniform per-operation "
+                                    "defect coefficient kappa cannot close P5; the ceiling "
+                                    "is independent of kappa",
+        "failures": failures,
+    }
+
+
+def validate(d: dict) -> list[str]:
+    failures = list(d.get("failures", []))
+    if d.get("schema") != SCHEMA:
+        failures.append("schema mismatch")
+    if d.get("source_generated_not_trajectory_fit") is not True or d.get("source_replay_used") is not False:
+        failures.append("route ceiling is not source-only")
+    if d.get("ceiling_is_about_the_proof_route_not_the_filter") is not True:
+        failures.append("route ceiling mis-states its own scope")
+    if not d.get("modes"):
+        failures.append("route ceiling produced no mode rows")
+    for mode, m in d.get("modes", {}).items():
+        for key in ("route_ceiling_absolute", "route_ceiling_at_shipping_prefix_factor",
+                    "certified_attitude_capture_radius_now"):
+            v = m.get(key)
+            if not (isinstance(v, (int, float)) and math.isfinite(float(v)) and float(v) > 0.0):
+                failures.append(f"{mode}: {key} is not finite positive")
+        if m.get("route_can_reach_P1_handoff") is not False:
+            failures.append(f"{mode}: route ceiling did not establish the obstruction")
+        if not float(m.get("certified_attitude_capture_radius_now", math.inf)) <= float(
+            m.get("route_ceiling_absolute", 0.0)
+        ):
+            failures.append(f"{mode}: reported radius exceeds its own route ceiling")
+    if not failures and d.get("P4_P5_UNIFORM_TRANSPORT_ROUTE_CEILING") != "BELOW_P1_HANDOFF":
+        failures.append("route ceiling status was not established")
+    return failures
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--domain", type=Path, default=DEFAULT_DOMAIN)
+    ap.add_argument("--output", type=Path, required=True)
+    args = ap.parse_args()
+    d = build(args.domain.resolve())
+    failures = validate(d)
+    out = dict(d)
+    out["validation_pass"] = not failures
+    out["validation_failures"] = failures
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(out, indent=2, sort_keys=True), encoding="utf-8")
+    print(json.dumps({
+        "P4_P5_UNIFORM_TRANSPORT_ROUTE_CEILING": out["P4_P5_UNIFORM_TRANSPORT_ROUTE_CEILING"],
+        "modes": {
+            mode: {
+                k: out["modes"][mode][k]
+                for k in (
+                    "certified_attitude_capture_radius_now",
+                    "route_ceiling_at_shipping_prefix_factor",
+                    "route_ceiling_absolute",
+                    "largest_bounded_P1_handoff_cayley_norm",
+                    "shortfall_factor_ceiling_vs_largest_handoff",
+                    "breakeven_injecting_operations_per_word",
+                )
+            }
+            for mode in out.get("modes", {})
+        },
+        "failures": failures,
+    }, indent=2, sort_keys=True))
+    return 0 if not failures else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ou3_p5_startup_capture_certificate.py
+++ b/tools/ou3_p5_startup_capture_certificate.py
@@ -22,6 +22,7 @@ import math
 from pathlib import Path
 
 import ou3_p4_nonlinear_word_certificate as P4
+import ou3_p4_p5_route_ceiling_certificate as CEILING
 import ou3_p5_heading_handoff_contract as HEADING
 import ou3_startup_stability_certificate as P1
 
@@ -137,6 +138,15 @@ def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
         r["outside_P4_nonlinear_design_radius"] for r in witnesses
     )
 
+    # The uniform transported-defect accounting has a ceiling that no choice of
+    # its constants can pass, so the obstruction below is proved rather than
+    # pending: see tools/ou3_p4_p5_route_ceiling_certificate.py.
+    ceiling = CEILING.build()
+    cf = CEILING.validate(ceiling)
+    if cf:
+        raise RuntimeError(f"route ceiling prerequisite failed: {cf}")
+    ceiling_row = ceiling["modes"]["H"]
+
     qn = float(heading["gauged_quality_handoff"]["full_attitude_cayley_norm_upper"])
     qt = float(heading["gauged_timeout_subbranch"]["full_attitude_cayley_norm_upper"])
     promoted_limit = float(P4.PROMOTED_CAYLEY_NORM_LIMIT)
@@ -161,6 +171,11 @@ def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
             "Simply enlarging q_design while retaining the isotropic B*W perturbation recurrence is not a P5 bridge. "
             "The ungauged timeout branch is not a full-heading node at all and must use the yaw quotient until gauge acquisition."
         ),
+        "uniform_transport_route_ceiling_rad": ceiling_row["route_ceiling_absolute"],
+        "uniform_transport_route_ceiling_at_shipping_prefix_factor_rad": ceiling_row["route_ceiling_at_shipping_prefix_factor"],
+        "uniform_transport_route_ceiling_shortfall_vs_largest_handoff": ceiling_row["shortfall_factor_ceiling_vs_largest_handoff"],
+        "uniform_transport_route_can_ever_reach_P1_handoff": ceiling_row["route_can_reach_P1_handoff"],
+        "obstruction_is_the_route_not_its_constants": True,
         "required_proof_structure": [
             "branch-specific exact SO(3) finite-angle dissipation on gauged normal/timeout nodes",
             "gravity-only yaw-quotient capture on the ungauged timeout branch until a magnetic gauge hybrid event",
@@ -204,6 +219,16 @@ def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
             "The local P4 nonlinear word bound is not valid/decreasing on the complete P1 handoff family; iterating it would extrapolate outside its proof domain."
             if obstruction else None
         ),
+        "N_H_words_unset_reason": (
+            "PROVED_UNIFORM_TRANSPORT_ROUTE_CEILING_BELOW_P1_HANDOFF" if obstruction else None
+        ),
+        "route_ceiling": {
+            "status": ceiling["P4_P5_UNIFORM_TRANSPORT_ROUTE_CEILING"],
+            "formula": ceiling["ceiling_formula"],
+            "H": ceiling_row,
+            "required_structural_change": ceiling["required_structural_change"],
+            "retired_search_direction": ceiling["retired_search_direction"],
+        },
         "required_next_certificate": (
             "use the staged outer-H bridge: exact early S/covariance bounds, exact large-angle gauged-vector dissipation, "
             "and a yaw-quotient timeout route; only then compute finite H-word capture into W_*"

--- a/tools/ou3_source_reachable_matrix_p3.py
+++ b/tools/ou3_source_reachable_matrix_p3.py
@@ -309,8 +309,15 @@ def translation_upper(tau: Interval,sigma: Interval,rs: Interval,Tpe: float,sche
     roots=[math.sqrt(v) for v in variances]
     total=up(sum(roots))
     noise=[up(r*total) for r in roots]
+    # Same construction evaluated downward, so a consumer that needs a lower
+    # bound on the word's own length (the injected-noise floor does) never
+    # borrows the upward-rounded horizon used for the covariance ceiling.
+    gap_lo=down(cadence[0]+h)
+    spacing_lo=down(max(Tpe,2.0*gap_lo))
+    Tword_lo=down(down(2.0*spacing_lo+gap_lo)+Tpe)
     return [up(u[i]+noise[i]) for i in range(3)]+[noise[3]],{
         "cadence_s":cadence,"gap_s_upper":gap,"word_horizon_s_upper":Tword,
+        "word_horizon_s_lower":Tword_lo,
     }
 
 
@@ -336,7 +343,14 @@ def mode_cell(mode: str,x: Interval,rho_trans: float,sigma: Interval,rs: Interva
     whitened=up((fhi*fhi/ra+mhi*mhi/rm)*qab+(3.0*qc*pair)/ra+(3.0*qba*pair)/ra+(6.0*pba)/ra)
     u0=up(1.0/alpha6+whitened/alpha6)
     T=timing["word_horizon_s_upper"]
-    uab=up(2.0*(1.0+T*T)*u0+6.0*(qg*T+qb*(T+T**3/3.0)))
+    # Endpoint propagation of the post-observation (theta,bias) bound through
+    # Phi=[[I,-T I],[0,I]].  Only the attitude row integrates the bias over the
+    # word, so only it pays the 2(1+T^2) factor; the bias row propagates as
+    # itself plus its own random walk.  Charging the attitude factor to the bias
+    # row inflated the binding P3 channel by more than an order of magnitude.
+    uab_prop=up(6.0*(qg*T+qb*(T+T**3/3.0)))
+    uab=up(2.0*(1.0+T*T)*u0+uab_prop)
+    uab_bias=up(2.0*u0+uab_prop)
 
     qtheta=pos(process["attitude_gyro_bias"]["theta_diagonal_lower"],"theta process")
     qbg=pos(process["attitude_gyro_bias"]["gyro_bias_diagonal_lower"],"bias process")
@@ -351,7 +365,7 @@ def mode_cell(mode: str,x: Interval,rho_trans: float,sigma: Interval,rs: Interva
     sS2=(sigma.lo*h*h*h)**2
     sa2=sigma.lo*sigma.lo
     scales2=[qtheta]*3+[qbg]*3+[sv2]*3+[sp2]*3+[sS2]*3+[sa2]*3
-    upper=[uab]*6+[utrans[0]]*3+[utrans[1]]*3+[utrans[2]]*3+[utrans[3]]*3
+    upper=[uab]*3+[uab_bias]*3+[utrans[0]]*3+[utrans[1]]*3+[utrans[2]]*3+[utrans[3]]*3
     rho=min(rho_trans,rho_att)
     if mode=="A":
         scales2 += [qba_d]*3

--- a/tools/ou3_source_reachable_matrix_p3_direct.py
+++ b/tools/ou3_source_reachable_matrix_p3_direct.py
@@ -27,13 +27,33 @@ import json
 import math
 from pathlib import Path
 
-from ou3_interval import Interval, symmetric_positive_definite_ldlt
+import functools
+
+from ou3_interval import (
+    Interval,
+    symmetric_gershgorin_upper,
+    symmetric_positive_definite_ldlt,
+)
+from ou3_interval_linear_algebra import matrix_inverse_gauss_jordan
+import ou3_p3_word_noise_accumulation as WORDNOISE
 import ou3_source_reachable_matrix_p3 as BASE
 import ou3_source_reachable_matrix_p3_factored as FACTORED
 
 DEFAULT_DOMAIN = FACTORED.DEFAULT_DOMAIN
 SCHEMA = FACTORED.SCHEMA
 MIN_USEFUL_DELTA = FACTORED.MIN_USEFUL_DELTA
+# The factored backend now carries the true exp(lambda*x.hi) tail factor, so the
+# exact series stays valid past the per-step domain.  Its order-22 truncation
+# still loses the enclosure eventually; the cap keeps the search inside the
+# region where the remainder is small, and any horizon whose enclosure is too
+# wide fails its own LDLT and is skipped anyway.
+WORD_SERIES_X_LIMIT = 2.5
+# X sub-cells per source cell.  The congruence cancels three decades, so the
+# enclosure certifies only on a narrow cell; 128 is the smallest power of two
+# that carries the full word horizon on the binding source cell.  Shorter
+# horizons tolerate a proportionally wider cell and use proportionally fewer.
+WORD_X_SUBCELLS = 128
+WORD_SUBCELL_REFERENCE_X = 0.25
 
 _ORIGINAL_MODE_CELL = BASE.mode_cell
 
@@ -66,6 +86,55 @@ def _subtract_delta(Omega, Sigma, delta: float):
 def _spd_at_delta(Omega, Sigma, delta: float) -> bool:
     ok, _ = symmetric_positive_definite_ldlt(_subtract_delta(Omega, Sigma, delta))
     return ok
+
+
+@functools.lru_cache(maxsize=200000)
+def _word_translation_information(block):
+    """``C' (C Q_scaled(X) C')^-1 C`` -- the word-noise information in the
+    word-scaled coordinates, read through the basis where the inverse is tight.
+
+    It depends only on the X sub-cell, so every ``sigma``, ``R_S`` and mode cell
+    that reaches the same horizon shares it."""
+    inv = _whitened_word_shape_inverse(block)
+    if inv is None:
+        return None
+    C = FACTORED._C_INTERVAL
+    A = BASE.matrix_symmetric_hull(
+        BASE.matrix_mul(BASE.matrix_mul(BASE.matrix_transpose(C), [list(r) for r in inv]), C)
+    )
+    return tuple(tuple(A[i][j] for j in range(4)) for i in range(4))
+
+
+def _word_translation_block_margin(information, sigma_root, information_diag) -> float:
+    """``delta`` for ``(Omega_word^-1 + D)^-1 >= delta Sigma`` on one X sub-cell.
+
+    Forming the posterior noise floor explicitly breaks down once the word
+    assimilates real measurement information: ``Omega (I + D Omega)^-1`` cancels
+    the measured directions almost exactly and no interval enclosure of it stays
+    definite past a sixty-four step horizon.  The information form
+    ``Omega^-1 + D <= (1/delta) Sigma^-1`` avoids that, but carrying it in the
+    rational congruence basis fails for the opposite reason: ``Sigma^-1`` there
+    is assembled from a diagonal spanning thirteen decades and is not
+    certifiably definite at all.
+
+    Normalising ``Sigma`` to the identity removes both problems.  With
+    ``G = Sigma^{1/2}`` diagonal, the statement is exactly
+
+        lambda_max( G (Omega^-1 + D) G )  <=  1/delta,
+
+    an upper bound on one symmetric matrix -- no inverse of an ill-conditioned
+    matrix, no definiteness test on a near-singular one.  ``Omega^-1`` is read in
+    the congruence basis, where it is well conditioned, and transported back by
+    the exact rational ``C``.
+    """
+    g = [Interval.outward_bounds(v, v) for v in sigma_root]
+    M = [[g[i] * information[i][j] * g[j] for j in range(4)] for i in range(4)]
+    for i in range(4):
+        M[i][i] = M[i][i] + Interval.outward_bounds(information_diag[i], information_diag[i])
+    top = symmetric_gershgorin_upper(BASE.matrix_symmetric_hull(M))
+    if not (math.isfinite(top) and top > 0.0):
+        return 0.0
+    return BASE.down(1.0 / top)
 
 
 def _certified_generalized_delta(Omega, Sigma, gate: float) -> float:
@@ -178,7 +247,239 @@ def _translation_direct_blocks(x: Interval, sigma: Interval, raw: dict,
     return Omega_tilde, Sigma_tilde, factor, qnorm
 
 
-def _assemble_mode_matrices(mode: str, raw: dict, trans_Omega, trans_Sigma):
+
+# --- word-accumulated injected-noise floor -----------------------------------
+#
+# The blocks above compare the covariance at the *word* endpoint against the
+# noise of a single IMU step.  That is a valid lower comparison but an extremely
+# weak one: on the S channel alone the two differ by (T/h)^7.  The routines
+# below build the accumulated floor the word actually injects, using only the
+# shipping recursion, and the cell keeps whichever of the two certifies more.
+
+
+@functools.lru_cache(maxsize=200000)
+def _whitened_word_shape(lo: float, hi: float):
+    """``C Q_scaled(X) C'`` on one X sub-cell, or ``None`` if it is not certifiable."""
+    X = Interval.outward_bounds(lo, hi)
+    if not (X.hi < WORD_SERIES_X_LIMIT):
+        return None
+    shape = FACTORED.process_shape_q(X)
+    Q = [[Interval.outward_bounds(X.lo, X.lo) * shape[i][j] for j in range(4)]
+         for i in range(4)]
+    C = FACTORED._C_INTERVAL
+    Oc = BASE.matrix_symmetric_hull(
+        BASE.matrix_mul(BASE.matrix_mul(C, BASE.matrix_symmetric_hull(Q)),
+                        BASE.matrix_transpose(C))
+    )
+    if not symmetric_positive_definite_ldlt(Oc)[0]:
+        return None
+    return tuple(tuple(Oc[i][j] for j in range(4)) for i in range(4))
+
+
+@functools.lru_cache(maxsize=200000)
+def _whitened_word_shape_inverse(block):
+    """``(C Q_scaled(X) C')^-1``.  The congruence leaves a condition number near
+    two, so this inverse is tight where the raw process matrix would not be."""
+    if block is None:
+        return None
+    try:
+        inv = matrix_inverse_gauss_jordan([list(row) for row in block])
+    except Exception:
+        return None
+    return tuple(tuple(inv[i][j] for j in range(4)) for i in range(4))
+
+
+def _x_subcells(lo: float, hi: float, count: int):
+    if not (0.0 < lo <= hi):
+        raise ValueError("positive x cell required")
+    if hi == lo:
+        return [(lo, hi)]
+    ratio = (hi / lo) ** (1.0 / count)
+    edges = [lo]
+    for _ in range(count - 1):
+        edges.append(edges[-1] * ratio)
+    edges.append(hi)
+    return [(BASE.down(edges[i]), BASE.up(edges[i + 1])) for i in range(count)]
+
+
+def _translation_word_margin(x: Interval, sigma: Interval, rs: Interval, raw: dict,
+                             live: dict, vector: dict, process: dict, sched: dict,
+                             mode: str):
+    """Certified translation margin against the word-accumulated noise floor.
+
+    Over ``N`` pure prediction steps the shipping recursion injects exactly
+    ``sum_k Phi^k Q Phi^k' = Q(N h)`` -- the *same* analytic family, evaluated at
+    the word horizon.  Scaled by ``diag(sigma T, sigma T^2, sigma T^3, sigma)``
+    the integrated-OU chain depends only on ``X = T/tau``, so the already
+    certified shape family supplies the accumulated floor with no recursion and
+    no interval amplification.
+
+    ``C Q_scaled(X) C'`` stays well conditioned for every ``X`` the word reaches,
+    but the congruence cancels three decades, so the enclosure is certifiable
+    only on a narrow ``X`` cell.  The source cell is therefore refined and the
+    margin is the minimum over its sub-cells.
+
+    Every admissible horizon is scanned and the best is kept, because the trade
+    is not monotone: a longer horizon injects more noise but also assimilates
+    more measurement information, and on a source cell with a small ``R_S`` the
+    second effect wins well before the full word.  ``N = 1`` reproduces the
+    single-step comparison, so the scan can only improve on it.
+    """
+    h = sched["dt_s"]
+    steps_cap = math.floor(BASE.down(float(raw["word_horizon_s_lower"]) / BASE.up(h)))
+    if steps_cap < 1:
+        raise RuntimeError("source word does not certainly contain one prediction step")
+    doublings = int(math.floor(math.log2(steps_cap)))
+
+    vc = vector["configured_measurement_bounds"]
+    ra = BASE.down(BASE.pos(vc["acc_measurement_std_mps2"], "acc std") ** 2)
+    rm = BASE.down(BASE.pos(vc["mag_measurement_std_uT"], "mag std") ** 2)
+    fhi = BASE.pos(live["specific_force_norm_upper_mps2"], "force upper")
+    mhi = BASE.pos(live["magnetic_vector_norm_upper_uT"], "mag upper")
+    qtheta = BASE.pos(process["attitude_gyro_bias"]["theta_diagonal_lower"], "theta process")
+    qba_d = BASE.pos(
+        process["active_accelerometer_bias"]["Q_accel_bias_lambda_min_lower"],
+        "active bias discrete process",
+    )
+    cadence_lo = float(raw["cadence_s"][0])
+    upper = raw["Sigma_diagonal_upper"]
+    physical = [upper[6], upper[9], upper[12], upper[15]]
+    C = FACTORED._C_INTERVAL
+    Ct = BASE.matrix_transpose(C)
+
+    best = None
+    for k in range(doublings, -1, -1):
+        steps = 2 ** k
+        horizon = BASE.down(steps * h)
+        # The congruence certifies only on a narrow X cell and the width it
+        # tolerates scales with X, so short horizons need far fewer sub-cells.
+        span = BASE.up(steps * x.hi)
+        count = max(8, min(WORD_X_SUBCELLS,
+                           int(math.ceil(WORD_X_SUBCELLS * span / WORD_SUBCELL_REFERENCE_X))))
+        cells = _x_subcells(BASE.down(steps * x.lo), span, count)
+        # Probe the ends before paying for the whole refinement: when a horizon
+        # is too long for the congruence it fails there first.
+        if any(_whitened_word_shape(*cells[i]) is None for i in (0, -1)):
+            continue
+        blocks = [_whitened_word_shape(lo, hi) for lo, hi in cells]
+        if any(b is None for b in blocks):
+            continue
+
+        word_scales = [
+            BASE.up(sigma.lo * horizon),
+            BASE.up(sigma.lo * horizon * horizon),
+            BASE.up(sigma.lo * horizon * horizon * horizon),
+            BASE.up(sigma.lo),
+        ]
+        # Sigma^{1/2} for the word-scaled translation coordinates.  Upper
+        # rounding here only lowers the reported margin.
+        sigma_root = [
+            BASE.up(math.sqrt(BASE.up(physical[i])) / BASE.down(word_scales[i]))
+            for i in range(4)
+        ]
+
+        # Measurement information the word can assimilate, per word-scaled
+        # coordinate.  No shipping update has a v or p column: the pseudo-update
+        # measures S, the accelerometer measures a_w with its attitude and bias
+        # cross terms, the magnetometer measures attitude only.
+        s_firings = BASE.up(BASE.up(horizon / BASE.down(cadence_lo)) + 1.0)
+        info_S = BASE.up(
+            s_firings * BASE.up(word_scales[2] * word_scales[2] / BASE.down(rs.lo * rs.lo))
+        )
+        per_sample_aw = BASE.up(
+            (fhi * fhi * qtheta + sigma.lo * sigma.lo + (qba_d if mode == "A" else 0.0)) / ra
+        )
+        per_sample_aw = BASE.up(per_sample_aw + BASE.up(mhi * mhi * qtheta / rm))
+        info_aw = BASE.up(float(steps) * per_sample_aw)
+        # G D G is diagonal because D is.
+        scaled_information = [
+            0.0,
+            0.0,
+            BASE.up(info_S * BASE.up(sigma_root[2] * sigma_root[2])),
+            BASE.up(info_aw * BASE.up(sigma_root[3] * sigma_root[3])),
+        ]
+
+        margin = math.inf
+        worst_index = 0
+        for index, block in enumerate(blocks):
+            information = _word_translation_information(block)
+            if information is None:
+                margin = 0.0
+                break
+            value = _word_translation_block_margin(
+                information, sigma_root, scaled_information
+            )
+            if value <= 0.0:
+                margin = 0.0
+                break
+            if value < margin:
+                margin, worst_index = value, index
+        if not margin > 0.0:
+            continue
+        candidate = (margin, blocks[worst_index], sigma_root, {
+            "accumulated_prediction_steps": steps,
+            "accumulated_horizon_s": horizon,
+            "word_horizon_s_lower": float(raw["word_horizon_s_lower"]),
+            "x_subcells": len(cells),
+            "S_zero_firings_upper": s_firings,
+            "S_channel_information_upper": info_S,
+            "a_w_channel_information_upper": info_aw,
+        })
+        if best is None or candidate[0] > best[0]:
+            best = candidate
+        elif candidate[0] < best[0]:
+            # The margin against horizon is unimodal: a longer horizon injects
+            # more noise but also assimilates more measurement information.
+            # Once a shorter horizon reports less, the peak is behind us.
+            break
+    if best is None:
+        raise RuntimeError("no admissible word horizon certified the translation floor")
+    return best
+
+
+def _attitude_bias_word_blocks(raw: dict, live: dict, vector: dict, process: dict,
+                               sched: dict):
+    """Return (Omega_posterior, Sigma) for one (theta, gyro-bias) axis pair."""
+    h = sched["dt_s"]
+    doublings = WORDNOISE.word_step_doublings(float(raw["word_horizon_s_lower"]), h)
+    steps = 2 ** doublings
+
+    ab = process["attitude_gyro_bias"]
+    qtheta = BASE.pos(ab["theta_diagonal_lower"], "theta process")
+    qbias = BASE.pos(ab["gyro_bias_diagonal_lower"], "gyro bias process")
+    cross = float(ab["cross_norm_upper"])
+    rho = BASE.down(1.0 - BASE.up(cross / BASE.down(math.sqrt(qtheta * qbias))))
+    if rho <= 0.0:
+        raise RuntimeError("scaled attitude/bias process comparison lost positivity")
+
+    coupling = BASE.up(h * BASE.up(math.sqrt(BASE.up(qbias / BASE.down(qtheta)))))
+    vc = vector["configured_measurement_bounds"]
+    ra = BASE.down(BASE.pos(vc["acc_measurement_std_mps2"], "acc std") ** 2)
+    rm = BASE.down(BASE.pos(vc["mag_measurement_std_uT"], "mag std") ** 2)
+    fhi = BASE.pos(live["specific_force_norm_upper_mps2"], "force upper")
+    mhi = BASE.pos(live["magnetic_vector_norm_upper_uT"], "mag upper")
+    # Attitude information per sample in the sqrt(q_theta) scaling.  The a_w and
+    # S informations do not belong here: no shipping update measures the gyro
+    # bias directly, and charging the accelerometer's a_w figure against these
+    # coordinates is what collapsed the binding P3 channel.
+    per_sample = BASE.up(BASE.up(fhi * fhi / ra + mhi * mhi / rm) * qtheta)
+    Omega = WORDNOISE.attitude_bias_word_noise(
+        rho, coupling, doublings, BASE.up(float(steps) * per_sample)
+    )
+    upper = raw["Sigma_diagonal_upper"]
+    Sigma = _diag_matrix([
+        BASE.up(upper[0] / qtheta),
+        BASE.up(upper[3] / qbias),
+    ])
+    return Omega, Sigma, {
+        "attitude_accumulated_prediction_steps": steps,
+        "scaled_attitude_bias_process_floor_lower": rho,
+        "scaled_bias_coupling_per_step": coupling,
+        "attitude_information_per_sample_upper": per_sample,
+    }
+
+def _assemble_mode_matrices(mode: str, raw: dict, trans_Omega, trans_Sigma,
+                            att_Omega=None, att_Sigma=None):
     n = 18 if mode == "H" else 21
     O = _zero_matrix(n)
     S = _zero_matrix(n)
@@ -186,17 +487,26 @@ def _assemble_mode_matrices(mode: str, raw: dict, trans_Omega, trans_Sigma):
     scales2 = raw["comparison_scale_diagonal_squared"]
     upper = raw["Sigma_diagonal_upper"]
 
-    trans_indices = set()
+    placed = set()
     for axis in range(3):
         idx = [6 + axis, 9 + axis, 12 + axis, 15 + axis]
-        trans_indices.update(idx)
+        placed.update(idx)
         for i in range(4):
             for j in range(4):
                 O[idx[i]][idx[j]] = trans_Omega[i][j]
                 S[idx[i]][idx[j]] = trans_Sigma[i][j]
 
+    if att_Omega is not None:
+        for axis in range(3):
+            idx = [axis, 3 + axis]
+            placed.update(idx)
+            for i in range(2):
+                for j in range(2):
+                    O[idx[i]][idx[j]] = att_Omega[i][j]
+                    S[idx[i]][idx[j]] = att_Sigma[i][j]
+
     for i in range(n):
-        if i in trans_indices:
+        if i in placed:
             continue
         O[i][i] = Interval.outward_bounds(qpost, qpost)
         sui = BASE.up(upper[i] / scales2[i])
@@ -243,7 +553,104 @@ def mode_cell(mode: str, x: Interval, rho_trans: float, sigma: Interval,
 
     limiting = "translation_RL_inverse_block" if trans_delta <= other else "attitude_bias_or_active_ba_block"
 
+    # Same inequality, with the word-accumulated injected-noise floor in place of
+    # the single-step one.  Both are lower comparisons for Omega_word, so the
+    # cell keeps whichever certifies more; a failure here can never lower the
+    # single-step result.
+    word = None
+    try:
+        wt_delta, wBlock, wSigmaRoot, wdiag = _translation_word_margin(
+            x, sigma, rs, raw, live, vector, process, sched, mode
+        )
+        aO, aS, adiag = _attitude_bias_word_blocks(raw, live, vector, process, sched)
+        wa_delta = _certified_generalized_delta(aO, aS, MIN_USEFUL_DELTA)
+        if wt_delta <= 0.0 or wa_delta <= 0.0:
+            raise RuntimeError("word-accumulated block lost positivity")
+        wba = math.inf
+        for i in (18, 19, 20):
+            if i >= len(raw["Sigma_diagonal_upper"]):
+                continue
+            sui = BASE.up(raw["Sigma_diagonal_upper"][i] / raw["comparison_scale_diagonal_squared"][i])
+            wba = min(wba, BASE.down(qpost / sui))
+        # Each block is independently certified, so the mode margin is the
+        # minimum over blocks of the *best* margin available for that block.
+        # Bundling them would let one block's weaker route discard another
+        # block's stronger one: on a short-tau source cell the translation
+        # horizon is capped while the attitude floor still carries the full word.
+        best_trans = max(wt_delta, trans_delta)
+        best_att = max(wa_delta, other)
+        word_delta = BASE.down(min(best_trans, best_att, wba))
+        if not word_delta > 0.0:
+            raise RuntimeError("word-accumulated margin lost positivity")
+
+        # The word route places three 4x4 translation blocks on [v,p,S,a_w] of
+        # each axis, three 2x2 blocks on (theta, gyro bias) of each axis, and the
+        # remaining active-bias coordinates on the diagonal.  Those index sets
+        # partition the mode, so the assembled comparison is block diagonal and
+        # is positive definite exactly when every block is -- there is no full
+        # assembly for the LDLT to see that the per-block tests do not.
+        covered = set()
+        for axis in range(3):
+            covered.update({axis, 3 + axis, 6 + axis, 9 + axis, 12 + axis, 15 + axis})
+        dimension = 18 if mode == "H" else 21
+        covered.update(range(18, dimension))
+        if covered != set(range(dimension)):
+            raise RuntimeError("word-accumulated block partition does not cover the mode")
+        def _blocks_hold(value: float) -> bool:
+            translation = (
+                value <= wt_delta if wt_delta >= trans_delta
+                else _spd_at_delta(tO, tS, value)
+            )
+            attitude = (
+                _spd_at_delta(aO, aS, value)
+                if wa_delta >= other else value <= other
+            )
+            return translation and attitude
+
+        wshrink = 0
+        word_ok = _blocks_hold(word_delta)
+        while not word_ok and wshrink < 12:
+            word_delta = BASE.down(0.5 * word_delta)
+            wshrink += 1
+            word_ok = _blocks_hold(word_delta)
+        if not word_ok:
+            raise RuntimeError("word-accumulated generalized delta did not re-certify")
+        word = {
+            "translation_margin_lower": wt_delta,
+            "attitude_bias_margin_lower": wa_delta,
+            "best_translation_margin_lower": best_trans,
+            "best_attitude_bias_margin_lower": best_att,
+            "translation_route": "word" if wt_delta >= trans_delta else "single_step",
+            "attitude_bias_route": "word" if wa_delta >= other else "single_step",
+            "active_accelerometer_bias_margin_lower": None if wba is math.inf else wba,
+            "margin_lower": word_delta,
+            "recertified": word_ok,
+            "block_diagonal_partition_covers_mode": True,
+            "translation_inequality_form": "information: (1/delta) Sigma^-1 - (Omega_word^-1 + H' R^-1 H) is SPD",
+            "rounding_boundary_downward_shrink_count": wshrink,
+            "limiting_block": (
+                "translation_RL_inverse_block" if best_trans <= min(best_att, wba)
+                else "attitude_gyro_bias_block" if best_att <= wba
+                else "active_accelerometer_bias_block"
+            ),
+            **wdiag,
+            **adiag,
+        }
+    except Exception as exc:  # fail-safe: never worse than the single-step route
+        word = {"margin_lower": 0.0, "unavailable_reason": str(exc)}
+
+    word_delta = float(word["margin_lower"])
+    if word_delta > full_delta:
+        full_delta = word_delta
+        limiting = word["limiting_block"]
+        noise_route = "WORD_ACCUMULATED_INJECTED_NOISE_FLOOR"
+    else:
+        noise_route = "SINGLE_STEP_INJECTED_NOISE_FLOOR"
+
     out = dict(raw)
+    out["word_accumulated_noise_floor"] = word
+    out["injected_noise_floor_route"] = noise_route
+    out["single_step_margin_lower"] = BASE.down(min(trans_delta, other))
     out["relative_Riccati_injection_margin_lower"] = full_delta
     out["direct_translation_generalized_margin_lower"] = trans_delta
     out["direct_nontranslation_margin_lower"] = other

--- a/tools/ou3_source_reachable_matrix_p3_factored.py
+++ b/tools/ou3_source_reachable_matrix_p3_factored.py
@@ -31,12 +31,14 @@ from __future__ import annotations
 
 import argparse
 from fractions import Fraction
+import functools
 import json
 import math
 from pathlib import Path
 
 from ou3_interval import Interval, hull
 import ou3_source_reachable_matrix_p3 as BASE
+import ou3_validated_transcendentals as VT
 
 BRANCH_X = BASE.BRANCH_X
 DEFAULT_DOMAIN = BASE.DEFAULT_DOMAIN
@@ -104,6 +106,33 @@ def _small_process_shape(x: Interval):
     ]
 
 
+@functools.lru_cache(maxsize=512)
+def _exact_series_coefficients(denominator_power: int, exp_terms, polynomial):
+    """Exact Taylor coefficients of ``numerator/x^denominator_power``.
+
+    They depend only on the source expression, not on the evaluation cell, so
+    the exact ``Fraction`` arithmetic is done once.  The word-horizon read of
+    this family evaluates it on two orders of magnitude more cells than the
+    per-step read did, and rebuilding these rationals on every cell was the
+    whole cost of that.
+    """
+    N = EXACT_SERIES_ORDER
+    coeff = [F(0) for _ in range(N+1)]
+    for degree,value in polynomial:
+        if degree <= N:
+            coeff[degree] += value
+    for lam,p in exp_terms:
+        for j,pj in p:
+            for n in range(j,N+1):
+                k=n-j
+                coeff[n] += pj * F((-lam)**k, math.factorial(k))
+    if any(coeff[n] != 0 for n in range(min(denominator_power,N+1))):
+        raise RuntimeError("exponential source cancellation order mismatch")
+    # Carry the float enclosures alongside the exact values: the Horner pass
+    # below converts every coefficient on every cell otherwise.
+    return tuple((c, _FI(c)) for c in coeff[denominator_power:])
+
+
 def _exact_scaled_entry(
     x: Interval,
     denominator_power: int,
@@ -119,31 +148,28 @@ def _exact_scaled_entry(
     if x.lo <= 0.0:
         raise ValueError("positive x required")
     N = EXACT_SERIES_ORDER
-    coeff = [F(0) for _ in range(N+1)]
-    for degree,value in polynomial.items():
-        if degree <= N:
-            coeff[degree] += value
-    for lam,p in exp_terms:
-        for j,pj in p.items():
-            for n in range(j,N+1):
-                k=n-j
-                coeff[n] += pj * F((-lam)**k, math.factorial(k))
-    if any(coeff[n] != 0 for n in range(min(denominator_power,N+1))):
-        raise RuntimeError("exponential source cancellation order mismatch")
-
-    scaled=coeff[denominator_power:]
-    y=_FI(scaled[-1])
-    for c in reversed(scaled[:-1]):
-        y=_FI(c)+x*y
+    scaled = _exact_series_coefficients(
+        denominator_power,
+        tuple((lam, tuple(sorted(pp.items()))) for lam, pp in exp_terms),
+        tuple(sorted(polynomial.items())),
+    )
+    y=scaled[-1][1]
+    for _, ci in reversed(scaled[:-1]):
+        y=ci+x*y
 
     rem=0.0
     for lam,p in exp_terms:
+        # The tail of exp(-lam*x) after order k is bounded by its next term times
+        # exp(lam*x.hi).  The literal 2.0 this used to carry is that factor at
+        # lam*x < ln 2, which held for the per-step read but silently expires the
+        # moment the same family is read at a word horizon.
+        growth=BASE.up(math.exp(lam*x.hi)*(1.0+1.0e-12))
         for j,pj in p.items():
             k=N-j+1
             if k<=0:
                 continue
             term=(
-                2.0*abs(float(pj))*(float(lam)**k)*(x.hi**(N+1))
+                growth*abs(float(pj))*(float(lam)**k)*(x.hi**(N+1))
                 /(math.factorial(k)*(x.lo**denominator_power))
             )
             rem=BASE.up(rem+term)
@@ -186,6 +212,8 @@ def _large_scaled_q(x: Interval):
 def _large_process_shape(x: Interval):
     # One additional exact cancelled power returns Q_scaled/x directly.
     return _large_family(x,1)
+
+
 
 
 def _branch_hull(x: Interval, small_fn, large_fn):


### PR DESCRIPTION
P4 certified `W_* = 3.29e-141` and an attitude Cayley radius of `1.1e-70`, and P5 has been an open "pending recurrence count" behind it. Three loose steps carried the whole stack; this PR sharpens them, then bounds what the accounting can ever report.

| | before | after |
| --- | --- | --- |
| P3 `delta` | `3.79233618771658e-35` | `2.29539973862766885e-20` |
| P4 `B` | `8.26237725542113e+34` | `1.73074152502409096e+10` |
| P4 `W_*` | `3.29172575174270652e-141` | `2.74835136346049263e-62` |
| P4 `mu_W` | `1.89616809385829038e-35` | `1.14769986931383397e-20` |
| certified attitude Cayley radius | `5.73735631780239850e-71` | `2.90423979800536192e-32` |

## P3 — `Omega_word` is the word's injected noise, not one IMU step

P3 certifies `Omega_word - delta Sigma_upper >> 0`. `Sigma_upper` is a word-horizon covariance, but the backend compared it against a single 5 ms `Q`. That is a valid lower bound — the word contains at least one prediction — but on the `S` channel the two differ by `(T/h)^7`.

Over `N` pure prediction steps the shipping recursion injects exactly `Omega_N = sum_k Phi^k Q (Phi^k)'`, which obeys the doubling identity `Omega_2m = Phi^m Omega_m Phi^m' + Omega_m`. That identity carries the `(theta, gyro-bias)` block in the new `tools/ou3_p3_word_noise_accumulation.py`. The translation block does not need it: for the integrated-OU chain the same sum is exactly `Q(N h)`, and scaled by `diag(sigma T, sigma T^2, sigma T^3, sigma)` the chain depends only on `X = T/tau`, so the analytic family the certificate already validates supplies the floor when read at the word horizon instead of at one step.

Three corrections were needed first:

- **The measurement information must be block structured.** The accelerometer's information lives in the `a_w` coordinate and is four orders above the attitude information, and no shipping update measures the gyro bias at all. One scalar bound charged the `a_w` figure against the bias coordinate and erased the accumulated bias floor.
- **The `2(1+T^2)` endpoint propagation belongs to the attitude row of `Sigma_upper`, not the gyro-bias row.** Only attitude integrates the bias over the word; sharing one value inflated the binding channel 22×.
- **The exact-series tail factor was a literal `2.0`**, which is `exp(lambda x)` at `lambda x < ln 2`. It now carries `exp(lambda x.hi)`, which also tightens the per-step read.

The comparison is then normalised rather than certified in the congruence basis. Forming the posterior explicitly breaks down once the word assimilates real information — `Omega (I + D Omega)^-1` cancels the measured directions almost exactly and no interval enclosure stays definite past a 64-step horizon — and the information form fails in the rational congruence basis for the opposite reason: `Sigma^-1` there is assembled from a diagonal spanning thirteen decades and is not certifiably definite. Normalising `Sigma` to the identity with the diagonal `G = Sigma^{1/2}` leaves

```
lambda_max( G (Omega_word^-1 + D) G )  <=  1/delta,
```

an upper bound on one symmetric matrix. `Omega^-1` is read in the congruence basis, where it is well conditioned, and transported back by the exact rational `C`. Each source cell is refined into up to 128 `X` sub-cells; every admissible horizon is scanned and the best kept (the trade is not monotone, and `N = 1` reproduces the single-step comparison, so the scan can only improve on it); each block keeps its own better route rather than being bundled.

The binding source cell moves to `tau` in `[1.4837, 1.7226]` s, with the translation block limiting at `2.295399738627669e-20` and the attitude/gyro-bias block at `1.602057713637565e-16`.

## P4 — metric-consistent structured defect transport

The nonlinear layer needs an upper bound `B` on `||r_word||_M / W_0`. The existing route obtained it by leaving the metric (`||z|| <= sqrt(W/m_-)`, then `||r||_M <= sqrt(m_+)||r||`), paying the full `sqrt(cond(Sigma))` of a covariance whose diagonal uppers span thirty-four decades, and bounding the gain isotropically as `||K|| <= sqrt(Sigma_max/R_min)`.

`tools/ou3_p4_metric_defect_transport.py` replaces both steps with three exact facts stated against the same source-derived bounds P4 already consumes:

- **Gain transport.** For `A = R^-1/2 H P^1/2`, `P^-1/2 K = A^T (A A^T + I)^-1 R^-1/2`, whose spectral norm is `max_i sigma_i/(1+sigma_i^2) <= 1/2`. Hence `||K q||_M <= sqrt(s) ||q|| / (2 sqrt(lambda_min R))`.
- **Chart transport.** `min_xi [c;xi]^T Sigma^-1 [c;xi] = c^T (Sigma_cc)^-1 c`, so each defect input is charged on its own marginal block. The exact word defects are quadratic in the attitude, gyro-bias and `a_w` coordinates only; the translation block never enters them.
- **Attitude-injection cost.** The quaternion injection remainder is attitude-supported, so it is charged on the conditional attitude covariance: every node is post-prediction, where `Sigma >= Q`, or is reached from one by at most three in-sample corrections.

Both gains bound the same quantity, so the producer keeps `min(B_isotropic, B_metric)` and can never be widened by the refinement.

## Route ceiling — why P5 still cannot close

`tools/ou3_p4_p5_route_ceiling_certificate.py` answers the prior question: what can this accounting *ever* report?

The certified attitude radius of a level is exactly `theta(W) = a_t sqrt(W)` with `a_t = sqrt(Sigma_tt_upper/s)`. Under four hypotheses the shipping producer satisfies — `delta <= 1` because `Omega_word <= Sigma`; the word must cover the all-accepted branch, so the injecting-operation count is at least the sample count; the exact Cayley cross term `0.5 d x c` is not slack; and the uniform accepted-injection bound is `a_t sqrt(W)`, the exact supremum of the attitude part of `K H z` on the metric ball — an attitude-supported defect costs at least `1/a_t` in the metric, so

```
kappa >= 0.5 a_t,   B >= F N 0.5 a_t,   theta_capture <= delta / (F N).
```

`a_t` cancels. The ceiling depends on neither `delta` nor the covariance enclosure nor any constant the P5 search has been sharpening.

| | value |
| --- | --- |
| ceiling at `delta = 1`, no prefix overshoot | `4.95049504950495e-03` rad |
| ceiling at the shipping prefix factor | `1.23762376237624e-03` rad |
| P1 handoff, normal gauged | `0.2721648148683776` rad |
| P1 handoff, timeout gauged | `0.5947333355555983` rad |
| shortfall at the ceiling | `120x` |
| break-even injecting operations per word | `1.68` |

The two widenings in this PR are the direct evidence: together they moved the reported radius thirty-nine decades and the ceiling not at all.

## P5

The capture gate consumes the ceiling, so `N_H_words` is unset for a proved reason — `PROVED_UNIFORM_TRANSPORT_ROUTE_CEILING_BELOW_P1_HANDOFF` — rather than a pending computation. The V42..V54 constant-sharpening line is retired here: it refines a quantity the ceiling is independent of.

The proof plan records the three structural changes a closing route needs, all required together:

1. Match each injected defect against its own operation's information decrease (`W - W+ = ||H z||^2_{s S^-1}` on the same step), removing both the `N`-fold accumulation and the dependence on the whole-word `delta`.
2. Carry a directional or block margin, so the attitude channel is not rate-limited by the gyro-bias channel of the same word.
3. Replace the Cayley quadratic remainder on the attitude channel with an exact finite-angle sector contraction, which is what makes a radius of order `0.3` rad expressible at all.

## Other changes

- New tests: `test_ou3_p3_word_noise_accumulation.py`, `test_ou3_p4_metric_defect_transport.py`, `test_ou3_p4_p5_route_ceiling.py`, plus a P5 case pinning the proved-ceiling reason. Wired into `tests/validation/Makefile` and the proof-fast workflows.
- Four stale obstruction-magnitude floors are restated as "many orders" floors, so a valid future widening no longer churns them.
- A P3 certificate build goes from 146 s to 209 s; the jobs that build it several times get their timeouts raised.

Full P3/P4/P5 validation subset green (144 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjkMkT4FXE3VFPRrTy4oA7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added word-horizon noise accumulation and improved P3 comparison certificates.
  - Added metric-consistent defect transport and P4/P5 route-ceiling certificates.
  - Startup-capture results now report route limits, shortfalls, and required structural changes.

- **Documentation**
  - Updated the proof plan with refined P3/P4 accounting and clarified P5 requirements.

- **Tests**
  - Added validation for noise accumulation, defect transport, route ceilings, and certificate integration.

- **CI**
  - Automated compilation and certificate execution for new validation artifacts.
  - Increased selected workflow time limits for longer validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->