### PR TITLE
OU-III: continue reachable full-word P4 certificate from #438

### DIFF
--- a/.github/workflows/ou3-p4-frontier-combined.yml
+++ b/.github/workflows/ou3-p4-frontier-combined.yml
@@ -1,0 +1,145 @@
+name: ou3-p4-frontier-combined
+
+on:
+  pull_request:
+    paths:
+      - 'tools/ou3_p4_translation_full_word_design.py'
+      - 'tools/ou3_p4_translation_full_word_interval.py'
+      - 'tools/ou3_p4_translation_full_word_interval_fast.py'
+      - 'tools/ou3_p4_source_path_reachability.py'
+      - 'tools/ou3_p4_post_translation_bottleneck.py'
+      - 'tools/ou3_p4_reachable_full_state_bridge.py'
+      - 'tools/ou3_p4_usable_status.py'
+      - 'tools/ou3_source_reachable_matrix_p3*.py'
+      - 'tools/ou3_explicit_information_word_certificate.py'
+      - 'tools/ou3_p3_word_algebra.py'
+      - 'tools/ou3_p4_exact_word_map.py'
+      - 'tools/ou3_proof_operating_domain.json'
+      - 'tests/validation/test_ou3_p4_translation_full_word_design.py'
+      - 'tests/validation/test_ou3_p4_translation_full_word_interval.py'
+      - 'tests/validation/test_ou3_p4_source_path_reachability.py'
+      - 'tests/validation/test_ou3_p4_post_translation_bottleneck.py'
+      - 'tests/validation/test_ou3_p4_reachable_full_state_bridge.py'
+      - 'tests/validation/test_ou3_p4_usable_status.py'
+      - '.github/workflows/ou3-p4-frontier-combined.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ou3-p4-frontier-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  full-word-translation:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install numerical dependency
+        run: |
+          sudo apt-get update
+          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3-numpy
+      - name: Compile replacement P4 backends
+        run: |
+          python3 -m py_compile \
+            tools/ou3_p4_translation_full_word_design.py \
+            tools/ou3_p4_translation_full_word_interval.py \
+            tools/ou3_p4_translation_full_word_interval_fast.py \
+            tools/ou3_p4_source_path_reachability.py \
+            tools/ou3_p4_post_translation_bottleneck.py \
+            tools/ou3_p4_reachable_full_state_bridge.py \
+            tools/ou3_p4_usable_status.py \
+            tests/validation/test_ou3_p4_translation_full_word_design.py \
+            tests/validation/test_ou3_p4_translation_full_word_interval.py \
+            tests/validation/test_ou3_p4_post_translation_bottleneck.py \
+            tests/validation/test_ou3_p4_reachable_full_state_bridge.py \
+            tests/validation/test_ou3_p4_usable_status.py
+      - name: Test fail-closed bridge and status gates
+        working-directory: tests/validation
+        run: |
+          python3 -m unittest -v \
+            test_ou3_p4_reachable_full_state_bridge \
+            test_ou3_p4_usable_status
+      - name: Validate declared one-second complete-word translation
+        run: |
+          python3 tools/ou3_p4_translation_full_word_interval_fast.py --output /tmp/p4-translation-full-word-interval.json
+          python3 - <<'PY'
+          import json
+          p=json.load(open('/tmp/p4-translation-full-word-interval.json'))
+          print('P4_COMPLETE_TRANSLATION_WORST_CELL_STATUS:',p['P4_COMPLETE_TRANSLATION_WORST_CELL_STATUS'])
+          for mode in ('H','A'):
+              r=p['modes'][mode]
+              print(f"P4_FULL_WORD_VALIDATED {mode} delta={r['complete_word_translation_margin_lower']:.17e} old={r['old_single_seed_translation_margin_lower']:.17e} factor={r['margin_widening_factor_lower']:.17e} dyadic_bits={r['dyadic_loewner_bits']}")
+          PY
+      - name: Diagnose post-translation full-state bottleneck
+        run: |
+          python3 tools/ou3_p4_post_translation_bottleneck.py --translation /tmp/p4-translation-full-word-interval.json --output /tmp/p4-post-translation-bottleneck.json
+      - name: Build reachable-path full-state target
+        run: |
+          python3 tools/ou3_p4_source_path_reachability.py --output /tmp/p4-source-path.json
+          python3 tools/ou3_p4_reachable_full_state_bridge.py \
+            --translation /tmp/p4-translation-full-word-interval.json \
+            --bottleneck /tmp/p4-post-translation-bottleneck.json \
+            --path /tmp/p4-source-path.json \
+            --output /tmp/p4-reachable-full-state-bridge.json
+          python3 - <<'PY'
+          import json
+          p=json.load(open('/tmp/p4-reachable-full-state-bridge.json'))
+          print('P4_REACHABLE_FULL_STATE_GRAPH', 'reachable=',p['reachable_state_count'], 'recurrent=',p['recurrent_state_count'], 'scc=',p['source_graph_strongly_connected_components'], 'old_worst_recurrent=',p['old_worst_corner_recurrent'])
+          for mode in ('H','A'):
+              r=p['modes'][mode]
+              print(f"P4_REACHABLE_FULL_STATE_TARGET {mode} translation={r['validated_translation_margin_lower']:.17e} nontranslation={r['direct_nontranslation_margin_lower']:.17e} cross_block_norm_lt={r['normalized_cross_block_spectral_norm_budget_upper_open']:.17e} entry_abs_lt={r['uniform_normalized_cross_block_entry_abs_budget_upper_open']:.17e}")
+          PY
+      - name: Probe longer design horizons
+        run: |
+          python3 tools/ou3_p4_translation_full_word_design.py --output /tmp/p4-translation-full-word-design.json
+      - name: Emit fail-closed usable-certificate status
+        run: |
+          python3 tools/ou3_p4_usable_status.py \
+            --translation /tmp/p4-translation-full-word-interval.json \
+            --design /tmp/p4-translation-full-word-design.json \
+            --path /tmp/p4-source-path.json \
+            --output /tmp/p4-usable-status.json
+
+  source-path-reachability:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - name: Compile source-path backend
+        run: |
+          python3 -m py_compile tools/ou3_p4_source_path_reachability.py tests/validation/test_ou3_p4_source_path_reachability.py
+      - name: Validate source-dynamic path graph
+        working-directory: tests/validation
+        run: python3 -m unittest -v test_ou3_p4_source_path_reachability
+      - name: Emit source-path result
+        run: |
+          python3 tools/ou3_p4_source_path_reachability.py --output /tmp/p4-source-path.json
+          python3 - <<'PY'
+          import json
+          p=json.load(open('/tmp/p4-source-path.json'))
+          print('P4_SOURCE_PATH_CERTIFICATE:',p.get('P2_SOURCE_PATH_CERTIFICATE'))
+          print('P4_SOURCE_PATH_GRAPH:',p['partition'])
+          print('P4_SOURCE_PATH_EDGES:',p['transition_edges'])
+          print('P4_RECURRENT_STATES:',p['recurrent_states'])
+          print('P4_OLD_WORST_CORNER_STATES:',p['old_worst_corner_state_count'])
+          print('P4_OLD_WORST_CORNER_INTERNAL_CYCLE:',p['old_worst_corner_has_internal_recurrent_cycle'])
+          PY
+
+  full-word-translation-2s:
+    continue-on-error: true
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install numerical dependency
+        run: |
+          sudo apt-get update
+          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3-numpy
+      - name: Diagnostic two-second complete-word translation
+        run: |
+          python3 tools/ou3_p4_translation_full_word_interval_fast.py --horizon-s 2.0 --output /tmp/p4-translation-full-word-2s.json
+          python3 - <<'PY'
+          import json
+          p=json.load(open('/tmp/p4-translation-full-word-2s.json'))
+          print('P4_COMPLETE_TRANSLATION_2S_STATUS:',p['P4_COMPLETE_TRANSLATION_WORST_CELL_STATUS'])
+          for mode in ('H','A'):
+              r=p['modes'][mode]
+              print(f"P4_FULL_WORD_VALIDATED_2S {mode} delta={r['complete_word_translation_margin_lower']:.17e} factor_vs_seed={r['margin_widening_factor_lower']:.17e} tau_leaves={r['tau_leaf_count']} dyadic_bits={r['dyadic_loewner_bits']}")
+          PY

