### PR TITLE
Show IMU lever-arm (off-CoG) correction explicitly in sensor sketches

### DIFF
--- a/sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino
+++ b/sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino
@@ -76,6 +76,47 @@ static constexpr float ROT_BIAS_TAU_S       = 5.0f;
 static constexpr float ROT_STILL_G_TOL_FRAC = 0.12f;
 static constexpr float ROT_STILL_GYRO_RAD_S = 0.15f;
 
+// ---------------------------------------------------------------------------
+// IMU installation lever arm (IMU position relative to the vessel centre of
+// gravity), in BODY-NED metres:  x = forward (towards the bow),
+//                                y = starboard,
+//                                z = down.
+//
+// A rigidly mounted IMU that does not sit exactly on the CoG does not measure
+// the CoG motion.  For a body-fixed offset r it measures
+//
+//     a_imu = a_cog + (alpha x r) + omega x (omega x r)
+//
+// i.e. the CoG specific force plus a tangential term (alpha = angular
+// acceleration) and a centripetal term (omega = angular rate).  Both terms are
+// deterministic and both are correlated with attitude, so an IMU bolted a few
+// decimetres away from the CoG leaks roll/pitch motion into the same
+// acceleration channel this filter integrates into heave, and biases the
+// attitude estimate that rides on it.
+//
+// The filter can subtract that term itself, but only if it is told r.  It is
+// left at ZERO here, which is also the filter's own default: a zero lever arm
+// means "IMU is at the CoG", the correction is switched off completely, and
+// the device behaves exactly as it did before this knob was exposed.  The call
+// is written out explicitly in resetFusion_() so the adjustment point is
+// visible rather than implied.
+//
+// To adjust for a real installation, measure the offset on the boat as
+// (IMU position - CoG position) along the three axes above and enter it here.
+// Example: an IMU 1.20 m forward of, 0.15 m to starboard of and 0.30 m ABOVE
+// the CoG (z is positive DOWN, so "above" is negative):
+//
+//     static constexpr float IMU_LEVER_ARM_X_M =  1.20f;
+//     static constexpr float IMU_LEVER_ARM_Y_M =  0.15f;
+//     static constexpr float IMU_LEVER_ARM_Z_M = -0.30f;
+//
+// A few centimetres of accuracy is plenty; a wrong sign is worse than leaving
+// the correction off, because it doubles the term instead of removing it.
+// ---------------------------------------------------------------------------
+static constexpr float IMU_LEVER_ARM_X_M = 0.0f;  // + forward (towards bow)
+static constexpr float IMU_LEVER_ARM_Y_M = 0.0f;  // + starboard
+static constexpr float IMU_LEVER_ARM_Z_M = 0.0f;  // + down
+
 using namespace atoms3r_ical;
 using Vector3f = Eigen::Vector3f;
 
@@ -526,6 +567,22 @@ private:
     ff.setAccNoiseFloorSigma(ACC_NOISE_FLOOR_SIGMA_DEFAULT);
     ff.enableClamp(true);
     ff.setFreqInputCutoffHz(6.0f);
+
+    // IMU installation lever-arm (off-CoG) correction.
+    //
+    // Set explicitly on every reset: fusion_.begin() builds a fresh MEKF, and
+    // the lever arm lives in that MEKF, so it has to be re-applied here rather
+    // than once at boot.
+    //
+    // The vector below is zero by default, which tells the filter the IMU sits
+    // on the centre of gravity and turns the correction off (identical to
+    // ff.mekf().clear_imu_lever_arm()).  Edit IMU_LEVER_ARM_*_M near the top of
+    // this sketch to enter the real installation offset -- nothing else has to
+    // change here.  Related knob, if the correction is enabled and the gyro is
+    // noisy: ff.mekf().set_alpha_smoothing_tau(seconds) low-passes the angular
+    // acceleration the tangential term is built from (0 = off).
+    ff.mekf().set_imu_lever_arm_body(
+        Vector3f(IMU_LEVER_ARM_X_M, IMU_LEVER_ARM_Y_M, IMU_LEVER_ARM_Z_M));
 
     rot_inited_   = false;
     rot_dpm_filt_ = 0.0f;

