### PR TITLE
Arm the front-end vibration guard in OU-II and TFG

### DIFF
--- a/doc/kalman_ou_iii/w3d-engine-noise-degradation.tex-part
+++ b/doc/kalman_ou_iii/w3d-engine-noise-degradation.tex-part
@@ -55,8 +55,8 @@ Table~\ref{tab:engine-noise-cruise} replays the eight stationary records
 through each family with the engine off and at the nominal cruise condition.
 This is the comparison that motivates the remedy of
 Sec.~\ref{sec:engine-noise-guard}, so it holds all three families in the same
-unconditioned configuration: OU--III's front-end guard, which ships armed, is
-switched off throughout this subsection and switched on again there.
+unconditioned configuration: the front-end guard, which ships armed in every
+family, is switched off throughout this subsection and switched on again there.
 All three degrade by a large factor.  OU--III's pooled 3-D displacement RMS
 goes from \SI{0.522}{m} to \SI{4.232}{m}, a factor of \num{8.1}; vertical RMS
 goes from \SI{0.179}{m} to \SI{0.828}{m}.  OU--II degrades by \num{5.2} and
@@ -339,6 +339,17 @@ residual cannot go to one while the guard is engaged; and no front-end filter
 helps with machinery whose orders reach into the wave band, because there is
 nothing there to separate them from the sea.  The \SI{800}{rpm} row is that
 limit showing itself early.
+
+Nothing in the mechanism depends on the translational state structure, which is
+the only thing the three families disagree about: all three level from the same
+private Mahony observer and feed the same accelerometer to a MEKF, and
+Table~\ref{tab:engine-noise-cruise} measures all three degrading.  The guard is
+therefore armed in all three at the operating point fitted here rather than
+refitted per family.  Over the same eight records at the nominal cruise
+condition it takes OU--II from \SI{3.363}{m} to \SI{0.657}{m} and TFG from
+\SI{14.026}{m} to \SI{0.785}{m}, residuals of \num{1.02} and \num{1.06}
+against their own engine-off baselines; the engine-off replays are bit-identical
+in each, exactly as they are for OU--III.
 
 \subsubsection{Scope}
 

--- a/docs/engine-noise-degradation.md
+++ b/docs/engine-noise-degradation.md
@@ -99,10 +99,11 @@ startup, and regularization.  456 replays run across five arms and a common
 engine-off baseline.
 
 This study is the controlled comparison that *motivates* the mitigation below,
-across three families of which only one has a guard, so it sets
-`OU_III_ACC_GUARD_HZ=0` throughout and keeps measuring the unconditioned
-measurement path.  What the shipped default actually does is the subject of
-`tools/ou3_engine_noise_mitigation.py`.
+so it sets `OU_II_ACC_GUARD_HZ=0`, `OU_III_ACC_GUARD_HZ=0` and
+`TFG_ACC_GUARD_HZ=0` throughout and keeps measuring the unconditioned
+measurement path in every family.  What the shipped default actually does is
+the subject of `tools/ou3_engine_noise_mitigation.py` and of the cross-family
+table at the end of the mitigation section.
 
 
 | Arm | What varies | Held fixed |
@@ -255,16 +256,20 @@ Matplotlib is unavailable.
 
 ## Mitigation: the front-end vibration guard
 
-`src/tuner/AccelVibrationGuard.h`, wired into
-`SeaStateFusionFilter_OU_III::updateCore_`, acts on the attribution above: the
-damage comes from out-of-band power in one sensor, its size follows how much of
-that power survives to the sample, and the wave band it must be separated from
-is a decade below it.  So the fix is to keep the vibration out of the
-measurement path rather than to change the estimator.
+`src/tuner/AccelVibrationGuard.h` acts on the attribution above: the damage
+comes from out-of-band power in one sensor, its size follows how much of that
+power survives to the sample, and the wave band it must be separated from is a
+decade below it.  So the fix is to keep the vibration out of the measurement
+path rather than to change the estimator.
 
-The guard sits at the single point where raw measurements arrive, so the Mahony
-proxy, the MEKF, and the tilt watchdog all read the same conditioned
-accelerometer.
+It is wired into all three families, at the single point in each where raw
+measurements arrive — `SeaStateFusionFilter_OU_II::updateCore_`,
+`SeaStateFusionFilter_OU_III::updateCore_` and
+`SeaStateFusionFilter_TFG::update` — so in each of them the Mahony proxy, the
+MEKF, and the attitude re-lock all read the same conditioned accelerometer.
+The corner, the cascade length, the detector and the covariance gain are the
+same numbers everywhere; the sweeps below were run on OU-III, and the
+cross-family result is at the end of this section.
 
 **Conditioning.** A two-pole one-pole cascade at 14 Hz, in the empty spectrum
 between the wave band and the machinery band.
@@ -415,25 +420,73 @@ over a 100:1 range of wave amplitude it varies by 0.02 %, which the unit test
 pins.  A big sea cannot look like machinery to it, and a near-still one cannot
 lower the bar.  This is what makes arming it by default safe.
 
+### All three families carry it
+
+The rectification mechanism is in the attitude loop, and OU-II, OU-III and TFG
+build that loop the same way: one private Mahony observer levelling from the
+accelerometer, feeding a MEKF that reads the same accelerometer.  Nothing in
+the defect depends on the translational state structure, which is the only
+thing the three disagree about, so the guard is armed in all three at the same
+operating point rather than fitted separately per family.
+
+Re-running the pooled protocol above — eight stationary records, 900 s scoring
+window, the same 2400 rpm nominal cruise condition — with the guard and the
+covariance arm both on:
+
+| Family | Engine off | 2400 rpm, guard off | 2400 rpm, guard+R | Residual |
+| --- | ---: | ---: | ---: | ---: |
+| OU-II | 0.642 | 3.363 (5.2x) | 0.657 | 1.024x |
+| OU-III | 0.522 | 4.232 (8.1x) | 0.577 | 1.104x |
+| TFG | 0.745 | 14.026 (18.8x) | 0.785 | 1.055x |
+
+Pooled 3-D displacement RMS in metres; the residual is the guarded cruise error
+against that family's own engine-off baseline.  Yaw RMS falls from 58.59 to
+2.00 deg on OU-II, 45.38 to 1.84 on OU-III and 74.35 to 2.83 on TFG.
+
+```
+python3 tools/engine_noise_guard_families.py --data-dir <wave-csv-dir>
+```
+
+That tool checks itself before it reports: the engine-off and unguarded-cruise
+columns must come back equal to `engine_noise_summary.csv` above, or the two
+studies are not on the same protocol and the comparison is void.  It also
+confirms what makes arming safe — the engine-off replay is bit-identical
+guarded and unguarded, in all three families.
+
+TFG had the most to lose — 18.8x its baseline unguarded against OU-III's 8.1x —
+and gains the most: a 17.9x reduction in pooled error at cruise, against 7.3x
+for OU-III and 5.1x for OU-II.  All three land within 6 % of their own
+engine-off baseline, so the ordering between the families at cruise is the
+ordering they have with the engine off, which is what the guard was for.  What
+remains is not the same in each: the group delay it costs is the same 22.7 ms
+everywhere, but what that delay is worth depends on the family's own error, so
+the residual is not expected to be equal across the three.
+
 ### Configuration
 
-The guard is **armed by default**: the OU-III filter constructor sets
-`ACC_VIBRATION_GUARD_HZ_DEFAULT = 14 Hz` with two poles.  Arming it is free
-because it is gated on its own detector, so there is no quiet-water case to
-trade away.
+The guard is **armed by default** in every family: each filter sets
+`ACC_VIBRATION_GUARD_HZ_DEFAULT = 14 Hz` with two poles and
+`ACC_VIBRATION_RACC_GAIN_DEFAULT = 0.75`.  Arming it is free because it is
+gated on its own detector, so there is no quiet-water case to trade away.
 
 | Variable | Default | Meaning |
 | --- | ---: | --- |