--- a/tests/validation/test_ou3_p4_reachable_full_state_bridge.py
+++ b/tests/validation/test_ou3_p4_reachable_full_state_bridge.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+import math
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "tools"))
+
+import ou3_p4_reachable_full_state_bridge as BRIDGE
+
+
+class P4ReachableFullStateBridgeTests(unittest.TestCase):
+    def test_cross_block_budget_is_schur_threshold_and_fail_closed(self):
+        translation = {
+            "P4_COMPLETE_TRANSLATION_WORST_CELL_STATUS": "PASS",
+            "modes": {
+                "H": {"complete_word_translation_margin_lower": 9.0e-24},
+                "A": {"complete_word_translation_margin_lower": 16.0e-24},
+            },
+        }
+        bottleneck = {
+            "modes": {
+                "H": {"existing_direct_nontranslation_margin_lower": 4.0e-28},
+                "A": {"existing_direct_nontranslation_margin_lower": 9.0e-28},
+            }
+        }
+        path = {
+            "path_graph_ready": True,
+            "partition": {"states": 800},
+            "recurrent_states": 800,
+            "strongly_connected_components": 1,
+            "old_worst_corner_has_internal_recurrent_cycle": True,
+        }
+        d = BRIDGE.build(translation, bottleneck, path)
+        self.assertEqual([], BRIDGE.validate(d))
+        self.assertEqual("NOT_ESTABLISHED", d["P4_USABLE_CERTIFICATE_STATUS"])
+        self.assertAlmostEqual(6.0e-26, d["modes"]["H"]["normalized_cross_block_spectral_norm_budget_upper_open"])
+        self.assertAlmostEqual(1.2e-25, d["modes"]["A"]["normalized_cross_block_spectral_norm_budget_upper_open"])
+        for mode in ("H", "A"):
+            self.assertFalse(d["modes"][mode]["cross_block_bound_validated"])
+            self.assertFalse(d["modes"][mode]["full_state_linear_certificate_established"])
+
+    def test_nonpass_translation_is_rejected(self):
+        d = BRIDGE.build(
+            {"P4_COMPLETE_TRANSLATION_WORST_CELL_STATUS": "NOT_ESTABLISHED", "modes": {}},
+            {"modes": {}},
+            {"path_graph_ready": True, "partition": {"states": 1}, "recurrent_states": 1},
+        )
+        f = BRIDGE.validate(d)
+        self.assertTrue(any("translation input is not PASS" in x for x in f))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/validation/test_ou3_p4_translation_full_word_design.py
+++ b/tests/validation/test_ou3_p4_translation_full_word_design.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+import math, sys, unittest
+ROOT=Path(__file__).resolve().parents[2]
+sys.path.insert(0,str(ROOT/'tools'))
+import ou3_p4_translation_full_word_design as D
+
+class P4TranslationFullWordDesignTests(unittest.TestCase):
+ @classmethod
+ def setUpClass(cls): cls.d=D.build()
+ def test_probe_is_design_only_and_valid(self):
+  self.assertEqual(D.validate(self.d),[])
+  self.assertTrue(self.d['ordinary_floating_point_design_only'])
+  self.assertFalse(self.d['validated_for_theorem_promotion'])
+  self.assertEqual(self.d['P4_USABLE_CERTIFICATE_STATUS'],'NOT_ESTABLISHED')
+ def test_complete_word_margin_is_reported(self):
+  for mode in ('H','A'):
+   for h,row in self.d['modes'][mode]['horizons'].items():
+    q=row['worst_grid_point']['translation_complete_word_generalized_margin_design']
+    self.assertTrue(math.isfinite(q) and q>0.0,(mode,h,q))
+    self.assertGreater(row['design_worst_to_old_margin_ratio'],0.0)
+ def test_no_replay(self): self.assertFalse(self.d['trajectory_replay_used'])
+
+if __name__=='__main__': unittest.main()

