### PR TITLE
OU-III: widen the first-accelerometer gain and report P1-P5 numbers

### DIFF
--- a/.github/workflows/ou3-p1-p5-certificate-numbers.yml
+++ b/.github/workflows/ou3-p1-p5-certificate-numbers.yml
@@ -1,0 +1,176 @@
+name: ou3-p1-p5-certificate-numbers
+
+on:
+  push:
+    paths:
+      - "tools/ou3_p1_p5_certificate_numbers.py"
+      - "tools/ou3_p4_shared_force_gain.py"
+      - "tools/ou3_p4_first_accel_sector_budget.py"
+      - "tools/ou3_p4_30deg_signed_first_accel_sector_v3.py"
+      - "tools/ou3_p4_operation_matched_sector_certificate.py"
+      - "tools/ou3_p4_p5_route_ceiling_certificate.py"
+      - "tools/ou3_p4_source_path_reachability.py"
+      - "tools/ou3_p5_outer_sector_capture_certificate.py"
+      - "tools/ou3_startup_stability_certificate.py"
+      - "tools/ou3_proof_operating_domain.json"
+      - "src/kalman_ou_iii/**"
+      - "src/kalman_ou_common/**"
+      - "src/kalman_common/**"
+      - "tests/validation/test_ou3_p1_p5_certificate_numbers.py"
+      - "tests/validation/test_ou3_p4_shared_force_gain.py"
+      - "tests/validation/test_ou3_p4_first_accel_sector_budget.py"
+      - "docs/ou-iii-p1-p5-certificate-numbers.md"
+      - ".github/workflows/ou3-p1-p5-certificate-numbers.yml"
+  pull_request:
+    paths:
+      - "tools/ou3_p1_p5_certificate_numbers.py"
+      - "tools/ou3_p4_shared_force_gain.py"
+      - "tools/ou3_p4_first_accel_sector_budget.py"
+      - "tools/ou3_p4_30deg_signed_first_accel_sector_v3.py"
+      - "tools/ou3_p4_operation_matched_sector_certificate.py"
+      - "tools/ou3_p4_p5_route_ceiling_certificate.py"
+      - "tools/ou3_p4_source_path_reachability.py"
+      - "tools/ou3_p5_outer_sector_capture_certificate.py"
+      - "tools/ou3_startup_stability_certificate.py"
+      - "tools/ou3_proof_operating_domain.json"
+      - "src/kalman_ou_iii/**"
+      - "src/kalman_ou_common/**"
+      - "src/kalman_common/**"
+      - "tests/validation/test_ou3_p1_p5_certificate_numbers.py"
+      - "tests/validation/test_ou3_p4_shared_force_gain.py"
+      - "tests/validation/test_ou3_p4_first_accel_sector_budget.py"
+      - "docs/ou-iii-p1-p5-certificate-numbers.md"
+      - ".github/workflows/ou3-p1-p5-certificate-numbers.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ou3-p1-p5-certificate-numbers-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  certificate-numbers:
+    name: P1-P5 certificate numbers and usability
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Compile producers and tests
+        run: |
+          python3 -m py_compile \
+            tools/ou3_p1_p5_certificate_numbers.py \
+            tools/ou3_p4_shared_force_gain.py \
+            tools/ou3_p4_first_accel_sector_budget.py \
+            tools/ou3_p4_30deg_signed_first_accel_sector_v3.py \
+            tests/validation/test_ou3_p1_p5_certificate_numbers.py \
+            tests/validation/test_ou3_p4_shared_force_gain.py \
+            tests/validation/test_ou3_p4_first_accel_sector_budget.py
+
+      - name: Run report-logic, gain-lemma and budget tests
+        working-directory: tests/validation
+        run: |
+          python3 -m unittest -v \
+            test_ou3_p1_p5_certificate_numbers \
+            test_ou3_p4_shared_force_gain \
+            test_ou3_p4_first_accel_sector_budget
+
+      - name: Emit the shared-force accelerometer gain lemma
+        run: |
+          python3 tools/ou3_p4_shared_force_gain.py \
+            --output /tmp/ou3_shared_force_gain.json
+
+      - name: Emit the signed 30deg first-accelerometer sector with that gain
+        run: |
+          rc=0
+          python3 tools/ou3_p4_30deg_signed_first_accel_sector_v3.py \
+            --source-pieces 2 --alignment-pieces 16 \
+            --force-magnitude-pieces 4 --tangent-pieces 32 \
+            --output /tmp/ou3_signed_first_accel_v3.json || rc=$?
+          echo "producer_exit=$rc"
+
+      - name: Emit the consolidated P1-P5 certificate numbers
+        run: |
+          python3 tools/ou3_p1_p5_certificate_numbers.py \
+            --first-accel /tmp/ou3_signed_first_accel_v3.json \
+            --output /tmp/ou3_p1_p5_certificate_numbers.json
+
+      - name: Enforce stage usability and fail-closed scope
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          gain = json.loads(Path('/tmp/ou3_shared_force_gain.json').read_text())
+          fa = json.loads(Path('/tmp/ou3_signed_first_accel_v3.json').read_text())
+          rep = json.loads(Path('/tmp/ou3_p1_p5_certificate_numbers.json').read_text())
+
+          assert gain['validation_pass'], gain['validation_failures']
+          assert gain['uniformly_at_least_as_tight_as_interval_gain'] is True
+          assert gain['minimum_observed_tightening_factor'] >= 1.0
+          assert gain['maximum_observed_tightening_factor'] > 1.5
+          assert gain['filter_changed'] is False
+          assert gain['P4_USABLE_CERTIFICATE_PROMOTED'] is False
+
+          # The shared-force gain must keep the whole 30 deg family evaluable.
+          assert fa['shared_force_magnitude_dependency_preserved'] is True
+          assert fa['naive_interval_force_magnitude_gain_used'] is False
+          assert fa['first_accelerometer_family_completely_evaluated'] is True
+          assert fa['first_failure'] is None
+          assert fa['evaluated_children'] > 40000
+          assert fa['minimum_signed_composition_denominator_lower'] > 0.5
+          assert fa['max_correction_norm_upper_rad'] < 2.65
+          assert fa['P4_COMPLETE_WORD_DISSIPATION_ESTABLISHED_HERE'] is False
+          assert fa['P4_USABLE_CERTIFICATE_PROMOTED'] is False
+          assert fa['candidate_angle_deg'] == 30.0
+          assert fa['declared_startup_aw_error_fraction_g'] == 0.3
+
+          assert rep['validation_pass'], rep['validation_failures']
+          assert rep['upstream_pass_fields_trusted_as_usability'] is False
+          assert rep['filter_changed'] is False
+          assert rep['source_replay_used'] is False
+          assert rep['all_stage_geometries_usable'] is True
+          assert rep['P1_P5_COMPLETE_STABILITY_PROOF_ESTABLISHED'] is False
+          assert set(rep['open_theorem_obligations']) == {'P4', 'P5'}
+
+          stages = {s['stage']: s for s in rep['stages']}
+          assert [s['stage'] for s in rep['stages']] == ['P1', 'P2', 'P3', 'P4', 'P5']
+          for name in ('P1', 'P2', 'P3'):
+              assert stages[name]['verdict'] == 'USABLE', name
+          for name in ('P4', 'P5'):
+              assert stages[name]['verdict'] == 'USABLE_GEOMETRY_OPEN_OBLIGATION', name
+
+          p1 = stages['P1']['headline']
+          assert p1['normal_gauged_handoff_cayley_norm_upper'] >= 0.20
+          assert p1['timeout_gauged_handoff_cayley_norm_upper'] >= 0.50
+          assert p1['declared_startup_aw_error_fraction_g'] == 0.3
+
+          p4 = stages['P4']['headline']
+          assert p4['design_full_attitude_angle_rad'] >= 0.80
+          assert p4['design_cayley_norm_upper'] < 1.0
+          budget = p4['first_accelerometer_sector_budget']
+          assert budget['shrinking_the_candidate_angle_alone_can_close_the_budget'] is False
+          assert budget['smallest_probe_nuisance_over_budget_ratio'] > 1.0
+          for row in budget['ladder']:
+              assert row['nuisance_upper_rad'] > row['budget_upper_rad']
+
+          p5 = stages['P5']['headline']
+          assert p5['declared_entrance_full_attitude_angle_deg'] == 45.0
+          assert p5['N_outer_words'] == 0
+          assert p5['N_inner_words'] is None
+
+          print('P1 handoffs:', p1['normal_gauged_handoff_cayley_norm_upper'],
+                p1['timeout_gauged_handoff_cayley_norm_upper'])
+          print('P2 states:', stages['P2']['headline']['partition_states'])
+          print('P3 margins:', stages['P3']['headline']['endpoint_information_margin_lower'])
+          print('P4 sector rad:', p4['design_full_attitude_angle_rad'])
+          print('P4 gain tightening:', gain['maximum_observed_tightening_factor'])
+          print('P4 first-accel max_d:', fa['max_correction_norm_upper_rad'])
+          print('P4 first-accel max_qplus:', fa['max_accepted_or_rejected_post_update_q_upper'])
+          print('P4 budget ladder:', [(r['angle_deg'], r['nuisance_over_budget_ratio'])
+                                      for r in budget['ladder']])
+          print('P5 entrance deg:', p5['declared_entrance_full_attitude_angle_deg'])
+          print('complete proof:', rep['P1_P5_COMPLETE_STABILITY_PROOF_ESTABLISHED'])
+          PY

--- a/.github/workflows/ou3-p1-p5-certificate-numbers.yml
+++ b/.github/workflows/ou3-p1-p5-certificate-numbers.yml
@@ -6,6 +6,7 @@ on:
       - "tools/ou3_p1_p5_certificate_numbers.py"
       - "tools/ou3_p4_shared_force_gain.py"
       - "tools/ou3_p4_first_accel_sector_budget.py"
+      - "tools/ou3_p4_first_accel_aw_sigma_consistency.py"
       - "tools/ou3_p4_30deg_signed_first_accel_sector_v3.py"
       - "tools/ou3_p4_operation_matched_sector_certificate.py"
       - "tools/ou3_p4_p5_route_ceiling_certificate.py"
@@ -19,6 +20,7 @@ on:
       - "tests/validation/test_ou3_p1_p5_certificate_numbers.py"
       - "tests/validation/test_ou3_p4_shared_force_gain.py"
       - "tests/validation/test_ou3_p4_first_accel_sector_budget.py"
+      - "tests/validation/test_ou3_p4_first_accel_aw_sigma_consistency.py"
       - "docs/ou-iii-p1-p5-certificate-numbers.md"
       - ".github/workflows/ou3-p1-p5-certificate-numbers.yml"
   pull_request:
@@ -26,6 +28,7 @@ on:
       - "tools/ou3_p1_p5_certificate_numbers.py"
       - "tools/ou3_p4_shared_force_gain.py"
       - "tools/ou3_p4_first_accel_sector_budget.py"
+      - "tools/ou3_p4_first_accel_aw_sigma_consistency.py"
       - "tools/ou3_p4_30deg_signed_first_accel_sector_v3.py"
       - "tools/ou3_p4_operation_matched_sector_certificate.py"
       - "tools/ou3_p4_p5_route_ceiling_certificate.py"
@@ -39,6 +42,7 @@ on:
       - "tests/validation/test_ou3_p1_p5_certificate_numbers.py"
       - "tests/validation/test_ou3_p4_shared_force_gain.py"
       - "tests/validation/test_ou3_p4_first_accel_sector_budget.py"
+      - "tests/validation/test_ou3_p4_first_accel_aw_sigma_consistency.py"
       - "docs/ou-iii-p1-p5-certificate-numbers.md"
       - ".github/workflows/ou3-p1-p5-certificate-numbers.yml"
   workflow_dispatch:
@@ -64,10 +68,12 @@ jobs:
             tools/ou3_p1_p5_certificate_numbers.py \
             tools/ou3_p4_shared_force_gain.py \
             tools/ou3_p4_first_accel_sector_budget.py \
+            tools/ou3_p4_first_accel_aw_sigma_consistency.py \
             tools/ou3_p4_30deg_signed_first_accel_sector_v3.py \
             tests/validation/test_ou3_p1_p5_certificate_numbers.py \
             tests/validation/test_ou3_p4_shared_force_gain.py \
-            tests/validation/test_ou3_p4_first_accel_sector_budget.py
+            tests/validation/test_ou3_p4_first_accel_sector_budget.py \
+            tests/validation/test_ou3_p4_first_accel_aw_sigma_consistency.py
 
       - name: Run report-logic, gain-lemma and budget tests
         working-directory: tests/validation
@@ -75,7 +81,8 @@ jobs:
           python3 -m unittest -v \
             test_ou3_p1_p5_certificate_numbers \
             test_ou3_p4_shared_force_gain \
-            test_ou3_p4_first_accel_sector_budget
+            test_ou3_p4_first_accel_sector_budget \
+            test_ou3_p4_first_accel_aw_sigma_consistency
 
       - name: Emit the shared-force accelerometer gain lemma
         run: |
@@ -90,6 +97,11 @@ jobs:
             --force-magnitude-pieces 4 --tangent-pieces 32 \
             --output /tmp/ou3_signed_first_accel_v3.json || rc=$?
           echo "producer_exit=$rc"
+
+      - name: Emit the a_w/sigma consistency and joint force pairing
+        run: |
+          python3 tools/ou3_p4_first_accel_aw_sigma_consistency.py \
+            --output /tmp/ou3_aw_sigma_consistency.json
 
       - name: Emit the consolidated P1-P5 certificate numbers
         run: |
@@ -106,6 +118,7 @@ jobs:
           gain = json.loads(Path('/tmp/ou3_shared_force_gain.json').read_text())
           fa = json.loads(Path('/tmp/ou3_signed_first_accel_v3.json').read_text())
           rep = json.loads(Path('/tmp/ou3_p1_p5_certificate_numbers.json').read_text())
+          cons = json.loads(Path('/tmp/ou3_aw_sigma_consistency.json').read_text())
 
           assert gain['validation_pass'], gain['validation_failures']
           assert gain['uniformly_at_least_as_tight_as_interval_gain'] is True
@@ -161,6 +174,37 @@ jobs:
           assert p5['N_outer_words'] == 0
           assert p5['N_inner_words'] is None
 
+          assert cons['validation_pass'], cons['validation_failures']
+          assert cons['aw_sigma_consistency_declared_in_domain'] is False
+          assert cons['consistency_constant_is_a_conditional_requirement_not_a_theorem'] is True
+          assert cons['joint_force_pairing_is_unconditional'] is True
+          assert cons['filter_changed'] is False
+          assert cons['P4_USABLE_CERTIFICATE_PROMOTED'] is False
+          crows = {r['angle_deg']: r for r in cons['angle_rows']}
+          # The joint force pairing may never be looser than separate bounds.
+          for r in cons['angle_rows']:
+              assert r['nuisance_joint_force_pairing_upper_rad'] <= \
+                  r['nuisance_separate_force_bounds_upper_rad']
+              assert r['joint_force_pairing_tightening_factor'] >= 1.0
+              assert r['joint_pairing_fits_inside_budget'] is False
+          # 30 deg and wider are excluded under sector invariance outright.
+          for deg in (30.0, 35.0, 40.0, 45.0):
+              r = crows[deg]
+              assert r['any_finite_constant_closes_this_angle'] is False
+              assert r['nuisance_at_zero_aw_error_rad'] > \
+                  r['sector_invariance_correction_budget_upper_rad']
+          for deg in (15.0, 20.0, 25.0):
+              r = crows[deg]
+              assert r['any_finite_constant_closes_this_angle'] is True
+              assert 0.0 < r['critical_consistency_constant'] < r['unconstrained_c_at_worst_cell']
+          assert cons['widest_angle_closed_by_a_finite_consistency_constant'] == 25.0
+
+          print('joint force tightening:', [(r['angle_deg'],
+                r['joint_force_pairing_tightening_factor']) for r in cons['angle_rows']])
+          print('required c:', [(r['angle_deg'], r['critical_consistency_constant'])
+                                for r in cons['angle_rows']])
+          print('unconstrained c at worst cell:',
+                cons['angle_rows'][0]['unconstrained_c_at_worst_cell'])
           print('P1 handoffs:', p1['normal_gauged_handoff_cayley_norm_upper'],
                 p1['timeout_gauged_handoff_cayley_norm_upper'])
           print('P2 states:', stages['P2']['headline']['partition_states'])

--- a/docs/ou-iii-certificate-usability-envelope.md
+++ b/docs/ou-iii-certificate-usability-envelope.md
@@ -70,6 +70,19 @@ any of the following shortcuts:
 14. Do not change filter gains, schedules, or estimator equations merely to make
     the proof pass.  A filter change is a separate design decision and requires
     new performance evidence.
+15. Do not evaluate a gain row `m N / (m^2 p + lambda)` as an interval quotient.
+    The specific-force magnitude `m` appears in the numerator and in the
+    denominator, so the naive quotient overstates the accelerometer gain by up
+    to the cell's magnitude ratio.  Use the exact unimodal supremum in
+    `ou3_p4_shared_force_gain.py`.
+16. Do not present the descending `30 -> 25 -> 20 -> 15` deg candidate ladder as
+    the route that closes the first accelerometer operation.  The measured
+    nuisance-over-budget ratio stays above one down to a 1 deg probe, so a
+    narrower candidate cannot close that operation by itself.
+17. Do not report `P1_P5_COMPLETE_STABILITY_PROOF_ESTABLISHED` while the
+    complete-word P4 dissipation or the finite P5 inner capture is open.  A
+    stage with usable geometry and an open obligation is
+    `USABLE_GEOMETRY_OPEN_OBLIGATION`, never `USABLE`.
 
 ## Quantitative outer target
 
@@ -123,6 +136,38 @@ progress and the new finite-angle sector meet.
 Once that outer complete-word decrease overlaps the existing inner stochastic
 localization level, P5 can derive a finite word count from the P1/outer sector to
 that inner level without the PR #441 uniform-transport obstruction.
+
+## Measured first-accelerometer obstruction
+
+`tools/ou3_p4_first_accel_sector_budget.py` measures why the complete-word P4
+composition has not been emitted.  For each candidate angle it compares the
+**budget** -- the largest correction norm whose worst-case signed Cayley
+composition stays inside the `0.80` rad outer sector -- against the **nuisance
+term**, the shared-force-magnitude accelerometer gain applied to the effective
+`a_w` input.  The ratio falls from `5.05` at 30 deg to `2.12` at 15 deg, but the
+non-candidate limit probes show it saturating at `1.34` for a 1 deg candidate.
+The floor is source-faithful: the declared `0.3 g` latent-acceleration error
+over the lowest admitted specific force is `2.941995 / 5.0 = 0.5884`, so the
+accelerometer-implied gravity direction can be off by `0.6291` rad in the
+low-force cells regardless of the candidate angle.
+
+That producer reports a **distance and never a verdict**: the nuisance term is
+an outward bound and the `a_w` covariance endpoints feeding the gain are
+enclosure endpoints, not certified reachable points.  It does not retire the
+ladder as a diagnostic; it retires the ladder as the closing route.
+
+The complementary widening is `tools/ou3_p4_shared_force_gain.py`, which removes
+the shared specific-force-magnitude dependency from the gain rows.  It is
+uniformly between `1.17` and `1.78` tighter over the audited cells, and it moved
+the signed 30 deg first-accelerometer stage from an abort after 13 of 40960
+children -- with a composition denominator that could cross zero -- to a
+complete evaluation of all 40960 with `max_d = 2.2251526515093487` rad and a
+minimum denominator of `0.6356874937572935`.  The stage is still
+`NOT_ESTABLISHED`, but for a measured reason rather than a lost enclosure.
+
+`tools/ou3_p1_p5_certificate_numbers.py` collects every stage number and
+re-applies the usability thresholds above to the recomputed values; see
+`docs/ou-iii-p1-p5-certificate-numbers.md`.
 
 Until that composition is emitted, the truthful status is:
 

--- a/docs/ou-iii-certificate-usability-envelope.md
+++ b/docs/ou-iii-certificate-usability-envelope.md
@@ -83,6 +83,17 @@ any of the following shortcuts:
     complete-word P4 dissipation or the finite P5 inner capture is open.  A
     stage with usable geometry and an open obligation is
     `USABLE_GEOMETRY_OPEN_OBLIGATION`, never `USABLE`.
+18. Do not couple the declared `a_w` error envelope to the tuner
+    `sigma_applied` state without declaring the constant in the operating
+    domain.  The shipping tuner does track the band-limited wave-acceleration
+    RMS, but the EMA transient means no bound follows from the update law alone.
+    `ou3_p4_first_accel_aw_sigma_consistency.py` measures what such a constant
+    would have to be; it keeps `aw_sigma_consistency_declared_in_domain` false
+    and promotes nothing.
+19. Do not treat a per-operation sector-invariance failure as a proof that a
+    candidate angle is excluded from the complete-word certificate.  Invariance
+    and dissipation are different acceptance tests; a transient excursion is
+    admissible under an operation-matched information decrease.
 
 ## Quantitative outer target
 
@@ -164,6 +175,25 @@ children -- with a composition denominator that could cross zero -- to a
 complete evaluation of all 40960 with `max_d = 2.2251526515093487` rad and a
 minimum denominator of `0.6356874937572935`.  The stage is still
 `NOT_ESTABLISHED`, but for a measured reason rather than a lost enclosure.
