### PR TITLE
Fix the two stale OU-III P5 validation expectations breaking main

### DIFF
--- a/tests/validation/test_ou3_p5_sample1_structured_full_gain_v11.py
+++ b/tests/validation/test_ou3_p5_sample1_structured_full_gain_v11.py
@@ -13,14 +13,22 @@ class StructuredFullGainV11Tests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # This deliberately coarse fixture is a semantic/fail-closed test, not
-        # the authoritative V10/V11 numerical certificate. V10 requires the
-        # focused 24^3 grid to close; the workflow emitter below supplies that.
+        # the authoritative V11 numerical certificate; the workflow emitter
+        # supplies the focused 24^3 grid for that.
         cls.d=V11.build(source_pieces=4,source_cell_index=0,p_pieces=4,tangent_pieces=4,axial_pieces=4)
 
-    def test_validate_fail_closed_coarse_prerequisite(self):
+    def test_validate_fail_closed_on_the_coarse_grid(self):
+        # V10's own enclosure has since tightened enough to close on this
+        # coarse grid, so the parent no longer contributes a prerequisite
+        # failure here. What the fixture still pins is the fail-closed rule
+        # that matters: V11's own joint cells do not all close on 4^3, so the
+        # certificate stays NOT_ESTABLISHED and validate() reports the witness
+        # rather than a spurious failure or an inherited PASS.
         failures=V11.validate(self.d)
-        self.assertEqual(failures,["V10 prerequisite did not pass"])
+        self.assertEqual(failures,[])
         self.assertEqual(self.d["P5_SAMPLE1_PSD_S_PERTURBATION_V11"],"NOT_ESTABLISHED")