-| `OU_III_ACC_GUARD_HZ` | 14 | conditioning corner; **0 removes the guard entirely** |
-| `OU_III_ACC_GUARD_POLES` | 2 | conditioning cascade length |
-| `OU_III_ACC_GUARD_RACC_GAIN` | 0.75 | covariance inflation gain; 0 disables |
-| `OU_III_ACC_GUARD_ENGAGE_LO` / `_HI` / `_TAU` | 0.03 / 0.08 / 5 | detector engagement band |
+| `<F>_ACC_GUARD_HZ` | 14 | conditioning corner; **0 removes the guard entirely** |
+| `<F>_ACC_GUARD_POLES` | 2 | conditioning cascade length |
+| `<F>_ACC_GUARD_RACC_GAIN` | 0.75 | covariance inflation gain; 0 disables |
+| `<F>_ACC_GUARD_ENGAGE_LO` / `_HI` / `_TAU` | 0.03 / 0.08 / 5 | detector engagement band |
 
-In code: `SeaStateFusionFilter_OU_III::setAccelVibrationGuard(cutoff_hz, poles)`,
-with `AccelVibrationGuard::setEngagement()` and `setDetectHz()` for the
-detector.  `accelVibrationRms()` and `accelVibrationGuardEngagement()` read
-back the health signal.  The simulator prints an `ACC_GUARD` line per record
-when a cutoff is configured.
+`<F>` is `OU_II`, `OU_III` or `TFG` for the matching simulator.  TFG also
+carries the first three as `Config` fields (`acc_vibration_guard_hz`,
+`acc_vibration_guard_poles`, `acc_vibration_racc_gain`), since that is how the
+rest of its front end is configured.
+
+In code: `setAccelVibrationGuard(cutoff_hz, poles)` and
+`setAccelVibrationRaccGain(gain)` on any of the three filters, with
+`setAccelVibrationEngagement()` for the detector band and
+`AccelVibrationGuard::setDetectHz()` for its corner.  `accelVibrationRms()` and
+`accelVibrationGuardEngagement()` read back the health signal.  Each simulator
+prints an `ACC_GUARD` line per record when a cutoff is configured.
 
 The engagement thresholds are absolute levels referenced to the accelerometer
 white noise this repository injects (1.51e-3 g per axis).  A noisier part

--- a/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
+++ b/src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
@@ -112,6 +112,7 @@
 #include "tuner/SeaStateAutoTuner.h"
 #include "tuner/WavePeriodEstimator.h"
 #include "tuner/VerticalAccelComplementary.h"
+#include "tuner/AccelVibrationGuard.h"
 #include "tuner/MagAutoTuner.h"
 #include "tuner/ContinuousMagHardIronEstimator.h"
 #include "kalman_ou_ii/Kalman3D_Wave_OU_II.h"
@@ -247,6 +248,55 @@ constexpr float MAG_DELAY_SEC              = 7.0f;
 // 0.05 deg/s -- so the observer that serves both has to estimate it.
 constexpr float STARTUP_PROXY_TWO_KP_DEFAULT = 0.2f;
 constexpr float STARTUP_PROXY_TWO_KI_DEFAULT = 0.02f;
+
+// Front-end accelerometer vibration guard, armed by default.
+//
+// docs/engine-noise-degradation.md is the measurement.  Machinery vibration
+// rectifies into a standing tilt error and from there into a displacement
+// offset, and at a routine cruise condition that costs a factor of eight in
+// pooled 3-D error; the guard holds every engine condition swept inside a
+// factor of 1.6 of the engine-off baseline.
+//
+// The study was run on OU-III, but nothing in it is specific to the
+// translational state structure, which is the only thing OU-II and OU-III
+// disagree about.  The mechanism is the attitude loop: vibration reaches the
+// accelerometer, the attitude correction wobbles at the vibration
+// frequencies, and the nonlinearity of the measurement model rectifies that
+// wobble into a static tilt.  Both filters level from the same private Mahony
+// observer with the same gains and feed the same accelerometer measurement to
+// a MEKF, so both inherit the defect and the remedy.
+//
+// Arming it costs nothing when there is no machinery, because the guard is
+// gated on its own detector and returns its input unchanged below the lower
+// rail.  Across the eight stationary records the clean detector reading is
+// 0.00796 to 0.00805 m/s^2 against a 0.03 rail, and the replays are
+// bit-identical to the unguarded ones.  That is why this is a default rather
+// than an option: there is no quiet-water case to trade away.
+//
+// Two poles at 14 Hz sits in the gap between the wave band and the lowest
+// crank order a small auxiliary diesel puts on the hull, and costs 22.7 ms of
+// group delay at full engagement.  Set the cutoff to zero to remove the guard
+// entirely and restore the unconditioned measurement path.
+constexpr float ACC_VIBRATION_GUARD_HZ_DEFAULT = 14.0f;
+constexpr int   ACC_VIBRATION_GUARD_POLES_DEFAULT = 2;
+
+// Vibration-aware accelerometer measurement covariance, on by default.
+//
+// Conditioning removes the machinery the guard can reach; what survives its
+// stopband still arrives as measurement error the MEKF does not know about.
+// This raises the commanded accelerometer sigma by the guard's own gated
+// excess, so the covariance and the measurement describe the same conditions.
+//
+// The gain is swept in docs/engine-noise-degradation.md, on OU-III, and 0.75
+// sits at the displacement optimum there with margin below the cliff: past
+// about 1.25 the accelerometer is de-weighted enough that the wave estimate
+// starts leaning on the OU prior instead, and displacement turns back up.
+// The trade is between the same two channels here, so the same point is
+// carried over rather than re-derived.
+//
+// Zero disables it.  Like the guard, it is driven by a gated excess that is
+// identically zero on a quiet installation, so it is bit-transparent there.
+constexpr float ACC_VIBRATION_RACC_GAIN_DEFAULT = 0.75f;
 
 // Frequency smoother dt (SeaStateFusionFilter_OU_II is designed for 200 Hz)
 constexpr float FREQ_SMOOTHER_DT = 1.0f / 200.0f;
@@ -463,6 +513,9 @@ public:
     {
         // Default cutoff ~max_freq_hz_ Hz: passes waves, kills 8–37 Hz engine band
         freq_input_lpf_.setCutoff(max_freq_hz_);
+        setAccelVibrationGuard(ACC_VIBRATION_GUARD_HZ_DEFAULT,
+                               ACC_VIBRATION_GUARD_POLES_DEFAULT);
+        setAccelVibrationRaccGain(ACC_VIBRATION_RACC_GAIN_DEFAULT);
         freq_stillness_.setTargetFreqHz(min_freq_hz_);
         startup_stage_   = StartupStage::Cold;
         startup_stage_t_ = 0.0f;
@@ -566,6 +619,78 @@ public:
         return vertical_accel_comp_.isInitialized();
     }
 
+    // Out-of-band accelerometer guard, ahead of the proxy and the MEKF.
+    //
+    // The cutoff sits in the gap between the wave band and the machinery band
+    // and stops vibration reaching the attitude loop, where it rectifies into a
+    // standing tilt error.  Armed by default; pass zero to remove it and
+    // restore the unconditioned measurement path exactly.  The cost is group
+    // delay, accelVibrationGuardDelaySec(), which appears in displacement as
+    // amplitude * 2 pi f * delay -- so prefer the highest corner that removes
+    // the machinery, not the lowest corner that fits above the waves.
+    void setAccelVibrationGuard(float cutoff_hz, int poles = 2) {
+        accel_guard_.setPoles(poles);
+        accel_guard_.setCutoffHz(cutoff_hz);
+    }
+
+    // Engagement band of the guard's detector.  Exposed mainly so a study can
+    // force the guard on over a quiet input and separate the delay it costs
+    // from the vibration it removes.
+    void setAccelVibrationEngagement(float lo_mps2, float hi_mps2,
+                                     float slew_tau_sec) noexcept {
+        accel_guard_.setEngagement(lo_mps2, hi_mps2, slew_tau_sec);
+    }
+
+    [[nodiscard]] float accelVibrationGuardDelaySec() const noexcept {
+        return accel_guard_.groupDelaySec();
+    }
+
+    // Vibration-aware accelerometer measurement covariance.
+    //
+    // The guard removes the machinery it can, but what survives its stopband
+    // still reaches the MEKF as measurement error the filter does not know
+    // about.  This tells it: the commanded accelerometer standard deviation
+    // becomes sqrt(sigma_base^2 + (gain * excess)^2), where excess is the
+    // guard's detector reading above its engagement floor.
+    //
+    // Zero disables it and leaves the commanded covariance exactly as the
+    // startup and stage logic set it.  Because the drive is the guard's own
+    // gated excess, it is identically zero on a quiet installation, so an
+    // enabled gain is still bit-transparent there.
+    void setAccelVibrationRaccGain(float gain) noexcept {
+        if (std::isfinite(gain) && gain >= 0.0f) racc_vibration_gain_ = gain;
+    }
+
+    [[nodiscard]] float accelVibrationRaccGain() const noexcept {
+        return racc_vibration_gain_;
+    }
+
+    // Accelerometer sigma currently commanded to the MEKF, m/s^2 per axis.
+    [[nodiscard]] Eigen::Vector3f accelVibrationRaccStd() const noexcept {
+        return racc_effective_;
+    }
+
+    [[nodiscard]] float accelVibrationGuardCutoffHz() const noexcept {
+        return accel_guard_.cutoffHz();
+    }
+
+    [[nodiscard]] int accelVibrationGuardPoles() const noexcept {
+        return accel_guard_.poles();
+    }
+
+    // How far the guard is currently engaged, in [0, 1].  Zero means the
+    // measurement path is the unconditioned one.
+    [[nodiscard]] float accelVibrationGuardEngagement() const noexcept {
+        return accel_guard_.engagement();
+    }
+
+    // Smoothed RMS of the out-of-band content the guard is removing, m/s^2.
+    // Zero when the guard is disabled, so it reads as a health signal only
+    // where it is actually measuring something.
+    [[nodiscard]] float accelVibrationRms() const noexcept {
+        return accel_guard_.removedRms();
+    }
+
     // Gains of the private Mahony observer, which serves both the vertical
     // channel and the startup attitude.  Same knob as
     // setWavePeriodComplementaryGains(); kept under this name because the