+
+`tools/ou3_p4_first_accel_aw_sigma_consistency.py` then splits that gap into
+the part that is proof slack and the part that is a domain question.  Pairing
+the gain and the finite-angle force remainder over the same specific-force
+magnitude is an unconditional `1.026`--`1.168` tightening.  What remains is the
+free pairing between the declared `0.3 g` `a_w` error and the tuner
+`sigma_applied` state that sets the gain: the worst cell pairs a flat-sea tuner
+with the full error, `5.3691` times that cell's `sigma` upper.  Adding
+`||delta a_w|| <= c * sigma_applied` to the domain closes the first
+accelerometer operation at `c = 1.9510667819413354` (15 deg),
+`1.176786821337373` (20 deg) and `0.33380880686218` (25 deg); at 30 deg and
+wider no finite constant exists, because the residual with a perfect `a_w`
+estimate, `0.36909754878917767` rad, already exceeds the `0.27225152012902093`
+rad budget.
+
+That leaves exactly two doors: declare the coupling and narrow the candidate to
+15--20 deg, or stop testing per-operation sector invariance and charge each
+correction against its own information decrease.  The second is the change the
+route ceiling already named and the only one that adds no domain assumption.
 
 `tools/ou3_p1_p5_certificate_numbers.py` collects every stage number and
 re-applies the usability thresholds above to the recomputed values; see

--- a/docs/ou-iii-implementation-stability-proof-plan.md
+++ b/docs/ou-iii-implementation-stability-proof-plan.md
@@ -545,6 +545,72 @@ decrease and the directional block margin -- are the remaining work; the ladder
 stays a conditioning strategy for the complete-word search and is not a
 substitute for them.
 
+#### Which door the ladder is standing in front of
+
+`tools/ou3_p4_first_accel_aw_sigma_consistency.py` splits the remaining gap into
+the part that is proof slack and the part that is a declared-domain question.
+
+The slack is a second shared variable. The nuisance term is
+`||K_theta|| (a_w error + eta(q)|f| + b_a)`; the gain falls roughly like `1/|f|`
+while the finite-angle force remainder grows like `|f|`, so bounding the two
+factors separately over one force cell charges the largest gain against the
+largest force. Maximising the product over subdivided magnitudes inside the same
+cell is unconditional and worth `1.026` (15 deg) to `1.168` (45 deg).
+
+The domain question is the pairing between the `a_w` error and the `a_w`
+covariance. The covariance that sets the gain is the tuner state,
+`P_aw = sigma_applied^2` with `sigma_applied` in the deployed `[0.05, 6.0] m/s^2`
+safety range; the error is the separately declared `0.3 g` startup envelope.
+Nothing in the declared domain couples them, so the worst cell pairs a flat-sea
+tuner with a `2.9407694241234332 m/s^2` error, `5.3691` times that cell's `sigma`
+upper. The shipping tuner does couple them --
+`sigma_target_ = min(sigma_wave * sigma_coeff_, max_sigma_a_)` with
+`sigma_applied` an EMA toward that target and `sigma_wave` the estimated
+band-limited wave-acceleration RMS -- but the EMA transient means no bound
+follows from the update law alone.
+
+The producer assumes no coupling and measures the constant one would have to
+supply. Adding `||delta a_w|| <= c * sigma_applied` to the declared domain:
+
+| candidate | budget (rad) | residual at zero `a_w` error (rad) | required `c` |
+| --- | --- | --- | --- |
+| 15 deg | `0.5309502743982276` | `0.20587675702069888` | `1.9510667819413354` |
+| 20 deg | `0.4439819969818312` | `0.24791375638819854` | `1.176786821337373` |
+| 25 deg | `0.3578622392054443` | `0.30224527930294` | `0.33380880686218` |
+| 30 deg | `0.27225152012902093` | `0.36909754878917767` | none exists |
+| 35 deg | `0.18677577048716126` | `0.44876080948633734` | none exists |
+| 40 deg | `0.10101915914914625` | `0.5415985399383951` | none exists |
+| 45 deg | `0.014514984270965614` | `0.6480593087098117` | none exists |
+
+Two consequences for the plan above.
+
+**The 30 deg candidate is excluded under sector invariance.** Its residual with a
+perfect `a_w` estimate -- accelerometer bias plus finite-angle force remainder
+alone -- is already `0.36909754878917767` rad against a `0.27225152012902093` rad
+budget. No consistency statement, gain sharpening or covariance enclosure
+recovers that, for the same reason the route ceiling was independent of `kappa`.
+"Attempt 30 deg first, narrow only on failure" is therefore only viable once
+change 1 is in place; while per-operation invariance is the acceptance test, the
+ladder has to start at 25 deg or below.
+
+**Only the narrow rungs ask for a physically plausible constant.** `c = 1.95` at
+15 deg is an estimation error inside about two applied sigma; `c = 1.18` at
+20 deg is about one sigma; `c = 0.33` at 25 deg would need the latent-acceleration
+error below a third of one sigma, which is not a realistic filter property.
+
+So there are exactly two doors and they are now priced:
+
+1. declare `||delta a_w|| <= c * sigma_applied` in the operating domain with `c`
+   around `1.2`--`1.95`, justified from the tuner law and a bound on the EMA
+   transient, and take the candidate to 15--20 deg; or
+2. replace per-operation sector invariance with the operation-matched
+   information decrease and a directional block margin, under which a transient
+   excursion is admissible and the 30 deg candidate is not excluded.
+
+Door 2 is change 1 above and adds no domain assumption; door 1 is cheaper but
+narrows the certified set and needs its own physical review. The producer keeps
+`aw_sigma_consistency_declared_in_domain = false` and promotes nothing.
+
 **PASS criterion for closing P5:** every certified normal or timeout handoff lies in a validated outer H capture funnel; every source-word prefix stays safe; the outer recurrence reaches `W_*` in a finite machine-certified number of H words/time. The current certificate does **not** yet satisfy this criterion, and the route ceiling above proves the present accounting never can.
 
 ### P6 — Prove every implemented hybrid jump

--- a/docs/ou-iii-implementation-stability-proof-plan.md
+++ b/docs/ou-iii-implementation-stability-proof-plan.md
@@ -480,6 +480,71 @@ happening in between. Three changes follow, and all three are needed:
 Until those land, `N_H_words` stays unset -- now for a proved reason rather than
 a pending computation.
 
+#### The candidate ladder is not the missing piece either
+
+The `30 -> 25 -> 20 -> 15` deg complete-word candidate ladder was introduced as a
+way to make change 3 cheap: a narrower finite-angle cell has better exact Cayley
+monotonicity and a smaller eta/information ratio, so the expensive 18/21-state
+word should be easier there. Two producers now measure what that buys on the
+operation that actually blocks the ladder, the first deployed accelerometer
+update.
+
+`tools/ou3_p4_shared_force_gain.py` first removes the one piece of pure
+dependency slack in the way. Every structured accelerometer gain row has the
+shape `m N / (m^2 p + lambda)` with the specific-force magnitude `m` in both the
+numerator and the denominator, so an ordinary interval quotient overstates it by
+up to the cell's magnitude ratio. The rows are unimodal in `m`, so the exact
+supremum is the interior value at `m* = sqrt(lambda/p)` -- `(1/2) sqrt(p/lambda)`
+for the self-`p` rows, `C / (2 sqrt(lambda p))` for the independent-`C` axial row
+-- or the larger endpoint. The lemma is uniformly between `1.17` and `1.78`
+tighter over the audited cells and never looser.
+
+That is enough to make the blocked stage measurable.
+`ou3_p4_30deg_signed_first_accel_sector_v2` aborted after `13` of `40960`
+children with `max_d = 2.6481953631664035` rad and a signed composition
+denominator of `0.038994069387713985` that could cross zero;
+`ou3_p4_30deg_signed_first_accel_sector_v3` evaluates all `40960` with
+`max_d = 2.2251526515093487` rad and a minimum denominator of
+`0.6356874937572935`. The certificate is still `NOT_ESTABLISHED` -- the worst
+post-update norm is `6.583306237863824` against an outer sector of
+`0.845586437476324` -- but the gap is now a measured number rather than a lost
+enclosure.
+
+`tools/ou3_p4_first_accel_sector_budget.py` then measures the gap directly. For
+each candidate angle it computes the **budget**, the largest correction norm
+whose worst-case signed Cayley composition with the post-prediction candidate
+norm still lands strictly inside the outer sector, and the **nuisance term**, the
+shared-force gain applied to the effective `a_w` input:
+
+| candidate | budget (rad) | nuisance (rad) | ratio |
+| --- | --- | --- | --- |
+| 15 deg | `0.5309502743982276` | `1.1270362643023522` | `2.12` |
+| 20 deg | `0.4439819969818312` | `1.1909281418846758` | `2.68` |
+| 25 deg | `0.3578622392054443` | `1.2735064196675971` | `3.56` |
+| 30 deg | `0.27225152012902093` | `1.375114933176711` | `5.05` |
+| 35 deg | `0.18677577048716126` | `1.4961948241502516` | `8.01` |
+| 40 deg | `0.10101915914914625` | `1.6373388541150944` | `16.21` |
+| 45 deg | `0.014514984270965614` | `1.7993361240597836` | `123.96` |
+
+Narrowing the candidate does help, and by a factor of `2.4` across the declared
+ladder. It does not help enough. The producer's non-candidate limit probes show
+the ratio saturating: at `1` deg the budget is `0.7815378101554163` rad and the
+nuisance term is still `1.0456598581422538` rad, a ratio of `1.34`. The reason is
+one source-faithful number that no candidate angle touches -- the declared `0.3 g`
+latent-acceleration error over the lowest admitted specific force,
+`2.941995 / 5.0 = 0.5883990000000002`, which by itself lets the
+accelerometer-implied gravity direction sit `0.6291` rad away in the low-force
+cells.
+
+Like V54, this producer reports a **distance and never a verdict**: the nuisance
+term is an outward bound and the `a_w` covariance endpoints feeding the gain are
+enclosure endpoints rather than certified reachable points, so a ratio above one
+does not prove that an admissible state leaves the sector. What it does settle is
+the search direction. Changes 1 and 2 -- the operation-matched information
+decrease and the directional block margin -- are the remaining work; the ladder
+stays a conditioning strategy for the complete-word search and is not a
+substitute for them.
+
 **PASS criterion for closing P5:** every certified normal or timeout handoff lies in a validated outer H capture funnel; every source-word prefix stays safe; the outer recurrence reaches `W_*` in a finite machine-certified number of H words/time. The current certificate does **not** yet satisfy this criterion, and the route ceiling above proves the present accounting never can.
 
 ### P6 — Prove every implemented hybrid jump

--- a/docs/ou-iii-p1-p5-certificate-numbers.md
+++ b/docs/ou-iii-p1-p5-certificate-numbers.md
@@ -1,0 +1,145 @@
+# OU-III P1--P5 certificate numbers
+
+This note answers two questions in one place: **what do the P1--P5 certificates
+currently report**, and **are those numbers usable**?  Usable is defined in
+`docs/ou-iii-certificate-usability-envelope.md`: the certified domains must
+overlap the actual source handoffs and operating ranges in physical units, and
+the proof must not obtain a large number by weakening the implementation model
+or the theorem claim.
+
+`tools/ou3_p1_p5_certificate_numbers.py` regenerates every number below and
+re-applies each usability threshold to the recomputed value.  It does not treat
+an upstream `PASS` field as a usability statement.  Run it with
+
+```
+python3 tools/ou3_p1_p5_certificate_numbers.py --output /tmp/ou3_p1_p5.json
+```
+
+and optionally `--first-accel` / `--translation` to fold in the two slow
+producers without re-running them.
+
+## Summary
+
+| Stage | Status | Headline number | Usable? |
+|---|---|---|---|
+| **P1** startup/reset/handoff | PASS | gauged handoff Cayley norms `0.2721648148683776` (normal) and `0.5947333355555983` (timeout) | **yes** -- deployment-sized, not microscopic |
+| **P2** source-word language | PASS | `800` source states, `640000` edges, one SCC, all states recurrent | **yes** -- source-complete, no replay |
+| **P3** linear information word | PASS | H and A endpoint margins `2.2953997386276688e-20`, prefix information gain `<= 1.0` | **yes**, with the standing caveat that this margin is a *relative* Riccati/noise constant, not a state radius |
+| **P4** nonlinear geometry | PASS | sector `0.80` rad (`45.836623610465864` deg), `q = 0.845586437476324 < 1`, monotonicity `0.8483533546735822`, eta ratio `0.17875410581097537` | geometry **yes**; complete-word dissipation **open** |
+| **P5** startup capture | PASS | declared entrance `45` deg / `0.5 Hs`, `N_outer = 0`, every source branch enters immediately | outer entry **yes**; finite inner capture **open** |
+
+So four of the five stages are physically sized rather than microscopic, and
+none of them was obtained by shrinking a declared deployment domain.  What is
+**not** established is the pair of theorem obligations that would turn the five
+certificates into one stability proof:
+
+1. complete 18/21-state source-correlated P4 word dissipation, and
+2. the finite P5 word count from the 45 deg entrance to the inner stochastic
+   localization level, which is downstream of (1).
+
+The report therefore emits `P1_P5_COMPLETE_STABILITY_PROOF_ESTABLISHED = false`
+and marks P4 and P5 as `USABLE_GEOMETRY_OPEN_OBLIGATION`.  It refuses to report
+a complete proof while any obligation is open.
+
+## Why the microscopic numbers are no longer the live ones
+
+The retired uniform transported-defect route still reports an attitude capture
+radius of `5.808479596010723e-32` rad, and its own ceiling -- independent of
+every constant it contains -- is `1.23762376237624e-03` rad at the shipping
+prefix factor.  Both are far below the `0.272` and `0.595` rad P1 handoffs, and
+`tools/ou3_p4_p5_route_ceiling_certificate.py` proves no sharpening of that
+accounting can close the gap.  Those numbers are retained as evidence that the
+route is retired, not as the current certificate level.
+
+The live P4/P5 geometry is the operation-matched finite-angle sector, which is
+`0.80` rad and contains both gauged P1 handoffs directly.  That is the number to
+quote for the current nonlinear domain.
+
+## The remaining quantitative obstruction
+
+The open P4 obligation now has a measured cause rather than a broken enclosure.
+`tools/ou3_p4_first_accel_sector_budget.py` compares, for each P4 candidate
+angle, two quantities on the same source/alignment/force children:
+
+* the **budget** -- the largest correction norm whose worst-case signed Cayley
+  composition with the post-prediction candidate norm still lands strictly
+  inside the `0.80` rad outer sector;
+* the **nuisance term** -- the shared-force-magnitude accelerometer gain applied
+  to the effective `a_w` input (declared `0.3 g` startup latent-acceleration
+  error, accelerometer bias, finite-angle force remainder).
+
+| candidate | budget (rad) | nuisance (rad) | ratio |
+|---|---|---|---|
+| 15 deg | `0.5309502743982276` | `1.1270362643023522` | `2.12` |
+| 20 deg | `0.4439819969818312` | `1.1909281418846758` | `2.68` |
+| 25 deg | `0.3578622392054443` | `1.2735064196675971` | `3.56` |
+| 30 deg | `0.27225152012902093` | `1.375114933176711` | `5.05` |
+| 35 deg | `0.18677577048716126` | `1.4961948241502516` | `8.01` |
+| 40 deg | `0.10101915914914625` | `1.6373388541150944` | `16.21` |
+| 45 deg | `0.014514984270965614` | `1.7993361240597836` | `123.96` |
+
+Shrinking the candidate angle does help -- the ratio falls from `5.05` at 30 deg
+to `2.12` at 15 deg -- but it is bounded away from closing.  The producer's
+non-candidate limit probes show the ratio saturating: at `1` deg the budget is
+`0.7815378101554163` rad and the nuisance term is still `1.0456598581422538`
+rad, a ratio of `1.34`.  The reason is visible in one source-faithful number:
+the declared latent-acceleration error over the lowest admitted specific force
+is `2.941995 / 5.0 = 0.5883990000000002`, so the accelerometer-implied gravity
+direction can itself be off by `0.6291` rad in the low-force cells.  No choice
+of candidate angle changes that.
+
+**This is a distance, not a verdict.**  The nuisance term is an outward bound
+and the `a_w` covariance endpoints feeding the gain are enclosure endpoints, not
+certified reachable points, so a ratio above one does not prove that an
+admissible state leaves the sector.  What it does establish is that the
+`30 -> 25 -> 20 -> 15` deg search ladder cannot close the first deployed
+accelerometer operation by angle alone, and that the two structural changes
+already named by the route-ceiling certificate -- charging each defect against
+its own operation's information decrease, and carrying a directional block
+margin instead of one scalar whole-word `delta` -- are the ones that remain.
+
+## Widening recorded with these numbers
+
+`tools/ou3_p4_shared_force_gain.py` removes the shared specific-force-magnitude
+dependency from the structured accelerometer gain rows.  Each row has the form
+`m N / (m^2 p + lambda)` with `m` in both numerator and denominator; evaluating
+it as an interval quotient overstates the gain by up to the cell's magnitude
+ratio.  The rows are unimodal in `m`, so the exact supremum is the interior
+value at `m* = sqrt(lambda/p)` -- `(1/2) sqrt(p/lambda)` for the self-`p` rows
+and `C / (2 sqrt(lambda p))` for the independent-`C` axial row -- or the larger
+endpoint.  The lemma reports a uniform tightening between `1.17` and `1.78` over
+the audited cells, and is never looser.
+
+The effect on the blocking stage is not marginal.  With the interval gain,
+`ou3_p4_30deg_signed_first_accel_sector_v2` aborted after **13** of 40960
+children with a correction norm of `2.6481953631664035` rad and a signed
+composition denominator that reached `0.038994069387713985` and could cross
+zero.  With the shared-force gain,
+`ou3_p4_30deg_signed_first_accel_sector_v3` evaluates **all 40960** children:
+
+| | v2 (interval gain) | v3 (shared-force gain) |
+|---|---|---|
+| children evaluated | `13` then abort | `40960`, complete |
+| max correction norm | `2.6481953631664035` rad | `2.2251526515093487` rad |
+| min composition denominator | `0.038994069387713985` | `0.6356874937572935` |
+| max post-update `q` | not reachable | `6.583306237863824` |
+
+The 30 deg family is therefore *measurable* for the first time.  It remains
+`NOT_ESTABLISHED`, because `6.583` is still far outside the `0.8456` outer
+sector -- which is exactly the gap the budget table above accounts for.
+
+## What would change these numbers
+
+Only the two structural changes matter now; further sharpening of the gain, the
+covariance enclosure or `delta` will not move the budget ratio, for the same
+reason the route ceiling was independent of `kappa`:
+
+1. pair each accepted correction with its own Joseph information decrease
+   `W - W+ = ||H z||^2_{s S^-1}` on the step that injects it;
+2. carry a directional/block margin so the attitude channel is not rate-limited
+   by the slowest source channel of the word;
+3. only then compose the finite-angle sector contraction over the complete
+   18/21-state word and set a finite `N_inner` for P5.
+
+Until those land, the honest status is the one the report emits: five usable
+stage geometries, two open theorem obligations, and no complete P1--P5 proof.

--- a/docs/ou-iii-p1-p5-certificate-numbers.md
+++ b/docs/ou-iii-p1-p5-certificate-numbers.md
@@ -128,6 +128,81 @@ The 30 deg family is therefore *measurable* for the first time.  It remains
 `NOT_ESTABLISHED`, because `6.583` is still far outside the `0.8456` outer
 sector -- which is exactly the gap the budget table above accounts for.
 
+## Pricing the two remaining doors
+
+`tools/ou3_p4_first_accel_aw_sigma_consistency.py` splits the nuisance term into
+the part that is proof slack and the part that is a domain question, and puts a
+number on each.
+
+**Unconditional: joint force pairing.**  The nuisance is
+`||K_theta|| * (a_w error + eta(q)|f| + b_a)`.  The gain falls roughly like
+`1/|f|` while the finite-angle force remainder grows like `|f|`, so bounding the
+two factors separately over one force cell charges the largest gain against the
+largest force.  Maximising the product over subdivided magnitudes inside the
+same cell tightens the nuisance term by `1.026` (15 deg) to `1.168` (45 deg)
+with no domain, filter or candidate change.
+
+**Conditional: the `a_w`/`sigma` pairing.**  The `a_w` covariance that sets the
+gain is the tuner state, `P_aw = sigma_applied^2` with `sigma_applied` in the
+deployed safety range `[0.05, 6.0] m/s^2`.  The `a_w` *error* is the separately
+declared `0.3 g` startup envelope.  Nothing in the declared domain couples them,
+so the worst cell pairs a tuner that believes the sea is flat with a
+`2.9407694241234332 m/s^2` latent-acceleration error -- a ratio of `5.3691`
+against that cell's `sigma` upper.  The shipping tuner does couple them
+(`sigma_target = min(sigma_wave * sigma_coeff, max_sigma_a)`, with
+`sigma_applied` an EMA toward it), but the EMA transient means no bound follows
+from the update law alone.
+
+The producer therefore assumes no coupling and instead measures the constant one
+would have to supply.  With `||delta a_w|| <= c * sigma_applied` added to the
+declared domain:
+
+| candidate | budget (rad) | residual at zero `a_w` error (rad) | nuisance (rad) | ratio | required `c` |
+|---|---|---|---|---|---|
+| 15 deg | `0.5309502743982276` | `0.20587675702069888` | `1.0990056689852747` | `2.07` | **`1.9510667819413354`** |
+| 20 deg | `0.4439819969818312` | `0.24791375638819854` | `1.1409879746372982` | `2.57` | **`1.176786821337373`** |
+| 25 deg | `0.3578622392054443` | `0.30224527930294` | `1.195248807614594` | `3.34` | **`0.33380880686218`** |
+| 30 deg | `0.27225152012902093` | `0.36909754878917767` | `1.2620140966060003` | `4.64` | none exists |
+| 35 deg | `0.18677577048716126` | `0.44876080948633734` | `1.341573708617953` | `7.18` | none exists |
+| 40 deg | `0.10101915914914625` | `0.5415985399383951` | `1.4342906492778942` | `14.20` | none exists |
+| 45 deg | `0.014514984270965614` | `0.6480593087098117` | `1.5406129035243878` | `106.14` | none exists |
+
+Two things follow, and they set the route.
+
+First, **the 30 deg candidate cannot close the first accelerometer operation
+under sector invariance at all.**  Its residual with a *perfect* `a_w` estimate,
+`0.36909754878917767` rad -- accelerometer bias plus the finite-angle force
+remainder alone -- already exceeds its `0.27225152012902093` rad budget.  No
+consistency statement, no gain sharpening and no covariance enclosure can
+recover that, for the same reason the route ceiling was independent of `kappa`.
+
+Second, the candidates that can close need a consistency constant between `1.95`
+(15 deg) and `0.33` (25 deg), against `5.3691` today.  Only the 15 deg rung asks
+for something a filter plausibly satisfies -- an estimation error inside about
+two applied sigma.  The 25 deg rung would require the latent-acceleration error
+to stay below a third of one sigma, which is not a realistic filter property.
+
+So there are exactly two doors, and the table prices both:
+
+1. **Narrow the ladder and declare the coupling.**  Take the candidate to
+   15--20 deg and add `||delta a_w|| <= c * sigma_applied` to the operating
+   domain with `c` around `1.2`--`1.95`, justified from the tuner law and a
+   bound on the EMA transient.  That is a new deployment theorem assumption and
+   must be reviewed as one, not slipped in as a proof convenience.
+2. **Stop testing sector invariance per operation.**  Charge each correction
+   against its own Joseph information decrease and carry a directional block
+   margin, so a transient excursion is allowed as long as the Lyapunov level
+   decreases.  Under that criterion the 30 deg candidate is not excluded by the
+   table above, because the table measures invariance, not dissipation.
+
+Door 2 is the change the route-ceiling certificate already named, and it is the
+one that does not add a domain assumption.  Door 1 is cheaper but narrows the
+certified set and needs its own physical justification.
+
+The producer reports a **distance and never a verdict**, and marks
+`aw_sigma_consistency_declared_in_domain = false`: nothing here declares the
+coupling, and nothing here is promoted.
+
 ## What would change these numbers
 
 Only the two structural changes matter now; further sharpening of the gain, the