--- a/sensors/full_marine_ins/atomS3R_ins_kalman_ou3/atomS3R_ins_kalman_ou3.ino
+++ b/sensors/full_marine_ins/atomS3R_ins_kalman_ou3/atomS3R_ins_kalman_ou3.ino
@@ -76,6 +76,47 @@ static constexpr float ROT_BIAS_TAU_S       = 5.0f;
 static constexpr float ROT_STILL_G_TOL_FRAC = 0.12f;
 static constexpr float ROT_STILL_GYRO_RAD_S = 0.15f;
 
+// ---------------------------------------------------------------------------
+// IMU installation lever arm (IMU position relative to the vessel centre of
+// gravity), in BODY-NED metres:  x = forward (towards the bow),
+//                                y = starboard,
+//                                z = down.
+//
+// A rigidly mounted IMU that does not sit exactly on the CoG does not measure
+// the CoG motion.  For a body-fixed offset r it measures
+//
+//     a_imu = a_cog + (alpha x r) + omega x (omega x r)
+//
+// i.e. the CoG specific force plus a tangential term (alpha = angular
+// acceleration) and a centripetal term (omega = angular rate).  Both terms are
+// deterministic and both are correlated with attitude, so an IMU bolted a few
+// decimetres away from the CoG leaks roll/pitch motion into the same
+// acceleration channel this filter integrates into heave, and biases the
+// attitude estimate that rides on it.
+//
+// The filter can subtract that term itself, but only if it is told r.  It is
+// left at ZERO here, which is also the filter's own default: a zero lever arm
+// means "IMU is at the CoG", the correction is switched off completely, and
+// the device behaves exactly as it did before this knob was exposed.  The call
+// is written out explicitly in resetFusion_() so the adjustment point is
+// visible rather than implied.
+//
+// To adjust for a real installation, measure the offset on the boat as
+// (IMU position - CoG position) along the three axes above and enter it here.
+// Example: an IMU 1.20 m forward of, 0.15 m to starboard of and 0.30 m ABOVE
+// the CoG (z is positive DOWN, so "above" is negative):
+//
+//     static constexpr float IMU_LEVER_ARM_X_M =  1.20f;
+//     static constexpr float IMU_LEVER_ARM_Y_M =  0.15f;
+//     static constexpr float IMU_LEVER_ARM_Z_M = -0.30f;
+//
+// A few centimetres of accuracy is plenty; a wrong sign is worse than leaving
+// the correction off, because it doubles the term instead of removing it.
+// ---------------------------------------------------------------------------
+static constexpr float IMU_LEVER_ARM_X_M = 0.0f;  // + forward (towards bow)
+static constexpr float IMU_LEVER_ARM_Y_M = 0.0f;  // + starboard
+static constexpr float IMU_LEVER_ARM_Z_M = 0.0f;  // + down
+
 using namespace atoms3r_ical;
 using Vector3f = Eigen::Vector3f;
 
@@ -526,6 +567,22 @@ private:
     ff.setAccNoiseFloorSigma(ACC_NOISE_FLOOR_SIGMA_DEFAULT);
     ff.enableClamp(true);
     ff.setFreqInputCutoffHz(6.0f);
+
+    // IMU installation lever-arm (off-CoG) correction.
+    //
+    // Set explicitly on every reset: fusion_.begin() builds a fresh MEKF, and
+    // the lever arm lives in that MEKF, so it has to be re-applied here rather
+    // than once at boot.
+    //
+    // The vector below is zero by default, which tells the filter the IMU sits
+    // on the centre of gravity and turns the correction off (identical to
+    // ff.mekf().clear_imu_lever_arm()).  Edit IMU_LEVER_ARM_*_M near the top of
+    // this sketch to enter the real installation offset -- nothing else has to
+    // change here.  Related knob, if the correction is enabled and the gyro is
+    // noisy: ff.mekf().set_alpha_smoothing_tau(seconds) low-passes the angular
+    // acceleration the tangential term is built from (0 = off).
+    ff.mekf().set_imu_lever_arm_body(
+        Vector3f(IMU_LEVER_ARM_X_M, IMU_LEVER_ARM_Y_M, IMU_LEVER_ARM_Z_M));
 
     rot_inited_   = false;
     rot_dpm_filt_ = 0.0f;