@@ -620,18 +745,34 @@ private:
         time_ += dt;
         startup_stage_t_ += dt;
 
+        // Strip out-of-band accelerometer vibration before anything reads it.
+        // This is the one place raw measurements enter, so filtering here is
+        // what keeps the guard's effect describable: the proxy, the MEKF, and
+        // the tilt watchdog below all see the same conditioned signal, and no
+        // consumer can be left on a different version of the accelerometer.
+        //
+        // Armed by default, and transparent below its detector's lower rail,
+        // in which case acc_in is acc unchanged.
+        const Eigen::Vector3f acc_in = accel_guard_.step(acc, dt);
+
         // Private Mahony observer for the wave-period estimator, the default
-        // sigma channel and the startup attitude.  It is fed the raw gyro and
-        // accelerometer, before the MEKF sees them, so that the levelling it
+        // sigma channel and the startup attitude.  It is fed gyro and
+        // accelerometer before the MEKF sees them, so that the levelling it
         // provides stays a pure function of the measurements.  Stepping it
         // unconditionally keeps its transient off the critical path when the
         // input source is switched at runtime.
-        vertical_accel_comp_.update(dt, gyro, acc, g_std);
+        vertical_accel_comp_.update(dt, gyro, acc_in, g_std);
+
+        // Tell the MEKF how much it should trust that sample before it uses
+        // it, so the covariance and the measurement describe the same
+        // conditions.  A no-op unless a gain is set and the guard sees
+        // machinery.
+        if (drive_mekf) apply_racc_vibration_inflation_();
 
         // MEKF updates first (attitude + latent a_w)
         if (drive_mekf) {
             mekf_->time_update(gyro, dt);
-            mekf_->measurement_update_acc_only(acc, tempC);
+            mekf_->measurement_update_acc_only(acc_in, tempC);
         }
 
         // The tilt watchdog reads and rewrites MEKF attitude, so it only has
@@ -666,10 +807,10 @@ private:
             if (tilt_over_limit_sec_ >= TILT_RESET_HOLD_SEC && tilt_reset_cooldown_sec_ <= 0.0f) {
                 if (startup_stage_ == StartupStage::Live) {
                     // In Live, re-lock only tilt while preserving yaw/north frame.
-                    mekf_->initialize_from_acc_preserve_yaw(acc);
+                    mekf_->initialize_from_acc_preserve_yaw(acc_in);
                 } else {
                     // During startup stages, accel-only re-lock is acceptable.
-                    mekf_->initialize_from_acc(acc);
+                    mekf_->initialize_from_acc(acc_in);
                     enterCold_();
                     resetTrackingState_();
                 }
@@ -1784,6 +1925,45 @@ private:
         }
     }
 