--- a/tests/validation/test_ou3_p4_usable_status.py
+++ b/tests/validation/test_ou3_p4_usable_status.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import sys,unittest
+ROOT=Path(__file__).resolve().parents[2]
+sys.path.insert(0,str(ROOT/'tools'))
+import ou3_p4_usable_status as S
+
+class P4UsableStatusTests(unittest.TestCase):
+    def test_partial_full_word_progress_does_not_promote_p4(self):
+        t={'P4_COMPLETE_TRANSLATION_WORST_CELL_STATUS':'PASS','modes':{m:{'complete_word_translation_margin_lower':1.3108509084723255e-29,'old_single_seed_translation_margin_lower':3.79233618e-35,'margin_widening_factor_lower':345657.88} for m in ('H','A')}}
+        d={'modes':{m:{'horizons':{'8.0':{'worst_grid_point':{'translation_complete_word_generalized_margin_design':1.412150733739027e-15}}}} for m in ('H','A')}}
+        p={'path_graph_ready':True,'old_worst_corner_has_internal_recurrent_cycle':True}
+        out=S.build_from_payloads(t,d,p)
+        self.assertEqual(S.validate(out),[])
+        self.assertEqual(out['P4_USABLE_CERTIFICATE_STATUS'],'NOT_ESTABLISHED')
+        self.assertTrue(out['meaningful_linear_improvement_established'])
+        self.assertTrue(out['old_worst_corner_has_internal_recurrent_cycle'])
+        for m in ('H','A'):
+            self.assertEqual(out['modes'][m]['translation_complete_word_progress'],'PASS')
+            self.assertFalse(out['modes'][m]['full_state_complete_word_validated'])
+            self.assertFalse(out['modes'][m]['exact_finite_angle_complete_return_map_validated'])
+
+if __name__=='__main__':unittest.main()

