### PR TITLE
Make clang-tidy blocking now that clang parse blockers are gone

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -48,13 +48,6 @@ jobs:
     name: ${{ matrix.gate }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    # clang-tidy reports but does not block. Two `constexpr float x = std::sqrt(...)`
-    # initializers in src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h and its OU-III
-    # counterpart are a GCC extension that clang rejects outright, so every TU
-    # including them fails to parse. Both files are in the frozen replay
-    # dependency closure, so the two-line fix needs an evidence regeneration to
-    # land. Drop this line once it does — see docs/quality-gates.md.
-    continue-on-error: ${{ matrix.gate == 'clang-tidy' }}
     strategy:
       fail-fast: false
       matrix:

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -29,38 +29,36 @@ have to re-derive them.
 | warnings | 1 real finding (`-Wreorder` in `KalmanQMEKF.h`) | 52 TUs clean |
 | sanitizers | never run | 6 suites, 0 ASan / 0 UBSan / 0 leak findings |
 | cppcheck | 5 findings — 3 false positives, 2 in frozen files | clean |
-| clang-tidy | 18 findings, 16 of them noise | 2 blockers, see below |
+| clang-tidy | 18 findings, 16 of them noise | blocking; former parse blockers fixed |
 | python | 96 ruff findings across 122 files | clean |
 | coverage | no tooling | 65.6% lines from the six sanitizer dirs |
 
 The codebase was in much better shape than the absence of tooling suggested.
 The warnings gate cost exactly one real fix to turn on.
 
-## The one thing that is not green
+## Resolved clang frontend blocker
 
-`clang-tidy` is **non-blocking** (`continue-on-error`) for one specific reason:
+`clang-tidy` was initially non-blocking because the OU-II and OU-III fusion
+headers contained `constexpr` initializers using `std::sqrt(2.0f)`. GCC accepted
+that as an extension, while the clang frontend rejected every translation unit
+that included either header.
 
-```
-src/kalman_ou_ii/SeaStateFusionFilter_OU_II.h:1375: error: constexpr variable
-  'C_HS' must be initialized by a constant expression
-```
+That blocker is gone. The replay-closure regeneration changed both headers to
+the portable C++20 spelling `std::numbers::sqrt2_v<float>` and verified that the
+filters compile under both `g++` and `clang++`. The relevant expressions now
+look like:
 
-`std::sqrt` in a `constexpr` initializer is a GCC extension. Clang rejects it,
-and clang-tidy uses the clang frontend, so any translation unit that includes
-`SeaStateFusionFilter_OU_II.h` or `_OU_III.h` fails to parse. That is also why
-this library does not currently build with clang at all.
-
-The fix is two lines per file — `std::sqrt(2.0f)` → `std::numbers::sqrt2_v<float>`,
-which is bitwise identical (`0x3FB504F3`) and so changes no numerical result:
-
-```diff
--        constexpr float K = std::sqrt(2.0f) / std::numbers::pi_v<float>;
-+        constexpr float K = std::numbers::sqrt2_v<float> / std::numbers::pi_v<float>;
+```cpp
+constexpr float C_HS =
+    2.0f * std::numbers::sqrt2_v<float> /
+    (std::numbers::pi_v<float> * std::numbers::pi_v<float>);
+constexpr float K =
+    std::numbers::sqrt2_v<float> / std::numbers::pi_v<float>;
 ```
 
-It is not applied here because both files are in the frozen replay dependency
-closure (below). Once it lands with an evidence regeneration, drop the
-`continue-on-error` from the `clang-tidy` matrix entry.
+There is therefore no remaining reason to suppress the clang-tidy job at the
+workflow level. `clang-tidy` is a normal blocking static-analysis gate: any
+current parse error or configured diagnostic fails CI.
 
 ## The frozen replay closure
 
@@ -82,8 +80,8 @@ Practical consequences:
 
 - `tools/quality_gates.sh` has no `--fix` mode. Adding one would need a frozen
   path filter first.
-- Three suppressions in `tools/cppcheck-suppressions.txt` and the clang-tidy
-  blocker above exist because the finding is inside the closure.
+- Three suppressions in `tools/cppcheck-suppressions.txt` remain for findings in
+  the frozen closure; the former clang frontend blocker has been resolved.
 - Changing compiler flags in `tests/kalman_ou_ii/Makefile` or
   `tests/kalman_ou_iii/Makefile` invalidates the evidence too. That is why the
   warnings gate compiles its own translation units instead of adding flags to


### PR DESCRIPTION
## Problem

The quality-gate workflow and documentation still say clang-tidy must remain non-blocking because `constexpr std::sqrt(2.0f)` expressions in the OU-II/OU-III fusion headers cannot be parsed by Clang.

That rationale is stale. Commit `ec4e0972faff134b44b3c3e36267a76bbc5a788a` replaced those expressions with `std::numbers::sqrt2_v<float>` as part of the sanctioned replay-closure regeneration and explicitly verified both filters with `clang++`.

## Changes

- remove `continue-on-error: ${{ matrix.gate == 'clang-tidy' }}` from `quality-gates.yml`
- remove the obsolete workflow comments describing the old parse blocker
- update `docs/quality-gates.md` to mark the clang frontend blocker resolved
- document clang-tidy as a normal blocking static-analysis gate
- keep the frozen replay-closure rules intact; no estimator/evidence files are touched

## Validation intent

This PR deliberately changes `.github/workflows/quality-gates.yml`, so its own PR CI runs clang-tidy under the new blocking policy. If a real current clang-tidy diagnostic remains, this PR should go red rather than hide it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Quality Improvements**
  - Static analysis now treats clang-tidy failures as blocking, improving confidence that code meets established quality standards.
  - A previously unresolved compiler compatibility issue in the replayed code has been addressed, allowing clang-tidy checks to run successfully.

- **Documentation**
  - Updated quality-gate documentation to reflect the resolved clang frontend issue and the current blocking behavior.
  - Clarified the remaining analysis suppressions used for frozen replay code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->