+    // The accelerometer sigma the startup and stage logic wants, before any
+    // vibration inflation.  Returns a zero vector when it is not known, which
+    // is the signal to leave the commanded covariance alone.
+    Eigen::Vector3f racc_base_std_() const {
+        if (warmup_Racc_active_ && Racc_warmup_std_ > 0.0f) {
+            return Eigen::Vector3f::Constant(Racc_warmup_std_);
+        }
+        if (Racc_nominal_std_.allFinite() && Racc_nominal_std_.minCoeff() > 0.0f) {
+            return Racc_nominal_std_;
+        }
+        return Eigen::Vector3f::Zero();
+    }
+
+    void apply_racc_vibration_inflation_() {
+        if (!mekf_ || !(racc_vibration_gain_ > 0.0f)) return;
+
+        const Eigen::Vector3f base = racc_base_std_();
+        if (!(base.minCoeff() > 0.0f)) return;
+
+        const float excess = accel_guard_.excessRms();
+        if (!(excess > 0.0f)) {
+            // Hand the base back once on the way down, then stay quiet, so a
+            // dormant guard leaves the stage logic's covariance untouched.
+            if (racc_inflated_) {
+                mekf_->set_Racc_std(base);
+                racc_effective_ = base;
+                racc_inflated_ = false;
+            }
+            return;
+        }
+
+        const float added = racc_vibration_gain_ * excess;
+        const Eigen::Vector3f effective =
+            (base.array().square() + added * added).sqrt().matrix();
+        mekf_->set_Racc_std(effective);
+        racc_effective_ = effective;
+        racc_inflated_ = true;
+    }
+
     void enterLive_() {
         startup_stage_   = StartupStage::Live;
         startup_stage_t_ = 0.0f;
@@ -1819,6 +1999,12 @@ private:
     float        startup_stage_t_ = 0.0f;
 
     bool  freeze_acc_bias_until_live_ = true;
+    // Vibration-aware measurement covariance, armed in the constructor at
+    // ACC_VIBRATION_RACC_GAIN_DEFAULT and inert until the guard sees machinery.
+    float racc_vibration_gain_        = 0.0f;
+    bool  racc_inflated_              = false;
+    Eigen::Vector3f racc_effective_   = Eigen::Vector3f::Zero();
+
     float Racc_warmup_std_            = 0.6f;
     bool  warmup_Racc_active_         = false;
     Eigen::Vector3f Racc_nominal_std_ = Eigen::Vector3f::Constant(0.0f);
@@ -1948,6 +2134,11 @@ private:
     VerticalAccelComplementary   vertical_accel_comp_{
         STARTUP_PROXY_TWO_KP_DEFAULT,
         STARTUP_PROXY_TWO_KI_DEFAULT};
+
+    // Armed in the constructor at ACC_VIBRATION_GUARD_HZ_DEFAULT, and dormant
+    // until its own detector sees machinery, so an unconditioned replay is
+    // bit-identical to a guarded one.
+    seastate::tuner::AccelVibrationGuard accel_guard_{};
 
     AdaptiveWaveBandPass         sigma_wave_band_{
         SIGMA_BAND_LOW_RATIO_DEFAULT,

--- a/src/kalman_tfg/SeaStateFusionFilter_TFG.h
+++ b/src/kalman_tfg/SeaStateFusionFilter_TFG.h
@@ -37,6 +37,7 @@
 
 #include "kalman_common/SeaStateFusionFilterCommon.h"
 #include "kalman_tfg/Kalman3D_Wave_TFG.h"
+#include "tuner/AccelVibrationGuard.h"
 #include "tuner/AdaptiveWaveBandPass.h"
 #include "tuner/ContinuousMagHardIronEstimator.h"
 #include "tuner/MagAutoTuner.h"
@@ -63,6 +64,51 @@ constexpr float TFG_NOMINAL_DT = 1.0f / 200.0f;
 constexpr float R_S_ACCEL_NOISE_DENSITY_DEFAULT =
     0.0148f * 0.0148f * TFG_NOMINAL_DT;
 constexpr float R_S_MSE_COEFF_DEFAULT = 0.0538f;
+
+// Front-end accelerometer vibration guard, armed by default, at deployed
+// OU-III's operating point.
+//
+// docs/engine-noise-degradation.md is the measurement.  Machinery vibration
+// rectifies into a standing tilt error and from there into a displacement
+// offset, and at a routine cruise condition that costs a factor of eight in
+// pooled 3-D error; the guard holds every engine condition swept inside a
+// factor of 1.6 of the engine-off baseline.
+//
+// The defect is in the attitude loop, not in the translational state: the
+// accelerometer is both the gravity reference and the wave measurement, the
+// attitude correction wobbles at the vibration frequencies, and the
+// nonlinearity of the measurement model rectifies that wobble into a static
+// tilt.  TFG levels from the same private Mahony observer at the same gains
+// and feeds the same accelerometer to its own MEKF, so it inherits both the
+// defect and the remedy, and the front end stays at coefficient parity with
+// OU-III by carrying the same corner.
+//
+// Arming it costs nothing when there is no machinery, because the guard is
+// gated on its own detector and returns its input unchanged below the lower
+// rail.  Across the eight stationary records the clean detector reading is
+// 0.00796 to 0.00805 m/s^2 against a 0.03 rail, and the replays are
+// bit-identical to the unguarded ones.
+//
+// Two poles at 14 Hz sits in the gap between the wave band and the lowest
+// crank order a small auxiliary diesel puts on the hull, and costs 22.7 ms of
+// group delay at full engagement.  Set the cutoff to zero to remove the guard
+// entirely and restore the unconditioned measurement path.
+constexpr float ACC_VIBRATION_GUARD_HZ_DEFAULT    = 14.0f;
+constexpr int   ACC_VIBRATION_GUARD_POLES_DEFAULT = 2;
+
+// Vibration-aware accelerometer measurement covariance, on by default.
+//
+// Conditioning removes the machinery the guard can reach; what survives its
+// stopband still arrives as measurement error the MEKF does not know about.
+// This raises the commanded accelerometer sigma by the guard's own gated
+// excess, so the covariance and the measurement describe the same conditions.
+// 0.75 is the displacement optimum of the OU-III sweep, with margin below the
+// point where de-weighting the only wave measurement there is starts to cost
+// more than the vibration does.
+//
+// Zero disables it.  Like the guard, it is driven by a gated excess that is
+// identically zero on a quiet installation, so it is bit-transparent there.
+constexpr float ACC_VIBRATION_RACC_GAIN_DEFAULT = 0.75f;
 
 enum class RSAdaptationLaw : uint8_t {
     LegacyCubic = 0,
@@ -156,6 +202,15 @@ public:
         float mag_hi_apply_fraction           = 1.0f;
         float mag_hi_slew_tau_sec             = 45.0f;
 
+        // Front-end accelerometer vibration guard and the vibration-aware
+        // accelerometer covariance it drives; see the defaults above.  A zero
+        // cutoff removes the guard and restores the unconditioned measurement
+        // path exactly, and a zero gain leaves the commanded covariance to the
+        // stage logic alone.
+        float acc_vibration_guard_hz    = ACC_VIBRATION_GUARD_HZ_DEFAULT;
+        int   acc_vibration_guard_poles = ACC_VIBRATION_GUARD_POLES_DEFAULT;
+        float acc_vibration_racc_gain   = ACC_VIBRATION_RACC_GAIN_DEFAULT;
+
         bool  wave_band_tuning      = true;
         float sigma_band_low_ratio  = SIGMA_BAND_LOW_RATIO_DEFAULT;
         float sigma_band_high_ratio = SIGMA_BAND_HIGH_RATIO_DEFAULT;
@@ -177,6 +232,11 @@ public:
         wave_period_.reset();
         vertical_complementary_.setGains(cfg.proxy_two_kp, cfg.proxy_two_ki);
         vertical_complementary_.reset();
+        setAccelVibrationGuard(cfg.acc_vibration_guard_hz, cfg.acc_vibration_guard_poles);
+        setAccelVibrationRaccGain(cfg.acc_vibration_racc_gain);
+        accel_guard_.reset();
+        racc_inflated_ = false;
+        racc_effective_.setZero();
         sigma_wave_band_.setRatios(cfg.sigma_band_low_ratio, cfg.sigma_band_high_ratio);
         sigma_wave_band_.setLimitsHz(cfg.sigma_band_min_hz, cfg.sigma_band_max_hz);
         sigma_wave_band_.reset();
@@ -202,7 +262,26 @@ public:
         applyPendingTune_();
         elapsed_sec_ += dt;
 
-        vertical_complementary_.update(dt, gyro, acc, cfg_.gravity_magnitude);
+        // Strip out-of-band accelerometer vibration before the attitude path
+        // reads it.  This is the one place raw measurements enter, so
+        // filtering here is what keeps the guard's effect describable: the
+        // proxy, the MEKF and the staged bootstrap all see the same
+        // conditioned signal, and no part of the attitude loop can be left on
+        // a different version of the accelerometer.
+        //
+        // The magnetic gravity gate and the tilt frame the magnetometer is
+        // acquired in stay on the raw signal, as they do in deployed OU-III,
+        // where the guard sits inside the fusion filter and those live in the
+        // wrapper above it.  Both average the specific force over ten seconds
+        // or more, so the machinery band is already far below their corner;
+        // keeping them raw costs nothing and keeps the front end at signal
+        // parity with OU-III rather than only coefficient parity.
+        //
+        // Armed by default, and transparent below its detector's lower rail,
+        // in which case acc_in is acc unchanged.
+        const Vector3f acc_in = accel_guard_.step(acc, dt);
+
+        vertical_complementary_.update(dt, gyro, acc_in, cfg_.gravity_magnitude);
         last_acc_body_ = acc;
         last_gyro_body_ = gyro;
         have_last_imu_ = true;
@@ -225,14 +304,20 @@ public:
             if (cfg_.startup_init_policy == StartupInitPolicy::MahonyProxy) {
                 tryProxyHandoff_();
             } else {
-                stagedColdStep_(gyro, acc, dt);
+                stagedColdStep_(gyro, acc_in, dt);
             }
             return;
         }
 
+        // Tell the MEKF how much it should trust that sample before it uses
+        // it, so the covariance and the measurement describe the same
+        // conditions.  A no-op unless a gain is set and the guard sees
+        // machinery.
+        applyRaccVibrationInflation_();
+
         periodicAwCovSyncTick_(dt);
         mekf_.time_update(gyro, dt);
-        mekf_.measurement_update_acc_only(acc, tempC);
+        mekf_.measurement_update_acc_only(acc_in, tempC);
 
         pseudo_elapsed_ += dt;
         if (pseudo_elapsed_ >= pseudo_period_sec_) {
@@ -289,6 +374,78 @@ public:
     [[nodiscard]] float pseudoUpdatePeriodSec() const noexcept { return pseudo_period_sec_; }
     [[nodiscard]] bool handoffTimedOut() const noexcept { return handoff_timed_out_; }
     [[nodiscard]] float getRSFilterInput() const noexcept { return RS_filter_input_; }
+
+    // Out-of-band accelerometer guard, ahead of the proxy and the MEKF.
+    //
+    // The cutoff sits in the gap between the wave band and the machinery band
+    // and stops vibration reaching the attitude loop, where it rectifies into a
+    // standing tilt error.  Armed by default; pass zero to remove it and
+    // restore the unconditioned measurement path exactly.  The cost is group
+    // delay, accelVibrationGuardDelaySec(), which appears in displacement as
+    // amplitude * 2 pi f * delay -- so prefer the highest corner that removes
+    // the machinery, not the lowest corner that fits above the waves.
+    void setAccelVibrationGuard(float cutoff_hz, int poles = ACC_VIBRATION_GUARD_POLES_DEFAULT) {
+        accel_guard_.setPoles(poles);
+        accel_guard_.setCutoffHz(cutoff_hz);
+    }
+
+    // Engagement band of the guard's detector.  Exposed mainly so a study can
+    // force the guard on over a quiet input and separate the delay it costs
+    // from the vibration it removes.
+    void setAccelVibrationEngagement(float lo_mps2, float hi_mps2,
+                                     float slew_tau_sec) noexcept {
+        accel_guard_.setEngagement(lo_mps2, hi_mps2, slew_tau_sec);
+    }
+
+    [[nodiscard]] float accelVibrationGuardDelaySec() const noexcept {
+        return accel_guard_.groupDelaySec();
+    }
+
+    // Vibration-aware accelerometer measurement covariance.
+    //
+    // The guard removes the machinery it can, but what survives its stopband
+    // still reaches the MEKF as measurement error the filter does not know
+    // about.  This tells it: the commanded accelerometer standard deviation
+    // becomes sqrt(sigma_base^2 + (gain * excess)^2), where excess is the
+    // guard's detector reading above its engagement floor.
+    //
+    // Zero disables it and leaves the commanded covariance exactly as the
+    // startup and stage logic set it.  Because the drive is the guard's own
+    // gated excess, it is identically zero on a quiet installation, so an
+    // enabled gain is still bit-transparent there.
+    void setAccelVibrationRaccGain(float gain) noexcept {
+        if (std::isfinite(gain) && gain >= 0.0f) racc_vibration_gain_ = gain;
+    }
+
+    [[nodiscard]] float accelVibrationRaccGain() const noexcept {
+        return racc_vibration_gain_;
+    }
+
+    // Accelerometer sigma currently commanded to the MEKF, m/s^2 per axis.
+    [[nodiscard]] Vector3f accelVibrationRaccStd() const noexcept {
+        return racc_effective_;
+    }
+
+    [[nodiscard]] float accelVibrationGuardCutoffHz() const noexcept {
+        return accel_guard_.cutoffHz();
+    }
+
+    [[nodiscard]] int accelVibrationGuardPoles() const noexcept {
+        return accel_guard_.poles();
+    }
+
+    // How far the guard is currently engaged, in [0, 1].  Zero means the
+    // measurement path is the unconditioned one.
+    [[nodiscard]] float accelVibrationGuardEngagement() const noexcept {
+        return accel_guard_.engagement();
+    }
+
+    // Smoothed RMS of the out-of-band content the guard is removing, m/s^2.
+    // Zero when the guard is disabled, so it reads as a health signal only
+    // where it is actually measuring something.
+    [[nodiscard]] float accelVibrationRms() const noexcept {
+        return accel_guard_.removedRms();
+    }
 
     void setAdaptEverySecs(float s) { if (s >= 0.0f && std::isfinite(s)) adapt_every_secs_ = s; }
     void setTauScaledPseudoCadence(bool on) { tau_scaled_pseudo_cadence_ = on; applyPseudoCadence_(); }
@@ -472,6 +629,47 @@ private:
         mekf_.set_linear_block_enabled(false);
         if (cfg_.freeze_acc_bias_until_live) mekf_.set_acc_bias_updates_enabled(false);
         mekf_.set_Racc_std(Vector3f::Constant(cfg_.Racc_warmup_std));
+        warmup_Racc_active_ = true;
+        racc_inflated_ = false;
+    }
+
+    // The accelerometer sigma the startup and stage logic wants, before any
+    // vibration inflation.  Returns a zero vector when it is not known, which
+    // is the signal to leave the commanded covariance alone.
+    [[nodiscard]] Vector3f raccBaseStd_() const {
+        if (warmup_Racc_active_ && cfg_.Racc_warmup_std > 0.0f) {
+            return Vector3f::Constant(cfg_.Racc_warmup_std);
+        }
+        if (Racc_nominal_.allFinite() && Racc_nominal_.minCoeff() > 0.0f) {
+            return Racc_nominal_;
+        }
+        return Vector3f::Zero();
+    }
+
+    void applyRaccVibrationInflation_() {
+        if (!(racc_vibration_gain_ > 0.0f)) return;
+
+        const Vector3f base = raccBaseStd_();
+        if (!(base.minCoeff() > 0.0f)) return;
+
+        const float excess = accel_guard_.excessRms();
+        if (!(excess > 0.0f)) {
+            // Hand the base back once on the way down, then stay quiet, so a
+            // dormant guard leaves the stage logic's covariance untouched.
+            if (racc_inflated_) {
+                mekf_.set_Racc_std(base);
+                racc_effective_ = base;
+                racc_inflated_ = false;
+            }
+            return;
+        }
+
+        const float added = racc_vibration_gain_ * excess;
+        const Vector3f effective =
+            (base.array().square() + added * added).sqrt().matrix();
+        mekf_.set_Racc_std(effective);
+        racc_effective_ = effective;
+        racc_inflated_ = true;
     }
 
     void enterLive_() {
@@ -482,6 +680,8 @@ private:
         mekf_.set_acc_bias_updates_enabled(false);
         maybeUnlockAccBias_();
         mekf_.set_Racc_std(Racc_nominal_);
+        warmup_Racc_active_ = false;
+        racc_inflated_ = false;
         commitTune_();
         mekf_.reset_aw_covariance_to_stationary();
     }
@@ -1001,6 +1201,17 @@ private:
     bool freeze_ou_channel_ = false;
     bool freeze_RS_channel_ = false;
     Vector3f Racc_nominal_{Vector3f::Constant(0.5f)};
+    bool     warmup_Racc_active_ = false;
+
+    // Armed in begin() at ACC_VIBRATION_GUARD_HZ_DEFAULT, and dormant until
+    // its own detector sees machinery, so an unconditioned replay is
+    // bit-identical to a guarded one.
+    seastate::tuner::AccelVibrationGuard accel_guard_{};
+    // Vibration-aware measurement covariance, armed in begin() at
+    // ACC_VIBRATION_RACC_GAIN_DEFAULT and inert until the guard sees machinery.
+    float    racc_vibration_gain_ = 0.0f;
+    bool     racc_inflated_ = false;
+    Vector3f racc_effective_{Vector3f::Zero()};
 
     float elapsed_sec_ = 0.0f;
     float live_sec_ = 0.0f;

--- a/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
+++ b/tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
@@ -219,6 +219,32 @@ public:
                 filter.setAccNoiseFloorSigma(v);
             }
 
+            // Out-of-band accelerometer guard ahead of the proxy and the
+            // MEKF.  Armed by default at the deployed corner; these override
+            // it, and a zero cutoff removes it entirely.
+            {
+                float guard_hz = 0.0f;
+                int guard_poles = ACC_VIBRATION_GUARD_POLES_DEFAULT;
+                env_int("OU_II_ACC_GUARD_POLES", guard_poles);
+                if (env_float("OU_II_ACC_GUARD_HZ", guard_hz)) {
+                    filter.setAccelVibrationGuard(guard_hz, guard_poles);
+                }
+                float racc_gain = 0.0f;
+                if (env_float("OU_II_ACC_GUARD_RACC_GAIN", racc_gain)) {
+                    filter.setAccelVibrationRaccGain(racc_gain);
+                }
+                float engage_lo = 0.0f, engage_hi = 0.0f, engage_tau = 0.0f;
+                const bool lo_set = env_float("OU_II_ACC_GUARD_ENGAGE_LO", engage_lo);
+                const bool hi_set = env_float("OU_II_ACC_GUARD_ENGAGE_HI", engage_hi);
+                const bool tau_set = env_float("OU_II_ACC_GUARD_ENGAGE_TAU", engage_tau);
+                if (lo_set || hi_set || tau_set) {
+                    filter.setAccelVibrationEngagement(
+                        lo_set ? engage_lo : -1.0f,
+                        hi_set ? engage_hi : -1.0f,
+                        tau_set ? engage_tau : -1.0f);
+                }
+            }
+
             if (env_float("OU_ADAPT_TAU_SEC", v)) {
                 filter.setAdaptationTimeConstants(v);
             }
@@ -526,6 +552,23 @@ public:
             }
             fixed_tuning_applied_ = true;
         }