--- a/tools/ou3_p4_reachable_full_state_bridge.py
+++ b/tools/ou3_p4_reachable_full_state_bridge.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Bridge validated translation/full-word results into the reachable full-state P4 test.
+
+This producer combines source-only objects on the same recurrent worst-cell route:
+
+* the outward-validated one-second complete-word translation margin;
+* the direct nontranslation generalized margin diagnostic;
+* the source-dynamic reachability graph; and, optionally,
+* an outward-validated complete-word translation/nontranslation cross-block
+  certificate covering every required recurrent source path/cell.
+
+For a normalized full-state endpoint comparison split into translation and
+nontranslation blocks,
+
+    G = [[A, C], [C^T, B]],
+
+with A >= a I and B >= b I, a sufficient Schur/Young condition for G >> 0 is
+
+    ||C||_2 < sqrt(a b).
+
+The bridge emits that budget and SVD-free sufficient variants.  When a
+cross-block certificate is supplied, it is accepted only if it is source-only,
+outward validated, covers all required reachable/recurrent paths, has matching
+18/21-state dimensions, and proves either
+
+    ||C||_1 ||C||_inf < a b
+
+or
+
+    ||C||_F < sqrt(a b).
+
+Without such an input the bridge remains a target-only object.  Even after the
+full-state *linear* endpoint closes, the nonlinear finite-angle return-map lift
+remains a separate P4 obligation, so this producer never promotes the final
+usable P4 certificate by itself.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+
+TRANSLATION_DIM = 12
+NONTRANSLATION_DIM = {"H": 6, "A": 9}
+
+
+def _positive_finite(x) -> float | None:
+    try:
+        q = float(x)
+    except (TypeError, ValueError):
+        return None
+    return q if math.isfinite(q) and q > 0.0 else None
+
+
+def _cross_mode_status(mode: str, cross: dict | None, product_budget: float,
+                       frobenius_budget: float, reachable: int,
+                       recurrent: int) -> dict:
+    pending = {
+        "provided": False,
+        "outward_validated": False,
+        "all_required_paths_checked": False,
+        "one_inf_product_upper": None,
+        "frobenius_norm_upper": None,
+        "one_inf_test_pass": False,
+        "frobenius_test_pass": False,
+        "accepted": False,
+        "reasons": ["no complete-word cross-block certificate supplied"],
+    }
+    if cross is None:
+        return pending
+
+    reasons: list[str] = []
+    if cross.get("source_only") is not True or cross.get("trajectory_replay_used") is not False:
+        reasons.append("cross-block certificate is not source-only")
+    if cross.get("outward_validated") is not True:
+        reasons.append("cross-block certificate is not outward validated")
+    if cross.get("all_required_paths_checked") is not True:
+        reasons.append("cross-block certificate does not cover all required paths")
+    if int(cross.get("reachable_state_count", -1)) != reachable:
+        reasons.append("cross-block reachable-state count does not match source graph")
+    if int(cross.get("recurrent_state_count", -1)) != recurrent:
+        reasons.append("cross-block recurrent-state count does not match source graph")
+
+    m = cross.get("modes", {}).get(mode, {})
+    if int(m.get("translation_block_dimension", -1)) != TRANSLATION_DIM:
+        reasons.append(f"{mode}: wrong translation cross-block dimension")
+    if int(m.get("nontranslation_block_dimension", -1)) != NONTRANSLATION_DIM[mode]:
+        reasons.append(f"{mode}: wrong nontranslation cross-block dimension")
+    if m.get("all_required_cells_checked") is not True:
+        reasons.append(f"{mode}: not all required source cells checked")
+
+    one = _positive_finite(m.get("normalized_cross_block_one_norm_upper"))
+    inf = _positive_finite(m.get("normalized_cross_block_inf_norm_upper"))
+    frob = _positive_finite(m.get("normalized_cross_block_frobenius_norm_upper"))
+    product = None if one is None or inf is None else one * inf
+    one_inf_pass = product is not None and math.isfinite(product) and product < product_budget
+    frob_pass = frob is not None and frob < frobenius_budget
+    if not (one_inf_pass or frob_pass):
+        reasons.append(f"{mode}: validated cross-block norm does not fit the Schur budget")
+
+    return {
+        "provided": True,
+        "outward_validated": cross.get("outward_validated") is True,
+        "all_required_paths_checked": cross.get("all_required_paths_checked") is True,
+        "one_norm_upper": one,
+        "inf_norm_upper": inf,
+        "one_inf_product_upper": product,
+        "frobenius_norm_upper": frob,
+        "one_inf_test_pass": one_inf_pass,
+        "frobenius_test_pass": frob_pass,
+        "accepted": not reasons,
+        "reasons": reasons,
+    }
+
+
+def build(translation: dict, bottleneck: dict, path: dict,
+          cross_block: dict | None = None) -> dict:
+    failures: list[str] = []
+    if translation.get("P4_COMPLETE_TRANSLATION_WORST_CELL_STATUS") != "PASS":
+        failures.append("validated complete-word translation input is not PASS")
+    if path.get("path_graph_ready") is not True:
+        failures.append("source-path graph is not ready")
+    if int(path.get("recurrent_states", 0)) <= 0:
+        failures.append("source-path graph has no recurrent states")
+
+    reachable = int(path.get("partition", {}).get("states", 0))
+    recurrent = int(path.get("recurrent_states", 0))
+    modes: dict[str, dict] = {}
+    all_linear = True
+    for mode in ("H", "A"):
+        tr = translation.get("modes", {}).get(mode, {})
+        bn = bottleneck.get("modes", {}).get(mode, {})
+        a = _positive_finite(tr.get("complete_word_translation_margin_lower"))
+        b = _positive_finite(bn.get("existing_direct_nontranslation_margin_lower"))
+        if a is None or b is None:
+            failures.append(f"{mode}: missing positive block margins")
+            all_linear = False
+            continue
+        budget = math.sqrt(a * b)
+        product_budget = a * b
+        n_non = NONTRANSLATION_DIM[mode]
+        entry_budget = budget / math.sqrt(TRANSLATION_DIM * n_non)
+        cross_status = _cross_mode_status(
+            mode, cross_block, product_budget, budget, reachable, recurrent
+        )
+        linear_ok = cross_status["accepted"]
+        all_linear = all_linear and linear_ok
+        modes[mode] = {
+            "validated_translation_margin_lower": a,
+            "direct_nontranslation_margin_lower": b,
+            "normalized_cross_block_spectral_norm_budget_upper_open": budget,
+            "normalized_cross_block_one_inf_norm_product_budget_upper_open": product_budget,
+            "normalized_cross_block_frobenius_norm_budget_upper_open": budget,
+            "uniform_normalized_cross_block_entry_abs_budget_upper_open": entry_budget,
+            "translation_block_dimension": TRANSLATION_DIM,
+            "nontranslation_block_dimension": n_non,
+            "full_state_dimension": TRANSLATION_DIM + n_non,
+            "full_state_sufficient_condition": "validated ||C||_2 < sqrt(delta_translation*delta_nontranslation)",
+            "svd_free_sufficient_condition": "validated ||C||_1*||C||_inf < delta_translation*delta_nontranslation",
+            "uniform_entry_sufficient_condition": "every normalized |C_ij| < sqrt(delta_translation*delta_nontranslation)/sqrt(n_translation*n_nontranslation)",
+            "cross_block": cross_status,
+            "cross_block_bound_validated": linear_ok,
+            "full_state_linear_certificate_established": linear_ok,
+        }
+
+    linear_status = "PASS" if all_linear and len(modes) == 2 else "PENDING"
+    next_obligation = (
+        "lift the validated reachable full-state linear endpoint through the exact finite-angle return map"
+        if linear_status == "PASS" else
+        "propagate the complete 18/21-state Phi/Omega endpoint on the reachable source graph and "
+        "outward-validate the normalized translation/nontranslation cross block on every required cell/path"
+    )
+    return {
+        "qualification": "OU3_P4_REACHABLE_FULL_STATE_CROSS_BLOCK_BRIDGE",
+        "source_only": True,
+        "trajectory_replay_used": False,
+        "reachable_state_count": reachable,
+        "recurrent_state_count": recurrent,
+        "source_graph_strongly_connected_components": int(path.get("strongly_connected_components", 0)),
+        "old_worst_corner_recurrent": bool(path.get("old_worst_corner_has_internal_recurrent_cycle", False)),
+        "cross_block_certificate_supplied": cross_block is not None,
+        "modes": modes,
+        "P4_FULL_STATE_LINEAR_STATUS": linear_status,
+        "P4_USABLE_CERTIFICATE_STATUS": "NOT_ESTABLISHED",
+        "next_obligation": next_obligation,
+        "failures": failures,
+    }
+
+
+def validate(d: dict) -> list[str]:
+    f = list(d.get("failures", []))
+    if d.get("source_only") is not True or d.get("trajectory_replay_used") is not False:
+        f.append("bridge is not source-only")
+    if d.get("P4_USABLE_CERTIFICATE_STATUS") != "NOT_ESTABLISHED":
+        f.append("bridge prematurely promoted P4")
+    if int(d.get("recurrent_state_count", 0)) <= 0:
+        f.append("bridge lost recurrent source graph")
+    linear_status = d.get("P4_FULL_STATE_LINEAR_STATUS")
+    if linear_status not in ("PASS", "PENDING"):
+        f.append("invalid full-state linear status")
+    accepted = []
+    for mode in ("H", "A"):
+        m = d.get("modes", {}).get(mode, {})
+        q = m.get("normalized_cross_block_spectral_norm_budget_upper_open")
+        p = m.get("normalized_cross_block_one_inf_norm_product_budget_upper_open")
+        e = m.get("uniform_normalized_cross_block_entry_abs_budget_upper_open")
+        if not isinstance(q, (int, float)) or not math.isfinite(float(q)) or float(q) <= 0.0:
+            f.append(f"{mode}: invalid cross-block budget")
+        if not isinstance(p, (int, float)) or not math.isfinite(float(p)) or float(p) <= 0.0:
+            f.append(f"{mode}: invalid one/inf product budget")
+        if not isinstance(e, (int, float)) or not math.isfinite(float(e)) or float(e) <= 0.0:
+            f.append(f"{mode}: invalid uniform entry budget")
+        if isinstance(q, (int, float)) and isinstance(p, (int, float)) and not math.isclose(float(p), float(q) * float(q), rel_tol=1e-14):
+            f.append(f"{mode}: one/inf product budget is not square of spectral budget")
+        if int(m.get("translation_block_dimension", 0)) != TRANSLATION_DIM:
+            f.append(f"{mode}: wrong translation dimension")
+        if int(m.get("nontranslation_block_dimension", 0)) != NONTRANSLATION_DIM[mode]:
+            f.append(f"{mode}: wrong nontranslation dimension")
+        if int(m.get("full_state_dimension", 0)) != TRANSLATION_DIM + NONTRANSLATION_DIM[mode]:
+            f.append(f"{mode}: wrong full-state dimension")
+        c = m.get("cross_block", {})
+        ok = m.get("cross_block_bound_validated") is True
+        accepted.append(ok)
+        if ok != (c.get("accepted") is True):
+            f.append(f"{mode}: inconsistent cross-block acceptance")
+        if (m.get("full_state_linear_certificate_established") is True) != ok:
+            f.append(f"{mode}: inconsistent full-state linear status")
+    if linear_status == "PASS" and not all(accepted):
+        f.append("full-state linear PASS without both validated mode cross blocks")
+    if linear_status == "PENDING" and all(accepted):
+        f.append("full-state linear status stayed pending after both modes passed")
+    return f
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--translation", type=Path, required=True)
+    ap.add_argument("--bottleneck", type=Path, required=True)
+    ap.add_argument("--path", type=Path, required=True)
+    ap.add_argument("--cross-block", type=Path)
+    ap.add_argument("--output", type=Path, required=True)
+    a = ap.parse_args()
+    d = build(
+        json.loads(a.translation.read_text(encoding="utf-8")),
+        json.loads(a.bottleneck.read_text(encoding="utf-8")),
+        json.loads(a.path.read_text(encoding="utf-8")),
+        json.loads(a.cross_block.read_text(encoding="utf-8")) if a.cross_block else None,
+    )
+    f = validate(d)
+    d["validation_failures"] = f
+    a.output.write_text(json.dumps(d, indent=2, sort_keys=True), encoding="utf-8")
+    print(json.dumps({
+        "status": d["P4_USABLE_CERTIFICATE_STATUS"],
+        "linear_status": d["P4_FULL_STATE_LINEAR_STATUS"],
+        "reachable_states": d["reachable_state_count"],
+        "recurrent_states": d["recurrent_state_count"],
+        "old_worst_corner_recurrent": d["old_worst_corner_recurrent"],
+        "modes": {
+            mode: {
+                "translation": d.get("modes", {}).get(mode, {}).get("validated_translation_margin_lower"),
+                "nontranslation": d.get("modes", {}).get(mode, {}).get("direct_nontranslation_margin_lower"),
+                "cross_block_budget": d.get("modes", {}).get(mode, {}).get("normalized_cross_block_spectral_norm_budget_upper_open"),
+                "one_inf_product_budget": d.get("modes", {}).get(mode, {}).get("normalized_cross_block_one_inf_norm_product_budget_upper_open"),
+                "uniform_entry_budget": d.get("modes", {}).get(mode, {}).get("uniform_normalized_cross_block_entry_abs_budget_upper_open"),
+                "cross_block_accepted": d.get("modes", {}).get(mode, {}).get("cross_block_bound_validated"),
+            }
+            for mode in ("H", "A")
+        },
+        "failures": f,
+    }, indent=2, sort_keys=True))
+    return 0 if not f else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ou3_p4_translation_full_word_design.py
+++ b/tools/ou3_p4_translation_full_word_design.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Fast source-derived design probe for complete-word P4 translation dissipation.
+
+This is deliberately NOT a theorem producer.  It reconstructs the exact P3
+limiting translation cell directly, then uses ordinary numpy arithmetic to ask
+whether longer complete words are worth validating.  No replay data are used.
+The validated theorem route lives in ou3_p4_translation_full_word_interval.py.
+"""
+from __future__ import annotations
+import argparse,itertools,json,math
+from pathlib import Path
+import numpy as np
+from ou3_interval import Interval
+import ou3_source_reachable_matrix_p3 as P3BASE
+import ou3_p4_worst_translation_cell as WORST
+
+REPO=Path(__file__).resolve().parents[1]; DEFAULT_DOMAIN=REPO/'tools'/'ou3_proof_operating_domain.json'
+HORIZONS_S=(1.0,2.0,4.0,8.0)
+
+def _mid(A): return np.asarray([[(x.lo+x.hi)*0.5 for x in r] for r in A],float)
+def _transition(tau,h):
+ x=h/tau; a=math.exp(-x); em1=math.expm1(-x); pva=-tau*em1
+ if abs(x)<1e-2:
+  x2=x*x;x3=x2*x;x4=x3*x;x5=x4*x; ppa=tau*tau*(.5*x2-x3/6+x4/24); psa=tau**3*(x3/6-x4/24+x5/120)
+ else: ppa=tau*tau*(x+em1); psa=tau**3*(.5*x*x-x-em1)
+ return np.array([[1,0,0,pva],[h,1,0,ppa],[.5*h*h,h,1,psa],[0,0,0,a]],float)
+def _Q(tau,sigma,h):
+ x=h/tau; q=_mid(P3BASE.qbar_integrated_ou(Interval.outward_bounds(x,x))); D=np.diag([sigma*tau,sigma*tau*tau,sigma*tau**3,sigma]); return .5*((D@q@D.T)+(D@q@D.T).T)
+def _upd(P,i,R):
+ c=P[:,i].copy(); d=float(P[i,i]+R); out=P-np.outer(c,c)/d; return .5*(out+out.T)
+def _one(tau,sigma,rs,h,T,upper,ra):
+ A=_transition(tau,h);Q=_Q(tau,sigma,h);P=np.zeros((4,4));n=max(1,int(math.ceil(T/h)))
+ for _ in range(n): P=A@P@A.T+Q;P=_upd(P,2,rs*rs);P=_upd(P,3,ra)
+ D=np.diag(1/np.sqrt(upper));G=D@P@D;delta=float(np.linalg.eigvalsh(.5*(G+G.T))[0])
+ return {'tau_s':tau,'sigma_aw_mps2':sigma,'R_S_std':rs,'horizon_s':T,'steps':n,'translation_complete_word_generalized_margin_design':delta}
+def _pts(a,b): return (a,math.sqrt(a*b),b)
+def build(domain_path=DEFAULT_DOMAIN):
+ p=Path(domain_path).resolve();modes={};fail=[]
+ for mode in ('H','A'):
+  try:
+   c=WORST.build_cell(mode,p);s=WORST.serializable(c);h=float(c['sched']['dt_s']);x=c['x'];tb=(h/x.hi,h/x.lo);sb=c['sigma'].as_list();rb=c['rs'].as_list();u=list(map(float,c['row']['Sigma_diagonal_upper']));upper=np.array([u[6],u[9],u[12],u[15]],float);ra=float(c['vector']['configured_measurement_bounds']['acc_measurement_std_mps2'])**2;rows=[]
+   for T in HORIZONS_S:
+    for tau,sigma,rs in itertools.product(_pts(*tb),_pts(*sb),_pts(*rb)): rows.append(_one(tau,sigma,rs,h,T,upper,ra))
+   hs={}
+   for T in HORIZONS_S:
+    rr=[r for r in rows if r['horizon_s']==T];w=min(rr,key=lambda r:r['translation_complete_word_generalized_margin_design']);b=max(rr,key=lambda r:r['translation_complete_word_generalized_margin_design']);old=float(c['row']['direct_translation_generalized_margin_lower']);hs[str(T)]={'worst_grid_point':w,'best_grid_point':b,'old_single_seed_translation_margin_lower':old,'design_worst_to_old_margin_ratio':w['translation_complete_word_generalized_margin_design']/old}
+   modes[mode]={'source_cell':s,'tau_s_derived_from_x_cell':list(tb),'translation_directional_covariance_upper':upper.tolist(),'grid_points_per_horizon':27,'horizons':hs}
+  except Exception as e: fail.append(f'{mode}: {e}')
+ return {'qualification':'OU3_P4_TRANSLATION_FULL_WORD_DESIGN_PROBE','source_parameters_from_theorem_domain':True,'trajectory_replay_used':False,'ordinary_floating_point_design_only':True,'validated_for_theorem_promotion':False,'P4_USABLE_CERTIFICATE_STATUS':'NOT_ESTABLISHED','modes':modes,'failures':fail}
+def validate(d):
+ f=list(d.get('failures',[]))
+ if d.get('trajectory_replay_used') is not False or d.get('ordinary_floating_point_design_only') is not True or d.get('validated_for_theorem_promotion') is not False:f.append('design qualification invalid')
+ for mode in ('H','A'):
+  for T in HORIZONS_S:
+   q=d.get('modes',{}).get(mode,{}).get('horizons',{}).get(str(T),{}).get('worst_grid_point',{}).get('translation_complete_word_generalized_margin_design')
+   if not isinstance(q,(int,float)) or not math.isfinite(q) or q<=0:f.append(f'{mode}: horizon {T} invalid')
+ if d.get('P4_USABLE_CERTIFICATE_STATUS')!='NOT_ESTABLISHED':f.append('design probe promoted P4')
+ return f
+def main():
+ ap=argparse.ArgumentParser();ap.add_argument('--domain',type=Path,default=DEFAULT_DOMAIN);ap.add_argument('--output',type=Path,required=True);a=ap.parse_args();d=build(a.domain);f=validate(d);d['validation_failures']=f;a.output.write_text(json.dumps(d,indent=2,sort_keys=True));print(json.dumps({'modes':{m:{h:d.get('modes',{}).get(m,{}).get('horizons',{}).get(h,{}).get('design_worst_to_old_margin_ratio') for h in map(str,HORIZONS_S)} for m in ('H','A')},'failures':f},indent=2));return 0 if not f else 2
+if __name__=='__main__':raise SystemExit(main())

--- a/tools/ou3_p4_usable_status.py
+++ b/tools/ou3_p4_usable_status.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Machine-readable status for the usable OU-III P4 replacement route.
+
+This consumer intentionally separates a successful *partial* full-word result
+from a usable nonlinear P4 certificate.  It consumes already-produced JSON so
+CI does not rerun the expensive outward-rounded translation calculation.
+
+A useful P4 may be promoted only after the complete source-reachable fixed-mode
+word, including attitude/gyro-bias (and active accelerometer bias in A mode), is
+validated and the exact finite-angle return map closes on a non-microscopic
+set.  The old scalar B*W frontier is never used for promotion here.
+"""
+from __future__ import annotations
+import argparse,json,math
+from pathlib import Path
+
+
+def build_from_payloads(translation: dict, design: dict, path: dict) -> dict:
+    failures=[]; modes={}
+    for mode in ('H','A'):
+        t=translation.get('modes',{}).get(mode,{})
+        delta=float(t.get('complete_word_translation_margin_lower',0.0))
+        old=float(t.get('old_single_seed_translation_margin_lower',0.0))
+        factor=float(t.get('margin_widening_factor_lower',0.0))
+        horizons=design.get('modes',{}).get(mode,{}).get('horizons',{})
+        d8=float(horizons.get('8.0',{}).get('worst_grid_point',{}).get('translation_complete_word_generalized_margin_design',0.0))
+        if not (delta>0 and old>0 and factor>1 and d8>0): failures.append(f'{mode}: incomplete full-word evidence')
+        modes[mode]={
+            'validated_one_second_translation_margin_lower':delta,
+            'old_single_seed_translation_margin_lower':old,
+            'validated_translation_widening_factor_lower':factor,
+            'eight_second_design_translation_margin':d8,
+            'translation_complete_word_progress':'PASS' if delta>old else 'NOT_ESTABLISHED',
+            'full_state_complete_word_validated':False,
+            'exact_finite_angle_complete_return_map_validated':False,
+            'usable_certificate_status':'NOT_ESTABLISHED',
+        }
+    recurrent=bool(path.get('old_worst_corner_has_internal_recurrent_cycle',False))
+    if path.get('path_graph_ready') is not True: failures.append('source path graph not ready')
+    return {
+        'qualification':'OU3_P4_USABLE_CERTIFICATE_STATUS',
+        'source_only':True,
+        'trajectory_replay_used_for_promotion':False,
+        'old_scalar_frontier_used_for_promotion':False,
+        'source_path_graph_ready':path.get('path_graph_ready') is True,
+        'old_worst_corner_has_internal_recurrent_cycle':recurrent,
+        'translation_complete_word_validated_on_old_worst_cell':translation.get('P4_COMPLETE_TRANSLATION_WORST_CELL_STATUS')=='PASS',
+        'meaningful_linear_improvement_established':all(modes[m]['validated_translation_widening_factor_lower']>1e5 for m in modes),
+        'P4_USABLE_CERTIFICATE_STATUS':'NOT_ESTABLISHED',
+        'next_blocker':(
+            'validate full-state complete-word Phi/Omega on the recurrent worst source cell and then validate the exact finite-angle complete return map; '
+            'the source-path graph cannot eliminate this corner because it contains an internal recurrent cycle'
+        ),
+        'modes':modes,
+        'failures':failures,
+    }
+
+
+def validate(d: dict) -> list[str]:
+    f=list(d.get('failures',[]))
+    if d.get('source_only') is not True or d.get('trajectory_replay_used_for_promotion') is not False: f.append('status is not source-only')
+    if d.get('old_scalar_frontier_used_for_promotion') is not False: f.append('retired scalar frontier was promoted')
+    if d.get('translation_complete_word_validated_on_old_worst_cell') is not True: f.append('validated translation progress missing')
+    if d.get('meaningful_linear_improvement_established') is not True: f.append('no meaningful validated linear improvement')
+    if d.get('P4_USABLE_CERTIFICATE_STATUS')!='NOT_ESTABLISHED': f.append('partial evidence prematurely promoted usable P4')
+    for mode in ('H','A'):
+        m=d.get('modes',{}).get(mode,{})
+        if m.get('translation_complete_word_progress')!='PASS': f.append(f'{mode}: translation progress did not pass')
+        if m.get('full_state_complete_word_validated') is not False: f.append(f'{mode}: full-state word incorrectly claimed')
+        if m.get('exact_finite_angle_complete_return_map_validated') is not False: f.append(f'{mode}: nonlinear return map incorrectly claimed')
+    return f
+
+
+def main() -> int:
+    ap=argparse.ArgumentParser();ap.add_argument('--translation',type=Path,required=True);ap.add_argument('--design',type=Path,required=True);ap.add_argument('--path',type=Path,required=True);ap.add_argument('--output',type=Path,required=True);a=ap.parse_args()
+    d=build_from_payloads(json.loads(a.translation.read_text()),json.loads(a.design.read_text()),json.loads(a.path.read_text()));f=validate(d);d['validation_failures']=f;a.output.write_text(json.dumps(d,indent=2,sort_keys=True))
+    print(json.dumps({'status':d['P4_USABLE_CERTIFICATE_STATUS'],'meaningful_linear_improvement':d['meaningful_linear_improvement_established'],'worst_corner_recurrent':d['old_worst_corner_has_internal_recurrent_cycle'],'modes':{m:{'validated_delta':d['modes'][m]['validated_one_second_translation_margin_lower'],'factor':d['modes'][m]['validated_translation_widening_factor_lower'],'design_8s_delta':d['modes'][m]['eight_second_design_translation_margin']} for m in ('H','A')},'next_blocker':d['next_blocker'],'failures':f},indent=2))
+    return 0 if not f else 2
+if __name__=='__main__':raise SystemExit(main())


### PR DESCRIPTION
Continuation of #438 after its head branch had to be rebuilt on current main and GitHub would not allow the closed PR to be reopened.

This preserves only the usable-certificate route:
- rigorous one-second complete-word translation validation;
- source-complete reachable-path graph from current main;
- post-translation full-state bottleneck from current main;
- fail-closed 18/21-state cross-block bridge;
- non-promoting longer-horizon design probe and usable-status output.

The obsolete microscopic scalar frontier files are intentionally not carried forward. Current main's stronger P2 reachability and outward-lower-enclosed Schur-budget implementations are retained rather than overwritten by the older #438 copies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated validation workflows for full-word translation, source-path reachability, and reachable full-state analysis.
  * Added design diagnostics that report translation margins across supported modes and time horizons.
  * Added certificate-status reporting that clearly distinguishes validated progress from requirements that remain incomplete.
  * Added fail-closed checks to prevent partial evidence from being presented as a completed usability certificate.

* **Tests**
  * Added coverage for bridge validation, status handling, margin reporting, and rejection of non-passing inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->