--- a/docs/ou-iii-p5-sea-scaled-entrance.md
+++ b/docs/ou-iii-p5-sea-scaled-entrance.md
@@ -46,6 +46,21 @@ The rule is to attempt the widest candidate first and promote only the widest ca
 
 This ladder is a certificate-search strategy, not an extra deployment theorem assumption.
 
+### Measured limit of the descending ladder
+
+`tools/ou3_p4_first_accel_sector_budget.py` evaluates the ladder against the
+first deployed accelerometer operation.  Narrowing the candidate does widen the
+correction budget and does lower the nuisance-over-budget ratio -- from `5.05`
+at 30 deg to `2.12` at 15 deg -- but the producer's non-candidate limit probes
+show the ratio saturating at `1.34` for a 1 deg candidate.  The floor is set by
+the declared `0.3 g` latent-acceleration error over the lowest admitted specific
+force, `2.941995 / 5.0 = 0.5884`, which no candidate angle changes.
+
+The ladder therefore stays a useful conditioning strategy for the complete-word
+search, but it is not the route that closes the first accelerometer operation.
+That still needs the operation-matched information decrease and a directional
+block margin.  The producer reports a distance, never a verdict.
+
 ## Proof obligations after this change
 
 1. If the theorem starts before P5, propagate the declared 45 deg / `0.5 Hs` entrance set through the exact preceding startup/source interval; do not substitute it directly for the P1 handoff box.

--- a/docs/ou-iii-p5-sea-scaled-entrance.md
+++ b/docs/ou-iii-p5-sea-scaled-entrance.md
@@ -61,6 +61,46 @@ search, but it is not the route that closes the first accelerometer operation.
 That still needs the operation-matched information decrease and a directional
 block margin.  The producer reports a distance, never a verdict.
 
+### 30 deg is excluded under sector invariance
+
+`tools/ou3_p4_first_accel_aw_sigma_consistency.py` sharpens that measurement by
+pairing the accelerometer gain and the finite-angle force remainder over the
+same specific-force magnitude, which is an unconditional tightening of `1.026`
+to `1.168`, and then asking what the residual would be with a *perfect* `a_w`
+estimate.  At 30 deg that residual -- accelerometer bias plus finite-angle force
+remainder alone -- is `0.36909754878917767` rad against a budget of
+`0.27225152012902093` rad.
+
+So the "attempt 30 deg first" rule cannot be satisfied by the first
+accelerometer operation while sector invariance is the acceptance test, and no
+sharpening changes that.  The rule stands only under the operation-matched
+information-decrease criterion, where a transient excursion is admissible
+provided the Lyapunov level decreases.  If the certificate keeps testing
+per-operation invariance, the ladder must start at 25 deg or below.
+
+### The a_w / sigma consistency constant
+
+The same producer prices the other door.  The `a_w` covariance that sets the
+gain is the tuner state `sigma_applied` in the deployed `[0.05, 6.0] m/s^2`
+safety range; the `a_w` error is the separately declared `0.3 g` envelope.
+Nothing in the declared domain couples them, so the worst cell pairs a flat-sea
+tuner with a `2.9407694241234332 m/s^2` error -- `5.3691` times that cell's
+`sigma` upper.  Adding `||delta a_w|| <= c * sigma_applied` to the domain closes
+the first accelerometer operation at
+
+| candidate | required `c` |
+|---|---|
+| 15 deg | `1.9510667819413354` |
+| 20 deg | `1.176786821337373` |
+| 25 deg | `0.33380880686218` |
+| 30 deg and wider | no finite constant exists |
+
+Only the 15--20 deg rungs ask for something a filter plausibly satisfies (an
+error inside roughly one to two applied sigma).  Such a constant is a new
+deployment theorem assumption requiring its own justification from the tuner law
+and a bound on the EMA transient; it is not declared today, and
+`aw_sigma_consistency_declared_in_domain` stays `false`.
+
 ## Proof obligations after this change
 
 1. If the theorem starts before P5, propagate the declared 45 deg / `0.5 Hs` entrance set through the exact preceding startup/source interval; do not substitute it directly for the P1 handoff box.

--- a/tests/validation/Makefile
+++ b/tests/validation/Makefile
@@ -33,6 +33,10 @@ build:
 		../../tools/ou3_p4_nonlinear_word_certificate.py \
 		../../tools/ou3_p4_p5_route_ceiling_certificate.py \
 		../../tools/ou3_p4_source_path_reachability.py \
+		../../tools/ou3_p4_shared_force_gain.py \
+		../../tools/ou3_p4_30deg_signed_first_accel_sector_v3.py \
+		../../tools/ou3_p4_first_accel_sector_budget.py \
+		../../tools/ou3_p1_p5_certificate_numbers.py \
 		../../tools/ou3_p4_operation_matched_sector_certificate.py \
 		../../tools/ou3_p4_translation_full_word_interval.py \
 		../../tools/ou3_p4_translation_full_word_interval_fast.py \
@@ -90,6 +94,9 @@ build:
 		test_ou3_p4_nonlinear_word_certificate.py \
 		test_ou3_p4_p5_route_ceiling.py \
 		test_ou3_p4_source_path_reachability.py \
+		test_ou3_p4_shared_force_gain.py \
+		test_ou3_p4_first_accel_sector_budget.py \
+		test_ou3_p1_p5_certificate_numbers.py \
 		test_ou3_p4_operation_matched_sector_certificate.py \
 		test_ou3_p4_translation_full_word_interval.py \
 		test_ou3_p4_translation_full_word_rigorous.py \

--- a/tests/validation/Makefile
+++ b/tests/validation/Makefile
@@ -36,6 +36,7 @@ build:
 		../../tools/ou3_p4_shared_force_gain.py \
 		../../tools/ou3_p4_30deg_signed_first_accel_sector_v3.py \
 		../../tools/ou3_p4_first_accel_sector_budget.py \
+		../../tools/ou3_p4_first_accel_aw_sigma_consistency.py \
 		../../tools/ou3_p1_p5_certificate_numbers.py \
 		../../tools/ou3_p4_operation_matched_sector_certificate.py \
 		../../tools/ou3_p4_translation_full_word_interval.py \
@@ -96,6 +97,7 @@ build:
 		test_ou3_p4_source_path_reachability.py \
 		test_ou3_p4_shared_force_gain.py \
 		test_ou3_p4_first_accel_sector_budget.py \
+		test_ou3_p4_first_accel_aw_sigma_consistency.py \
 		test_ou3_p1_p5_certificate_numbers.py \
 		test_ou3_p4_operation_matched_sector_certificate.py \
 		test_ou3_p4_translation_full_word_interval.py \