+        self.assertGreater(self.d["unclosed_joint_cells"],0)
+        self.assertIsNotNone(self.d["first_unclosed_joint_cell"])
 
     def test_omitted_covariance_terms_are_now_explicit(self):
         for k in (

--- a/tests/validation/test_ou3_p5_sample1_structured_full_gain_v12.py
+++ b/tests/validation/test_ou3_p5_sample1_structured_full_gain_v12.py
@@ -12,8 +12,8 @@ import ou3_p5_sample1_structured_full_gain_v12 as V12
 class StructuredFullGainV12Tests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        # Semantic/fail-closed fixture only.  V10 is intentionally not expected
-        # to close on this 4^3 grid; the workflow's 24^3 emitter is authoritative.
+        # Semantic/fail-closed fixture only; the workflow's 24^3 emitter is
+        # the authoritative V12 certificate.
         cls.d=V12.build(source_pieces=4,source_cell_index=0,p_pieces=4,tangent_pieces=4,axial_pieces=4)
 
     def test_interval_ldlt_lambda_lower_on_diagonal_spd(self):
@@ -24,10 +24,16 @@ class StructuredFullGainV12Tests(unittest.TestCase):
         self.assertGreater(lam,1.999999999999)
         self.assertLessEqual(lam,2.0)
 
-    def test_validate_fail_closed_coarse_prerequisite(self):
+    def test_validate_fail_closed_on_the_coarse_grid(self):
+        # V10 now closes on this coarse grid, so no prerequisite failure is
+        # raised here; V12's own joint cells still do not close on 4^3, and the
+        # certificate has to stay NOT_ESTABLISHED with a recorded witness
+        # instead of inheriting the parent's PASS.
         failures=V12.validate(self.d)
-        self.assertEqual(failures,["V10 prerequisite did not pass"])
+        self.assertEqual(failures,[])
         self.assertEqual(self.d["P5_SAMPLE1_PSD_S_ACTUAL_INNOVATION_V12"],"NOT_ESTABLISHED")
+        self.assertGreater(self.d["unclosed_joint_cells"],0)
+        self.assertIsNotNone(self.d["first_unclosed_joint_cell"])
 
     def test_actual_nominal_innovation_replaces_noise_only_floor(self):
         self.assertIs(self.d["actual_nominal_innovation_lambda_certified_by_interval_LDLT"],True)

--- a/tools/ou3_p5_45deg_first_accel_tilt_yaw_source_bound.py
+++ b/tools/ou3_p5_45deg_first_accel_tilt_yaw_source_bound.py
@@ -25,10 +25,12 @@ left to the next source-correlated numerical stage.
 from __future__ import annotations
 
 import argparse
+import functools
 import json
 import math
 from pathlib import Path
 
+import ou3_source_domain_contract as SOURCE
 import ou3_p5_first_accel_exact_source_v2 as EXACT
 import ou3_p5_first_accel_rotation_gauge as RG
 import ou3_p5_full_h_prefix_cells as FULL
@@ -38,6 +40,20 @@ import ou3_p5_45deg_first_accel_signed_source_bound_v2 as V2
 DEFAULT_DOMAIN = V1.DEFAULT_DOMAIN
 SCHEMA = 3
 DEFAULT_TANGENT_CELLS = 96
+
+
+@functools.lru_cache(maxsize=1)
+def _deployed_prediction_dt_s() -> float:
+    """Return the deployed IMU prediction step with binary32 semantics.
+
+    ``FREQ_SMOOTHER_DT`` is ``constexpr float 1.0f / 200.0f``, so the shipping
+    cadence is the binary32 neighbour 0.004999999888241291 s, not the binary64
+    spelling of the decimal 0.005.  Reading it back from the header is what
+    makes this a check on the deployed constant rather than on a literal
+    retyped here.
+    """
+    text = SOURCE.DEFAULT_HEADER.read_text(encoding="utf-8")
+    return SOURCE.parse_const(text, "FREQ_SMOOTHER_DT")
 
 
 def build(domain_path: Path = DEFAULT_DOMAIN, *, source_pieces: int = 2,
@@ -159,11 +175,14 @@ def validate(d: dict) -> list[str]:
     if not (math.isfinite(factor) and factor > 1.0):
         f.append("startup sample1 improvement factor is not strict")
     dt = float(d.get("next_prediction_dt_s", -1.0))
-    # FULL._source_cell() deliberately carries outward-rounded source literals.
-    # Accept that certified enclosure instead of requiring exactly one binary64
-    # ULP around the decimal spelling 0.005.  Four ULPs is still <4e-18 s and
-    # cannot hide a different deployed cadence.
-    if not math.isclose(dt, 0.005, rel_tol=0.0, abs_tol=4.0 * math.ulp(0.005)):
+    # Compare against the deployed binary32 constant, not the binary64 spelling
+    # of 0.005: FREQ_SMOOTHER_DT is 1.0f/200.0f, which rounds to
+    # 0.004999999888241291 s, some 1.1e-10 s below the decimal value.  The
+    # adjacent binary32 cadences are 4.7e-10 s away, so a few binary64 ULPs of
+    # slack around the parsed constant still cannot hide a different cadence.
+    dt_deployed = _deployed_prediction_dt_s()
+    if not math.isclose(dt, dt_deployed, rel_tol=0.0,
+                        abs_tol=4.0 * math.ulp(dt_deployed)):
         f.append("next prediction step is not the deployed 5 ms interval")
     if d.get("P5_DEPLOYED_STARTUP_TILT_YAW_FIRST_ACCEL_SUBROUTE") == "PASS" and f:
         f.append("PASS carries validation failures")


### PR DESCRIPTION
Fixes the three assertion failures in the main build's `ou-evidence / commit` job
([run 33541491462](https://github.com/bareboat-necessities/ocean-imu/actions/runs/33541491462/job/99979427013)).
They come from two independent causes; both are stale expectations in the checks, not
producer regressions.

## 1. Deployed prediction step compared against the wrong constant

`tools/ou3_p5_45deg_first_accel_tilt_yaw_source_bound.py`

`validate` checked the carried prediction step against the binary64 spelling of `0.005`
with a four-ULP window. The step it validates comes from `FREQ_SMOOTHER_DT`, which is
`constexpr float 1.0f / 200.0f` and is therefore parsed with the binary32 semantics the
source-domain contract applies everywhere else: `0.004999999888241291` s — about
`1.1e-10` s below the decimal value, roughly `1.3e8` binary64 ULPs outside the window.
The check could never pass, so the producer reported

```
next prediction step is not the deployed 5 ms interval
PASS carries validation failures
```

and `test_P1_tilt_intersection_is_only_deployed_startup_subroute` failed.

The validator now reads the constant back from the deployed header and compares against
that. The adjacent binary32 cadences are `4.7e-10` s away, so the few-ULP slack still
cannot hide a different deployed cadence, and the check is bound to the shipping constant
rather than to a decimal literal retyped in the validator.

## 2. V11/V12 coarse fixtures assumed a V10 prerequisite failure

`tests/validation/test_ou3_p5_sample1_structured_full_gain_v11.py`
`tests/validation/test_ou3_p5_sample1_structured_full_gain_v12.py`

Both semantic fixtures build on a deliberately coarse `4^3` grid and asserted that
`validate` returns exactly `["V10 prerequisite did not pass"]`. V10's own enclosure has
since tightened — the exact monotone gain enclosure lifted over the full source-cell-0
cover — and it now closes on that grid too: 64 joint cells, none unclosed, max combined
directional correction `8.2269` rad inside the 9 rad range. The parent no longer
contributes a prerequisite failure, so both tests failed on a stale expectation.

The tests now assert the fail-closed property the fixtures exist to pin: V11 leaves 31 of
64 joint cells unclosed and V12 all 64, so both certificates stay `NOT_ESTABLISHED` with a
recorded witness instead of inheriting V10's `PASS`, and `validate` reports no spurious
failure. The stale prose about V10 needing the focused `24^3` grid is corrected with it.

## Scope

No producer numerics, filter source, declared domain, or promoted claim changes.

## Verification

The three previously failing tests pass locally:

- `test_ou3_p5_45deg_sample1_h_group_norms` — 7 tests, OK
- `test_ou3_p5_sample1_structured_full_gain_v11` + `_v12` — 12 tests, OK

A full `unittest discover` was also run in this container; the remaining failures there are
environmental (no `numpy`/`matplotlib`, and the fingerprinted simulation records are not
fetched, so the archive-provenance and publication-tree checks cannot run) and are
unrelated to this diff. CI has those prerequisites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UF7yin7Q8UaFCraiTLtDGS

---
_Generated by [Claude Code](https://claude.ai/code/session_01UF7yin7Q8UaFCraiTLtDGS)_