--- a/sensors/full_marine_ins/atomS3R_ins_pii_observer/atomS3R_ins_pii_observer.ino
+++ b/sensors/full_marine_ins/atomS3R_ins_pii_observer/atomS3R_ins_pii_observer.ino
@@ -504,6 +504,17 @@ class FusionApp {
     fusion_.configure(cfg);
     fusion_.reset();
 
+    // IMU installation lever arm (off-CoG) correction: not available here.
+    //
+    // An IMU mounted away from the vessel centre of gravity measures
+    // a_imu = a_cog + (alpha x r) + omega x (omega x r) for a body-fixed offset
+    // r, which leaks roll/pitch motion into the heave channel.  The PII
+    // observer takes no lever-arm input, so this sketch has nothing to set and
+    // implicitly assumes r = 0 (IMU at the CoG) -- mount it as close to the CoG
+    // as the boat allows.  The OU-II / OU-III sketches in this same directory
+    // do expose the knob (Kalman3D_Wave_OU_*::set_imu_lever_arm_body), and show
+    // it set explicitly to zero with instructions for entering a real offset.
+
     rot_inited_ = false;
     rot_dpm_filt_ = 0.0f;
     gyro_bias_ok_ = false;


### PR DESCRIPTION
## What

The OU-II and OU-III MEKFs already model the rigid-body terms an IMU picks up when it is not bolted at the vessel centre of gravity,

```
a_imu = a_cog + (alpha x r) + omega x (omega x r)
```

via `Kalman3D_Wave_OU_{II,III}::set_imu_lever_arm_body(r)`. Until now no real-sensor sketch referenced it, so nothing on the device side showed where that installation offset is entered.

## Changes

**`sensors/full_marine_ins/atomS3R_ins_kalman_ou3/atomS3R_ins_kalman_ou3.ino`**
**`sensors/full_marine_ins/atomS3R_ins_kalman_ou2/atomS3R_ins_kalman_ou2.ino`**

- New `IMU_LEVER_ARM_X_M` / `_Y_M` / `_Z_M` constants near the other tuning constants, all `0.0f`, with a comment block covering the physics, the BODY-NED axis convention (x forward, y starboard, z down), a worked non-zero example, and the warning that a wrong sign is worse than leaving the correction off.
- `resetFusion_()` now calls `ff.mekf().set_imu_lever_arm_body(Vector3f(...))` right after the other filter knobs, with a comment explaining why it has to be re-applied on every reset (`fusion_.begin()` builds a fresh MEKF) and pointing at the related `set_alpha_smoothing_tau()` knob.

**`sensors/full_marine_ins/atomS3R_ins_pii_observer/atomS3R_ins_pii_observer.ino`**

- Comment only. `AdaptiveVerticalPIIMahony` exposes no lever-arm input, so the sketch implicitly assumes the IMU is at the CoG; the note says so and points at the OU sketches. The compass/AHRS and basic IMU sketches were left alone for the same reason.

## Behavior

Unchanged. A zero vector sets `use_imu_lever_arm_ = false`, which is the filter's own default, so the correction stays off and the call exists purely to document and locate the adjustment point.

## Verification

Both sketch call sites were extracted into standalone translation units and compiled against the real headers (`g++ -std=c++20 -DEIGEN_NON_ARDUINO -I src`, system Eigen): `SeaStateFusion_OU_III` and `SeaStateFusion_OU_II` each `begin()` + `raw().mekf().set_imu_lever_arm_body(Vector3f(0,0,0))` compile clean. Full Arduino/M5Unified builds were not run in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzpC8sMfnA6bZXjvEHdse7

---
_Generated by [Claude Code](https://claude.ai/code/session_01DzpC8sMfnA6bZXjvEHdse7)_