+    }
+
+    // Vibration-guard telemetry, so a replay can say whether the guard engaged
+    // and how much out-of-band accelerometer content it was seeing.  The shared
+    // runner owns the adapter, so end-of-record is the destructor; silent
+    // unless a cutoff was configured, which keeps an unguarded run unchanged.
+    ~FusionAdapter_OU_II() override {
+        const auto& filter = fusion_.raw();
+        if (!(filter.accelVibrationGuardCutoffHz() > 0.0f)) return;
+        std::cout << "ACC_GUARD cutoff_hz=" << filter.accelVibrationGuardCutoffHz()
+                  << " poles=" << filter.accelVibrationGuardPoles()
+                  << " engagement=" << filter.accelVibrationGuardEngagement()
+                  << " out_of_band_rms_mps2=" << filter.accelVibrationRms()
+                  << " delay_sec=" << filter.accelVibrationGuardDelaySec()
+                  << " racc_gain=" << filter.accelVibrationRaccGain()
+                  << " racc_std_mps2=" << filter.accelVibrationRaccStd().x()
+                  << "\n";
     }
 
     FilterSnapshot snapshot() const override {

--- a/tests/kalman_tfg/kalman_tfg-sim.cpp
+++ b/tests/kalman_tfg/kalman_tfg-sim.cpp
@@ -150,6 +150,17 @@ public:
         if (float v = 0.0f; env_float("TFG_MAG_HI_RIDGE_REL", v)) cfg.mag_hi_model_ridge_relative = v;
         if (float v = 0.0f; env_float("TFG_ACC_BIAS_UNLOCK_SEC", v)) cfg.acc_bias_unlock_sec = v;
 
+        // Out-of-band accelerometer guard ahead of the proxy and the MEKF.
+        // Armed by default at the deployed corner; these override it, and a
+        // zero cutoff removes it entirely.
+        if (float v = 0.0f; env_float("TFG_ACC_GUARD_HZ", v)) cfg.acc_vibration_guard_hz = v;
+        if (const char* g = std::getenv("TFG_ACC_GUARD_POLES")) {
+            cfg.acc_vibration_guard_poles = std::atoi(g);
+        }
+        if (float v = 0.0f; env_float("TFG_ACC_GUARD_RACC_GAIN", v)) {
+            cfg.acc_vibration_racc_gain = v;
+        }
+
         tuning_ = load_tuning_mode();
         load_fixed_tuning_();
 
@@ -175,6 +186,34 @@ public:
                 fusion_.setSigmaBandRatios(lo, hi);
             }
         }