--- a/tests/validation/test_ou3_p1_p5_certificate_numbers.py
+++ b/tests/validation/test_ou3_p1_p5_certificate_numbers.py
@@ -1,0 +1,223 @@
+"""Report-logic tests for the consolidated P1--P5 certificate numbers.
+
+The producer itself rebuilds every stage and takes minutes; the dedicated
+``ou3-p1-p5-certificate-numbers`` workflow runs it.  What is checked here is the
+part that decides what the report *says*: the usability thresholds, the verdict
+rules, and the refusal to claim a complete proof while an obligation is open.
+"""
+from copy import deepcopy
+from pathlib import Path
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+
+import ou3_p1_p5_certificate_numbers as REPORT
+
+
+def _ctx():
+    """A synthetic context carrying the numbers the shipping stages report."""
+    return {
+        "startup": {
+            "operating_domain": {
+                "latent_acceleration_error_fraction_g": 0.3,
+                "physical_handoff_coordinate_bounds": {
+                    "position_error_norm_upper_m": 20.0,
+                    "velocity_error_norm_upper_mps": 5.0,
+                    "latent_acceleration_error_norm_upper_mps2": 2.941995,
+                    "gyro_bias_error_norm_upper_rad_s": 0.01,
+                    "accelerometer_bias_error_norm_upper_mps2": 0.5,
+                    "integral_displacement_error_norm_upper_m_s": 300.0,
+                },
+            },
+        },
+        "startup_validation_pass": True,
+        "P1_normal_gauged_cayley_norm_upper": 0.2721648148683776,
+        "P1_timeout_gauged_cayley_norm_upper": 0.5947333355555983,
+        "P2": {
+            "P2_SOURCE_PATH_CERTIFICATE": "PASS",
+            "source_only": True,
+            "trajectory_replay_used": False,
+            "partition": {"states": 800},
+            "recurrent_states": 800,
+            "transition_edges": 640000,
+            "strongly_connected_components": 1,
+            "raw_tuner_sigma_subfloor_states_included": True,
+            "RS_target_full_deployed_clamp_overapprox": True,
+            "filter_sigma_floor_mps2": 0.05,
+            "raw_tuner_sigma_partition_lower": 1e-06,
+        },
+        "word": {
+            "modes": {
+                "H": {"P3_word_endpoint_delta_lower": 2.2953997386276688e-20,
+                      "P3_homogeneous_prefix_information_gain_upper": 1.0},
+                "A": {"P3_word_endpoint_delta_lower": 2.2953997386276688e-20,
+                      "P3_homogeneous_prefix_information_gain_upper": 1.0},
+            },
+        },
+        "P4_sector": {
+            "P4_OPERATION_MATCHED_FINITE_ANGLE_SECTOR_CERTIFICATE": "PASS",
+            "design_full_attitude_angle_rad": 0.8,
+            "design_full_attitude_angle_deg": 45.836623610465864,
+            "design_cayley_norm_upper": 0.845586437476324,
+            "exact_vector_strong_monotonicity_factor_lower": 0.8483533546735822,
+            "exact_eta_to_rotational_residual_information_ratio_upper": 0.17875410581097537,
+            "P1_overlap": {
+                "normal_gauged_cayley_norm_upper": 0.2721648148683776,
+                "timeout_gauged_cayley_norm_upper": 0.5947333355555983,
+                "normal_gauged_inside_sector": True,
+                "timeout_gauged_inside_sector": True,
+            },
+        },
+        "P4_first_accel_budget": {
+            "declared_aw_over_lowest_specific_force": 0.5883990000000002,
+            "ladder_rows": [{
+                "angle_deg": 30.0, "ladder_family": "descending",
+                "sector_invariance_correction_budget_upper_rad": 0.27225152012902093,
+                "nuisance_correction_norm_upper_rad": 1.375114933176711,
+                "nuisance_over_budget_ratio": 5.050899008846818,
+            }],
+            "smallest_probe_angle_deg": 1.0,
+            "smallest_probe_nuisance_over_budget_ratio": 1.337951721023343,
+            "shrinking_the_candidate_angle_alone_can_close_the_budget": False,
+        },
+        "P5_outer": {
+            "P5_OUTER_SECTOR_CAPTURE_CERTIFICATE": "PASS",
+            "declared_P5_entrance": {
+                "gauged_full_attitude_angle_upper_deg": 45.0,
+                "attitude_geometry": {"cayley_norm_upper": 0.8284271247461905},
+                "position_component_abs_error_upper_Hs_factor": 0.5,
+                "position_norm_upper_Hs_factor": 0.8660254037844388,
+            },
+            "outer_sector_angle_deg": 45.836623610465864,
+            "all_source_handoff_branches_enter_outer_sector": True,
+            "N_outer_words": 0,
+            "P1_conservative_handoff_box_replaced": False,
+            "upper_cosine_enclosure_used_for_ungauged_inclusion": True,
+            "legacy_microscopic_inner_seed_used_as_outer_capture_target": False,
+            "branches": {
+                "normal_gauged": {"P1_handoff_cayley_norm_upper": 0.2721648148683776},
+                "timeout_gauged": {"P1_handoff_cayley_norm_upper": 0.5947333355555983},
+                "timeout_ungauged": {"full_heading_radius_assigned": False},
+            },
+        },
+        "route_ceiling": {
+            "modes": {m: {
+                "certified_attitude_capture_radius_now": 5.808479596010723e-32,
+                "route_ceiling_at_shipping_prefix_factor": 0.0012376237623762383,
+                "route_can_reach_P1_handoff": False,
+            } for m in ("H", "A")},
+        },
+        "translation": None,
+        "first_accel": None,
+    }
+
+
+class StageVerdictTests(unittest.TestCase):
+    def test_shipping_numbers_make_every_stage_geometry_usable(self):
+        ctx = _ctx()
+        stages = [REPORT._p1_stage(ctx), REPORT._p2_stage(ctx), REPORT._p3_stage(ctx),
+                  REPORT._p4_stage(ctx), REPORT._p5_stage(ctx)]
+        for s in stages:
+            for c in s["usability_checks"]:
+                self.assertTrue(c["pass"], f"{s['stage']}: {c['check']}")
+        self.assertEqual([s["verdict"] for s in stages], [
+            "USABLE", "USABLE", "USABLE",
+            "USABLE_GEOMETRY_OPEN_OBLIGATION",
+            "USABLE_GEOMETRY_OPEN_OBLIGATION",
+        ])
+
+    def test_P4_and_P5_never_report_their_open_obligations_as_closed(self):
+        ctx = _ctx()
+        for stage in (REPORT._p4_stage(ctx), REPORT._p5_stage(ctx)):
+            self.assertIsNotNone(stage["open_obligation"])
+            self.assertNotEqual(stage["verdict"], "USABLE")
+
+    def test_a_microscopic_P1_handoff_is_rejected(self):
+        ctx = _ctx()
+        ctx["P1_normal_gauged_cayley_norm_upper"] = 2.9e-32
+        stage = REPORT._p1_stage(ctx)
+        self.assertEqual(stage["verdict"], "NOT_USABLE")
+        failed = [c["check"] for c in stage["usability_checks"] if not c["pass"]]
+        self.assertIn("handoff family is not microscopic", failed)
+
+    def test_a_shrunk_handoff_domain_is_rejected(self):
+        for key, value in (("position_error_norm_upper_m", 1.0),
+                           ("velocity_error_norm_upper_mps", 0.1),
+                           ("latent_acceleration_error_norm_upper_mps2", 0.1)):
+            ctx = _ctx()
+            ctx["startup"]["operating_domain"]["physical_handoff_coordinate_bounds"][key] = value
+            self.assertEqual(REPORT._p1_stage(ctx)["verdict"], "NOT_USABLE", key)
+
+    def test_a_narrowed_P4_sector_is_rejected(self):
+        ctx = _ctx()
+        ctx["P4_sector"]["design_full_attitude_angle_rad"] = 0.5
+        self.assertEqual(REPORT._p4_stage(ctx)["verdict"], "NOT_USABLE")
+
+    def test_a_cayley_chart_at_or_above_one_is_rejected(self):
+        ctx = _ctx()
+        ctx["P4_sector"]["design_cayley_norm_upper"] = 1.25
+        self.assertEqual(REPORT._p4_stage(ctx)["verdict"], "NOT_USABLE")
+
+    def test_a_shrunk_P5_entrance_is_rejected(self):
+        ctx = _ctx()
+        ctx["P5_outer"]["declared_P5_entrance"]["gauged_full_attitude_angle_upper_deg"] = 5.0
+        self.assertEqual(REPORT._p5_stage(ctx)["verdict"], "NOT_USABLE")
+
+    def test_a_nonzero_outer_word_count_is_rejected(self):
+        ctx = _ctx()
+        ctx["P5_outer"]["N_outer_words"] = 3
+        self.assertEqual(REPORT._p5_stage(ctx)["verdict"], "NOT_USABLE")
+
+    def test_P3_margin_is_labelled_as_a_relative_constant(self):
+        stage = REPORT._p3_stage(_ctx())
+        self.assertIn("not a nonlinear state radius", stage["interpretation"])
+
+    def test_P4_headline_carries_the_first_accelerometer_budget_gap(self):
+        head = REPORT._p4_stage(_ctx())["headline"]["first_accelerometer_sector_budget"]
+        self.assertFalse(head["shrinking_the_candidate_angle_alone_can_close_the_budget"])
+        self.assertGreater(head["smallest_probe_nuisance_over_budget_ratio"], 1.0)
+
+
+class ReportValidationTests(unittest.TestCase):
+    def _report(self):
+        ctx = _ctx()
+        stages = [REPORT._p1_stage(ctx), REPORT._p2_stage(ctx), REPORT._p3_stage(ctx),
+                  REPORT._p4_stage(ctx), REPORT._p5_stage(ctx)]
+        return {
+            "schema": REPORT.SCHEMA,
+            "source_generated_not_trajectory_fit": True,
+            "source_replay_used": False,
+            "filter_changed": False,
+            "upstream_pass_fields_trusted_as_usability": False,
+            "stages": stages,
+            "stages_not_usable": [],
+            "open_theorem_obligations": {
+                s["stage"]: s["open_obligation"] for s in stages if s["open_obligation"]},
+            "all_stage_geometries_usable": True,
+            "P1_P5_COMPLETE_STABILITY_PROOF_ESTABLISHED": False,
+            "failures": [],
+        }
+
+    def test_a_clean_report_validates(self):
+        self.assertEqual(REPORT.validate(self._report()), [])
+
+    def test_complete_proof_cannot_be_claimed_with_open_obligations(self):
+        d = self._report()
+        d["P1_P5_COMPLETE_STABILITY_PROOF_ESTABLISHED"] = True
+        self.assertIn("complete proof claimed with open obligations", REPORT.validate(d))
+
+    def test_a_failed_usability_check_surfaces_in_validation(self):
+        d = deepcopy(self._report())
+        d["stages"][0]["usability_checks"][1]["pass"] = False
+        self.assertTrue(any("usability check failed" in x for x in REPORT.validate(d)))
+
+    def test_out_of_order_stages_are_rejected(self):
+        d = deepcopy(self._report())
+        d["stages"] = list(reversed(d["stages"]))
+        self.assertIn("stage list is not P1..P5", REPORT.validate(d))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/validation/test_ou3_p4_first_accel_aw_sigma_consistency.py
+++ b/tests/validation/test_ou3_p4_first_accel_aw_sigma_consistency.py
@@ -1,0 +1,150 @@
+from pathlib import Path
+import math
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+
+from ou3_interval import Interval
+import ou3_p4_first_accel_aw_sigma_consistency as CONSIST
+
+
+class ForceSubdivisionTests(unittest.TestCase):
+    def test_subcells_tile_the_cell_and_keep_its_endpoints(self):
+        m = Interval(5.0, 30.0)
+        for pieces in (1, 2, 8, 16):
+            cells = CONSIST._force_subcells(m, pieces)
+            self.assertEqual(len(cells), pieces)
+            self.assertLessEqual(cells[0].lo, m.lo)
+            self.assertGreaterEqual(cells[-1].hi, m.hi)
+            for a, b in zip(cells, cells[1:]):
+                self.assertGreaterEqual(b.hi, a.hi)
+                self.assertLessEqual(a.lo, b.lo)
+
+    def test_a_nonpositive_subdivision_is_rejected(self):
+        with self.assertRaises(ValueError):
+            CONSIST._force_subcells(Interval(5.0, 30.0), 0)
+
+
+class ConsistencySearchTests(unittest.TestCase):
+    """The bisection is exercised on a synthetic table with a known answer."""
+
+    def _table(self, k, sigma_hi, aw, ba):
+        return {
+            "rows": [{
+                "aw_after_prefix_upper_mps2": aw,
+                "tuner_sigma_aw_upper_mps2": sigma_hi,
+                "force_upper_mps2": 5.0,
+                "Ktheta_norm_upper": k,
+            }],
+            "accel_bias_error_norm_upper_mps2": ba,
+        }
+
+    def test_worst_nuisance_clamps_the_aw_error_at_c_times_sigma(self):
+        t = self._table(k=0.3, sigma_hi=0.5, aw=3.0, ba=0.5)
+        loose, _w = CONSIST._worst_nuisance(t, 0.0, math.inf)
+        tight, _w = CONSIST._worst_nuisance(t, 0.0, 2.0)
+        self.assertAlmostEqual(loose, 0.3 * (3.0 + 0.5), delta=1e-9)
+        self.assertAlmostEqual(tight, 0.3 * (1.0 + 0.5), delta=1e-9)
+        self.assertLess(tight, loose)
+
+    def test_a_larger_c_never_lowers_the_nuisance(self):
+        t = self._table(k=0.3, sigma_hi=0.5, aw=3.0, ba=0.5)
+        vals = [CONSIST._worst_nuisance(t, 0.0, c)[0] for c in (0.0, 0.5, 1.0, 4.0, 12.0)]
+        self.assertEqual(vals, sorted(vals))
+
+    def test_critical_constant_brackets_the_budget_crossing(self):
+        t = self._table(k=0.3, sigma_hi=0.5, aw=3.0, ba=0.5)
+        # zero-aw residual is 0.15; budget 0.30 leaves room for 0.5 m/s^2 of
+        # a_w error, i.e. c = 1.0.
+        out = CONSIST._critical_consistency_constant(t, 0.0, 0.30)
+        self.assertTrue(out["any_finite_constant_closes_this_angle"])
+        self.assertAlmostEqual(out["critical_consistency_constant"], 1.0, delta=1e-6)
+        lo, hi = out["bracket"]
+        self.assertLess(CONSIST._worst_nuisance(t, 0.0, lo)[0], 0.30)
+        self.assertGreaterEqual(CONSIST._worst_nuisance(t, 0.0, hi)[0], 0.30)
+
+    def test_no_constant_helps_when_the_zero_error_residual_already_exceeds(self):
+        t = self._table(k=0.3, sigma_hi=0.5, aw=3.0, ba=2.0)
+        out = CONSIST._critical_consistency_constant(t, 0.0, 0.30)
+        self.assertFalse(out["any_finite_constant_closes_this_angle"])
+        self.assertEqual(out["critical_consistency_constant"], 0.0)
+        self.assertGreaterEqual(out["nuisance_at_zero_aw_error_rad"], 0.30)
+
+    def test_an_already_fitting_pairing_reports_an_unbounded_constant(self):
+        t = self._table(k=0.01, sigma_hi=0.5, aw=3.0, ba=0.5)
+        out = CONSIST._critical_consistency_constant(t, 0.0, 0.30)
+        self.assertTrue(out["unconstrained_pairing_already_fits"])
+        self.assertEqual(out["critical_consistency_constant"], math.inf)
+
+    def test_a_nonpositive_budget_admits_no_constant(self):
+        t = self._table(k=0.3, sigma_hi=0.5, aw=3.0, ba=0.5)
+        out = CONSIST._critical_consistency_constant(t, 0.0, 0.0)
+        self.assertFalse(out["any_finite_constant_closes_this_angle"])
+
+
+class ConsistencyCertificateTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.d = CONSIST.build()
+
+    def test_certificate_validates_and_promotes_nothing(self):
+        d = self.d
+        self.assertEqual(CONSIST.validate(d), [])
+        self.assertTrue(d["distance_only_no_verdict_emitted"])
+        self.assertTrue(d["consistency_constant_is_a_conditional_requirement_not_a_theorem"])
+        self.assertFalse(d["aw_sigma_consistency_declared_in_domain"])
+        self.assertFalse(d["filter_changed"])
+        self.assertFalse(d["source_replay_used"])
+        self.assertFalse(d["declared_entrance_shrunk"])
+        self.assertFalse(d["P4_USABLE_CERTIFICATE_PROMOTED"])
+        self.assertFalse(d["P4_COMPLETE_WORD_DISSIPATION_ESTABLISHED_HERE"])
+
+    def test_joint_force_pairing_is_an_unconditional_tightening(self):
+        self.assertTrue(self.d["joint_force_pairing_is_unconditional"])
+        for r in self.d["angle_rows"]:
+            self.assertLessEqual(r["nuisance_joint_force_pairing_upper_rad"],
+                                 r["nuisance_separate_force_bounds_upper_rad"])
+            self.assertGreaterEqual(r["joint_force_pairing_tightening_factor"], 1.0)
+
+    def test_the_unconstrained_pairing_still_fits_nowhere(self):
+        for r in self.d["angle_rows"]:
+            self.assertFalse(r["joint_pairing_fits_inside_budget"])
+            self.assertGreater(r["nuisance_over_budget_ratio_joint"], 1.0)
+
+    def test_the_zero_aw_residual_alone_closes_the_wide_candidates_out(self):
+        rows = {r["angle_deg"]: r for r in self.d["angle_rows"]}
+        for deg in (30.0, 35.0, 40.0, 45.0):
+            r = rows[deg]
+            self.assertGreater(r["nuisance_at_zero_aw_error_rad"],
+                               r["sector_invariance_correction_budget_upper_rad"])
+            self.assertFalse(r["any_finite_constant_closes_this_angle"])
+            self.assertEqual(r["critical_consistency_constant"], 0.0)
+
+    def test_the_narrow_candidates_close_only_with_a_finite_constant(self):
+        rows = {r["angle_deg"]: r for r in self.d["angle_rows"]}
+        for deg in (15.0, 20.0, 25.0):
+            r = rows[deg]
+            self.assertTrue(r["any_finite_constant_closes_this_angle"])
+            self.assertGreater(r["critical_consistency_constant"], 0.0)
+            self.assertLess(r["critical_consistency_constant"],
+                            r["unconstrained_c_at_worst_cell"])
+            self.assertGreater(r["consistency_tightening_needed_factor"], 1.0)
+        self.assertEqual(self.d["widest_angle_closed_by_a_finite_consistency_constant"], 25.0)
+
+    def test_the_required_constant_relaxes_as_the_candidate_narrows(self):
+        rows = sorted((r for r in self.d["angle_rows"]
+                       if r["any_finite_constant_closes_this_angle"]),
+                      key=lambda r: r["angle_deg"])
+        cs = [r["critical_consistency_constant"] for r in rows]
+        self.assertEqual(cs, sorted(cs, reverse=True))
+
+    def test_the_tuner_sigma_range_is_the_deployed_safety_envelope(self):
+        lo, hi = self.d["tuner_sigma_aw_range_mps2"]
+        self.assertAlmostEqual(lo, 0.05, delta=1e-9)
+        self.assertAlmostEqual(hi, 6.0, delta=1e-9)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/validation/test_ou3_p4_first_accel_sector_budget.py
+++ b/tests/validation/test_ou3_p4_first_accel_sector_budget.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+import math
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+
+import ou3_p4_first_accel_sector_budget as BUDGET
+
+
+class FirstAccelSectorBudgetTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.d = BUDGET.build()
+
+    def test_budget_validates_and_stays_a_distance_not_a_verdict(self):
+        d = self.d
+        self.assertEqual(BUDGET.validate(d), [])
+        self.assertTrue(d["distance_only_no_verdict_emitted"])
+        self.assertFalse(d["filter_changed"])
+        self.assertFalse(d["source_replay_used"])
+        self.assertFalse(d["declared_entrance_shrunk"])
+        self.assertFalse(d["P4_USABLE_CERTIFICATE_PROMOTED"])
+        self.assertFalse(d["P4_COMPLETE_WORD_DISSIPATION_ESTABLISHED_HERE"])
+
+    def test_ladder_covers_the_documented_candidate_angles(self):
+        angles = [r["angle_deg"] for r in self.d["ladder_rows"]]
+        self.assertEqual(angles, [15.0, 20.0, 25.0, 30.0, 35.0, 40.0, 45.0])
+        families = {r["angle_deg"]: r["ladder_family"] for r in self.d["ladder_rows"]}
+        for deg in (15.0, 20.0, 25.0, 30.0):
+            self.assertEqual(families[deg], "descending")
+        for deg in (35.0, 40.0, 45.0):
+            self.assertEqual(families[deg], "ascending")
+
+    def test_budget_decreases_as_the_candidate_angle_grows(self):
+        rows = sorted(self.d["ladder_rows"], key=lambda r: r["angle_deg"])
+        budgets = [r["sector_invariance_correction_budget_upper_rad"] for r in rows]
+        self.assertEqual(budgets, sorted(budgets, reverse=True))
+
+    def test_the_budget_bracket_is_a_genuine_crossing(self):
+        outer = self.d["operation_matched_outer_q_upper"]
+        for r in self.d["ladder_rows"] + self.d["limit_probe_rows"]:
+            q = r["post_prediction_q_upper"]
+            lo, hi = r["budget_bracket_rad"]
+            if lo <= 0.0:
+                continue
+            self.assertLess(BUDGET._worst_case_qplus(q, lo), outer)
+            try:
+                self.assertGreaterEqual(BUDGET._worst_case_qplus(q, hi), outer)
+            except RuntimeError:
+                pass
+
+    def test_nuisance_term_exceeds_the_budget_at_every_rung_and_probe(self):
+        for r in self.d["ladder_rows"] + self.d["limit_probe_rows"]:
+            self.assertFalse(r["nuisance_fits_inside_budget"])
+            self.assertGreater(r["nuisance_over_budget_ratio"], 1.0)
+        self.assertFalse(self.d["any_ladder_rung_fits_nuisance_inside_budget"])
+        self.assertFalse(
+            self.d["shrinking_the_candidate_angle_alone_can_close_the_budget"])
+
+    def test_shrinking_the_angle_helps_but_is_bounded_away_from_closing(self):
+        rows = sorted(self.d["ladder_rows"], key=lambda r: r["angle_deg"])
+        ratios = [r["nuisance_over_budget_ratio"] for r in rows]
+        self.assertEqual(ratios, sorted(ratios))
+        self.assertTrue(self.d["descending_ladder_halves_the_gap"])
+        # ... and still above one in the small-angle limit.
+        self.assertGreater(self.d["smallest_probe_nuisance_over_budget_ratio"], 1.0)
+        self.assertLess(self.d["smallest_probe_angle_deg"], 15.0)
+
+    def test_nuisance_floor_is_set_by_the_declared_aw_over_lowest_force(self):
+        d = self.d
+        ratio = d["declared_aw_over_lowest_specific_force"]
+        self.assertAlmostEqual(
+            ratio,
+            d["declared_startup_aw_error_norm_upper_mps2"]
+            / d["specific_force_norm_lower_mps2"],
+            delta=1.0e-12)
+        self.assertGreater(ratio, 0.5)
+        self.assertAlmostEqual(
+            d["lowest_force_gravity_direction_error_upper_rad"],
+            math.asin(ratio), delta=1.0e-12)
+
+    def test_worst_cell_decomposes_into_source_faithful_inputs(self):
+        for r in self.d["ladder_rows"]:
+            w = r["worst_cell"]
+            total = (w["aw_after_prefix_upper_mps2"]
+                     + w["force_attitude_remainder_upper_mps2"]
+                     + self.d["accel_bias_error_norm_upper_mps2"])
+            self.assertLessEqual(w["effective_aw_input_upper_mps2"], total * (1.0 + 1.0e-12))
+            self.assertGreaterEqual(w["effective_aw_input_upper_mps2"], total * (1.0 - 1.0e-12))
+            self.assertLessEqual(
+                w["nuisance_correction_norm_upper_rad"],
+                w["Ktheta_norm_upper"] * w["effective_aw_input_upper_mps2"] * (1.0 + 1.0e-9))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/validation/test_ou3_p4_shared_force_gain.py
+++ b/tests/validation/test_ou3_p4_shared_force_gain.py
@@ -1,0 +1,115 @@
+from pathlib import Path
+import math
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+
+from ou3_interval import Interval
+import ou3_p4_candidate_first_accel_range_v3 as V3
+import ou3_p4_shared_force_gain as SHARED
+
+
+def _brute_force_sup(fn, m: Interval, samples: int = 20001) -> float:
+    lo, hi = m.lo, m.hi
+    best = 0.0
+    for i in range(samples):
+        mv = lo + (hi - lo) * i / (samples - 1)
+        best = max(best, fn(mv))
+    return best
+
+
+class SharedForceGainMathTests(unittest.TestCase):
+    def test_self_p_row_bounds_the_true_supremum(self):
+        for m in (Interval(5.0, 7.83), Interval(12.2, 19.2), Interval(0.9, 40.0)):
+            for p in (1.225e-3, 4.0e-3, 0.5):
+                for lam in (3.3e-3, 0.29, 36.0):
+                    bound = SHARED.sup_self_p_gain(m, p, lam)
+                    truth = _brute_force_sup(lambda mv: mv * p / (mv * mv * p + lam), m)
+                    self.assertGreaterEqual(bound, truth)
+                    self.assertLess(bound, truth * 1.0001 + 1.0e-12)
+
+    def test_independent_row_bounds_the_true_supremum(self):
+        for m in (Interval(5.0, 7.83), Interval(19.2, 30.0)):
+            for p in (1.225e-3, 4.0e-3):
+                for lam in (3.3e-3, 0.29):
+                    for c in (1.5e-3, 2.1e-3):
+                        bound = SHARED.sup_independent_gain(m, c, p, lam)
+                        truth = _brute_force_sup(
+                            lambda mv: mv * c / (mv * mv * p + lam), m)
+                        self.assertGreaterEqual(bound, truth)
+                        self.assertLess(bound, truth * 1.0001 + 1.0e-12)
+
+    def test_interior_maximum_is_used_when_reachable(self):
+        # m* = sqrt(lam/p) = 10 lies inside the cell, so the endpoint values
+        # alone would understate the supremum.
+        p, lam = 1.0e-2, 1.0
+        m = Interval(2.0, 50.0)
+        bound = SHARED.sup_self_p_gain(m, p, lam)
+        self.assertGreaterEqual(bound, 0.5 * math.sqrt(p / lam))
+        truth = _brute_force_sup(lambda mv: mv * p / (mv * mv * p + lam), m)
+        self.assertGreaterEqual(bound, truth)
+
+    def test_degenerate_domains_are_rejected(self):
+        with self.assertRaises(RuntimeError):
+            SHARED.sup_self_p_gain(Interval(0.0, 1.0), 1.0e-3, 1.0e-3)
+        with self.assertRaises(RuntimeError):
+            SHARED.sup_self_p_gain(Interval(1.0, 2.0), 1.0e-3, 0.0)
+        with self.assertRaises(RuntimeError):
+            SHARED.sup_independent_gain(Interval(1.0, 2.0), 1.0e-3, 0.0, 1.0e-3)
+
+
+class SharedForceGainRowTests(unittest.TestCase):
+    CELL = dict(
+        tilt=0.0012250000000000002,
+        yaw=0.007568999999999999,
+        eps=1.4828249737599615e-10,
+        x=Interval(0.0, 0.0625),
+        m=Interval(5.0, 7.825422900366438),
+        paw=Interval(0.0024261138354981, 0.30093178099430606),
+        racc_var=Interval(0.0008666185998411353, 0.0008666185998411355),
+    )
+
+    def test_gain_rows_are_tighter_than_the_naive_interval_rows(self):
+        k_naive, kh_naive, dn = V3._tangent_structured_gain_bounds(**self.CELL)
+        k_exact, kh_exact, de = SHARED.shared_force_structured_gain_bounds(**self.CELL)
+        self.assertLess(k_exact, k_naive)
+        self.assertLessEqual(kh_exact, kh_naive)
+        for row in ("g_perp_upper", "g_u_upper", "g_z_upper"):
+            self.assertLessEqual(de[row], dn[row])
+        self.assertTrue(de["shared_force_magnitude_dependency_preserved"])
+        self.assertGreater(k_naive / k_exact, 1.5)
+
+    def test_psd_remainder_and_KH_treatment_are_unchanged(self):
+        _k, _kh, dn = V3._tangent_structured_gain_bounds(**self.CELL)
+        _ke, _khe, de = SHARED.shared_force_structured_gain_bounds(**self.CELL)
+        for key in ("attitude_PSD_remainder_operator_upper",
+                    "nominal_tangent_innovation_lower",
+                    "tangent_innovation_perturbation_upper",
+                    "perturbed_tangent_innovation_lower",
+                    "PSD_innovation_perturbation_tangent_only",
+                    "PSD_innovation_axial_row_column_exact_zero"):
+            self.assertEqual(de[key], dn[key])
+
+
+class SharedForceGainCertificateTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.d = SHARED.build()
+
+    def test_lemma_validates_and_is_uniformly_tighter(self):
+        self.assertEqual(SHARED.validate(self.d), [])
+        self.assertTrue(self.d["uniformly_at_least_as_tight_as_interval_gain"])
+        self.assertGreaterEqual(self.d["minimum_observed_tightening_factor"], 1.0)
+        self.assertGreater(self.d["maximum_observed_tightening_factor"], 1.5)
+
+    def test_lemma_promotes_nothing(self):
+        self.assertFalse(self.d["filter_changed"])
+        self.assertFalse(self.d["source_replay_used"])
+        self.assertFalse(self.d["P4_USABLE_CERTIFICATE_PROMOTED"])
+        self.assertFalse(self.d["P4_COMPLETE_WORD_DISSIPATION_ESTABLISHED_HERE"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ou3_p1_p5_certificate_numbers.py
+++ b/tools/ou3_p1_p5_certificate_numbers.py
@@ -1,0 +1,499 @@
+#!/usr/bin/env python3
+"""Consolidated P1--P5 certificate numbers and usability verdicts for OU-III.
+
+``docs/ou-iii-certificate-usability-envelope.md`` states what *usable* means for
+each stage of the deployed OU-III stability proof.  Until now the numbers behind
+that prose lived in eight separate producers, so answering "what are the current
+certificate numbers, and are they usable?" meant running them one at a time and
+reading fields out of eight JSON files.
+
+This producer recomputes the stages and emits one report: per stage, the
+headline physical numbers, the explicit usability checks with their thresholds,
+and a per-stage verdict.  It does **not** trust an upstream ``PASS`` field as a
+usability statement -- every threshold is re-applied here against the recomputed
+number, in the spirit of the final composition gate.
+
+Two stage obligations are open by construction and are reported as such:
+the complete-word P4 full-state dissipation and the P5 finite capture into the
+inner stochastic localization level.  A stage whose geometry is usable but whose
+theorem obligation is open is reported as ``USABLE_GEOMETRY_OPEN_OBLIGATION``,
+never as complete.
+
+The slowest inputs -- the rigorous complete-word translation block and the
+signed first-accelerometer sector -- may be supplied as pre-computed JSON so
+that a report can be produced without re-running them.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+import ou3_p4_first_accel_sector_budget as BUDGET
+import ou3_p4_nonlinear_word_certificate as WORD
+import ou3_p4_operation_matched_sector_certificate as SECTOR
+import ou3_p4_p5_route_ceiling_certificate as CEILING
+import ou3_p4_source_path_reachability as P2
+import ou3_p5_outer_sector_capture_certificate as P5
+import ou3_startup_stability_certificate as P1
+
+REPO = Path(__file__).resolve().parents[1]
+DEFAULT_DOMAIN = REPO / "tools" / "ou3_proof_operating_domain.json"
+SCHEMA = 1
+
+# Minimum usability contracts.  These mirror the "Quantitative outer target"
+# and "Non-regression rules" sections of the usability envelope note.  CI
+# rejects regression below them; a stronger proof may raise them.
+MIN_NORMAL_HANDOFF_CAYLEY = 0.20
+MIN_TIMEOUT_HANDOFF_CAYLEY = 0.50
+MIN_HANDOFF_POSITION_ERROR_M = 20.0
+MIN_HANDOFF_VELOCITY_ERROR_MPS = 5.0
+MIN_HANDOFF_AW_ERROR_MPS2 = 2.9
+MIN_SECTOR_ANGLE_RAD = 0.80
+MIN_SECTOR_MONOTONICITY = 0.80
+MAX_SECTOR_ETA_RATIO = 0.25
+MIN_P5_ENTRANCE_ANGLE_DEG = 45.0
+MICROSCOPIC_CAYLEY_THRESHOLD = 1.0e-6
+
+
+def _check(name: str, value, threshold, ok: bool, note: str = "") -> dict:
+    row = {"check": name, "value": value, "threshold": threshold, "pass": bool(ok)}
+    if note:
+        row["note"] = note
+    return row
+
+
+def _verdict(checks: list[dict], open_obligation: str | None) -> str:
+    if not all(c["pass"] for c in checks):
+        return "NOT_USABLE"
+    return "USABLE_GEOMETRY_OPEN_OBLIGATION" if open_obligation else "USABLE"
+
+
+def _p1_stage(d: dict) -> dict:
+    normal = float(d["P1_normal_gauged_cayley_norm_upper"])
+    timeout = float(d["P1_timeout_gauged_cayley_norm_upper"])
+    box = d["startup"]["operating_domain"]["physical_handoff_coordinate_bounds"]
+    checks = [
+        _check("startup certificate validates", d["startup_validation_pass"], True,
+               d["startup_validation_pass"] is True),
+        _check("normal gauged handoff Cayley norm", normal, MIN_NORMAL_HANDOFF_CAYLEY,
+               normal >= MIN_NORMAL_HANDOFF_CAYLEY),
+        _check("timeout gauged handoff Cayley norm", timeout, MIN_TIMEOUT_HANDOFF_CAYLEY,
+               timeout >= MIN_TIMEOUT_HANDOFF_CAYLEY),
+        _check("handoff position error bound (m)",
+               box["position_error_norm_upper_m"], MIN_HANDOFF_POSITION_ERROR_M,
+               float(box["position_error_norm_upper_m"]) >= MIN_HANDOFF_POSITION_ERROR_M),
+        _check("handoff velocity error bound (m/s)",
+               box["velocity_error_norm_upper_mps"], MIN_HANDOFF_VELOCITY_ERROR_MPS,
+               float(box["velocity_error_norm_upper_mps"]) >= MIN_HANDOFF_VELOCITY_ERROR_MPS),
+        _check("handoff latent-acceleration error bound (m/s^2)",
+               box["latent_acceleration_error_norm_upper_mps2"], MIN_HANDOFF_AW_ERROR_MPS2,
+               float(box["latent_acceleration_error_norm_upper_mps2"]) >= MIN_HANDOFF_AW_ERROR_MPS2),
+        _check("handoff family is not microscopic", min(normal, timeout),
+               f"> {MICROSCOPIC_CAYLEY_THRESHOLD}",
+               min(normal, timeout) > MICROSCOPIC_CAYLEY_THRESHOLD),
+    ]
+    return {
+        "stage": "P1",
+        "title": "startup / reset / Live handoff",
+        "status": "PASS" if d["startup_validation_pass"] else "NOT_ESTABLISHED",
+        "headline": {
+            "normal_gauged_handoff_cayley_norm_upper": normal,
+            "timeout_gauged_handoff_cayley_norm_upper": timeout,
+            "ungauged_timeout_route": "gravity-direction yaw quotient",
+            "physical_handoff_coordinate_bounds": box,
+            "declared_startup_aw_error_fraction_g":
+                d["startup"]["operating_domain"]["latent_acceleration_error_fraction_g"],
+        },
+        "usability_checks": checks,
+        "open_obligation": None,
+        "verdict": _verdict(checks, None),
+    }
+
+
+def _p2_stage(d: dict) -> dict:
+    p2 = d["P2"]
+    states = int(p2["partition"]["states"])
+    recurrent = int(p2["recurrent_states"])
+    checks = [
+        _check("source-path certificate", p2["P2_SOURCE_PATH_CERTIFICATE"], "PASS",
+               p2["P2_SOURCE_PATH_CERTIFICATE"] == "PASS"),
+        _check("source-only language", p2["source_only"], True, p2["source_only"] is True),
+        _check("no replay used", p2["trajectory_replay_used"], False,
+               p2["trajectory_replay_used"] is False),
+        _check("partition states", states, "> 0", states > 0),
+        _check("every state recurrent", recurrent, states, recurrent == states),
+        _check("raw tuner sigma subfloor states retained",
+               p2["raw_tuner_sigma_subfloor_states_included"], True,
+               p2["raw_tuner_sigma_subfloor_states_included"] is True),
+        _check("R_S target uses full deployed clamp",
+               p2["RS_target_full_deployed_clamp_overapprox"], True,
+               p2["RS_target_full_deployed_clamp_overapprox"] is True),
+    ]
+    return {
+        "stage": "P2",
+        "title": "complete source-word language / path graph",
+        "status": p2["P2_SOURCE_PATH_CERTIFICATE"],
+        "headline": {
+            "partition_states": states,
+            "transition_edges": p2["transition_edges"],
+            "strongly_connected_components": p2["strongly_connected_components"],
+            "recurrent_states": recurrent,
+            "filter_sigma_floor_mps2": p2["filter_sigma_floor_mps2"],
+            "raw_tuner_sigma_partition_lower": p2["raw_tuner_sigma_partition_lower"],
+        },
+        "usability_checks": checks,
+        "open_obligation": None,
+        "verdict": _verdict(checks, None),
+    }
+
+
+def _p3_stage(d: dict) -> dict:
+    word = d["word"]
+    modes = {m: word["modes"][m] for m in ("H", "A") if m in word.get("modes", {})}
+    deltas = {m: float(v["P3_word_endpoint_delta_lower"]) for m, v in modes.items()}
+    prefix = {m: float(v["P3_homogeneous_prefix_information_gain_upper"])
+              for m, v in modes.items()}
+    checks = [
+        _check("H endpoint information margin", deltas.get("H"), "> 0",
+               deltas.get("H", 0.0) > 0.0),
+        _check("A endpoint information margin", deltas.get("A"), "> 0",
+               deltas.get("A", 0.0) > 0.0),
+        _check("H prefix information gain bound", prefix.get("H"), "<= 1",
+               prefix.get("H", math.inf) <= 1.0),
+        _check("A prefix information gain bound", prefix.get("A"), "<= 1",
+               prefix.get("A", math.inf) <= 1.0),
+    ]
+    return {
+        "stage": "P3",
+        "title": "validated H/A linear information-word certificate",
+        "status": "PASS" if all(c["pass"] for c in checks) else "NOT_ESTABLISHED",
+        "headline": {
+            "endpoint_information_margin_lower": deltas,
+            "prefix_information_gain_upper": prefix,
+        },
+        "interpretation": (
+            "the endpoint margin is a relative Riccati/noise comparison constant;"
+            " it is not a nonlinear state radius and must not be advertised as one"
+        ),
+        "usability_checks": checks,
+        "open_obligation": None,
+        "verdict": _verdict(checks, None),
+    }
+
+
+def _p4_stage(d: dict) -> dict:
+    s = d["P4_sector"]
+    ceiling = d["route_ceiling"]
+    budget = d["P4_first_accel_budget"]
+    angle = float(s["design_full_attitude_angle_rad"])
+    q = float(s["design_cayley_norm_upper"])
+    mono = float(s["exact_vector_strong_monotonicity_factor_lower"])
+    eta = float(s["exact_eta_to_rotational_residual_information_ratio_upper"])
+    checks = [
+        _check("finite-angle sector certificate",
+               s["P4_OPERATION_MATCHED_FINITE_ANGLE_SECTOR_CERTIFICATE"], "PASS",
+               s["P4_OPERATION_MATCHED_FINITE_ANGLE_SECTOR_CERTIFICATE"] == "PASS"),
+        _check("design sector angle (rad)", angle, MIN_SECTOR_ANGLE_RAD,
+               angle >= MIN_SECTOR_ANGLE_RAD),
+        _check("Cayley chart stays below one", q, "< 1", q < 1.0),
+        _check("exact vector strong monotonicity", mono, MIN_SECTOR_MONOTONICITY,
+               mono > MIN_SECTOR_MONOTONICITY),
+        _check("exact eta / residual information ratio", eta, MAX_SECTOR_ETA_RATIO,
+               eta < MAX_SECTOR_ETA_RATIO),
+        _check("normal P1 handoff inside sector",
+               s["P1_overlap"]["normal_gauged_inside_sector"], True,
+               s["P1_overlap"]["normal_gauged_inside_sector"] is True),
+        _check("timeout P1 handoff inside sector",
+               s["P1_overlap"]["timeout_gauged_inside_sector"], True,
+               s["P1_overlap"]["timeout_gauged_inside_sector"] is True),
+    ]
+    retired = {m: {
+        "certified_attitude_capture_radius_now":
+            ceiling["modes"][m]["certified_attitude_capture_radius_now"],
+        "route_ceiling_at_shipping_prefix_factor":
+            ceiling["modes"][m]["route_ceiling_at_shipping_prefix_factor"],
+        "route_can_reach_P1_handoff":
+            ceiling["modes"][m]["route_can_reach_P1_handoff"],
+    } for m in ceiling["modes"]}
+    head = {
+        "design_full_attitude_angle_rad": angle,
+        "design_full_attitude_angle_deg": s["design_full_attitude_angle_deg"],
+        "design_cayley_norm_upper": q,
+        "exact_vector_strong_monotonicity_factor_lower": mono,
+        "exact_eta_to_rotational_residual_information_ratio_upper": eta,
+        "retired_uniform_transport_route": retired,
+        "first_accelerometer_sector_budget": {
+            "declared_aw_over_lowest_specific_force":
+                budget["declared_aw_over_lowest_specific_force"],
+            "ladder": [{
+                "angle_deg": r["angle_deg"],
+                "family": r["ladder_family"],
+                "budget_upper_rad": r["sector_invariance_correction_budget_upper_rad"],
+                "nuisance_upper_rad": r["nuisance_correction_norm_upper_rad"],
+                "nuisance_over_budget_ratio": r["nuisance_over_budget_ratio"],
+            } for r in budget["ladder_rows"]],
+            "smallest_probe_angle_deg": budget["smallest_probe_angle_deg"],
+            "smallest_probe_nuisance_over_budget_ratio":
+                budget["smallest_probe_nuisance_over_budget_ratio"],
+            "shrinking_the_candidate_angle_alone_can_close_the_budget":
+                budget["shrinking_the_candidate_angle_alone_can_close_the_budget"],
+        },
+    }
+    if d.get("first_accel") is not None:
+        fa = d["first_accel"]
+        head["signed_first_accelerometer_30deg"] = {
+            "status": fa.get("P4_30DEG_SIGNED_FIRST_ACCEL_SECTOR_CERTIFICATE"),
+            "family_completely_evaluated":
+                fa.get("first_accelerometer_family_completely_evaluated"),
+            "evaluated_children": fa.get("evaluated_children"),
+            "max_correction_norm_upper_rad": fa.get("max_correction_norm_upper_rad"),
+            "max_post_update_q_upper":
+                fa.get("max_accepted_or_rejected_post_update_q_upper"),
+            "minimum_composition_denominator_lower":
+                fa.get("minimum_signed_composition_denominator_lower"),
+        }
+    if d.get("translation") is not None:
+        tr = d["translation"]
+        head["complete_word_translation_block"] = {
+            "status": tr.get("P4_COMPLETE_TRANSLATION_WORST_CELL_STATUS"),
+            "modes": {m: {
+                "complete_word_translation_margin_lower":
+                    tr["modes"][m]["complete_word_translation_margin_lower"],
+                "margin_widening_factor_lower":
+                    tr["modes"][m]["margin_widening_factor_lower"],
+            } for m in tr.get("modes", {})},
+        }
+    return {
+        "stage": "P4",
+        "title": "nonlinear finite-angle sector and complete-word dissipation",
+        "status": s["P4_OPERATION_MATCHED_FINITE_ANGLE_SECTOR_CERTIFICATE"],
+        "headline": head,
+        "usability_checks": checks,
+        "open_obligation": (
+            "complete 18/21-state source-correlated word dissipation is not established;"
+            " the first deployed accelerometer update still reports a nuisance correction"
+            " above the sector-invariance budget at every candidate angle"
+        ),
+        "verdict": _verdict(checks, "complete-word dissipation"),
+    }
+
+
+def _p5_stage(d: dict) -> dict:
+    p5 = d["P5_outer"]
+    e = p5["declared_P5_entrance"]
+    checks = [
+        _check("outer capture certificate", p5["P5_OUTER_SECTOR_CAPTURE_CERTIFICATE"],
+               "PASS", p5["P5_OUTER_SECTOR_CAPTURE_CERTIFICATE"] == "PASS"),
+        _check("declared entrance full-attitude angle (deg)",
+               e["gauged_full_attitude_angle_upper_deg"], MIN_P5_ENTRANCE_ANGLE_DEG,
+               float(e["gauged_full_attitude_angle_upper_deg"]) >= MIN_P5_ENTRANCE_ANGLE_DEG),
+        _check("all source handoff branches enter the outer sector",
+               p5["all_source_handoff_branches_enter_outer_sector"], True,
+               p5["all_source_handoff_branches_enter_outer_sector"] is True),
+        _check("outer words needed from handoff", p5["N_outer_words"], 0,
+               p5["N_outer_words"] == 0),
+        _check("P1 handoff box not replaced",
+               p5["P1_conservative_handoff_box_replaced"], False,
+               p5["P1_conservative_handoff_box_replaced"] is False),
+        _check("ungauged inclusion uses the upper cosine enclosure",
+               p5["upper_cosine_enclosure_used_for_ungauged_inclusion"], True,
+               p5["upper_cosine_enclosure_used_for_ungauged_inclusion"] is True),
+        _check("no full heading radius assigned to the ungauged branch",
+               p5["branches"]["timeout_ungauged"]["full_heading_radius_assigned"], False,
+               p5["branches"]["timeout_ungauged"]["full_heading_radius_assigned"] is False),
+        _check("legacy microscopic inner seed not used as capture target",
+               p5["legacy_microscopic_inner_seed_used_as_outer_capture_target"], False,
+               p5["legacy_microscopic_inner_seed_used_as_outer_capture_target"] is False),
+    ]
+    return {
+        "stage": "P5",
+        "title": "startup entrance into the outer sector and finite inner capture",
+        "status": p5["P5_OUTER_SECTOR_CAPTURE_CERTIFICATE"],
+        "headline": {
+            "declared_entrance_full_attitude_angle_deg":
+                e["gauged_full_attitude_angle_upper_deg"],
+            "declared_entrance_cayley_norm_upper":
+                e["attitude_geometry"]["cayley_norm_upper"],
+            "entrance_position_component_abs_error_upper_Hs_factor":
+                e["position_component_abs_error_upper_Hs_factor"],
+            "entrance_position_norm_upper_Hs_factor":
+                e["position_norm_upper_Hs_factor"],
+            "outer_sector_angle_deg": p5["outer_sector_angle_deg"],
+            "N_outer_words": p5["N_outer_words"],
+            "N_inner_words": None,
+            "branch_handoff_cayley_norms": {
+                b: p5["branches"][b].get("P1_handoff_cayley_norm_upper")
+                for b in p5["branches"]
+            },
+        },
+        "usability_checks": checks,
+        "open_obligation": (
+            "finite capture from the outer sector to the inner stochastic localization"
+            " level is downstream of the open P4 complete-word dissipation; N_inner"
+            " remains unset"
+        ),
+        "verdict": _verdict(checks, "finite inner capture"),
+    }
+
+
+def build(domain_path: Path = DEFAULT_DOMAIN, *, translation: dict | None = None,
+          first_accel: dict | None = None, source_pieces: int = 2,
+          alignment_pieces: int = 16, force_magnitude_pieces: int = 4) -> dict:
+    path = Path(domain_path).resolve()
+
+    startup = P1.build(path)
+    startup_failures = P1.validate(startup)
+    sector = SECTOR.build(path)
+    sector_failures = SECTOR.validate(sector)
+    p2 = P2.build(path)
+    p2_failures = P2.validate(p2)
+    word = WORD.build(path)
+    word_failures = WORD.validate(word)
+    p5 = P5.build(path)
+    p5_failures = P5.validate(p5)
+    ceiling = CEILING.build(path)
+    ceiling_failures = CEILING.validate(ceiling)
+    budget = BUDGET.build(path, source_pieces=source_pieces,
+                          alignment_pieces=alignment_pieces,
+                          force_magnitude_pieces=force_magnitude_pieces)
+    budget_failures = BUDGET.validate(budget)
+
+    overlap = sector["P1_overlap"]
+    ctx = {
+        "startup": startup,
+        "startup_validation_pass": not startup_failures,
+        "P1_normal_gauged_cayley_norm_upper": overlap["normal_gauged_cayley_norm_upper"],
+        "P1_timeout_gauged_cayley_norm_upper": overlap["timeout_gauged_cayley_norm_upper"],
+        "P2": p2,
+        "word": word,
+        "P4_sector": sector,
+        "P4_first_accel_budget": budget,
+        "P5_outer": p5,
+        "route_ceiling": ceiling,
+        "translation": translation,
+        "first_accel": first_accel,
+    }
+
+    stages = [_p1_stage(ctx), _p2_stage(ctx), _p3_stage(ctx),
+              _p4_stage(ctx), _p5_stage(ctx)]
+
+    failures: list[str] = []
+    failures += [f"P1 startup: {x}" for x in startup_failures]
+    failures += [f"P2 source path: {x}" for x in p2_failures]
+    failures += [f"P3/P4 word: {x}" for x in word_failures]
+    failures += [f"P4 sector: {x}" for x in sector_failures]
+    failures += [f"P4 first-accel budget: {x}" for x in budget_failures]
+    failures += [f"P5 outer: {x}" for x in p5_failures]
+    failures += [f"route ceiling: {x}" for x in ceiling_failures]
+
+    not_usable = [s["stage"] for s in stages if s["verdict"] == "NOT_USABLE"]
+    open_obligations = {s["stage"]: s["open_obligation"]
+                        for s in stages if s["open_obligation"]}
+
+    return {
+        "schema": SCHEMA,
+        "qualification": "OU3_P1_P5_CERTIFICATE_NUMBERS_AND_USABILITY",
+        "source_generated_not_trajectory_fit": True,
+        "source_replay_used": False,
+        "filter_changed": False,
+        "upstream_pass_fields_trusted_as_usability": False,
+        "minimum_usability_contracts": {
+            "normal_handoff_cayley_norm_lower": MIN_NORMAL_HANDOFF_CAYLEY,
+            "timeout_handoff_cayley_norm_lower": MIN_TIMEOUT_HANDOFF_CAYLEY,
+            "handoff_position_error_lower_m": MIN_HANDOFF_POSITION_ERROR_M,
+            "handoff_velocity_error_lower_mps": MIN_HANDOFF_VELOCITY_ERROR_MPS,
+            "handoff_latent_acceleration_error_lower_mps2": MIN_HANDOFF_AW_ERROR_MPS2,
+            "sector_angle_lower_rad": MIN_SECTOR_ANGLE_RAD,
+            "sector_strong_monotonicity_lower": MIN_SECTOR_MONOTONICITY,
+            "sector_eta_information_ratio_upper": MAX_SECTOR_ETA_RATIO,
+            "P5_entrance_angle_lower_deg": MIN_P5_ENTRANCE_ANGLE_DEG,
+            "microscopic_cayley_threshold": MICROSCOPIC_CAYLEY_THRESHOLD,
+        },
+        "stages": stages,
+        "stages_not_usable": not_usable,
+        "open_theorem_obligations": open_obligations,
+        "all_stage_geometries_usable": not not_usable,
+        "P1_P5_COMPLETE_STABILITY_PROOF_ESTABLISHED": not not_usable and not open_obligations,
+        "translation_block_supplied": translation is not None,
+        "signed_first_accelerometer_supplied": first_accel is not None,
+        "next_obligation": (
+            "close the complete 18/21-state P4 word dissipation with an operation-matched"
+            " information decrease and a directional block margin, then derive the finite"
+            " P5 inner capture word count from the declared 45 deg entrance"
+        ),
+        "failures": failures,
+    }
+
+
+def validate(d: dict) -> list[str]:
+    f = list(d.get("failures", []))
+    if d.get("schema") != SCHEMA:
+        f.append("schema mismatch")
+    for k in ("source_generated_not_trajectory_fit",):
+        if d.get(k) is not True:
+            f.append(f"{k} is not true")
+    for k in ("source_replay_used", "filter_changed",
+              "upstream_pass_fields_trusted_as_usability"):
+        if d.get(k) is not False:
+            f.append(f"{k} is not false")
+    stages = d.get("stages", [])
+    if [s["stage"] for s in stages] != ["P1", "P2", "P3", "P4", "P5"]:
+        f.append("stage list is not P1..P5")
+    for s in stages:
+        if s["verdict"] not in ("USABLE", "USABLE_GEOMETRY_OPEN_OBLIGATION", "NOT_USABLE"):
+            f.append(f"{s['stage']}: unknown verdict")
+        for c in s.get("usability_checks", []):
+            if not c["pass"]:
+                f.append(f"{s['stage']}: usability check failed: {c['check']}")
+    if d.get("P1_P5_COMPLETE_STABILITY_PROOF_ESTABLISHED") is True and d.get(
+            "open_theorem_obligations"):
+        f.append("complete proof claimed with open obligations")
+    return list(dict.fromkeys(f))
+
+
+def _load(p: Path | None) -> dict | None:
+    if p is None:
+        return None
+    return json.loads(Path(p).read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--domain", type=Path, default=DEFAULT_DOMAIN)
+    ap.add_argument("--translation", type=Path, default=None,
+                    help="pre-computed ou3_p4_translation_full_word_rigorous output")
+    ap.add_argument("--first-accel", type=Path, default=None,
+                    help="pre-computed ou3_p4_30deg_signed_first_accel_sector_v3 output")
+    ap.add_argument("--source-pieces", type=int, default=2)
+    ap.add_argument("--alignment-pieces", type=int, default=16)
+    ap.add_argument("--force-magnitude-pieces", type=int, default=4)
+    ap.add_argument("--output", type=Path, required=True)
+    a = ap.parse_args()
+    d = build(a.domain.resolve(), translation=_load(a.translation),
+              first_accel=_load(a.first_accel), source_pieces=a.source_pieces,
+              alignment_pieces=a.alignment_pieces,
+              force_magnitude_pieces=a.force_magnitude_pieces)
+    vf = validate(d)
+    d["validation_pass"] = not vf
+    d["validation_failures"] = vf
+    a.output.parent.mkdir(parents=True, exist_ok=True)
+    a.output.write_text(json.dumps(d, indent=2, sort_keys=True), encoding="utf-8")
+    print(json.dumps({
+        "stages": [{
+            "stage": s["stage"],
+            "status": s["status"],
+            "verdict": s["verdict"],
+            "open_obligation": s["open_obligation"],
+        } for s in d["stages"]],
+        "all_stage_geometries_usable": d["all_stage_geometries_usable"],
+        "P1_P5_COMPLETE_STABILITY_PROOF_ESTABLISHED":
+            d["P1_P5_COMPLETE_STABILITY_PROOF_ESTABLISHED"],
+        "validation_failures": vf,
+    }, indent=2, sort_keys=True))
+    return 0 if not vf else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ou3_p4_30deg_signed_first_accel_sector_v3.py
+++ b/tools/ou3_p4_30deg_signed_first_accel_sector_v3.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""V3 signed 30 deg first-accelerometer sector with shared-force-magnitude gain.
+
+V2 preserved the shared ``X/(X+lambda)`` dependency inside the ``KH`` ratios but
+still obtained the accelerometer gain rows ``K`` from an ordinary interval
+quotient in which the specific-force magnitude ``m`` appears in the numerator
+and in the denominator.  On the audited live force cells that costs up to a
+factor of ``1.78``, and it is what drove the first-accelerometer correction
+family past the ``3`` rad monotone Cayley chart: V2 aborted after 13 of 40960
+children with ``max_d = 2.6482`` rad and a composition denominator that could
+reach zero.
+
+This stage swaps in ``ou3_p4_shared_force_gain``.  Nothing else changes -- same
+filter, same declared 30 deg candidate, same 0.3 g startup ``a_w`` envelope,
+same source/alignment/force/tangent children, same signed composition -- and
+the resulting bounds are pointwise no larger than V2's.  With the slack removed
+the complete 30 deg family becomes evaluable for the first time: every child
+composes, the correction family stays inside the monotone Cayley chart, and the
+certificate reports a finite worst post-update norm instead of an abort.
+
+That worst norm is still far outside the operation-matched outer sector, so the
+certificate remains ``NOT_ESTABLISHED``.  The residual gap is reported here as
+a measured quantity rather than as a broken enclosure, and
+``ou3_p4_first_accel_nuisance_floor.py`` accounts for where it comes from.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import ou3_p4_30deg_signed_first_accel_sector_v2 as V2
+import ou3_p4_candidate_first_accel_range_v3 as RANGE
+import ou3_p4_shared_force_gain as SHARED
+
+DEFAULT_DOMAIN = V2.DEFAULT_DOMAIN
+SCHEMA = 3
+
+
+def build(domain_path: Path = DEFAULT_DOMAIN, *, source_pieces: int = 2,
+          alignment_pieces: int = 16, force_magnitude_pieces: int = 4,
+          tangent_pieces: int = 32) -> dict:
+    old = RANGE._tangent_structured_gain_bounds
+    try:
+        RANGE._tangent_structured_gain_bounds = SHARED.shared_force_structured_gain_bounds
+        out = dict(V2.build(
+            Path(domain_path).resolve(),
+            source_pieces=source_pieces,
+            alignment_pieces=alignment_pieces,
+            force_magnitude_pieces=force_magnitude_pieces,
+            tangent_pieces=tangent_pieces,
+        ))
+    finally:
+        RANGE._tangent_structured_gain_bounds = old
+
+    out["schema"] = SCHEMA
+    out["qualification"] = "OU3_P4_30DEG_SIGNED_FIRST_ACCEL_SHARED_FORCE_GAIN"
+    out["shared_force_magnitude_dependency_preserved"] = True
+    out["naive_interval_force_magnitude_gain_used"] = False
+    out["first_accelerometer_family_completely_evaluated"] = out["first_failure"] is None
+    return out
+
+
+def validate(d: dict) -> list[str]:
+    base = dict(d)
+    base["schema"] = V2.SCHEMA
+    failures = V2.validate(base)
+    if d.get("schema") != SCHEMA:
+        failures.append("schema mismatch")
+    if d.get("shared_force_magnitude_dependency_preserved") is not True:
+        failures.append("shared force-magnitude dependency is not preserved")
+    if d.get("naive_interval_force_magnitude_gain_used") is not False:
+        failures.append("naive interval force-magnitude gain is still active")
+    if d.get("first_accelerometer_family_completely_evaluated") is not True:
+        failures.append("shared-force gain did not make the 30deg family evaluable")
+    return list(dict.fromkeys(failures))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--domain", type=Path, default=DEFAULT_DOMAIN)
+    ap.add_argument("--source-pieces", type=int, default=2)
+    ap.add_argument("--alignment-pieces", type=int, default=16)
+    ap.add_argument("--force-magnitude-pieces", type=int, default=4)
+    ap.add_argument("--tangent-pieces", type=int, default=32)
+    ap.add_argument("--output", type=Path, required=True)
+    a = ap.parse_args()
+    d = build(a.domain.resolve(), source_pieces=a.source_pieces,
+              alignment_pieces=a.alignment_pieces,
+              force_magnitude_pieces=a.force_magnitude_pieces,
+              tangent_pieces=a.tangent_pieces)
+    vf = validate(d)
+    d["validation_pass"] = not vf
+    d["validation_failures"] = vf
+    a.output.parent.mkdir(parents=True, exist_ok=True)
+    a.output.write_text(json.dumps(d, indent=2, sort_keys=True), encoding="utf-8")
+    print(json.dumps({
+        "status": d["P4_30DEG_SIGNED_FIRST_ACCEL_SECTOR_CERTIFICATE"],
+        "evaluable": d["first_accelerometer_family_completely_evaluated"],
+        "evaluated": d["evaluated_children"],
+        "q_pre": d["post_prediction_q_upper"],
+        "q_outer": d["operation_matched_outer_q_upper"],
+        "max_d": d["max_correction_norm_upper_rad"],
+        "max_qplus": d["max_accepted_or_rejected_post_update_q_upper"],
+        "min_den": d["minimum_signed_composition_denominator_lower"],
+        "validation_failures": vf,
+    }, indent=2, sort_keys=True))
+    return 0 if not vf else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ou3_p4_first_accel_aw_sigma_consistency.py
+++ b/tools/ou3_p4_first_accel_aw_sigma_consistency.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""Joint force pairing and the a_w/sigma consistency constant for P4's first accelerometer.
+
+``ou3_p4_first_accel_sector_budget`` shows that the nuisance part of the first
+deployed accelerometer correction exceeds the sector-invariance budget at every
+candidate angle, and that shrinking the candidate cannot close it.  This
+producer isolates the two remaining reasons and reports what each is worth.
+
+**Unconditional part -- joint force pairing.**  The nuisance term is
+``||K_theta|| * (a_w error + eta(q) |f| + b_a)``.  The gain falls roughly like
+``1/|f|`` while the finite-angle force remainder grows like ``|f|``, so bounding
+the two factors separately over one force cell charges the largest gain against
+the largest force.  Maximising the product over subdivided magnitudes inside the
+same cell is an exact dependency-preserving tightening: no domain, filter or
+candidate changes, and the result is never looser.
+
+**Conditional part -- the a_w/sigma pairing.**  The a_w covariance seeding the
+gain is the tuner state, ``P_aw = sigma_applied^2`` with
+``sigma_applied`` in the deployed safety range ``[0.05, 6.0] m/s^2``.  The a_w
+*error* is the separately declared ``0.3 g`` startup envelope.  The two are
+currently free to be chosen independently, so the worst cell pairs a tuner that
+believes the sea is flat (``sigma_applied = 0.05``, hence the largest gain) with
+a ``2.94 m/s^2`` latent-acceleration error -- a 60-sigma pairing.
+
+The shipping tuner does couple them: ``sigma_target_ = min(sigma_wave *
+sigma_coeff_, max_sigma_a_)`` with ``sigma_wave`` the estimated band-limited
+wave-acceleration RMS, and ``sigma_applied`` an EMA toward that target.  But no
+*declared domain statement* currently bounds the latent-acceleration error in
+terms of the tuner state, and the EMA transient means one cannot be inferred
+from the update law alone.
+
+So this producer does not assume a coupling.  It **measures the constant a
+coupling would have to supply**: the largest ``c`` such that adding
+
+    ||delta a_w|| <= c * sigma_applied
+
+to the declared domain brings the first-accelerometer nuisance term inside the
+sector-invariance budget, reported per candidate angle.  ``c = inf`` reproduces
+today's unconstrained pairing.  The result is explicitly conditional and
+promotes nothing: it converts an open search into one declared-domain question
+with a number attached.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+from ou3_interval import Interval
+import ou3_p4_first_accel_sector_budget as BUDGET
+import ou3_p4_candidate_aw_capture_budget as AWB
+import ou3_p4_operation_matched_sector_certificate as SECTOR
+import ou3_p4_p5_entrance_search_domain as ENTRANCE
+import ou3_p4_shared_force_gain as SHARED
+import ou3_p5_effective_vector_input as VEFF
+import ou3_p5_first_accel_rotation_gauge as RG
+import ou3_p5_first_accel_rotation_gauge_v3 as RG3
+import ou3_p5_first_accel_structured_gain as SG
+import ou3_p5_full_h_prefix_cells as FULL
+import ou3_p5_full_h_prefix_cells_v3 as FULL3
+import ou3_vector_uco_certificate as VECTOR
+
+REPO = Path(__file__).resolve().parents[1]
+DEFAULT_DOMAIN = REPO / "tools" / "ou3_proof_operating_domain.json"
+SCHEMA = 1
+LADDER_DEG = (15.0, 20.0, 25.0, 30.0, 35.0, 40.0, 45.0)
+CONSISTENCY_SEARCH_UPPER = 1024.0
+CONSISTENCY_BISECTION_STEPS = 50
+
+
+def up(x: float) -> float:
+    return math.nextafter(float(x), math.inf)
+
+
+def down(x: float) -> float:
+    return math.nextafter(float(x), -math.inf)
+
+
+def _force_subcells(m: Interval, pieces: int) -> list[Interval]:
+    """Geometric subdivision of one audited force cell, endpoints preserved."""
+    if pieces < 1:
+        raise ValueError("positive force subdivision required")
+    if pieces == 1:
+        return [m]
+    return RG._geom_ranges(m.lo, m.hi, pieces)
+
+
+def _gain_table(path: Path, domain: dict, *, source_pieces: int,
+                alignment_pieces: int, force_magnitude_pieces: int,
+                force_subpieces: int) -> dict:
+    """Angle-independent gain rows, one per subdivided force magnitude."""
+    RG3._install_backend(path, source_pieces)
+    FULL3._install_backend()
+    h = float(FULL._source_cell()["dt_s"])
+    tilt, yaw, eps = RG._attitude_covariance_epsilon(path, h)
+    vc = VECTOR.build()["configured_measurement_bounds"]
+    racc_var = FULL._R_diag(float(vc["acc_measurement_std_mps2"]))[0][0]
+    startup = domain["startup"]
+    handoff = startup["physical_handoff_coordinate_bounds"]
+    aw0 = float(handoff["latent_acceleration_error_norm_upper_mps2"])
+    ba = float(handoff["accelerometer_bias_error_norm_upper_mps2"])
+    pnorm = AWB._p5_position_norm_upper(domain)
+    live = domain["normal_live"]
+    force_lower = float(live["specific_force_norm_lower_mps2"])
+    force_upper = float(live["specific_force_norm_upper_mps2"])
+    force_cells = RG._geom_ranges(force_lower, force_upper, force_magnitude_pieces)
+    xcells = SG._linear_cells(alignment_pieces)
+
+    rows = []
+    sigma_lo = math.inf
+    sigma_hi = 0.0
+    for si, (src, phase) in enumerate(RG._source_phase_children(source_pieces)):
+        sigma = src["sigma_aw_mps2"]
+        sigma_lo = min(sigma_lo, sigma.lo)
+        sigma_hi = max(sigma_hi, sigma.hi)
+        P0 = FULL._initial_covariance(src, path)
+        Fm, Q, _ = FULL._transition_and_Q(src, domain)
+        Pp = FULL._psd_tighten(FULL.matrix_add(
+            FULL.matrix_mul(FULL.matrix_mul(Fm, P0), FULL.matrix_transpose(Fm)), Q))
+        _s, _a, paw_pred = RG._scalar_axis_structure(Pp)
+        paw = RG._due_paw_and_error_norm(Pp, src, 0.0, 0.0)[0] if phase == "due" else paw_pred
+        intercept, slope, _d = AWB._s_phase_affine_aw_bound(src, phase, Pp, domain, pnorm)
+        aw = up(intercept + up(slope * aw0))
+        for xi, x in enumerate(xcells):
+            for mi, m in enumerate(force_cells):
+                for mj, ms in enumerate(_force_subcells(m, force_subpieces)):
+                    k, _kh, _gd = SHARED.shared_force_structured_gain_bounds(
+                        tilt=tilt, yaw=yaw, eps=eps, x=x, m=ms,
+                        paw=paw, racc_var=racc_var)
+                    rows.append({
+                        "source_phase_cell": si, "pseudo_phase": phase,
+                        "alignment_cell": xi, "force_cell": mi, "force_subcell": mj,
+                        "force_magnitude_mps2": ms.as_list(),
+                        "force_upper_mps2": ms.hi,
+                        "alignment_x": x.as_list(),
+                        "tuner_sigma_aw_mps2": sigma.as_list(),
+                        "tuner_sigma_aw_upper_mps2": sigma.hi,
+                        "aw_after_prefix_upper_mps2": aw,
+                        "Ktheta_norm_upper": k,
+                    })
+    return {
+        "rows": rows,
+        "accel_bias_error_norm_upper_mps2": ba,
+        "declared_startup_aw_error_norm_upper_mps2": aw0,
+        "specific_force_norm_lower_mps2": force_lower,
+        "specific_force_norm_upper_mps2": force_upper,
+        "tuner_sigma_aw_lower_mps2": sigma_lo,
+        "tuner_sigma_aw_upper_mps2": sigma_hi,
+        "prediction_step_s": h,
+    }
+
+
+def _worst_nuisance(table: dict, eta_per_vector: float, c: float) -> tuple[float, dict]:
+    """Worst nuisance correction over all rows for a consistency constant ``c``."""
+    ba = table["accel_bias_error_norm_upper_mps2"]
+    worst = 0.0
+    witness = None
+    for r in table["rows"]:
+        aw = r["aw_after_prefix_upper_mps2"]
+        if math.isfinite(c):
+            aw = min(aw, up(c * r["tuner_sigma_aw_upper_mps2"]))
+        eta_force = up(eta_per_vector * r["force_upper_mps2"])
+        rho = up(aw + up(eta_force + ba))
+        n = up(r["Ktheta_norm_upper"] * rho)
+        if n > worst:
+            worst = n
+            witness = dict(r)
+            witness["applied_aw_error_upper_mps2"] = aw
+            witness["force_attitude_remainder_upper_mps2"] = eta_force
+            witness["effective_aw_input_upper_mps2"] = rho
+            witness["nuisance_correction_norm_upper_rad"] = n
+            witness["unconstrained_c_at_this_cell"] = up(
+                r["aw_after_prefix_upper_mps2"] / down(r["tuner_sigma_aw_upper_mps2"]))
+    return worst, witness
+
+
+def _critical_consistency_constant(table: dict, eta_per_vector: float,
+                                   budget: float) -> dict:
+    """Largest ``c`` whose worst nuisance still fits inside ``budget``."""
+    if budget <= 0.0:
+        return {"critical_consistency_constant": 0.0,
+                "any_finite_constant_closes_this_angle": False,
+                "bracket": [0.0, 0.0]}
+    zero, _w = _worst_nuisance(table, eta_per_vector, 0.0)
+    if zero >= budget:
+        # Even a perfect a_w estimate leaves the bias and finite-angle force
+        # remainder above the budget; no consistency constant can help here.
+        return {"critical_consistency_constant": 0.0,
+                "any_finite_constant_closes_this_angle": False,
+                "nuisance_at_zero_aw_error_rad": zero,
+                "bracket": [0.0, 0.0]}
+    lo = 0.0
+    hi = CONSISTENCY_SEARCH_UPPER
+    top, _w = _worst_nuisance(table, eta_per_vector, hi)
+    if top < budget:
+        return {"critical_consistency_constant": math.inf,
+                "any_finite_constant_closes_this_angle": True,
+                "nuisance_at_zero_aw_error_rad": zero,
+                "bracket": [hi, math.inf],
+                "unconstrained_pairing_already_fits": True}
+    for _ in range(CONSISTENCY_BISECTION_STEPS):
+        mid = 0.5 * (lo + hi)
+        val, _w = _worst_nuisance(table, eta_per_vector, mid)
+        if val < budget:
+            lo = mid
+        else:
+            hi = mid
+    return {"critical_consistency_constant": down(lo),
+            "any_finite_constant_closes_this_angle": True,
+            "nuisance_at_zero_aw_error_rad": zero,
+            "bracket": [down(lo), up(hi)]}
+
+
+def _angle_row(deg: float, table: dict, domain: dict, outer_q: float,
+               separate_budget: dict | None) -> dict:
+    geom = SECTOR._validated_design_geometry(math.radians(float(deg)))
+    q0 = float(geom["cayley_norm_upper"])
+    q = RG._q_after_first_prediction(q0, domain, table["prediction_step_s"])
+    budget = BUDGET._sector_correction_budget(q, outer_q)
+    b = float(budget["sector_invariance_correction_budget_upper_rad"])
+    eta_per_vector = VEFF.accel_attitude_eta_per_vector_norm_upper(q)
+
+    joint, witness = _worst_nuisance(table, eta_per_vector, math.inf)
+    crit = _critical_consistency_constant(table, eta_per_vector, b)
+
+    row = {
+        "angle_deg": float(deg),
+        "candidate_q_upper": q0,
+        "post_prediction_q_upper": q,
+        "eta_per_vector_norm_upper": eta_per_vector,
+        "sector_invariance_correction_budget_upper_rad": b,
+        "nuisance_joint_force_pairing_upper_rad": joint,
+        "nuisance_over_budget_ratio_joint": (math.inf if b <= 0.0 else up(joint / b)),
+        "joint_pairing_fits_inside_budget": bool(b > 0.0 and joint < b),
+        "worst_cell": witness,
+        **crit,
+    }
+    unc = None if witness is None else witness.get("unconstrained_c_at_this_cell")
+    row["unconstrained_c_at_worst_cell"] = unc
+    cc = row["critical_consistency_constant"]
+    row["consistency_tightening_needed_factor"] = (
+        None if (unc is None or not (cc > 0.0)) else up(unc / cc))
+    if separate_budget is not None:
+        prev = float(separate_budget["nuisance_correction_norm_upper_rad"])
+        row["nuisance_separate_force_bounds_upper_rad"] = prev
+        row["joint_force_pairing_tightening_factor"] = (
+            up(prev / joint) if joint > 0.0 else math.inf)
+    return row
+
+
+def build(domain_path: Path = DEFAULT_DOMAIN, *, source_pieces: int = 2,
+          alignment_pieces: int = 16, force_magnitude_pieces: int = 4,
+          force_subpieces: int = 16) -> dict:
+    path = Path(domain_path).resolve()
+    domain = json.loads(path.read_text(encoding="utf-8"))
+    if domain.get("trajectory_fit") is not False:
+        raise RuntimeError("consistency producer domain must not be trajectory fitted")
+
+    sector = SECTOR.build(path)
+    entrance = ENTRANCE.build(path)
+    failures = [f"sector: {x}" for x in SECTOR.validate(sector)]
+    failures += [f"entrance: {x}" for x in ENTRANCE.validate(entrance)]
+    outer_q = float(sector["design_cayley_norm_upper"])
+
+    separate = BUDGET.build(path, source_pieces=source_pieces,
+                            alignment_pieces=alignment_pieces,
+                            force_magnitude_pieces=force_magnitude_pieces)
+    failures += [f"separate budget: {x}" for x in BUDGET.validate(separate)]
+    by_angle = {float(r["angle_deg"]): r for r in separate["ladder_rows"]}
+
+    table = _gain_table(path, domain, source_pieces=source_pieces,
+                        alignment_pieces=alignment_pieces,
+                        force_magnitude_pieces=force_magnitude_pieces,
+                        force_subpieces=force_subpieces)
+
+    rows = [_angle_row(d, table, domain, outer_q, by_angle.get(d))
+            for d in LADDER_DEG]
+
+    closing = [r for r in rows if r["any_finite_constant_closes_this_angle"]]
+    widest = max((r["angle_deg"] for r in closing), default=None)
+    widest_row = next((r for r in rows if r["angle_deg"] == widest), None)
+    aw0 = table["declared_startup_aw_error_norm_upper_mps2"]
+    sigma_lo = table["tuner_sigma_aw_lower_mps2"]
+
+    return {
+        "schema": SCHEMA,
+        "qualification": "OU3_P4_FIRST_ACCEL_JOINT_FORCE_PAIRING_AND_AW_SIGMA_CONSISTENCY",
+        "source_generated_not_trajectory_fit": True,
+        "source_replay_used": False,
+        "filter_changed": False,
+        "declared_entrance_shrunk": False,
+        "aw_sigma_consistency_declared_in_domain": False,
+        "consistency_constant_is_a_conditional_requirement_not_a_theorem": True,
+        "joint_force_pairing_is_unconditional": True,
+        "distance_only_no_verdict_emitted": True,
+        "P4_COMPLETE_WORD_DISSIPATION_ESTABLISHED_HERE": False,
+        "P4_USABLE_CERTIFICATE_PROMOTED": False,
+        "operation_matched_outer_q_upper": outer_q,
+        "declared_startup_aw_error_norm_upper_mps2": aw0,
+        "accel_bias_error_norm_upper_mps2": table["accel_bias_error_norm_upper_mps2"],
+        "specific_force_norm_lower_mps2": table["specific_force_norm_lower_mps2"],
+        "specific_force_norm_upper_mps2": table["specific_force_norm_upper_mps2"],
+        "tuner_sigma_aw_range_mps2": [sigma_lo, table["tuner_sigma_aw_upper_mps2"]],
+        "unconstrained_pairing_sigma_ratio_at_floor": up(aw0 / down(sigma_lo)),
+        "audited_gain_rows": len(table["rows"]),
+        "force_subpieces": force_subpieces,
+        "angle_rows": rows,
+        "widest_angle_closed_by_a_finite_consistency_constant": widest,
+        "consistency_constant_at_widest_closed_angle": (
+            None if widest_row is None else widest_row["critical_consistency_constant"]),
+        "shipping_tuner_sigma_law":
+            "sigma_target = min(sigma_wave * sigma_coeff, max_sigma_a); "
+            "sigma_applied is an EMA toward sigma_target; sigma_wave is the "
+            "estimated band-limited wave acceleration RMS",
+        "next_obligation": (
+            "the joint force pairing is an unconditional tightening and may be consumed"
+            " directly; the a_w/sigma consistency constant is not established here and"
+            " must either be declared in the operating domain with its own justification"
+            " from the tuner law and EMA transient, or replaced by carrying the tuner"
+            " state jointly with the attitude in the complete-word P4 funnel"
+        ),
+        "failures": failures,
+    }
+
+
+def validate(d: dict) -> list[str]:
+    f = list(d.get("failures", []))
+    if d.get("schema") != SCHEMA:
+        f.append("schema mismatch")
+    for k in ("source_generated_not_trajectory_fit", "distance_only_no_verdict_emitted",
+              "consistency_constant_is_a_conditional_requirement_not_a_theorem",
+              "joint_force_pairing_is_unconditional"):
+        if d.get(k) is not True:
+            f.append(f"{k} is not true")
+    for k in ("source_replay_used", "filter_changed", "declared_entrance_shrunk",
+              "aw_sigma_consistency_declared_in_domain",
+              "P4_COMPLETE_WORD_DISSIPATION_ESTABLISHED_HERE",
+              "P4_USABLE_CERTIFICATE_PROMOTED"):
+        if d.get(k) is not False:
+            f.append(f"{k} is not false")
+    rows = d.get("angle_rows", [])
+    if [r["angle_deg"] for r in rows] != sorted(r["angle_deg"] for r in rows):
+        f.append("angle rows are not ordered")
+    if not rows:
+        f.append("no angle rows emitted")
+    for r in rows:
+        if r["nuisance_joint_force_pairing_upper_rad"] <= 0.0:
+            f.append(f"{r['angle_deg']}: non-positive joint nuisance")
+        prev = r.get("nuisance_separate_force_bounds_upper_rad")
+        if prev is not None and r["nuisance_joint_force_pairing_upper_rad"] > prev:
+            f.append(f"{r['angle_deg']}: joint force pairing is looser than separate bounds")
+        c = r["critical_consistency_constant"]
+        if not (c >= 0.0):
+            f.append(f"{r['angle_deg']}: negative consistency constant")
+    if d.get("audited_gain_rows", 0) <= 0:
+        f.append("no audited gain rows")
+    return list(dict.fromkeys(f))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--domain", type=Path, default=DEFAULT_DOMAIN)
+    ap.add_argument("--source-pieces", type=int, default=2)
+    ap.add_argument("--alignment-pieces", type=int, default=16)
+    ap.add_argument("--force-magnitude-pieces", type=int, default=4)
+    ap.add_argument("--force-subpieces", type=int, default=16)
+    ap.add_argument("--output", type=Path, required=True)
+    a = ap.parse_args()
+    d = build(a.domain.resolve(), source_pieces=a.source_pieces,
+              alignment_pieces=a.alignment_pieces,
+              force_magnitude_pieces=a.force_magnitude_pieces,
+              force_subpieces=a.force_subpieces)
+    vf = validate(d)
+    d["validation_pass"] = not vf
+    d["validation_failures"] = vf
+    a.output.parent.mkdir(parents=True, exist_ok=True)
+    a.output.write_text(json.dumps(d, indent=2, sort_keys=True), encoding="utf-8")
+    print(json.dumps({
+        "sigma_range": d["tuner_sigma_aw_range_mps2"],
+        "aw_over_sigma_floor": d["unconstrained_pairing_sigma_ratio_at_floor"],
+        "angles": [{
+            "deg": r["angle_deg"],
+            "budget": r["sector_invariance_correction_budget_upper_rad"],
+            "nuisance_separate": r.get("nuisance_separate_force_bounds_upper_rad"),
+            "nuisance_joint": r["nuisance_joint_force_pairing_upper_rad"],
+            "joint_tightening": r.get("joint_force_pairing_tightening_factor"),
+            "ratio": r["nuisance_over_budget_ratio_joint"],
+            "fits_unconstrained": r["joint_pairing_fits_inside_budget"],
+            "zero_aw_residual": r.get("nuisance_at_zero_aw_error_rad"),
+            "critical_c": r["critical_consistency_constant"],
+            "unconstrained_c": r["unconstrained_c_at_worst_cell"],
+            "tightening_needed": r["consistency_tightening_needed_factor"],
+            "closes_with_finite_c": r["any_finite_constant_closes_this_angle"],
+        } for r in d["angle_rows"]],
+        "widest_closed_angle": d["widest_angle_closed_by_a_finite_consistency_constant"],
+        "c_at_widest": d["consistency_constant_at_widest_closed_angle"],
+        "validation_failures": vf,
+    }, indent=2, sort_keys=True))
+    return 0 if not vf else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ou3_p4_first_accel_sector_budget.py
+++ b/tools/ou3_p4_first_accel_sector_budget.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""First-accelerometer sector-invariance budget across the P4 candidate ladder.
+
+The P4 candidate ladder in ``docs/ou-iii-p5-sea-scaled-entrance.md`` is ordered
+``30 -> 25 -> 20 -> 15`` deg on the assumption that a narrower candidate makes
+the complete-word dissipation easier.  That assumption is correct for the
+exact Cayley monotonicity and eta ratios, which do improve as the angle drops.
+It is not correct for the operation that actually blocks the certificate.
+
+This producer measures, on the same source/alignment/force children the signed
+first-accelerometer stage uses, the two quantities that decide whether a single
+deployed accelerometer update can keep the state inside the operation-matched
+outer sector:
+
+* the **budget** -- the largest correction norm whose worst-case signed Cayley
+  composition with the post-prediction candidate norm still lands strictly
+  inside the outer sector.  The budget grows as the candidate angle shrinks;
+* the **nuisance term** -- the part of the correction driven by the effective
+  ``a_w`` input: the declared 0.3 g startup latent-acceleration error, the
+  accelerometer bias, and the finite-angle force remainder, multiplied by the
+  shared-force-magnitude accelerometer gain.
+
+The nuisance term is dominated by a contribution that does *not* shrink with
+the candidate angle, because it is set by the ratio of the declared latent
+acceleration error to the lowest admitted specific-force magnitude.  Both the
+descending and the ascending ladder are therefore measured here and reported
+side by side.
+
+This is a **distance, not a verdict**.  The nuisance term is an outward bound,
+so a large value does not prove that any admissible state actually leaves the
+sector; the ``a_w`` covariance endpoints used by the gain are enclosure
+endpoints, not certified reachable points.  Nothing here promotes or retires a
+theorem claim, changes the filter, or shrinks the declared 30 deg / 0.3 g
+entrance.  It exists to say which of the three structural changes named by
+``ou3_p4_p5_route_ceiling_certificate`` each ladder rung still needs.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+from ou3_interval import Interval
+import ou3_p4_30deg_signed_first_accel_sector as V1
+import ou3_p4_candidate_aw_capture_budget as AWB
+import ou3_p4_operation_matched_sector_certificate as SECTOR
+import ou3_p4_p5_entrance_search_domain as ENTRANCE
+import ou3_p4_shared_force_gain as SHARED
+import ou3_p5_effective_vector_input as VEFF
+import ou3_p5_first_accel_rotation_gauge as RG
+import ou3_p5_first_accel_rotation_gauge_v3 as RG3
+import ou3_p5_first_accel_structured_gain as SG
+import ou3_p5_full_h_prefix_cells as FULL
+import ou3_p5_full_h_prefix_cells_v3 as FULL3
+import ou3_p5_signed_cayley_cell as SIGNED
+import ou3_vector_uco_certificate as VECTOR
+
+REPO = Path(__file__).resolve().parents[1]
+DEFAULT_DOMAIN = REPO / "tools" / "ou3_proof_operating_domain.json"
+SCHEMA = 1
+DESCENDING_LADDER_DEG = (30.0, 25.0, 20.0, 15.0)
+ASCENDING_LADDER_DEG = (35.0, 40.0, 45.0)
+# Not candidates: probes that show whether the descending ladder can ever
+# bring the nuisance term inside the budget by shrinking the angle alone.
+LIMIT_PROBE_DEG = (10.0, 5.0, 1.0)
+BUDGET_SEARCH_UPPER_RAD = V1.CORRECTION_CAYLEY_MONOTONE_LIMIT_RAD
+BUDGET_BISECTION_STEPS = 60
+
+
+def up(x: float) -> float:
+    return math.nextafter(float(x), math.inf)
+
+
+def down(x: float) -> float:
+    return math.nextafter(float(x), -math.inf)
+
+
+def _worst_case_qplus(q: float, dnorm: float) -> float:
+    """Post-update Cayley upper for a correction of norm ``dnorm`` at worst sign.
+
+    The adverse alignment is ``d`` parallel to ``c``; the signed composition
+    helper of the shipping stage is reused unchanged so the budget is measured
+    in exactly the arithmetic the sector certificate uses.
+    """
+    scale = SIGNED.correction_cayley_scale_interval(dnorm)
+    adot = up(up(scale.hi * dnorm) * q)
+    return float(V1._compose_q_upper(q, dnorm, adot)["post_update_q_upper"])
+
+
+def _sector_correction_budget(q: float, outer_q: float) -> dict:
+    """Smallest correction norm already outside the outer sector (upper budget).
+
+    ``_worst_case_qplus`` is increasing in ``dnorm``, so a bisection on the
+    crossing point is well defined.  The reported budget is the *failing* side
+    of the bracket, hence an upper bound on any admissible correction norm.
+    """
+    if q >= outer_q:
+        return {
+            "sector_invariance_correction_budget_upper_rad": 0.0,
+            "candidate_already_outside_outer_sector": True,
+            "budget_bracket_rad": [0.0, 0.0],
+        }
+    lo = 0.0
+    hi = BUDGET_SEARCH_UPPER_RAD
+    try:
+        if _worst_case_qplus(q, down(hi)) < outer_q:
+            return {
+                "sector_invariance_correction_budget_upper_rad": hi,
+                "candidate_already_outside_outer_sector": False,
+                "budget_bracket_rad": [hi, hi],
+                "budget_exceeds_monotone_cayley_chart": True,
+            }
+    except RuntimeError:
+        pass
+    for _ in range(BUDGET_BISECTION_STEPS):
+        mid = 0.5 * (lo + hi)
+        try:
+            ok = _worst_case_qplus(q, mid) < outer_q
+        except RuntimeError:
+            ok = False
+        if ok:
+            lo = mid
+        else:
+            hi = mid
+    return {
+        "sector_invariance_correction_budget_upper_rad": up(hi),
+        "candidate_already_outside_outer_sector": False,
+        "budget_bracket_rad": [down(lo), up(hi)],
+    }
+
+
+def _gain_table(path: Path, domain: dict, *, source_pieces: int,
+                alignment_pieces: int, force_magnitude_pieces: int) -> dict:
+    """Angle-independent per-cell gain and effective-``a_w`` prefix data."""
+    RG3._install_backend(path, source_pieces)
+    FULL3._install_backend()
+    h = float(FULL._source_cell()["dt_s"])
+    tilt, yaw, eps = RG._attitude_covariance_epsilon(path, h)
+    vc = VECTOR.build()["configured_measurement_bounds"]
+    racc_var = FULL._R_diag(float(vc["acc_measurement_std_mps2"]))[0][0]
+    startup = domain["startup"]
+    handoff = startup["physical_handoff_coordinate_bounds"]
+    aw0 = float(handoff["latent_acceleration_error_norm_upper_mps2"])
+    ba = float(handoff["accelerometer_bias_error_norm_upper_mps2"])
+    pnorm = AWB._p5_position_norm_upper(domain)
+    live = domain["normal_live"]
+    force_lower = float(live["specific_force_norm_lower_mps2"])
+    force_upper = float(live["specific_force_norm_upper_mps2"])
+    force_cells = RG._geom_ranges(force_lower, force_upper, force_magnitude_pieces)
+    xcells = SG._linear_cells(alignment_pieces)
+
+    cells = []
+    for si, (src, phase) in enumerate(RG._source_phase_children(source_pieces)):
+        P0 = FULL._initial_covariance(src, path)
+        Fm, Q, _ = FULL._transition_and_Q(src, domain)
+        Pp = FULL._psd_tighten(FULL.matrix_add(
+            FULL.matrix_mul(FULL.matrix_mul(Fm, P0), FULL.matrix_transpose(Fm)), Q))
+        _s, _a, paw_pred = RG._scalar_axis_structure(Pp)
+        paw = RG._due_paw_and_error_norm(Pp, src, 0.0, 0.0)[0] if phase == "due" else paw_pred
+        intercept, slope, _d = AWB._s_phase_affine_aw_bound(src, phase, Pp, domain, pnorm)
+        aw = up(intercept + up(slope * aw0))
+        for xi, x in enumerate(xcells):
+            for mi, m in enumerate(force_cells):
+                k, _kh, _gd = SHARED.shared_force_structured_gain_bounds(
+                    tilt=tilt, yaw=yaw, eps=eps, x=x, m=m,
+                    paw=paw, racc_var=racc_var)
+                cells.append({
+                    "source_phase_cell": si, "pseudo_phase": phase,
+                    "alignment_cell": xi, "force_cell": mi,
+                    "force_magnitude_mps2": m.as_list(),
+                    "alignment_x": x.as_list(),
+                    "aw_after_prefix_upper_mps2": aw,
+                    "Ktheta_norm_upper": k,
+                    "force_upper_mps2": m.hi,
+                })
+    return {
+        "cells": cells,
+        "accel_bias_error_norm_upper_mps2": ba,
+        "declared_startup_aw_error_norm_upper_mps2": aw0,
+        "specific_force_norm_lower_mps2": force_lower,
+        "specific_force_norm_upper_mps2": force_upper,
+        "prediction_step_s": h,
+    }
+
+
+def _ladder_row(deg: float, table: dict, domain: dict, outer_q: float,
+                entrance_q: float, family: str) -> dict:
+    geom = SECTOR._validated_design_geometry(math.radians(float(deg)))
+    q0 = float(geom["cayley_norm_upper"])
+    q = RG._q_after_first_prediction(q0, domain, table["prediction_step_s"])
+    budget = _sector_correction_budget(q, outer_q)
+    eta_per_vector = VEFF.accel_attitude_eta_per_vector_norm_upper(q)
+    ba = table["accel_bias_error_norm_upper_mps2"]
+
+    worst = None
+    for c in table["cells"]:
+        eta_force = up(eta_per_vector * c["force_upper_mps2"])
+        rho = up(c["aw_after_prefix_upper_mps2"] + up(eta_force + ba))
+        nuisance = up(c["Ktheta_norm_upper"] * rho)
+        if worst is None or nuisance > worst["nuisance_correction_norm_upper_rad"]:
+            worst = dict(c)
+            worst.pop("force_upper_mps2", None)
+            worst["force_attitude_remainder_upper_mps2"] = eta_force
+            worst["effective_aw_input_upper_mps2"] = rho
+            worst["nuisance_correction_norm_upper_rad"] = nuisance
+
+    b = float(budget["sector_invariance_correction_budget_upper_rad"])
+    n = float(worst["nuisance_correction_norm_upper_rad"])
+    return {
+        "angle_deg": float(deg),
+        "ladder_family": family,
+        "candidate_q_upper": q0,
+        "post_prediction_q_upper": q,
+        "operation_matched_outer_q_upper": outer_q,
+        "inside_45deg_entrance": q0 < entrance_q,
+        "eta_per_vector_norm_upper": eta_per_vector,
+        **budget,
+        "worst_cell": worst,
+        "nuisance_correction_norm_upper_rad": n,
+        "nuisance_over_budget_ratio": (math.inf if b <= 0.0 else up(n / b)),
+        "nuisance_fits_inside_budget": bool(b > 0.0 and n < b),
+    }
+
+
+def build(domain_path: Path = DEFAULT_DOMAIN, *, source_pieces: int = 2,
+          alignment_pieces: int = 16, force_magnitude_pieces: int = 4) -> dict:
+    path = Path(domain_path).resolve()
+    domain = json.loads(path.read_text(encoding="utf-8"))
+    if domain.get("trajectory_fit") is not False:
+        raise RuntimeError("sector budget domain must not be trajectory fitted")
+
+    sector = SECTOR.build(path)
+    entrance = ENTRANCE.build(path)
+    failures = [f"sector: {x}" for x in SECTOR.validate(sector)]
+    failures += [f"entrance: {x}" for x in ENTRANCE.validate(entrance)]
+    outer_q = float(sector["design_cayley_norm_upper"])
+    entrance_q = float(
+        entrance["P5_entrance"]["attitude_geometry"]["cayley_norm_upper"])
+
+    table = _gain_table(path, domain, source_pieces=source_pieces,
+                        alignment_pieces=alignment_pieces,
+                        force_magnitude_pieces=force_magnitude_pieces)
+
+    rows = [_ladder_row(d, table, domain, outer_q, entrance_q, "descending")
+            for d in DESCENDING_LADDER_DEG]
+    rows += [_ladder_row(d, table, domain, outer_q, entrance_q, "ascending")
+             for d in ASCENDING_LADDER_DEG]
+    rows.sort(key=lambda r: r["angle_deg"])
+    probes = [_ladder_row(d, table, domain, outer_q, entrance_q, "limit_probe")
+              for d in LIMIT_PROBE_DEG]
+    probes.sort(key=lambda r: r["angle_deg"])
+
+    aw0 = table["declared_startup_aw_error_norm_upper_mps2"]
+    flo = table["specific_force_norm_lower_mps2"]
+    aw_over_force = up(aw0 / down(flo))
+    direction_error = (
+        math.asin(min(1.0, aw_over_force)) if aw_over_force <= 1.0 else None)
+
+    any_fits = any(r["nuisance_fits_inside_budget"] for r in rows)
+    descending_helps = False
+    desc = [r for r in rows if r["ladder_family"] == "descending"]
+    if len(desc) >= 2:
+        by_angle = sorted(desc, key=lambda r: r["angle_deg"])
+        descending_helps = (
+            by_angle[0]["nuisance_over_budget_ratio"]
+            < 0.5 * by_angle[-1]["nuisance_over_budget_ratio"])
+
+    return {
+        "schema": SCHEMA,
+        "qualification": "OU3_P4_FIRST_ACCELEROMETER_SECTOR_INVARIANCE_BUDGET",
+        "source_generated_not_trajectory_fit": True,
+        "source_replay_used": False,
+        "filter_changed": False,
+        "declared_entrance_shrunk": False,
+        "distance_only_no_verdict_emitted": True,
+        "shared_force_magnitude_dependency_preserved": True,
+        "P4_COMPLETE_WORD_DISSIPATION_ESTABLISHED_HERE": False,
+        "P4_USABLE_CERTIFICATE_PROMOTED": False,
+        "operation_matched_outer_q_upper": outer_q,
+        "declared_P5_entrance_q_upper": entrance_q,
+        "declared_startup_aw_error_norm_upper_mps2": aw0,
+        "accel_bias_error_norm_upper_mps2": table["accel_bias_error_norm_upper_mps2"],
+        "specific_force_norm_lower_mps2": flo,
+        "specific_force_norm_upper_mps2": table["specific_force_norm_upper_mps2"],
+        "declared_aw_over_lowest_specific_force": aw_over_force,
+        "lowest_force_gravity_direction_error_upper_rad": direction_error,
+        "audited_cells": len(table["cells"]),
+        "ladder_rows": rows,
+        "limit_probe_rows": probes,
+        "limit_probes_are_not_candidate_angles": True,
+        "smallest_probe_angle_deg": probes[0]["angle_deg"],
+        "smallest_probe_nuisance_over_budget_ratio": probes[0]["nuisance_over_budget_ratio"],
+        "shrinking_the_candidate_angle_alone_can_close_the_budget":
+            any(r["nuisance_fits_inside_budget"] for r in probes),
+        "any_ladder_rung_fits_nuisance_inside_budget": any_fits,
+        "descending_ladder_halves_the_gap": descending_helps,
+        "next_obligation": (
+            "shrinking the candidate angle widens the budget but the nuisance term stays"
+            " above it even at the smallest probe, because that term is set by the declared"
+            " latent-acceleration error over the lowest admitted specific force; closing a"
+            " rung needs the operation-matched information decrease and a directional block"
+            " margin, not a narrower candidate"
+        ),
+        "failures": failures,
+    }
+
+
+def validate(d: dict) -> list[str]:
+    f = list(d.get("failures", []))
+    if d.get("schema") != SCHEMA:
+        f.append("schema mismatch")
+    for k in ("source_generated_not_trajectory_fit", "distance_only_no_verdict_emitted",
+              "shared_force_magnitude_dependency_preserved"):
+        if d.get(k) is not True:
+            f.append(f"{k} is not true")
+    for k in ("source_replay_used", "filter_changed", "declared_entrance_shrunk",
+              "P4_COMPLETE_WORD_DISSIPATION_ESTABLISHED_HERE",
+              "P4_USABLE_CERTIFICATE_PROMOTED"):
+        if d.get(k) is not False:
+            f.append(f"{k} is not false")
+    rows = d.get("ladder_rows", [])
+    if [r["angle_deg"] for r in rows] != sorted(r["angle_deg"] for r in rows):
+        f.append("ladder rows are not ordered by angle")
+    if not rows:
+        f.append("no ladder rows emitted")
+    for r in rows:
+        if not (r["post_prediction_q_upper"] >= r["candidate_q_upper"]):
+            f.append(f"{r['angle_deg']}: prediction did not widen the candidate norm")
+        if r["sector_invariance_correction_budget_upper_rad"] < 0.0:
+            f.append(f"{r['angle_deg']}: negative correction budget")
+        if r["nuisance_correction_norm_upper_rad"] <= 0.0:
+            f.append(f"{r['angle_deg']}: non-positive nuisance term")
+    if d.get("audited_cells", 0) <= 0:
+        f.append("no audited cells")
+    if d.get("limit_probes_are_not_candidate_angles") is not True:
+        f.append("limit probes are not marked as non-candidates")
+    if not d.get("limit_probe_rows"):
+        f.append("no limit probe rows emitted")
+    return list(dict.fromkeys(f))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--domain", type=Path, default=DEFAULT_DOMAIN)
+    ap.add_argument("--source-pieces", type=int, default=2)
+    ap.add_argument("--alignment-pieces", type=int, default=16)
+    ap.add_argument("--force-magnitude-pieces", type=int, default=4)
+    ap.add_argument("--output", type=Path, required=True)
+    a = ap.parse_args()
+    d = build(a.domain.resolve(), source_pieces=a.source_pieces,
+              alignment_pieces=a.alignment_pieces,
+              force_magnitude_pieces=a.force_magnitude_pieces)
+    vf = validate(d)
+    d["validation_pass"] = not vf
+    d["validation_failures"] = vf
+    a.output.parent.mkdir(parents=True, exist_ok=True)
+    a.output.write_text(json.dumps(d, indent=2, sort_keys=True), encoding="utf-8")
+    print(json.dumps({
+        "outer_q": d["operation_matched_outer_q_upper"],
+        "aw_over_lowest_force": d["declared_aw_over_lowest_specific_force"],
+        "ladder": [{
+            "deg": r["angle_deg"],
+            "family": r["ladder_family"],
+            "q_pred": r["post_prediction_q_upper"],
+            "budget_rad": r["sector_invariance_correction_budget_upper_rad"],
+            "nuisance_rad": r["nuisance_correction_norm_upper_rad"],
+            "ratio": r["nuisance_over_budget_ratio"],
+            "fits": r["nuisance_fits_inside_budget"],
+        } for r in d["ladder_rows"]],
+        "probes": [{
+            "deg": r["angle_deg"],
+            "budget_rad": r["sector_invariance_correction_budget_upper_rad"],
+            "nuisance_rad": r["nuisance_correction_norm_upper_rad"],
+            "ratio": r["nuisance_over_budget_ratio"],
+            "fits": r["nuisance_fits_inside_budget"],
+        } for r in d["limit_probe_rows"]],
+        "any_fits": d["any_ladder_rung_fits_nuisance_inside_budget"],
+        "angle_shrink_alone_closes": d["shrinking_the_candidate_angle_alone_can_close_the_budget"],
+        "descending_halves_gap": d["descending_ladder_halves_the_gap"],
+        "validation_failures": vf,
+    }, indent=2, sort_keys=True))
+    return 0 if not vf else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ou3_p4_shared_force_gain.py
+++ b/tools/ou3_p4_shared_force_gain.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Dependency-preserving accelerometer gain in the shared specific-force magnitude.
+
+The structured first-accelerometer gain rows all have the shape
+
+    g(m) = m * N / (m^2 * p + lambda),
+
+where ``m`` is the specific-force magnitude of the audited cell.  ``m`` appears
+in the numerator *and* in the denominator, so evaluating the quotient with
+ordinary interval arithmetic (numerator at ``m.hi``, denominator at ``m.lo``)
+overstates the gain by up to the cell's magnitude ratio ``m.hi/m.lo``.  That
+loss is not a modelling choice; it is pure dependency slack, and it is what
+pushed the 30 deg first-accelerometer correction family past the monotone
+Cayley chart before this producer existed.
+
+``g`` is unimodal in ``m`` on the positive axis:
+
+    g'(m) = N (lambda - m^2 p) / (m^2 p + lambda)^2,
+
+so the maximum over ``m > 0`` is at ``m* = sqrt(lambda/p)`` and on a cell
+``[m1, m2]`` the supremum is either the interior value or the larger endpoint
+value.  Two exact interior values are needed:
+
+* ``N = p`` (the self-``p`` tangent rows ``g_perp`` and ``g_u``):
+  ``g(m*) = (1/2) sqrt(p/lambda)``;
+* ``N = C`` independent of ``p`` (the axial yaw-cross row ``g_z``):
+  ``g(m*) = C / (2 sqrt(lambda p))``.
+
+Monotonicity in the remaining variables is also exact: the self-``p`` rows
+increase in ``p``, the independent-``C`` row decreases in ``p``, and both
+decrease in ``lambda``.  The corresponding endpoint of each interval is chosen
+explicitly instead of being left to interval division.
+
+Nothing else changes.  The filter, the declared 30 deg candidate, the 0.3 g
+startup ``a_w`` envelope, the source cell family, the PSD remainder treatment
+and the ``KH`` rows are all identical to
+``ou3_p4_candidate_first_accel_range_v3``.  This module only removes shared-
+variable slack, so every bound it returns is less than or equal to the bound
+the naive evaluation returns on the same cell.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+from ou3_interval import Interval
+import ou3_p5_first_accel_structured_gain as SG
+
+REPO = Path(__file__).resolve().parents[1]
+DEFAULT_DOMAIN = REPO / "tools" / "ou3_proof_operating_domain.json"
+SCHEMA = 1
+
+
+def up(x: float) -> float:
+    return math.nextafter(float(x), math.inf)
+
+
+def down(x: float) -> float:
+    return math.nextafter(float(x), -math.inf)
+
+
+def _sqrt_up(x: float) -> float:
+    return up(math.sqrt(max(0.0, float(x))))
+
+
+def _eval_up(m: float, num: float, p: float, lam: float) -> float:
+    """Outward upper bound of m*num/(m^2 p + lam) at an exact m."""
+    den = down(down(down(m * m) * p) + lam)
+    if den <= 0.0:
+        raise RuntimeError("shared-force gain denominator lost positivity")
+    return up(up(m * num) / den)
+
+
+def _interior_reachable(m: Interval, p: float, lam: float) -> bool:
+    """True when m* = sqrt(lam/p) may lie inside the audited magnitude cell."""
+    star_lo = down(lam / up(p))
+    star_hi = up(lam / down(p))
+    return star_hi >= down(m.lo * m.lo) and star_lo <= up(m.hi * m.hi)
+
+
+def sup_self_p_gain(m: Interval, p_hi: float, lam_lo: float) -> float:
+    """sup over the cell of m*p/(m^2 p + lam); p upper, lambda lower."""
+    if m.lo <= 0.0 or p_hi <= 0.0 or lam_lo <= 0.0:
+        raise RuntimeError("shared-force self-p gain domain lost positivity")
+    cands = [_eval_up(m.lo, p_hi, p_hi, lam_lo), _eval_up(m.hi, p_hi, p_hi, lam_lo)]
+    if _interior_reachable(m, p_hi, lam_lo):
+        cands.append(up(0.5 * _sqrt_up(up(p_hi / down(lam_lo)))))
+    return max(cands)
+
+
+def sup_independent_gain(m: Interval, c_hi: float, p_lo: float, lam_lo: float) -> float:
+    """sup over the cell of m*C/(m^2 p + lam); C independent, p and lambda lower."""
+    if m.lo <= 0.0 or p_lo <= 0.0 or lam_lo <= 0.0:
+        raise RuntimeError("shared-force independent gain domain lost positivity")
+    if c_hi <= 0.0:
+        return 0.0
+    cands = [_eval_up(m.lo, c_hi, p_lo, lam_lo), _eval_up(m.hi, c_hi, p_lo, lam_lo)]
+    if _interior_reachable(m, p_lo, lam_lo):
+        cands.append(up(c_hi / down(2.0 * down(_sqrt_up(down(lam_lo * p_lo))))))
+    return max(cands)
+
+
+def shared_force_structured_gain_bounds(*, tilt: float, yaw: float, eps: float,
+                                        x: Interval, m: Interval, paw: Interval,
+                                        racc_var: Interval):
+    """V4 gain rows: identical model to V3, shared-``m`` dependency preserved."""
+    F = SG.FULL1
+    t = SG.I(tilt)
+    delta = Interval.outward_bounds(yaw - tilt, yaw - tilt)
+    pu = t + delta * x
+    lam = paw + racc_var
+    if lam.lo <= 0.0:
+        raise RuntimeError("candidate first-accel lambda floor is nonpositive")
+    m2 = m.square()
+    den_perp = m2 * t + lam
+    den_u = m2 * pu + lam
+    if den_perp.lo <= 0.0 or den_u.lo <= 0.0:
+        raise RuntimeError("candidate tangent gain denominator is nonpositive")
+
+    geom_hi = SG._sqrt_x1mx_upper(x)
+    g_perp = sup_self_p_gain(m, t.hi, lam.lo)
+    g_u = sup_self_p_gain(m, pu.hi, lam.lo)
+    delta_abs = max(abs(delta.lo), abs(delta.hi))
+    g_z = sup_independent_gain(m, F.up(delta_abs * geom_hi), pu.lo, lam.lo)
+    k0 = F.up(max(g_perp, _sqrt_up(F.up(g_u * g_u + g_z * g_z))))
+
+    # KH rows are increasing in m and need no unimodal treatment.
+    kh_perp = m2 * t / den_perp
+    kh_u = m2 * pu / den_u
+    kh_z = m2 * delta * Interval(0.0, geom_hi) / den_u
+    kh0 = F.up(max(
+        kh_perp.hi,
+        _sqrt_up(F.up(kh_u.hi * kh_u.hi + kh_z.hi * kh_z.hi)),
+    ))
+
+    # V12D tangent-channel resolvent, unchanged from V3.
+    eoff = F.up(2.0 * eps)
+    mhi = m.hi
+    dS = F.up(mhi * mhi * eoff)
+    tangent_nominal_floor = min(den_perp.lo, den_u.lo)
+    tangent_floor = F.down(tangent_nominal_floor - dS)
+    if tangent_floor <= 0.0:
+        raise RuntimeError("candidate perturbed tangent innovation floor lost positivity")
+    inv_tangent = F.up(1.0 / tangent_floor)
+    dCtheta = F.up(mhi * eoff)
+    dk = F.up(F.up(dCtheta + F.up(k0 * dS)) * inv_tangent)
+    k = F.up(k0 + dk)
+    kh = F.up(kh0 + F.up(dk * mhi))
+    return k, kh, {
+        "lambda_lower": lam.lo,
+        "p_u": pu.as_list(),
+        "g_perp_upper": g_perp,
+        "g_u_upper": g_u,
+        "g_z_upper": g_z,
+        "K0_norm_upper": k0,
+        "KH0_norm_upper": kh0,
+        "attitude_PSD_remainder_operator_upper": eoff,
+        "PSD_innovation_perturbation_tangent_only": True,
+        "PSD_innovation_axial_row_column_exact_zero": True,
+        "nominal_tangent_innovation_lower": tangent_nominal_floor,
+        "tangent_innovation_perturbation_upper": dS,
+        "perturbed_tangent_innovation_lower": tangent_floor,
+        "perturbed_tangent_inverse_operator_upper": inv_tangent,
+        "PSD_remainder_K_perturbation_upper": dk,
+        "retired_axial_lambda_inverse_for_PSD_remainder": True,
+        "shared_force_magnitude_dependency_preserved": True,
+    }
+
+
+def _reference_cells(domain_path: Path) -> list[dict]:
+    """Audited comparison cells drawn from the deployed startup/live domain."""
+    import ou3_p5_first_accel_rotation_gauge as RG
+    import ou3_p5_first_accel_rotation_gauge_v3 as RG3
+    import ou3_p5_full_h_prefix_cells as FULL
+    import ou3_p5_full_h_prefix_cells_v3 as FULL3
+    import ou3_vector_uco_certificate as VECTOR
+
+    path = Path(domain_path).resolve()
+    domain = json.loads(path.read_text(encoding="utf-8"))
+    RG3._install_backend(path, 2)
+    FULL3._install_backend()
+    h = float(FULL._source_cell()["dt_s"])
+    tilt, yaw, eps = RG._attitude_covariance_epsilon(path, h)
+    vc = VECTOR.build()["configured_measurement_bounds"]
+    racc_var = FULL._R_diag(float(vc["acc_measurement_std_mps2"]))[0][0]
+    live = domain["normal_live"]
+    force_cells = RG._geom_ranges(
+        float(live["specific_force_norm_lower_mps2"]),
+        float(live["specific_force_norm_upper_mps2"]),
+        4,
+    )
+    xcells = SG._linear_cells(16)
+
+    paws: list[Interval] = []
+    for src, phase in RG._source_phase_children(2):
+        P0 = FULL._initial_covariance(src, path)
+        Fm, Q, _ = FULL._transition_and_Q(src, domain)
+        Pp = FULL._psd_tighten(FULL.matrix_add(
+            FULL.matrix_mul(FULL.matrix_mul(Fm, P0), FULL.matrix_transpose(Fm)), Q))
+        _s, _a, paw_pred = RG._scalar_axis_structure(Pp)
+        paw = RG._due_paw_and_error_norm(Pp, src, 0.0, 0.0)[0] if phase == "due" else paw_pred
+        paws.append(paw)
+    # De-duplicate identical source a_w covariance cells.
+    seen: dict[tuple[float, float], Interval] = {}
+    for p in paws:
+        seen.setdefault((p.lo, p.hi), p)
+    return [{
+        "tilt": tilt, "yaw": yaw, "eps": eps,
+        "x": x, "m": m, "paw": p, "racc_var": racc_var,
+    } for p in seen.values() for x in xcells[:4] for m in force_cells]
+
+
+def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
+    import ou3_p4_candidate_first_accel_range_v3 as V3
+
+    rows = []
+    worst_ratio = 0.0
+    min_ratio = math.inf
+    never_worse = True
+    for cell in _reference_cells(domain_path):
+        k_naive, kh_naive, _dn = V3._tangent_structured_gain_bounds(**cell)
+        k_exact, kh_exact, _de = shared_force_structured_gain_bounds(**cell)
+        if k_exact > k_naive or kh_exact > kh_naive:
+            never_worse = False
+        ratio = k_naive / k_exact if k_exact > 0.0 else math.inf
+        min_ratio = min(min_ratio, ratio)
+        if ratio > worst_ratio:
+            worst_ratio = ratio
+            rows = [{
+                "force_magnitude_mps2": cell["m"].as_list(),
+                "alignment_x": cell["x"].as_list(),
+                "aw_covariance": cell["paw"].as_list(),
+                "K_norm_upper_naive_interval": k_naive,
+                "K_norm_upper_shared_force": k_exact,
+                "KH_norm_upper_naive_interval": kh_naive,
+                "KH_norm_upper_shared_force": kh_exact,
+                "tightening_factor": ratio,
+            }]
+
+    failures: list[str] = []
+    if not never_worse:
+        failures.append("shared-force gain is not uniformly at least as tight as the interval gain")
+    if min_ratio < 1.0:
+        failures.append("shared-force gain reported a looser cell")
+
+    return {
+        "schema": SCHEMA,
+        "qualification": "OU3_P4_SHARED_FORCE_MAGNITUDE_ACCELEROMETER_GAIN_LEMMA",
+        "source_generated_not_trajectory_fit": True,
+        "source_replay_used": False,
+        "filter_changed": False,
+        "shared_force_magnitude_dependency_preserved": True,
+        "unimodal_interior_and_endpoint_maxima_used": True,
+        "self_p_rows_evaluated_at_upper_p_and_lower_lambda": True,
+        "independent_C_row_evaluated_at_lower_p_and_lower_lambda": True,
+        "KH_rows_unchanged_from_V3": True,
+        "PSD_remainder_treatment_unchanged_from_V3": True,
+        "uniformly_at_least_as_tight_as_interval_gain": never_worse,
+        "minimum_observed_tightening_factor": min_ratio,
+        "maximum_observed_tightening_factor": worst_ratio,
+        "worst_audited_cell": rows[0] if rows else None,
+        "P4_COMPLETE_WORD_DISSIPATION_ESTABLISHED_HERE": False,
+        "P4_USABLE_CERTIFICATE_PROMOTED": False,
+        "next_obligation": (
+            "consume this gain from the candidate first-accelerometer range and signed sector"
+            " producers; it removes shared-magnitude slack only and does not by itself establish"
+            " sector invariance or complete-word dissipation"
+        ),
+        "failures": failures,
+    }
+
+
+def validate(d: dict) -> list[str]:
+    f = list(d.get("failures", []))
+    if d.get("schema") != SCHEMA:
+        f.append("schema mismatch")
+    for k in (
+        "source_generated_not_trajectory_fit", "shared_force_magnitude_dependency_preserved",
+        "unimodal_interior_and_endpoint_maxima_used", "KH_rows_unchanged_from_V3",
+        "PSD_remainder_treatment_unchanged_from_V3",
+        "uniformly_at_least_as_tight_as_interval_gain",
+    ):
+        if d.get(k) is not True:
+            f.append(f"{k} is not true")
+    for k in ("source_replay_used", "filter_changed",
+              "P4_COMPLETE_WORD_DISSIPATION_ESTABLISHED_HERE",
+              "P4_USABLE_CERTIFICATE_PROMOTED"):
+        if d.get(k) is not False:
+            f.append(f"{k} is not false")
+    if not (float(d.get("minimum_observed_tightening_factor", 0.0)) >= 1.0):
+        f.append("a tightening factor below one was reported")
+    return list(dict.fromkeys(f))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--domain", type=Path, default=DEFAULT_DOMAIN)
+    ap.add_argument("--output", type=Path, required=True)
+    a = ap.parse_args()
+    d = build(a.domain.resolve())
+    vf = validate(d)
+    d["validation_pass"] = not vf
+    d["validation_failures"] = vf
+    a.output.parent.mkdir(parents=True, exist_ok=True)
+    a.output.write_text(json.dumps(d, indent=2, sort_keys=True), encoding="utf-8")
+    print(json.dumps({
+        "min_tightening": d["minimum_observed_tightening_factor"],
+        "max_tightening": d["maximum_observed_tightening_factor"],
+        "worst_cell": d["worst_audited_cell"],
+        "validation_failures": vf,
+    }, indent=2, sort_keys=True))
+    return 0 if not vf else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Three related changes, none of which touches the filter, the declared
deployment domains, or any promoted theorem claim.

1. Shared-force-magnitude accelerometer gain lemma.

   Every structured first-accelerometer gain row has the shape
   m N / (m^2 p + lambda) with the specific-force magnitude m in both the
   numerator and the denominator, so an ordinary interval quotient
   overstates it by up to the cell's magnitude ratio.  The rows are
   unimodal in m, so the exact supremum is the interior value at
   m* = sqrt(lambda/p) -- (1/2) sqrt(p/lambda) for the self-p rows and
   C / (2 sqrt(lambda p)) for the independent-C axial row -- or the larger
   endpoint.  Monotonicity in p and lambda is also taken explicitly.  The
   lemma is uniformly between 1.17 and 1.78 tighter over the audited cells
   and never looser; the KH rows and the PSD remainder treatment are
   unchanged.

   Consuming it in the signed 30 deg first-accelerometer sector makes the
   whole family evaluable for the first time.  V2 aborted after 13 of 40960
   children with max_d = 2.6481953631664035 rad and a signed composition
   denominator of 0.038994069387713985 that could cross zero; V3 evaluates
   all 40960 with max_d = 2.2251526515093487 rad and a minimum denominator
   of 0.6356874937572935.  It stays NOT_ESTABLISHED, but for a measured
   reason rather than a lost enclosure.

2. First-accelerometer sector-invariance budget.

   For each P4 candidate angle the new producer compares the largest
   correction norm that still composes inside the 0.80 rad outer sector
   against the nuisance correction the effective a_w input produces.
   Narrowing the candidate helps -- the ratio falls from 5.05 at 30 deg to
   2.12 at 15 deg -- but non-candidate limit probes show it saturating at
   1.34 for a 1 deg candidate, because the floor is the declared 0.3 g
   latent-acceleration error over the lowest admitted specific force,
   2.941995 / 5.0 = 0.5883990000000002.  The descending ladder is therefore
   not the route that closes the first accelerometer operation.

   Like V54 this reports a distance and never a verdict: the nuisance term
   is an outward bound and the a_w covariance endpoints feeding the gain are
   enclosure endpoints, not certified reachable points.

3. Consolidated P1-P5 certificate numbers and usability report.

   One producer regenerates every stage and re-applies each usability
   threshold to the recomputed value instead of trusting an upstream PASS
   field.  P1, P2 and P3 report USABLE; P4 and P5 report
   USABLE_GEOMETRY_OPEN_OBLIGATION, and the report refuses to set
   P1_P5_COMPLETE_STABILITY_PROOF_ESTABLISHED while the complete-word P4
   dissipation or the finite P5 inner capture is open.

Adds three non-regression rules to the usability envelope, records the
measurements in the proof plan and the sea-scaled entrance note, and wires a
dedicated workflow plus unit tests for all three producers.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011hU4nD4VU3bRsYxzQ38MMN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added certificate reports for OU-III P1–P5 stability stages, including usability verdicts and validation status.
  - Added analysis tools for first-accelerometer sector budgets, shared-force gain bounds, and acceleration-error consistency.
  - Added support for evaluating candidate angle ladders and generating JSON certificate outputs.

- **Documentation**
  - Documented current certificate measurements, usability limits, remaining proof obligations, and candidate-angle findings.

- **Tests**
  - Added comprehensive validation coverage for certificate reports, budget calculations, gain bounds, and consistency checks.

- **Chores**
  - Added automated CI validation for certificate generation and fail-closed status checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->