+        {
+            float engage_lo = 0.0f, engage_hi = 0.0f, engage_tau = 0.0f;
+            const bool lo_set = env_float("TFG_ACC_GUARD_ENGAGE_LO", engage_lo);
+            const bool hi_set = env_float("TFG_ACC_GUARD_ENGAGE_HI", engage_hi);
+            const bool tau_set = env_float("TFG_ACC_GUARD_ENGAGE_TAU", engage_tau);
+            if (lo_set || hi_set || tau_set) {
+                fusion_.setAccelVibrationEngagement(
+                    lo_set ? engage_lo : -1.0f,
+                    hi_set ? engage_hi : -1.0f,
+                    tau_set ? engage_tau : -1.0f);
+            }
+        }
+    }
+
+    // Vibration-guard telemetry, so a replay can say whether the guard engaged
+    // and how much out-of-band accelerometer content it was seeing.  The shared
+    // runner owns the adapter, so end-of-record is the destructor; silent
+    // unless a cutoff was configured, which keeps an unguarded run unchanged.
+    ~FusionAdapter_TFG() override {
+        if (!(fusion_.accelVibrationGuardCutoffHz() > 0.0f)) return;
+        std::cout << "ACC_GUARD cutoff_hz=" << fusion_.accelVibrationGuardCutoffHz()
+                  << " poles=" << fusion_.accelVibrationGuardPoles()
+                  << " engagement=" << fusion_.accelVibrationGuardEngagement()
+                  << " out_of_band_rms_mps2=" << fusion_.accelVibrationRms()
+                  << " delay_sec=" << fusion_.accelVibrationGuardDelaySec()
+                  << " racc_gain=" << fusion_.accelVibrationRaccGain()
+                  << " racc_std_mps2=" << fusion_.accelVibrationRaccStd().x()
+                  << "\n";
     }
 
     void updateMag(const Vector3f& mag_body_ned) override {

--- a/tests/validation/test_ou_article_ablations.py
+++ b/tests/validation/test_ou_article_ablations.py
@@ -2,6 +2,7 @@
 
 import csv
 import math
+import re
 import unittest
 from pathlib import Path
 
@@ -466,6 +467,45 @@ class OuArticleVibrationGuardContractTests(unittest.TestCase):
         self.assertIn("mekf_->measurement_update_acc_only(acc_in, tempC);", filt)
         self.assertNotIn("measurement_update_acc_only(acc,", filt)
 
+    def test_every_estimator_family_carries_the_same_guard(self):
+        """OU-II and TFG inherit the defect, so they inherit the remedy.
+
+        The rectification mechanism is in the attitude loop, which all three
+        families build the same way: one private Mahony observer levelling from
+        the accelerometer, feeding a MEKF that reads the same accelerometer.
+        The degradation study measures all three degrading, so a guard armed in
+        only one of them would leave the other two shipping the defect.
+        """
+
+        for family, path, mekf, gravity in (
+            ("OU-II",
+             ROOT / "src" / "kalman_ou_ii" / "SeaStateFusionFilter_OU_II.h",
+             "mekf_->measurement_update_acc_only(acc_in, tempC);",
+             "vertical_accel_comp_.update(dt, gyro, acc_in, g_std);"),
+            ("TFG",
+             ROOT / "src" / "kalman_tfg" / "SeaStateFusionFilter_TFG.h",
+             "mekf_.measurement_update_acc_only(acc_in, tempC);",
+             "vertical_complementary_.update(dt, gyro, acc_in, cfg_.gravity_magnitude);"),
+        ):
+            with self.subTest(family=family):
+                filt = path.read_text(encoding="utf-8")
+                # Same corner, same cascade, same covariance gain as OU-III.
+                for name, value in (("ACC_VIBRATION_GUARD_HZ_DEFAULT", "14.0f"),
+                                    ("ACC_VIBRATION_GUARD_POLES_DEFAULT", "2"),
+                                    ("ACC_VIBRATION_RACC_GAIN_DEFAULT", "0.75f")):
+                    self.assertRegex(filt, rf"constexpr \S+ +{name} +=  *{re.escape(value)};")
+                # Armed rather than merely available.
+                self.assertIn("setAccelVibrationGuard(", filt)
+                self.assertIn("setAccelVibrationRaccGain(", filt)
+                # Driven by the guard's own gated excess, which is what keeps
+                # it inert on a quiet installation.
+                self.assertIn("accel_guard_.excessRms()", filt)
+                # One conditioning point ahead of the whole attitude loop.
+                self.assertIn("accel_guard_.step(acc, dt);", filt)
+                self.assertIn(gravity, filt)
+                self.assertIn(mekf, filt)
+                self.assertNotIn("measurement_update_acc_only(acc,", filt)
+
     def test_covariance_inflation_helps_where_the_guard_leaves_most(self):
         """The arm exists to attack what conditioning cannot reach."""
 
@@ -487,16 +527,19 @@ class OuArticleVibrationGuardContractTests(unittest.TestCase):
                 self.assertLessEqual(both_pitch, guard_pitch * 1.05, condition)
 
     def test_degradation_study_pins_the_guard_off(self):
-        """It is the unguarded comparison, and OU-III now arms the guard.
+        """It is the unguarded comparison, and all three families arm the guard.
 
-        Without this the degradation study would silently measure a guarded
-        OU-III against an unguarded OU-II and TFG.
+        Without this the degradation study would silently measure the shipped
+        guarded configuration and report it as the damage the guard exists to
+        undo.
         """
 
         tool = (ROOT / "tools" / "engine_noise_degradation.py").read_text(
             encoding="utf-8"
         )
-        self.assertIn('"OU_III_ACC_GUARD_HZ": "0"', tool)
+        for prefix in ("OU_II", "OU_III", "TFG"):
+            with self.subTest(prefix=prefix):
+                self.assertIn(f'"{prefix}_ACC_GUARD_HZ": "0"', tool)
 
         mitigation = (ROOT / "tools" / "ou3_engine_noise_mitigation.py").read_text(
             encoding="utf-8"

--- a/tools/engine_noise_degradation.py
+++ b/tools/engine_noise_degradation.py
@@ -302,13 +302,16 @@ def invoke(binary: Path, input_path: Path, setting: Setting,
             # Every gate in this study was fitted to a vibration-free input, so
             # collect the metrics instead of stopping on the first failure.
             "W3D_COLLECT_ALL_GATES": "1",
-            # OU-III now arms its front-end vibration guard by default.  This
-            # study is the controlled comparison that motivates it, across three
-            # families of which only one has a guard, so it pins the guard off
-            # and keeps measuring the unconditioned measurement path.  What the
-            # default actually does is tools/ou3_engine_noise_mitigation.py.
-            # OU-II and TFG ignore the variable.
+            # All three families now arm the front-end vibration guard by
+            # default.  This study is the controlled comparison that motivates
+            # it, so it pins the guard off in every family and keeps measuring
+            # the unconditioned measurement path.  What the default actually
+            # does is tools/ou3_engine_noise_mitigation.py.  Each simulator
+            # ignores the prefixes that are not its own, so setting all three
+            # here keeps one env block for one protocol.
+            "OU_II_ACC_GUARD_HZ": "0",
             "OU_III_ACC_GUARD_HZ": "0",
+            "TFG_ACC_GUARD_HZ": "0",
         }
     )
     env.update(setting.env())

--- a/tools/engine_noise_guard_families.py
+++ b/tools/engine_noise_guard_families.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Cross-family check that the front-end vibration guard behaves the same way.
+
+``tools/ou3_engine_noise_mitigation.py`` is the full mitigation study: it sweeps
+engine conditions, both guard stages, release behaviour and the corner choice,
+and it is the generator of the committed evidence in
+``reports/results/engine_noise_mitigation/``.  It runs OU-III, because that is
+where the guard was designed.
+
+This is the much smaller question that follows from arming the guard everywhere:
+having established on OU-III what the guard does, does it do the same thing in
+the other two families at the same operating point?  It replays the eight
+stationary records through each family with the engine off and at the nominal
+cruise condition, guard off and guard+R, and pools 3-D displacement error the
+same way the degradation study does.
+
+Two of the four cells per family are already committed evidence -- the
+engine-off and unguarded-cruise columns are the degradation study's own numbers
+-- so the run checks itself: if those do not come back equal to
+``reports/results/engine_noise_degradation/engine_noise_summary.csv``, the two
+studies are not on the same protocol and the comparison is void.
+
+Nothing is written to disk.  The table it prints is the one at the end of the
+mitigation section of ``docs/engine-noise-degradation.md``.
+
+Usage:
+
+    make -C tests/kalman_ou_ii kalman_ou_ii-sim
+    make -C tests/kalman_ou_iii kalman_ou_iii-sim
+    make -C tests/kalman_tfg kalman_tfg-sim
+    python3 tools/engine_noise_guard_families.py --data-dir <wave-csv-dir>
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import os
+import re
+import subprocess
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_WINDOW_SEC = 900.0
+DEGRADATION_SUMMARY = (
+    ROOT / "reports" / "results" / "engine_noise_degradation" / "engine_noise_summary.csv"
+)
+
+# The nominal cruise condition of the degradation study: the one condition it
+# reports as a table rather than a sweep point.
+CRUISE_RPM = "2400"
+
+# Tolerance on the self-check against the committed degradation summary.  The
+# replays are deterministic and the two studies pool the same way, so what is
+# left is float summation order; a genuine protocol mismatch moves these cells
+# by percent, not by parts per million.
+SELF_CHECK_REL_TOL = 1e-4
+
+
+@dataclass(frozen=True)
+class Family:
+    label: str
+    simulator: Path
+    env_prefix: str
+
+
+FAMILIES = (
+    Family("OU-II", ROOT / "tests" / "kalman_ou_ii" / "kalman_ou_ii-sim", "OU_II"),
+    Family("OU-III", ROOT / "tests" / "kalman_ou_iii" / "kalman_ou_iii-sim", "OU_III"),
+    Family("TFG", ROOT / "tests" / "kalman_tfg" / "kalman_tfg-sim", "TFG"),
+)
+
+# The same eight stationary records the degradation and mitigation studies use.
+RECORDS = tuple(
+    f"wave_data_{family}_H{tail}.csv"
+    for family in ("jonswap", "pmstokes")
+    for tail in (
+        "0.270_L14.047_A30.00_P60.00",
+        "1.500_L50.710_A-30.00_P120.00",
+        "4.000_L112.766_A30.00_P30.00",
+        "8.500_L202.839_A-30.00_P72.00",
+    )
+)
+
+CONDITIONS = {"engine off": {}, "2400 rpm": {"W3D_ENGINE_RPM": CRUISE_RPM}}
+
+RMS_3D_RE = re.compile(r"^3D RMS \(m\): ([0-9.eE+-]+)", re.MULTILINE)
+YAW_RMS_RE = re.compile(r"^Angles RMS \(deg\): \S+ \S+ Yaw=([0-9.eE+-]+)", re.MULTILINE)
+GUARD_RE = re.compile(r"^ACC_GUARD (.*)$", re.MULTILINE)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data-dir", type=Path, required=True,
+                        help="directory containing the versioned wave CSVs")
+    parser.add_argument("--window-sec", type=float, default=DEFAULT_WINDOW_SEC,
+                        help="trailing scoring window in seconds (default: 900)")
+    parser.add_argument("--jobs", type=int, default=4,
+                        help="parallel simulator processes (default: 4)")
+    parser.add_argument("--no-self-check", action="store_true",
+                        help="skip the comparison against the committed degradation summary")
+    return parser.parse_args()
+
+
+def find_record(data_dir: Path, name: str) -> Path:
+    matches = list(data_dir.rglob(name))
+    if len(matches) != 1:
+        raise FileNotFoundError(
+            f"expected exactly one {name} under {data_dir}, found {len(matches)}"
+        )
+    return matches[0]
+
+
+def arm_env(family: Family, arm: str) -> dict[str, str]:
+    """Explicit in both arms, so neither inherits whatever the filter defaults to."""
+    if arm == "off":
+        return {
+            f"{family.env_prefix}_ACC_GUARD_HZ": "0",
+            f"{family.env_prefix}_ACC_GUARD_RACC_GAIN": "0",
+        }
+    # guard+R is the shipped configuration, so it is left to the filter
+    # defaults rather than restated here: restating them would let this study
+    # keep passing after the deployed point moved.
+    return {}
+
+
+def run_one(family: Family, input_path: Path, condition: str, arm: str,
+            window_sec: float) -> dict[str, Any]:
+    env = os.environ.copy()
+    env.update({
+        "W3D_WRITE_TIMESERIES": "0",
+        "W3D_VALIDATION_WINDOW_SEC": f"{window_sec:.9g}",
+        # The deployed gates were fitted to a vibration-free input; collect the
+        # metrics rather than stopping on the first one this study crosses.
+        "W3D_COLLECT_ALL_GATES": "1",
+    })
+    env.update(CONDITIONS[condition])
+    env.update(arm_env(family, arm))
+
+    completed = subprocess.run(
+        [str(family.simulator), "--input", str(input_path.resolve())],
+        cwd=family.simulator.parent, env=env, text=True,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False,
+    )
+    if completed.returncode not in (0, 1):
+        tail = "\n".join(completed.stdout.splitlines()[-30:])
+        raise RuntimeError(
+            f"{family.label} {input_path.name} {condition} guard={arm}: "
+            f"simulator exit {completed.returncode}\n{tail}"
+        )
+    if condition != "engine off" and "ENGINE_VIBRATION" not in completed.stdout:
+        raise RuntimeError(f"{family.label}: engine model did not engage")
+    if arm == "off" and "ACC_GUARD" in completed.stdout:
+        raise RuntimeError(f"{family.label}: guard was not switched off")
+    if arm != "off" and "ACC_GUARD" not in completed.stdout:
+        raise RuntimeError(f"{family.label}: guard is not armed by default")
+
+    disp = RMS_3D_RE.search(completed.stdout)
+    yaw = YAW_RMS_RE.search(completed.stdout)
+    if not disp or not yaw:
+        raise RuntimeError(f"{family.label} {input_path.name}: no scoring summary")
+    guard = GUARD_RE.search(completed.stdout)
+    return {
+        "family": family.label,
+        "record": input_path.name,
+        "condition": condition,
+        "arm": arm,
+        "disp_3d_rms_m": float(disp.group(1)),
+        "yaw_rms_deg": float(yaw.group(1)),
+        "guard": guard.group(1) if guard else "",
+    }
+
+
+def pooled(rows: list[dict[str, Any]], family: str, condition: str, arm: str,
+           key: str) -> float:
+    values = [
+        row[key] for row in rows
+        if row["family"] == family and row["condition"] == condition and row["arm"] == arm
+    ]
+    if not values:
+        raise KeyError(f"no rows for {family} {condition} {arm}")
+    return math.sqrt(sum(v * v for v in values) / len(values))
+
+
+def committed_degradation() -> dict[tuple[str, str], float]:
+    """The engine-off and unguarded-cruise cells this study must reproduce."""
+    wanted = {"baseline": "engine off", "cruise": "2400 rpm"}
+    out: dict[tuple[str, str], float] = {}
+    with DEGRADATION_SUMMARY.open(encoding="utf-8", newline="") as stream:
+        for row in csv.DictReader(stream):
+            if row["arm"] == "baseline":
+                out[(row["family"], wanted["baseline"])] = float(row["disp_3d_rms_m"])
+            elif row["arm"] == "speed" and row["rpm"] == f"{float(CRUISE_RPM):.1f}":
+                out[(row["family"], wanted["cruise"])] = float(row["disp_3d_rms_m"])
+    return out
+
+
+def main() -> int:
+    args = parse_args()
+    if not (math.isfinite(args.window_sec) and args.window_sec > 0.0):
+        raise SystemExit("--window-sec must be positive and finite")
+
+    missing = [f.label for f in FAMILIES if not f.simulator.exists()]
+    if missing:
+        raise SystemExit(
+            "build the simulators first; missing: " + ", ".join(missing)
+        )
+
+    inputs = {name: find_record(args.data_dir, name) for name in RECORDS}
+    jobs = [
+        (family, inputs[name], condition, arm)
+        for family in FAMILIES
+        for name in RECORDS
+        for condition in CONDITIONS
+        for arm in ("off", "guard+R")
+    ]
+    with ThreadPoolExecutor(max_workers=max(1, args.jobs)) as pool:
+        rows = list(pool.map(
+            lambda job: run_one(*job, args.window_sec), jobs))
+
+    if not args.no_self_check:
+        committed = committed_degradation()
+        for (family, condition), expected in committed.items():
+            got = pooled(rows, family, condition, "off", "disp_3d_rms_m")
+            if abs(got - expected) > SELF_CHECK_REL_TOL * max(abs(expected), 1.0):
+                raise SystemExit(
+                    f"{family} {condition} unguarded: {got:.9g} m against the "
+                    f"committed {expected:.9g} m -- this study and the "
+                    f"degradation study are not on the same protocol"
+                )
+
+    print(f"Pooled over {len(RECORDS)} stationary records, "
+          f"{args.window_sec:.0f} s scoring window\n")
+    header = (f"{'Family':8s} {'engine off':>11s} {'2400 off':>11s} "
+              f"{'2400 guard+R':>13s} {'residual':>9s} {'yaw off':>9s} {'yaw +R':>8s}")
+    print(header)
+    print("-" * len(header))
+    for family in FAMILIES:
+        base = pooled(rows, family.label, "engine off", "off", "disp_3d_rms_m")
+        cruise_off = pooled(rows, family.label, "2400 rpm", "off", "disp_3d_rms_m")
+        cruise_on = pooled(rows, family.label, "2400 rpm", "guard+R", "disp_3d_rms_m")
+        yaw_off = pooled(rows, family.label, "2400 rpm", "off", "yaw_rms_deg")
+        yaw_on = pooled(rows, family.label, "2400 rpm", "guard+R", "yaw_rms_deg")
+        print(f"{family.label:8s} {base:11.3f} {cruise_off:11.3f} "
+              f"{cruise_on:13.3f} {cruise_on / base:8.3f}x {yaw_off:9.2f} {yaw_on:8.2f}")
+
+    print("\nEngine-off replays, guarded against unguarded:")
+    for family in FAMILIES:
+        guarded = pooled(rows, family.label, "engine off", "guard+R", "disp_3d_rms_m")
+        base = pooled(rows, family.label, "engine off", "off", "disp_3d_rms_m")
+        same = "identical" if guarded == base else f"DIFFER by {guarded - base:.3e} m"
+        print(f"  {family.label:8s} {same}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The engine-noise degradation study measures all three estimator families degrading heavily under machinery vibration, but only OU-III carried the remedy. This arms the same guard, at the same operating point, in OU-II and TFG.

## Why it carries over unchanged

The damage is done in the attitude loop, not in the translational state, which is the only thing the three families disagree about. The accelerometer is both the gravity reference and the wave measurement; vibration makes the attitude correction wobble, and the nonlinearity of the measurement model rectifies that wobble into a standing tilt that leaks gravity into horizontal acceleration. All three level from the same private Mahony observer at the same gains and feed the same accelerometer to a MEKF, so all three inherit the defect and the remedy alike. The corner, the cascade, the detector and the covariance gain are therefore adopted rather than refitted per family.

## What changed

- `AccelVibrationGuard` sits at the single point where raw measurements enter each filter — `SeaStateFusionFilter_OU_II::updateCore_` and `SeaStateFusionFilter_TFG::update` — so the Mahony proxy, the MEKF and the attitude re-lock all read the same conditioned accelerometer.
- Both filters gain the second stage as well: the commanded accelerometer sigma is raised by the guard's own gated excess, which attacks the part conditioning cannot reach.
- Same public API as OU-III (`setAccelVibrationGuard`, `setAccelVibrationRaccGain`, `setAccelVibrationEngagement`, and the read-backs). TFG additionally exposes the first three as `Config` fields, since that is how the rest of its front end is configured.
- Both simulators gain the `<F>_ACC_GUARD_*` env knobs and the per-record `ACC_GUARD` telemetry line, matching OU-III's.
- `tools/engine_noise_degradation.py` now pins the guard off in every family. It is the unguarded comparison that motivates the mitigation, and without this it would have started measuring the shipped configuration and reporting it as the damage the guard exists to undo.

## Measured

Pooled over the eight stationary records, 900 s scoring window, at the 2400 rpm nominal cruise condition, guard and covariance both on:

| Family | Engine off | 2400 rpm, guard off | 2400 rpm, guard+R | Residual |
| --- | ---: | ---: | ---: | ---: |
| OU-II | 0.642 | 3.363 (5.2x) | 0.657 | 1.024x |
| OU-III | 0.522 | 4.232 (8.1x) | 0.577 | 1.104x |
| TFG | 0.745 | 14.026 (18.8x) | 0.785 | 1.055x |

3-D displacement RMS in metres. Yaw RMS falls from 58.59 to 2.00 deg on OU-II and 74.35 to 2.83 on TFG.

`tools/engine_noise_guard_families.py` reproduces this. It checks itself before it reports: the engine-off and unguarded-cruise cells must come back equal to the committed `engine_noise_summary.csv`, or the two studies are not on the same protocol. They do, to nine significant figures, and the OU-III row reproduces the committed mitigation summary exactly.

## Bit-transparency

With no engine the detector never reaches its lower rail, so the guard returns its input unchanged and the replay is bit-identical to the unguarded one — verified in both new families over the shipped record set, and re-checked by the tool above. Every committed quality gate still passes unchanged, and all three test suites (`tests/kalman_ou_ii`, `tests/kalman_ou_iii`, `tests/kalman_tfg`) pass.

## Evidence contract

The committed OU replay evidence pins a dependency closure that includes the OU-II filter and simulator, so `make all` reports

```
validation: replay dependency differs from replay provenance: src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h
validation: replay dependency differs from replay provenance: tests/kalman_ou_ii/kalman_ou_ii-sim.cpp
```

until the full replay is regenerated. This is the same state the tree was in when the guard first landed in OU-III (`fde5d29`), and is resolved by the "Regenerate the full OU validation and robustness evidence" run. Verified against a clean tree that no other test regresses: the remaining failures in `tests/validation` are present on `main` in this environment too.

---
_Generated by [Claude Code](https://claude.ai/code/session_019vpbyG528cLnjjBcYxP6Qu)_