### PR TITLE
Fix canonical OU-III P3 enclosure and decide P4 feasibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,106 @@ Before finishing:
 
 While preparing PRs make sure you do not leave dangling and obsolete
 tests, .md files, tools, .py files and data files. Everything that PR
-makes obsolete should be clean up before making PR ready, obsolete .yml GitHub workflows too. 
+makes obsolete should be clean up before making PR ready, obsolete .yml GitHub workflows too.
 Do not keep all historical context in .md files. It creates unnecessary bloat.
 Documentation should state current behavior. It doesn't need to explain what
 PR changed. What PR changed belongs to PR meta, but not to the committed files.
+
+## OU-III proof research protocol
+
+The objective is to establish or falsify the declared OU-III theorem stages. Existing proof constructions are hypotheses, not requirements. Do not preserve a proof method merely because earlier commits used it.
+
+The mandatory research state machine is:
+
+`EXECUTE -> FAILURE ANALYSIS -> REPLAN -> EXECUTE`
+
+Never go directly from a failed mathematical attempt to another refinement of the same idea.
+
+### Failure analysis is mandatory
+
+After every mathematical, enclosure, conditioning, or numerical failure, stop implementation and record in `docs/ou3-proof-research-state.md`:
+
+1. the exact failed inequality, quantity, source class, state direction, or numerical operation;
+2. whether the failure is a theorem failure, proof-method failure, enclosure failure, conditioning failure, implementation defect, CI failure, or infrastructure failure;
+3. which hypothesis or strategy the evidence invalidates;
+4. what the failure does not invalidate;
+5. the current limiting quantity;
+6. the next falsifiable experiment.
+
+If essentially the same mechanism has already failed once, list at least three qualitatively different alternatives before choosing the next method. The alternatives must not all be variants of subdivision, tighter scalar norms, or increased search depth.
+
+### Two-strike rule and quantitative permission
+
+A proof tactic gets one initial implementation and at most one mathematically motivated refinement. After the second failure of substantially the same mechanism, freeze it as a dead end and perform an architecture review.
+
+Do not repeat subdivision, interval refinement, tighter scalar norm bounds, additional remainder lemmas, or increased search depth unless a scaling argument predicts quantitatively that the change can cross the required theorem threshold. "Try it and see" is not sufficient.
+
+A rejected route may be revisited only after documenting the new mathematical fact that makes the previous rejection inapplicable.
+
+### Master inequality before implementation
+
+Before implementing a new proof lemma, identify where it enters the controlling theorem inequality and estimate whether improving it can materially change the final margin.
+
+For P4, the controlling object is the complete-word ratio
+
+`rho_w = V_after(F_w(x)) / V_before(x)`.
+
+Local reset, Joseph, sector, measurement, or remainder bounds are subordinate lemmas. Do not create a new P4 micro-certificate unless it is required by a complete-word formulation already shown to be feasible and its expected contribution can materially move `rho_w` through 1.
+
+### Distinguish a false theorem from a bad enclosure
+
+Before rigorous certification of a new P4 formulation, run a non-promoting, high-precision complete-word feasibility diagnostic that preserves the exact matrix/group structure and introduces essentially no interval pessimism.
+
+Interpret the result as follows:
+
+- diagnostic `rho` clearly below 1: rigorous enclosure work is justified;
+- diagnostic `rho` near 1: identify the limiting state direction and reconsider the theorem/metric before interval implementation;
+- diagnostic `rho` above 1: abandon that P4 formulation rather than sharpening unrelated bounds.
+
+The diagnostic must report worst H/A ratios, the limiting legal word/source/phase, a maximizing state direction or generalized eigenvector, operation-by-operation margin consumption, and distance to `rho=1`.
+
+### Independent critic pass
+
+After every important proof failure, perform a critic pass before further implementation:
+
+- assume the current proof architecture is wrong;
+- state the strongest reason to abandon it;
+- propose an alternative that does not share the failed mechanism;
+- compare the alternatives against the actual limiting quantity.
+
+Only after this pass may implementation resume.
+
+### Research ledger
+
+Maintain `docs/ou3-proof-research-state.md` as a short current-state ledger with:
+
+- Current hypothesis
+- Evidence
+- Current limiter
+- Failed approaches / DEAD_ENDS
+- Retained facts
+- Alternatives
+- Next falsifiable experiment
+
+Keep it concise and current. It is research state, not a chronological PR history.
+
+### One research question per PR
+
+Do not let an OU-III proof PR absorb successive unrelated theorem stages. A feasibility result that justifies a new rigorous proof stage starts a new PR unless the current PR explicitly defines that stage as its research question.
+
+### Immutable OU-III constraints
+
+Do not move these constraints for proof convenience:
+
+- canonical P3 usefulness threshold = `1e-18`;
+- no replay fitting;
+- no artificial operating-domain reduction to obtain PASS;
+- no deployed-filter change to make the proof easier;
+- same-history source correlation must be preserved;
+- both H=18 and A=21 are required;
+- lever arm remains zero/disabled in the current proof scope;
+- dormant vibration-guard branch remains transparent;
+- P4 cannot promote before canonical P3;
+- P5 cannot promote before strict canonical P4 contraction.
+
+A failed proof attempt is evidence. Prefer abandoning a bad proof architecture over accumulating increasingly elaborate bounds around it. The goal is not to make the current algorithm pass; the goal is to determine the mathematically correct route to the theorem, or determine that the current theorem formulation cannot be certified.

--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -4,32 +4,70 @@ This file is the current research ledger required by the root `AGENTS.md`. Keep 
 
 ## State
 
-**FAILURE ANALYSIS / REPLAN**
+**REPLAN COMPLETE — NEXT EXECUTION AUTHORIZED**
 
 Current PR research question: make canonical P3 reach one rigorous numerical PASS/FAIL verdict at the unchanged `1e-18` gate; only if P3 passes, run one non-promoting structure-exact P4 complete-word feasibility diagnostic. P5 is out of scope.
 
-## Current hypothesis
+## Failure classification
 
-The present P3 failure is an enclosure/conditioning failure in the translation covariance lower, not yet a numerical P3 theorem failure. The absolute entrywise enclosure of `F L F^T + Q` followed by `C - eps I` can erase the small integrated-`S` one-step SPD direction before the complete 13--26-sample segment floor is formed.
+The current canonical run is **not a numerical P3 theorem FAIL**. It is blocked earlier by a translation-covariance enclosure/conditioning failure:
 
-The leading alternative is a relative/congruence-normalized Loewner enclosure applied to the prediction or complete segment, because P3 needs a rigorous complete-segment floor, not an artificially strong absolute point lower at every 5-ms intermediate step.
+`Loewner prediction lower lost strict SPD; split x cell`
+
+There is also a separate implementation defect in the initial `x` partition helper: subcells adjacent to the `x=0.01` process-series branch are emitted as nested/overlapping intervals because branch-endpoint clamping is applied to every subcell instead of only the boundary subcell. That creates redundant work but does not explain the adaptive recursion failure by itself.
 
 ## Evidence
 
-- The deterministic source-node 137 / gap-13 case reproduces `Loewner prediction lower lost strict SPD; split x cell`.
-- Repeated adaptive subdivision reaches the configured depth limit without closing the current absolute point-lower construction.
-- Canonical P3 therefore does not yet reach the translation, H, or A margin calculation; this run is not evidence that the `1e-18` theorem gate fails.
-- The frozen P2 contract retains same-history source correlation and rejects independent Cartesian `tau/sigma/R_S` extrema.
+For the deterministic source-node 137 / gap-13 failure, diagnostic evaluation of the first prediction on the widest initial small-`x` cell gives:
 
-## Current limiter
+- `x = [0.0073253899652235745, 0.009999999999999998]`;
+- center `lambda_min ~= 3.405e-10`;
+- absolute row-radius `eps ~= 1.142e-5`;
+- `eps/lambda_min ~= 3.35e4`;
+- limiting center eigenvector approximately `[0.090, -0.448, 0.890, -0.0077]`, dominated by the poorly scaled `p/S` directions.
 
-The limiting object is the rigorous Loewner lower used to construct `common_boundary_floor` for a complete legal 13--26-sample translation segment. The immediate experiment must measure conditioning of the first failed prediction and how the relative enclosure error scales under subdivision.
+Following the existing geometric subdivision down one branch reduces `eps/lambda_min` approximately by a factor of two per split, but at depth 12 it is still about `8.26`. Thus approximately four additional binary levels would be needed merely to make this first 5-ms prediction plausible. A full binary refinement to that scale is on the order of `2^16` leaves for the widest initial cell before considering the complete 800-source x 14-gap family. Deeper subdivision is therefore rejected as a tractable proof architecture even though its local error scaling is understood.
+
+A non-rigorous point diagnostic over the theorem-relevant **complete 13-sample segment** is qualitatively better: across the source-137 tau endpoints the final covariance has `lambda_min ~= 2.02e-5 ... 2.83e-5`, roughly five orders of magnitude above the one-sample floor. This is diagnostic evidence only, but it quantitatively supports moving the enclosure target to the complete segment.
+
+A one-step full congruence normalization of the same wide interval reduces the relative enclosure mismatch substantially (`eps/lambda_min` from roughly `3.35e4` to roughly `1.17e3`) but still leaves a large one-step deficit. Therefore normalizing each 5-ms step is not the selected architecture.
+
+Canonical P3 still has not reached translation/H/A margin calculation, so none of these diagnostic numbers are P3 theorem margins.
+
+## What the failure invalidates
+
+- Requiring a useful absolute point Loewner lower after every uncertain 5-ms prediction.
+- Blindly increasing `MAX_ADAPTIVE_X_DEPTH` as the response to the same strict-SPD failure.
+- Treating the current one-step enclosure mechanism as part of the theorem rather than as one proof tactic.
+
+## What the failure does not invalidate
+
+- The `1e-18` canonical P3 usefulness threshold.
+- The same-history P2-V1 source language.
+- Existence of a rigorous complete 13--26-sample translation floor.
+- H=18/A=21 full-state joining, which has not yet received a translation margin from this backend.
+- P4 feasibility or infeasibility, because P4 remains blocked by canonical P3.
+
+## Critic pass
+
+Assume the current absolute one-step architecture is wrong. The strongest reason to abandon it is that it spends proof precision on a property the theorem does not require: a well-conditioned point lower after every 5-ms intermediate prediction in coordinates whose integrated `S` direction is extremely small. The complete segment accumulates much more process covariance, so certifying the segment directly attacks the actual `common_boundary_floor` quantity.
+
+Qualitatively different alternatives considered:
+
+1. deeper adaptive subdivision of the same absolute lower;
+2. one-step relative/congruence-normalized lower;
+3. complete-segment relative/congruence or verified generalized-eigenvalue lower;
+4. complete-segment Gramian/Riccati formulation that never asks for intermediate strict point floors;
+5. a different Lyapunov/covariance representation if complete-segment covariance comparison remains ill-conditioned.
+
+**Selection:** pursue (3), with (4) as the immediate fallback. It attacks the theorem-relevant segment floor and the point diagnostic shows about five orders of magnitude more smallest-eigenvalue headroom at 13 samples. Options (1) and (2) still spend excessive complexity on the unnecessary one-step floor.
 
 ## DEAD_ENDS
 
-- **REJECTED: endpoint-only 800-node P2 ancestry as a P3 source model.** It loses the staged/committed path memory required by the frozen P2-V1 interface.
+- **REJECTED: endpoint-only 800-node P2 ancestry as a P3 source model.** It loses staged/committed path memory required by the frozen P2-V1 interface.
 - **REJECTED: independent Cartesian `tau/sigma/R_S` extrema.** They destroy source-history correlation and are forbidden by the P2 consumer contract.
-- **REJECTED: recursive absolute entrywise Loewner point lower plus blind deeper subdivision.** The same strict-SPD mechanism has already failed repeatedly through the configured adaptive depth. Do not increase depth without a quantitative scaling argument showing the theorem threshold can be crossed.
+- **REJECTED: recursive absolute entrywise Loewner point lower plus blind deeper subdivision.** Its local error scales with width, but the depth/leaf count needed for the first prediction is not a viable source-complete architecture.
+- **REJECTED: one-step congruence normalization as the primary architecture.** It improves conditioning materially but still leaves a large one-step relative deficit while solving a property P3 does not require.
 - **REJECTED for current #471 scope: accumulating additional P4 micro-certificates before complete-word feasibility is known.** Local reset/sector/remainder bounds are subordinate to the complete-word ratio.
 
 A rejected route may be resurrected only after recording the new mathematical fact that invalidates its rejection.
@@ -44,24 +82,13 @@ A rejected route may be resurrected only after recording the new mathematical fa
 - Existing exact Joseph, co-rotated accelerometer, reset, and finite-angle identities remain useful structural facts, but they do not authorize P4 promotion.
 - P4 is blocked until canonical P3 passes; P5 is blocked until canonical P4 strictly contracts.
 
-## Alternatives under review
-
-1. **Relative/congruence-normalized Loewner enclosure.** Normalize the covariance family near identity with a verified factor/solve, certify `B(x) >= alpha I`, then map the result back to the required segment floor.
-2. **Complete-segment Gramian/Riccati lower.** Avoid demanding strict intermediate point floors and certify the complete 13--26-sample segment directly.
-3. **Verified generalized-eigenvalue formulation.** Compare the interval covariance family directly with a chosen positive reference matrix instead of subtracting an absolute `eps I` in poorly scaled physical coordinates.
-4. **Different Lyapunov/covariance representation.** Use only if the first three show that the present covariance representation itself is the limiting architecture.
-
 ## Next falsifiable experiment
 
-For source node 137 / gap 13, record at the first failed prediction and at successive existing subdivision depths:
+1. Fix the independent `x`-partition boundary bug and add a focused non-overlap/branch-coverage regression.
+2. Build a **diagnostic-only complete-segment reference matrix** for source 137 / gap 13 from a high-precision midpoint calculation.
+3. Using verified/outward operations, compare the full 13-sample covariance family directly against that reference by congruence/generalized eigenvalue and attempt to certify `P_segment(x) >= alpha P_ref`, `alpha > 0`, without requiring intermediate point-SPD floors.
+4. Report `alpha`, relative enclosure radius, limiting direction, and subdivision scaling.
 
-- `x` interval and depth;
-- center matrix and radius matrix;
-- absolute row radius `eps`;
-- diagnostic `lambda_min(center)` and `eps/lambda_min(center)`;
-- high-precision midpoint/end-point references for diagnosis only;
-- limiting direction/coordinate.
-
-**Decision rule:** if interval width shrinks but the relative SPD margin does not improve enough to plausibly close the required bound, the absolute-collapse tactic remains frozen and implementation moves to one of the qualitatively different alternatives above. Do not increase `MAX_ADAPTIVE_X_DEPTH`.
+**Decision rule:** if the complete-segment relative comparison closes with modest subdivision, generalize it to the source-complete boundary-floor calculation. If it exhibits the same conditioning pathology as the one-step architecture, freeze it after one refinement and move to the segment Gramian/Riccati alternative. Do not increase `MAX_ADAPTIVE_X_DEPTH`.
 
 Before any new P4 proof producer, first obtain the canonical P3 numeric verdict. If P3 passes, the only P4 work allowed in #471 is the non-promoting high-precision complete-word ratio diagnostic `rho_w = V_after(F_w(x)) / V_before(x)` required by the PR scope.

--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -1,0 +1,67 @@
+# OU-III proof research state
+
+This file is the current research ledger required by the root `AGENTS.md`. Keep it short and replace stale state rather than accumulating PR history.
+
+## State
+
+**FAILURE ANALYSIS / REPLAN**
+
+Current PR research question: make canonical P3 reach one rigorous numerical PASS/FAIL verdict at the unchanged `1e-18` gate; only if P3 passes, run one non-promoting structure-exact P4 complete-word feasibility diagnostic. P5 is out of scope.
+
+## Current hypothesis
+
+The present P3 failure is an enclosure/conditioning failure in the translation covariance lower, not yet a numerical P3 theorem failure. The absolute entrywise enclosure of `F L F^T + Q` followed by `C - eps I` can erase the small integrated-`S` one-step SPD direction before the complete 13--26-sample segment floor is formed.
+
+The leading alternative is a relative/congruence-normalized Loewner enclosure applied to the prediction or complete segment, because P3 needs a rigorous complete-segment floor, not an artificially strong absolute point lower at every 5-ms intermediate step.
+
+## Evidence
+
+- The deterministic source-node 137 / gap-13 case reproduces `Loewner prediction lower lost strict SPD; split x cell`.
+- Repeated adaptive subdivision reaches the configured depth limit without closing the current absolute point-lower construction.
+- Canonical P3 therefore does not yet reach the translation, H, or A margin calculation; this run is not evidence that the `1e-18` theorem gate fails.
+- The frozen P2 contract retains same-history source correlation and rejects independent Cartesian `tau/sigma/R_S` extrema.
+
+## Current limiter
+
+The limiting object is the rigorous Loewner lower used to construct `common_boundary_floor` for a complete legal 13--26-sample translation segment. The immediate experiment must measure conditioning of the first failed prediction and how the relative enclosure error scales under subdivision.
+
+## DEAD_ENDS
+
+- **REJECTED: endpoint-only 800-node P2 ancestry as a P3 source model.** It loses the staged/committed path memory required by the frozen P2-V1 interface.
+- **REJECTED: independent Cartesian `tau/sigma/R_S` extrema.** They destroy source-history correlation and are forbidden by the P2 consumer contract.
+- **REJECTED: recursive absolute entrywise Loewner point lower plus blind deeper subdivision.** The same strict-SPD mechanism has already failed repeatedly through the configured adaptive depth. Do not increase depth without a quantitative scaling argument showing the theorem threshold can be crossed.
+- **REJECTED for current #471 scope: accumulating additional P4 micro-certificates before complete-word feasibility is known.** Local reset/sector/remainder bounds are subordinate to the complete-word ratio.
+
+A rejected route may be resurrected only after recording the new mathematical fact that invalidates its rejection.
+
+## Retained facts
+
+- Canonical P3 useful gate remains exactly `1e-18`.
+- `OU3_P2_CORRELATED_STAGE_TRANSFER_V1` and same-history source correlation are retained.
+- Both H=18 and A=21 remain required.
+- Zero/disabled lever arm and dormant/transparent vibration-guard branch remain the current proof scope.
+- No replay fitting, operating-domain shrink for PASS, or deployed-filter change is permitted.
+- Existing exact Joseph, co-rotated accelerometer, reset, and finite-angle identities remain useful structural facts, but they do not authorize P4 promotion.
+- P4 is blocked until canonical P3 passes; P5 is blocked until canonical P4 strictly contracts.
+
+## Alternatives under review
+
+1. **Relative/congruence-normalized Loewner enclosure.** Normalize the covariance family near identity with a verified factor/solve, certify `B(x) >= alpha I`, then map the result back to the required segment floor.
+2. **Complete-segment Gramian/Riccati lower.** Avoid demanding strict intermediate point floors and certify the complete 13--26-sample segment directly.
+3. **Verified generalized-eigenvalue formulation.** Compare the interval covariance family directly with a chosen positive reference matrix instead of subtracting an absolute `eps I` in poorly scaled physical coordinates.
+4. **Different Lyapunov/covariance representation.** Use only if the first three show that the present covariance representation itself is the limiting architecture.
+
+## Next falsifiable experiment
+
+For source node 137 / gap 13, record at the first failed prediction and at successive existing subdivision depths:
+
+- `x` interval and depth;
+- center matrix and radius matrix;
+- absolute row radius `eps`;
+- diagnostic `lambda_min(center)` and `eps/lambda_min(center)`;
+- high-precision midpoint/end-point references for diagnosis only;
+- limiting direction/coordinate.
+
+**Decision rule:** if interval width shrinks but the relative SPD margin does not improve enough to plausibly close the required bound, the absolute-collapse tactic remains frozen and implementation moves to one of the qualitatively different alternatives above. Do not increase `MAX_ADAPTIVE_X_DEPTH`.
+
+Before any new P4 proof producer, first obtain the canonical P3 numeric verdict. If P3 passes, the only P4 work allowed in #471 is the non-promoting high-precision complete-word ratio diagnostic `rho_w = V_after(F_w(x)) / V_before(x)` required by the PR scope.

--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -14,33 +14,45 @@ The current canonical run is **not a numerical P3 theorem FAIL**. It is blocked 
 
 `Loewner prediction lower lost strict SPD; split x cell`
 
-There is also a separate implementation defect in the initial `x` partition helper: subcells adjacent to the `x=0.01` process-series branch are emitted as nested/overlapping intervals because branch-endpoint clamping is applied to every subcell instead of only the boundary subcell. That creates redundant work but does not explain the adaptive recursion failure by itself.
+The previously identified `x=0.01` branch-partition defect is already fixed on the live PR branch: branch clamping is now applied only to the actual boundary subcell. It was an implementation defect and is not the remaining mathematical limiter.
 
 ## Evidence
 
-For the deterministic source-node 137 / gap-13 failure, diagnostic evaluation of the first prediction on the widest initial small-`x` cell gives:
+For source node 137 / gap 13, the first uncertain prediction on the widest initial small-`x` cell has diagnostic center `lambda_min ~= 3.405e-10`, absolute row-radius `eps ~= 1.142e-5`, and `eps/lambda_min ~= 3.35e4`. Existing binary subdivision improves that ratio by about 2x per level, but at depth 12 it is still about `8.26`; roughly four additional binary levels would be needed merely to make this first 5-ms prediction plausible. That is not a viable source-complete architecture.
 
-- `x = [0.0073253899652235745, 0.009999999999999998]`;
-- center `lambda_min ~= 3.405e-10`;
-- absolute row-radius `eps ~= 1.142e-5`;
-- `eps/lambda_min ~= 3.35e4`;
-- limiting center eigenvector approximately `[0.090, -0.448, 0.890, -0.0077]`, dominated by the poorly scaled `p/S` directions.
+The theorem-relevant 13-sample point covariance is much healthier. On source 137 its diagnostic `lambda_min` is about `2.02e-5 ... 2.83e-5` across the tau endpoints. Across the ten physical tau cells, using the actual low-sigma/strongest-`R_S` source in each cell, the 13-sample point floor remains strict; the longest-tau cell still has `lambda_min ~= 1.20e-6`.
 
-Following the existing geometric subdivision down one branch reduces `eps/lambda_min` approximately by a factor of two per split, but at depth 12 it is still about `8.26`. Thus approximately four additional binary levels would be needed merely to make this first 5-ms prediction plausible. A full binary refinement to that scale is on the order of `2^16` leaves for the widest initial cell before considering the complete 800-source x 14-gap family. Deeper subdivision is therefore rejected as a tractable proof architecture even though its local error scaling is understood.
+Point diagnostics also show the 13-sample covariance increasing in Loewner order as `x=h/tau` increases on all ten tau cells: a 101-point grid produced positive minimum eigenvalue increments, with the smallest observed increment about `4.3e-9`. This is feasibility evidence only, not a proof of monotonicity.
 
-A non-rigorous point diagnostic over the theorem-relevant **complete 13-sample segment** is qualitatively better: across the source-137 tau endpoints the final covariance has `lambda_min ~= 2.02e-5 ... 2.83e-5`, roughly five orders of magnitude above the one-sample floor. This is diagnostic evidence only, but it quantitatively supports moving the enclosure target to the complete segment.
+Two segment-level interval experiments have now failed:
 
-A one-step full congruence normalization of the same wide interval reduces the relative enclosure mismatch substantially (`eps/lambda_min` from roughly `3.35e4` to roughly `1.17e3`) but still leaves a large one-step deficit. Therefore normalizing each 5-ms step is not the selected architecture.
+1. **Post-hoc congruence normalization of the old natural interval Riccati recursion.** Dependency has already exploded before normalization. Even with 256 tau subcells, the normalized common lower remains strongly non-SPD (worst diagnostic normalized `lambda_min - eps` about `-80`).
+2. **Natural-interval derivative/monotonicity propagation.** Propagating `P(x)` and `dP/dx` as ordinary interval boxes inherits the same recursive dependency loss; subdivision improves widths but does not produce a usable derivative-SPD certificate.
 
-Canonical P3 still has not reached translation/H/A margin calculation, so none of these diagnostic numbers are P3 theorem margins.
+Therefore the rejected mechanism is now broader than the original `C-eps I` step: **recursive natural interval covariance boxes that forget the repeated scalar source parameter at every Riccati operation are frozen as a dead end.**
 
-## What the failure invalidates
+Canonical P3 still has not reached translation/H/A margin calculation, so none of these diagnostic values are P3 theorem margins.
 
-- Requiring a useful absolute point Loewner lower after every uncertain 5-ms prediction.
-- Blindly increasing `MAX_ADAPTIVE_X_DEPTH` as the response to the same strict-SPD failure.
-- Treating the current one-step enclosure mechanism as part of the theorem rather than as one proof tactic.
+## Master P3 quantity
 
-## What the failure does not invalidate
+The new backend is relevant only if it produces the complete-segment matrix lower used by canonical P3:
+
+`P_segment(x) >= L_segment > 0`.
+
+That lower enters the existing translation gate directly through
+
+`D_h L_segment D_h^T - delta * Sigma_upper > 0`,
+
+which is what `_certified_delta` tests before the H/A precision join. Improving unrelated one-step quantities is not useful unless it sharpens this complete-segment comparison.
+
+## What the failures invalidate
+
+- A useful absolute point Loewner lower after every uncertain 5-ms prediction.
+- Blindly increasing `MAX_ADAPTIVE_X_DEPTH`.
+- Post-hoc normalization of a covariance interval after natural Riccati dependency has already exploded.
+- Natural-interval `P,dP/dx` recursion as a monotonicity proof engine.
+
+## What the failures do not invalidate
 
 - The `1e-18` canonical P3 usefulness threshold.
 - The same-history P2-V1 source language.
@@ -48,27 +60,28 @@ Canonical P3 still has not reached translation/H/A margin calculation, so none o
 - H=18/A=21 full-state joining, which has not yet received a translation margin from this backend.
 - P4 feasibility or infeasibility, because P4 remains blocked by canonical P3.
 
-## Critic pass
+## Critic pass and alternatives
 
-Assume the current absolute one-step architecture is wrong. The strongest reason to abandon it is that it spends proof precision on a property the theorem does not require: a well-conditioned point lower after every 5-ms intermediate prediction in coordinates whose integrated `S` direction is extremely small. The complete segment accumulates much more process covariance, so certifying the segment directly attacks the actual `common_boundary_floor` quantity.
+Assume the interval covariance recursion architecture is wrong. Its strongest defect is loss of the fact that the entire segment depends on **one repeated scalar** `x=h/tau`. Ordinary interval arithmetic replaces that one-dimensional curve by a new Cartesian matrix box after every operation.
 
-Qualitatively different alternatives considered:
+Qualitatively different alternatives:
 
-1. deeper adaptive subdivision of the same absolute lower;
-2. one-step relative/congruence-normalized lower;
-3. complete-segment relative/congruence or verified generalized-eigenvalue lower;
-4. complete-segment Gramian/Riccati formulation that never asks for intermediate strict point floors;
-5. a different Lyapunov/covariance representation if complete-segment covariance comparison remains ill-conditioned.
+1. **Univariate centered Taylor-model / polynomial enclosure of the complete 13-sample Riccati map.** Preserve the same scalar symbol through all prediction and measurement operations and bound only a final remainder.
+2. **Verified polynomial collocation/Bernstein or Chebyshev enclosure of each complete-segment matrix entry.** Again preserve one-dimensional dependence rather than recursively hulling matrices.
+3. **Analytic complete-segment Gramian/Riccati lower in a different information/covariance representation.** Avoid intervalizing the covariance recursion itself.
+4. **Different Lyapunov representation** if the complete-segment covariance map remains unsuitable.
 
-**Selection:** pursue (3), with (4) as the immediate fallback. It attacks the theorem-relevant segment floor and the point diagnostic shows about five orders of magnitude more smallest-eigenvalue headroom at 13 samples. Options (1) and (2) still spend excessive complexity on the unnecessary one-step floor.
+**Selection:** pursue (1) once. It directly attacks the failed dependency mechanism, and the point map is smooth with generalized source-137 ratio `P(x)` versus the low-`x` endpoint close to `1 ... 1.08`, so a centered model should be proving a relative statement near unity rather than recovering five orders of lost SPD margin. If this Taylor-model attempt fails after one mathematically motivated refinement, freeze it and move to (3), not another interval subdivision variant.
 
 ## DEAD_ENDS
 
-- **REJECTED: endpoint-only 800-node P2 ancestry as a P3 source model.** It loses staged/committed path memory required by the frozen P2-V1 interface.
-- **REJECTED: independent Cartesian `tau/sigma/R_S` extrema.** They destroy source-history correlation and are forbidden by the P2 consumer contract.
-- **REJECTED: recursive absolute entrywise Loewner point lower plus blind deeper subdivision.** Its local error scales with width, but the depth/leaf count needed for the first prediction is not a viable source-complete architecture.
-- **REJECTED: one-step congruence normalization as the primary architecture.** It improves conditioning materially but still leaves a large one-step relative deficit while solving a property P3 does not require.
-- **REJECTED for current #471 scope: accumulating additional P4 micro-certificates before complete-word feasibility is known.** Local reset/sector/remainder bounds are subordinate to the complete-word ratio.
+- **REJECTED: endpoint-only 800-node P2 ancestry.** It loses staged/committed path memory.
+- **REJECTED: independent Cartesian `tau/sigma/R_S` extrema.** They destroy source-history correlation.
+- **REJECTED: recursive absolute entrywise Loewner point lower plus deeper subdivision.** Tractable depth is insufficient.
+- **REJECTED: one-step congruence normalization as the primary architecture.** It improves conditioning but still solves an unnecessary one-step property.
+- **REJECTED: post-hoc complete-segment normalization of natural interval Riccati boxes.** Dependency has already exploded before normalization.
+- **REJECTED: natural-interval derivative/monotonicity recursion.** It shares the same dependency loss.
+- **REJECTED for #471: additional P4 micro-certificates before complete-word feasibility.**
 
 A rejected route may be resurrected only after recording the new mathematical fact that invalidates its rejection.
 
@@ -79,16 +92,21 @@ A rejected route may be resurrected only after recording the new mathematical fa
 - Both H=18 and A=21 remain required.
 - Zero/disabled lever arm and dormant/transparent vibration-guard branch remain the current proof scope.
 - No replay fitting, operating-domain shrink for PASS, or deployed-filter change is permitted.
-- Existing exact Joseph, co-rotated accelerometer, reset, and finite-angle identities remain useful structural facts, but they do not authorize P4 promotion.
+- Existing exact Joseph, co-rotated accelerometer, reset, and finite-angle identities remain structural facts only; they do not authorize P4 promotion.
 - P4 is blocked until canonical P3 passes; P5 is blocked until canonical P4 strictly contracts.
 
 ## Next falsifiable experiment
 
-1. Fix the independent `x`-partition boundary bug and add a focused non-overlap/branch-coverage regression.
-2. Build a **diagnostic-only complete-segment reference matrix** for source 137 / gap 13 from a high-precision midpoint calculation.
-3. Using verified/outward operations, compare the full 13-sample covariance family directly against that reference by congruence/generalized eigenvalue and attempt to certify `P_segment(x) >= alpha P_ref`, `alpha > 0`, without requiring intermediate point-SPD floors.
-4. Report `alpha`, relative enclosure radius, limiting direction, and subdivision scaling.
+Build a **source-137 / gap-13 diagnostic-only univariate centered Taylor model** for the complete segment in `x=h/tau`.
 
-**Decision rule:** if the complete-segment relative comparison closes with modest subdivision, generalize it to the source-complete boundary-floor calculation. If it exhibits the same conditioning pathology as the one-step architecture, freeze it after one refinement and move to the segment Gramian/Riccati alternative. Do not increase `MAX_ADAPTIVE_X_DEPTH`.
+Requirements:
+
+- carry the single normalized scalar source coordinate symbolically through all 13 predictions and both scalar measurement updates per sample;
+- use the existing validated transition/process series and outward remainder bounds;
+- use a verified reciprocal expansion for innovation denominators rather than natural interval division;
+- compare the final matrix against a high-precision point reference by congruence/generalized eigenvalue;
+- report polynomial order, remainder norm, certified relative `alpha`, limiting direction, and number of structural branch splits.
+
+**Predicted success criterion:** point diagnostics suggest the exact generalized relative floor is near 1 across source 137, so the first rigorous model should certify a clearly positive `alpha` with only the required `x=0.01` analytic-branch split and modest model order. If it cannot do that, one refinement of model order/remainder formulation is allowed; a second failure triggers architecture review and the analytic segment Gramian/Riccati alternative.
 
 Before any new P4 proof producer, first obtain the canonical P3 numeric verdict. If P3 passes, the only P4 work allowed in #471 is the non-promoting high-precision complete-word ratio diagnostic `rho_w = V_after(F_w(x)) / V_before(x)` required by the PR scope.

--- a/tests/validation/test_ou3_p3_p2_v1_stage_phase_translation.py
+++ b/tests/validation/test_ou3_p3_p2_v1_stage_phase_translation.py
@@ -25,8 +25,15 @@ class P2V1StagePhaseTranslationTests(unittest.TestCase):
         M = P._identity_floor(0.25)
         ok, _ = symmetric_positive_definite_ldlt(M)
         self.assertTrue(ok)
-        self.assertEqual(M[0][0].lo, 0.25)
-        self.assertEqual(M[0][1].lo, 0.0)
+        # A point interval is deliberately expanded outward by one ULP.  Do
+        # not require the rigorous lower endpoint to round back to the nominal
+        # decimal value exactly.
+        self.assertEqual(M[0][0].lo, math.nextafter(0.25, -math.inf))
+        self.assertEqual(M[0][0].hi, math.nextafter(0.25, math.inf))
+        self.assertLessEqual(M[0][0].lo, 0.25)
+        self.assertGreaterEqual(M[0][0].hi, 0.25)
+        self.assertLessEqual(M[0][1].lo, 0.0)
+        self.assertGreaterEqual(M[0][1].hi, 0.0)
 
     def test_certified_delta_matches_simple_diagonal_case(self):
         M = P._identity_floor(1.0)

--- a/tests/validation/test_ou3_p4_p3_metric_attachment.py
+++ b/tests/validation/test_ou3_p4_p3_metric_attachment.py
@@ -155,6 +155,16 @@ class Ou3P4P3MetricAttachmentTests(unittest.TestCase):
             large["reset_metric_amplitude_fraction_upper"],
         )
 
+    def test_reset_budget_rejects_energy_outside_candidate_cayley_funnel(self):
+        with self.assertRaises(ValueError):
+            R.reset_row_at_energy(
+                W=1.0,
+                candidate_q_upper=0.1,
+                theta_covariance_upper=1.0,
+                theta_information_upper=1.0,
+                correction_gain=0.1,
+            )
+
     def test_metric_module_has_no_theorem_promotion_shortcut(self):
         self.assertEqual(M.JOIN_FACTOR, 0.5)
         self.assertEqual(M.PHASES, tuple(range(26)))

--- a/tests/validation/test_ou3_p4_p3_metric_attachment.py
+++ b/tests/validation/test_ou3_p4_p3_metric_attachment.py
@@ -8,6 +8,7 @@ sys.path.insert(0, str(TOOLS))
 
 import ou3_p4_p3_metric_attachment as M
 import ou3_p4_signed_joseph_feasibility as J
+import ou3_p4_source_correlated_reset_budget as R
 
 
 class Ou3P4P3MetricAttachmentTests(unittest.TestCase):
@@ -110,10 +111,55 @@ class Ou3P4P3MetricAttachmentTests(unittest.TestCase):
         self.assertGreater(J.down(0.25 - eta_over_y2), 0.0)
         self.assertLess(J.down(0.10 - eta_over_y2), 0.0)
 
+    def test_reset_correction_bound_is_homogeneous_in_metric_energy(self):
+        base = R.correction_gain_per_sqrt_energy(
+            theta_covariance_upper=4.0,
+            vector_norm_upper=3.0,
+            measurement_variance_lower=2.0,
+            eta_tangent_squared_coefficient_upper=0.0,
+        )
+        nonlinear = R.correction_gain_per_sqrt_energy(
+            theta_covariance_upper=4.0,
+            vector_norm_upper=3.0,
+            measurement_variance_lower=2.0,
+            eta_tangent_squared_coefficient_upper=0.1,
+        )
+        self.assertGreaterEqual(base["attitude_correction_norm_per_sqrt_metric_energy_upper"], 2.0)
+        self.assertLess(base["attitude_correction_norm_per_sqrt_metric_energy_upper"], 2.000001)
+        self.assertGreater(
+            nonlinear["attitude_correction_norm_per_sqrt_metric_energy_upper"],
+            base["attitude_correction_norm_per_sqrt_metric_energy_upper"],
+        )
+
+    def test_exact_reset_fraction_shrinks_with_metric_funnel(self):
+        large = R.reset_row_at_energy(
+            W=0.1,
+            candidate_q_upper=0.5,
+            theta_covariance_upper=0.01,
+            theta_information_upper=100.0,
+            correction_gain=0.1,
+        )
+        small = R.reset_row_at_energy(
+            W=0.01,
+            candidate_q_upper=0.5,
+            theta_covariance_upper=0.01,
+            theta_information_upper=100.0,
+            correction_gain=0.1,
+        )
+        self.assertEqual(large["reset_inverse_operator_norm_upper"], 1.0)
+        self.assertEqual(small["reset_inverse_operator_norm_upper"], 1.0)
+        self.assertGreater(large["cayley_composition_denominator_lower"], 0.0)
+        self.assertGreater(small["cayley_composition_denominator_lower"], 0.0)
+        self.assertLess(
+            small["reset_metric_amplitude_fraction_upper"],
+            large["reset_metric_amplitude_fraction_upper"],
+        )
+
     def test_metric_module_has_no_theorem_promotion_shortcut(self):
         self.assertEqual(M.JOIN_FACTOR, 0.5)
         self.assertEqual(M.PHASES, tuple(range(26)))
         self.assertEqual(M.BASE.MIN_USEFUL_DELTA, 1.0e-18)
+        self.assertFalse(R.RESET.build()["source_correlated_correction_norm_bound_supplied_here"])
 
 
 if __name__ == "__main__":

--- a/tests/validation/test_ou3_p4_signed_vector_directional_coefficients.py
+++ b/tests/validation/test_ou3_p4_signed_vector_directional_coefficients.py
@@ -22,7 +22,8 @@ class Ou3P4SignedVectorDirectionalCoefficientsTests(unittest.TestCase):
             })
         audit = {"expected_source_phase_mode_classes": 3200, "rows": rows}
         cayley = {
-            "exact_vector_residual_norm_factor_lower": 0.8,
+            "chart_sigma_min_lower": 0.8,
+            "exact_vector_information_retention_factor_lower": 0.64,
             "outer_angle_rad": 0.8,
         }
         remainder = {"acc_eta_force_rotation_quadratic_coefficient_upper": 0.1}

--- a/tools/ou3_p3_frozen_full_matrix_translation.py
+++ b/tools/ou3_p3_frozen_full_matrix_translation.py
@@ -114,13 +114,7 @@ def _ipow(x: Interval, n: int) -> Interval:
 
 
 def _normalized_integral_series(x: Interval, m: int) -> Interval:
-    """Enclose sum_{n>=0} (-1)^n x^n/(n+m)! for m=1,2,3.
-
-    These are respectively (1-e^-x)/x, (x+e^-x-1)/x^2 and
-    (x^2/2-x+1-e^-x)/x^3.  The deployed source cells have x<=0.015, so a
-    short exact-rational series plus a geometric factorial tail is tight and
-    avoids cancellation.
-    """
+    """Enclose sum_{n>=0} (-1)^n x^n/(n+m)! for m=1,2,3."""
     if m not in (1, 2, 3) or not (0.0 < x.lo <= x.hi < 0.05):
         raise ValueError("transition series outside audited small-x range")
     y = I(0.0)
@@ -160,7 +154,6 @@ def _scaled_Q(x: Interval):
 
 
 def _measurement_update(P, coordinate: int, R: float):
-    """Natural interval enclosure of P-Pe(e'Pe+R)^-1e'P for one scalar row."""
     den = P[coordinate][coordinate] + I(R)
     if den.lo <= 0.0:
         raise RuntimeError("measurement innovation denominator lost positivity")
@@ -178,7 +171,6 @@ def _split_x(lo: float, hi: float, count: int):
         cuts.add(SCALED.BRANCH_X)
     base = sorted(cuts)
     out = []
-    # Geometric refinement on each branch piece.
     total_log = math.log(hi / lo)
     for a, b in zip(base, base[1:]):
         n = max(1, int(math.ceil(count * math.log(b / a) / total_log))) if total_log > 0 else 1
@@ -190,10 +182,9 @@ def _split_x(lo: float, hi: float, count: int):
         for k in range(n):
             aa = math.nextafter(edges[k], -math.inf) if k else a
             bb = math.nextafter(edges[k + 1], math.inf) if k + 1 < n else b
-            # Do not let outward rounding cross the exact-series branch.
-            if b == SCALED.BRANCH_X:
+            if b == SCALED.BRANCH_X and k + 1 == n:
                 bb = math.nextafter(SCALED.BRANCH_X, -math.inf)
-            if a == SCALED.BRANCH_X:
+            if a == SCALED.BRANCH_X and k == 0:
                 aa = SCALED.BRANCH_X
             out.append(Interval(aa, bb))
     return out
@@ -275,18 +266,12 @@ def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
         upper = [float(x) for x in upper]
         if float(timing["word_horizon_s_lower"]) + 1e-15 < HORIZON_S:
             raise RuntimeError("chosen frozen suffix exceeds certified P3 word")
-
-        # In normalized coordinates larger sigma means smaller measurement noise
-        # and therefore a smaller selected-process posterior.  Use sigma.hi to
-        # make both measurements maximally informative.  Physical comparison at
-        # the end uses sigma.lo, also conservative.
         R_aw_norm = BASE.down(ra / BASE.up(sigma.hi * sigma.hi))
         rS = BASE.down(rs.lo * axis_factor)
         denomS = BASE.up(sigma.hi * sigma.hi * h ** 6)
         R_S_norm = BASE.down(BASE.down(rS * rS) / denomS)
         if not (R_aw_norm > 0.0 and R_S_norm > 0.0):
             raise RuntimeError("normalized measurement noise lost positivity")
-
         xlo = BASE.down(h / tau.hi)
         xhi = BASE.up(h / tau.lo)
         subrows = []
@@ -388,9 +373,6 @@ def validate(d: dict) -> list[str]:
         f.append("invalid interval-closed count")
     if not 0 <= int(d.get("useful_gate_pass_cells", -1)) <= NODES.EXPECTED_STATES:
         f.append("invalid useful-cell count")
-    # A diagnostic remains valid even if some cells do not close: that result
-    # chooses the next subdivision/refinement.  Never turn a numerical miss into
-    # a validation failure or a false theorem promotion.
     return list(dict.fromkeys(f))
 
 

--- a/tools/ou3_p4_signed_vector_directional_coefficients.py
+++ b/tools/ou3_p4_signed_vector_directional_coefficients.py
@@ -13,6 +13,13 @@ geometry gives
     ||y_R||^2 >= a_R ||h_R||^2,       a_R=4/(4+q^2),
     ||eta_R||^2 <= s^2 ||h_R||^2,     s=sin(theta/2).
 
+The current Cayley certificate exposes ``a_R`` as
+``chart_sigma_min_lower``: for c=q u, the exact residual-to-linear-tangent
+amplitude ratio is cos(theta/2), hence its squared ratio is
+cos^2(theta/2)=4/(4+q^2).  This is deliberately *not* the separate
+``exact_vector_information_retention_factor_lower=cos^4(theta/2)`` used for the
+Jacobian information bound.
+
 Thus on the pure rotational tangent direction
 
     y' S^-1 y - eta' R^-1 eta
@@ -51,7 +58,7 @@ import ou3_p4_signed_joseph_feasibility as AUDIT
 
 REPO = Path(__file__).resolve().parents[1]
 DEFAULT_DOMAIN = REPO / "tools" / "ou3_proof_operating_domain.json"
-SCHEMA = 1
+SCHEMA = 2
 MODES = ("H", "A")
 
 
@@ -79,11 +86,18 @@ def evaluate(audit: dict, cayley: dict, remainder: dict, mag: dict) -> dict:
     if failures:
         return {"schema": SCHEMA, "failures": failures}
 
-    aR = float(cayley["exact_vector_residual_norm_factor_lower"])
+    # For the exact vector residual r=(R-I)v versus h=[c]xv, the *squared*
+    # norm retention is cos^2(theta/2)=4/(4+q^2).  The Cayley producer's
+    # chart_sigma_min_lower is exactly that scalar.  Do not use its cos^4
+    # Jacobian-information factor here.
+    aR = float(cayley["chart_sigma_min_lower"])
+    jacobian_info = float(cayley["exact_vector_information_retention_factor_lower"])
     s2 = float(remainder["acc_eta_force_rotation_quadratic_coefficient_upper"])
     A = float(mag["effective_tangent_coordinate_gain_lower"])
     beta = float(mag["effective_vs_linear_tangent_defect_ratio_upper"])
-    if not (0.0 < aR <= 1.0 and 0.0 <= s2 < 1.0 and 0.0 < A <= 1.0 and 0.0 <= beta < 1.0):
+    if not (0.0 < aR <= 1.0 and 0.0 < jacobian_info <= aR <= 1.0):
+        failures.append("Cayley residual/information retention factors invalid")
+    if not (0.0 <= s2 < 1.0 and 0.0 < A <= 1.0 and 0.0 <= beta < 1.0):
         failures.append("finite-angle tangent coefficients invalid")
 
     A2_lo = mul_down(A, A)
@@ -146,6 +160,7 @@ def evaluate(audit: dict, cayley: dict, remainder: dict, mag: dict) -> dict:
         "linear_tangent_form_interface_matches_P3": True,
         "outer_angle_rad": float(cayley["outer_angle_rad"]),
         "accelerometer_exact_residual_vs_tangent_norm_squared_lower": aR,
+        "cayley_jacobian_information_retention_factor_lower_not_used_for_residual": jacobian_info,
         "accelerometer_eta_vs_tangent_norm_squared_upper": s2,
         "magnetometer_effective_tangent_gain_lower": A,
         "magnetometer_effective_tangent_gain_squared_lower": A2_lo,
@@ -198,6 +213,12 @@ def validate(d: dict) -> list[str]:
             f.append(f"{key} is not false")
     if int(d.get("source_phase_mode_classes_scanned", 0)) != 800 * 2 * 2:
         f.append("directional coefficient audit did not cover 800 x 2 x H/A")
+    residual = d.get("accelerometer_exact_residual_vs_tangent_norm_squared_lower")
+    jac = d.get("cayley_jacobian_information_retention_factor_lower_not_used_for_residual")
+    if not isinstance(residual, (int, float)) or not (0.0 < float(residual) <= 1.0):
+        f.append("invalid accelerometer exact-residual retention factor")
+    if not isinstance(jac, (int, float)) or not (0.0 < float(jac) <= float(residual or 0.0)):
+        f.append("invalid separated Cayley Jacobian-information factor")
     positive = True
     for mode in MODES:
         row = d.get("worst_by_mode", {}).get(mode, {})

--- a/tools/ou3_p4_source_correlated_reset_budget.py
+++ b/tools/ou3_p4_source_correlated_reset_budget.py
@@ -170,7 +170,9 @@ def reset_row_at_energy(
 
     sqrtW = sqrt_up(W)
     q_energy = sqrt_up(mul_up(utheta, W))
-    q = min(qc, q_energy)
+    if q_energy > qc:
+        raise ValueError("funnel energy exceeds candidate Cayley radius")
+    q = q_energy
     delta = mul_up(kappa, sqrtW)
     if delta > RESET_CORRECTION_UTILITY_MAX_RAD:
         raise RuntimeError("correction radius exceeds validated exact-reset utility range")

--- a/tools/ou3_p4_source_correlated_reset_budget.py
+++ b/tools/ou3_p4_source_correlated_reset_budget.py
@@ -1,0 +1,531 @@
+#!/usr/bin/env python3
+"""Source-correlated correction and exact reset budget for OU-III P4.
+
+The exact reset transport retained after PR #466 is parameterized by the
+shipping attitude-correction norm ``delta``.  A global fixed correction cap is
+not a source-faithful way to supply that parameter: the Kalman correction is a
+state-dependent quantity and must shrink with the P4 Lyapunov state.
+
+This module closes that interface without changing the filter or the frozen P3
+/P4 theorem gates.  Let the attached P3 metric at one source/phase class be the
+shipping covariance ``P`` and let
+
+    V = z' P^-1 z.
+
+For one accepted 3-vector update, with ``S = H P H' + R`` and the attitude rows
+``K_theta`` of the implemented Kalman gain,
+
+    K_theta S K_theta' <= P_theta <= U_theta I.
+
+The exact innovation is ``y = h + eta``.  The linear Kalman inequality gives
+
+    h' S^-1 h <= V,
+
+while the retained 0.8-rad pure-vector remainder and ``S >= R = r I`` give
+
+    eta' S^-1 eta <= s^2 |v|^2 U_theta/r * V = gamma_eta V.
+
+Therefore, by the triangle inequality in the ``S^-1`` norm,
+
+    |dtheta| <= kappa sqrt(V),
+    kappa = sqrt(U_theta) * (1 + sqrt(gamma_eta)).               (1)
+
+For accelerometer updates the co-rotated ``a_w`` coordinate from #466 is
+essential: ``eta`` is pure attitude rotation, so neither ``a_w`` nor ``b_a`` is
+charged a second time in (1).  Magnetometer uses the same pure-vector bound.
+
+To obtain a finite reset budget, choose an information-energy funnel ``V<=W``.
+For a candidate attitude radius q_c, every source class obeys the chart bound if
+
+    W <= q_c^2 / U_theta.
+
+Equation (1) simultaneously gives ``delta <= kappa sqrt(W)``.  The module then
+feeds the *same source/phase* ``q=sqrt(U_theta W)`` and correction radius into
+``ou3_p4_exact_reset_transport.reset_defect_bound`` and reports
+
+    eps_reset = sqrt(M_theta) |rho_theta| / sqrt(W),
+
+where ``M_theta`` is the attached post-update information-metric upper for that
+same class.  Thus the exact shipped reset contributes an amplitude perturbation
+bounded by ``eps_reset sqrt(W)``.  Because both q and delta are O(sqrt(W)), the
+reset mismatch is O(W) and eps_reset -> 0 as W -> 0; no affine disturbance is
+introduced.
+
+The declared 30/25/20/15 degree values are certificate-search candidates only,
+not new deployment assumptions.  All nonlinear remainder coefficients still
+come from the frozen 0.8-rad outer geometry.  This producer is a prerequisite
+for the complete signed H18/A21 word and cannot promote P4 by itself.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+import ou3_p4_exact_reset_transport as RESET
+import ou3_p4_p3_metric_attachment as METRIC
+import ou3_p4_vector_remainder_sector as REMAINDER
+import ou3_validated_transcendentals as VT
+import ou3_vector_uco_certificate as VECTOR
+
+REPO = Path(__file__).resolve().parents[1]
+DEFAULT_DOMAIN = REPO / "tools" / "ou3_proof_operating_domain.json"
+SCHEMA = 1
+MODES = ("H", "A")
+MEASUREMENTS = ("accelerometer", "magnetometer")
+RESET_CORRECTION_UTILITY_MAX_RAD = RESET.CAYLEY_MONOTONE_NORM_MAX
+
+
+def down(x: float) -> float:
+    return math.nextafter(float(x), -math.inf)
+
+
+def up(x: float) -> float:
+    return math.nextafter(float(x), math.inf)
+
+
+def sqrt_up(x: float) -> float:
+    x = float(x)
+    if not (math.isfinite(x) and x >= 0.0):
+        raise ValueError("finite nonnegative square-root input required")
+    return up(math.sqrt(x))
+
+
+def mul_up(a: float, b: float) -> float:
+    return up(float(a) * float(b))
+
+
+def div_up(a: float, b: float) -> float:
+    b = float(b)
+    if not (math.isfinite(b) and b > 0.0):
+        raise ValueError("strict positive denominator required")
+    return up(float(a) / b)
+
+
+def _positive(x, label: str) -> float:
+    y = float(x)
+    if not (math.isfinite(y) and y > 0.0):
+        raise RuntimeError(f"{label} must be finite positive")
+    return y
+
+
+def _candidate_q_upper(angle_deg: float) -> float:
+    angle = float(angle_deg) * math.pi / 180.0
+    if not (math.isfinite(angle) and 0.0 < angle < math.pi):
+        raise ValueError("candidate attitude angle must lie in (0,180 deg)")
+    half_hi = up(0.5 * angle)
+    s_hi = VT.sin_point(half_hi).hi
+    c_lo = VT.cos_point(half_hi).lo
+    if not c_lo > 0.0:
+        raise RuntimeError("candidate Cayley radius reaches chart antipode")
+    return div_up(mul_up(2.0, s_hi), c_lo)
+
+
+def correction_gain_per_sqrt_energy(
+    theta_covariance_upper: float,
+    vector_norm_upper: float,
+    measurement_variance_lower: float,
+    eta_tangent_squared_coefficient_upper: float,
+) -> dict:
+    """Return kappa in ||dtheta|| <= kappa sqrt(V), with outward rounding."""
+    utheta = _positive(theta_covariance_upper, "theta covariance upper")
+    vmax = _positive(vector_norm_upper, "measurement vector norm upper")
+    rlo = _positive(measurement_variance_lower, "measurement variance lower")
+    s2 = float(eta_tangent_squared_coefficient_upper)
+    if not (math.isfinite(s2) and s2 >= 0.0):
+        raise ValueError("nonlinear eta coefficient must be finite nonnegative")
+
+    gamma = div_up(mul_up(mul_up(s2, mul_up(vmax, vmax)), utheta), rlo)
+    root_gamma = sqrt_up(gamma)
+    innovation_amplitude_gain = up(1.0 + root_gamma)
+    innovation_energy_gain = mul_up(innovation_amplitude_gain, innovation_amplitude_gain)
+    kappa = mul_up(sqrt_up(utheta), innovation_amplitude_gain)
+    return {
+        "theta_covariance_upper": utheta,
+        "vector_norm_upper": vmax,
+        "measurement_variance_lower": rlo,
+        "eta_tangent_squared_coefficient_upper": s2,
+        "eta_Sinv_energy_gain_upper": gamma,
+        "exact_innovation_Sinv_amplitude_gain_upper": innovation_amplitude_gain,
+        "exact_innovation_Sinv_energy_gain_upper": innovation_energy_gain,
+        "attitude_correction_norm_per_sqrt_metric_energy_upper": kappa,
+    }
+
+
+def reset_row_at_energy(
+    *,
+    W: float,
+    candidate_q_upper: float,
+    theta_covariance_upper: float,
+    theta_information_upper: float,
+    correction_gain: float,
+) -> dict:
+    """Evaluate the exact reset mismatch for one source/phase operation class."""
+    W = _positive(W, "funnel energy W")
+    qc = _positive(candidate_q_upper, "candidate Cayley radius")
+    utheta = _positive(theta_covariance_upper, "theta covariance upper")
+    mtheta = _positive(theta_information_upper, "theta information upper")
+    kappa = _positive(correction_gain, "correction gain")
+
+    sqrtW = sqrt_up(W)
+    q_energy = sqrt_up(mul_up(utheta, W))
+    q = min(qc, q_energy)
+    delta = mul_up(kappa, sqrtW)
+    if delta > RESET_CORRECTION_UTILITY_MAX_RAD:
+        raise RuntimeError("correction radius exceeds validated exact-reset utility range")
+    exact = RESET.reset_defect_bound(q, delta)
+    rho = float(exact["reset_attitude_defect_norm_upper"])
+    eps = div_up(mul_up(sqrt_up(mtheta), rho), sqrtW)
+    return {
+        "funnel_energy_upper": W,
+        "state_cayley_norm_upper": q,
+        "correction_norm_upper": delta,
+        "reset_attitude_defect_norm_upper": rho,
+        "reset_metric_amplitude_fraction_upper": eps,
+        "reset_metric_energy_fraction_upper": mul_up(eps, eps),
+        "cayley_composition_denominator_lower": exact["cayley_composition_denominator_lower"],
+        "reset_inverse_operator_norm_upper": exact["reset_inverse_operator_norm_upper"],
+    }
+
+
+def _measurement_constants(domain: dict, vector: dict, remainder: dict) -> dict:
+    live = domain["normal_live"]
+    vc = vector["configured_measurement_bounds"]
+    acc_std = _positive(vc["acc_measurement_std_mps2"], "accelerometer std")
+    mag_std = _positive(vc["mag_measurement_std_uT"], "magnetometer std")
+    return {
+        "accelerometer": {
+            "vector_norm_upper": _positive(live["specific_force_norm_upper_mps2"], "specific force upper"),
+            "measurement_variance_lower": down(acc_std * acc_std),
+            "eta_tangent_squared_coefficient_upper": float(
+                remainder["acc_eta_force_rotation_quadratic_coefficient_upper"]
+            ),
+        },
+        "magnetometer": {
+            "vector_norm_upper": _positive(live["magnetic_vector_norm_upper_uT"], "magnetic norm upper"),
+            "measurement_variance_lower": down(mag_std * mag_std),
+            "eta_tangent_squared_coefficient_upper": float(
+                remainder["mag_eta_squared_over_linear_rotation_squared_upper"]
+            ),
+        },
+    }
+
+
+def _operation_classes(metric: dict, constants: dict):
+    """Yield exact finite and frozen source classes without Cartesian source hulling."""
+    frozen_by_source = {
+        int(row["source_node"]): row
+        for row in metric["frozen_clock"]["source_rows"]
+    }
+    for endpoint in metric["endpoint_rows"]:
+        source = int(endpoint["source_node"])
+        for phase in range(26):
+            env = endpoint[
+                "boundary_history_envelope" if phase == 0 else "positive_phase_history_envelope"
+            ]
+            for mode in MODES:
+                utheta = float(env[f"{mode}_bias_covariance_upper"]["theta_covariance_upper"])
+                mtheta = float(
+                    endpoint["finite_phase_information_metric_upper_group_diagonal"][mode][phase]["theta"]
+                )
+                for measurement in MEASUREMENTS:
+                    gain = correction_gain_per_sqrt_energy(
+                        utheta,
+                        constants[measurement]["vector_norm_upper"],
+                        constants[measurement]["measurement_variance_lower"],
+                        constants[measurement]["eta_tangent_squared_coefficient_upper"],
+                    )
+                    yield {
+                        "branch": "finite",
+                        "source_node": source,
+                        "phase": phase,
+                        "mode": mode,
+                        "measurement": measurement,
+                        "theta_covariance_upper": utheta,
+                        "theta_information_upper": mtheta,
+                        "correction": gain,
+                    }
+
+        # Frozen clock holds the positive-phase same-history covariance upper,
+        # with a separately certified arbitrary-duration information metric.
+        env = endpoint["positive_phase_history_envelope"]
+        frow = frozen_by_source[source]
+        for mode in MODES:
+            utheta = float(env[f"{mode}_bias_covariance_upper"]["theta_covariance_upper"])
+            mtheta = float(frow["information_metric_upper_group_diagonal"][mode]["theta"])
+            for measurement in MEASUREMENTS:
+                gain = correction_gain_per_sqrt_energy(
+                    utheta,
+                    constants[measurement]["vector_norm_upper"],
+                    constants[measurement]["measurement_variance_lower"],
+                    constants[measurement]["eta_tangent_squared_coefficient_upper"],
+                )
+                yield {
+                    "branch": "frozen",
+                    "source_node": source,
+                    "phase": None,
+                    "mode": mode,
+                    "measurement": measurement,
+                    "theta_covariance_upper": utheta,
+                    "theta_information_upper": mtheta,
+                    "correction": gain,
+                }
+
+
+def evaluate(metric: dict, domain: dict, vector: dict, remainder: dict, reset: dict) -> dict:
+    failures = [f"metric: {x}" for x in METRIC.validate(metric)]
+    failures += [f"vector: {x}" for x in VECTOR.validate(vector)]
+    failures += [f"remainder: {x}" for x in REMAINDER.validate(remainder)]
+    failures += [f"reset: {x}" for x in RESET.validate(reset)]
+    if failures:
+        return {"schema": SCHEMA, "failures": failures}
+    if metric.get("same_history_P3_frontier_consumed") is not True:
+        failures.append("P3 metric attachment is not same-history")
+    if metric.get("independent_cartesian_tau_sigma_R_S_extrema_used") is not False:
+        failures.append("P3 metric attachment reintroduced Cartesian tuner extrema")
+    if remainder.get("accelerometer_corotated_aw_coordinate_used") is not True:
+        failures.append("accelerometer nonlinear remainder lost co-rotated a_w coordinate")
+    if reset.get("parametric_reset_defect_bound_available") is not True:
+        failures.append("exact reset prerequisite does not expose parametric defect bound")
+
+    constants = _measurement_constants(domain, vector, remainder)
+    classes = list(_operation_classes(metric, constants))
+    finite_expected = 800 * 26 * len(MODES) * len(MEASUREMENTS)
+    frozen_expected = 800 * len(MODES) * len(MEASUREMENTS)
+    finite_count = sum(row["branch"] == "finite" for row in classes)
+    frozen_count = sum(row["branch"] == "frozen" for row in classes)
+    if finite_count != finite_expected:
+        failures.append(f"finite reset scan covered {finite_count}, expected {finite_expected}")
+    if frozen_count != frozen_expected:
+        failures.append(f"frozen reset scan covered {frozen_count}, expected {frozen_expected}")
+
+    raw_angles = domain.get("certificate_search", {}).get(
+        "p4_complete_word_full_attitude_candidate_deg", []
+    )
+    angles = [float(x) for x in raw_angles]
+    if angles != [30.0, 25.0, 20.0, 15.0]:
+        failures.append("declared P4 certificate-search angle candidates changed")
+
+    worst_gain = {
+        mode: {
+            measurement: {"value": 0.0, "limiting_class": None}
+            for measurement in MEASUREMENTS
+        }
+        for mode in MODES
+    }
+    for row in classes:
+        k = float(row["correction"]["attitude_correction_norm_per_sqrt_metric_energy_upper"])
+        slot = worst_gain[row["mode"]][row["measurement"]]
+        if k > slot["value"]:
+            slot["value"] = k
+            slot["limiting_class"] = {
+                "branch": row["branch"],
+                "source_node": row["source_node"],
+                "phase": row["phase"],
+            }
+
+    candidates = []
+    for angle in angles:
+        qc = _candidate_q_upper(angle)
+        modes = {}
+        for mode in MODES:
+            mode_rows = [row for row in classes if row["mode"] == mode]
+            # A common W must keep both the actual Cayley state and the shipping
+            # correction inside the domains of the exact reset formulas.
+            W_angle = min(
+                down((qc * qc) / float(row["theta_covariance_upper"]))
+                for row in mode_rows
+            )
+            W_corr = min(
+                down((RESET_CORRECTION_UTILITY_MAX_RAD / float(
+                    row["correction"]["attitude_correction_norm_per_sqrt_metric_energy_upper"]
+                )) ** 2)
+                for row in mode_rows
+            )
+            W = down(min(W_angle, W_corr))
+            if not (math.isfinite(W) and W > 0.0):
+                failures.append(f"{mode} {angle:g} deg candidate lost positive funnel energy")
+                continue
+
+            worst_eps = 0.0
+            limiting = None
+            min_denom = math.inf
+            max_delta = 0.0
+            max_q = 0.0
+            for row in mode_rows:
+                try:
+                    rr = reset_row_at_energy(
+                        W=W,
+                        candidate_q_upper=qc,
+                        theta_covariance_upper=row["theta_covariance_upper"],
+                        theta_information_upper=row["theta_information_upper"],
+                        correction_gain=row["correction"][
+                            "attitude_correction_norm_per_sqrt_metric_energy_upper"
+                        ],
+                    )
+                except Exception as exc:
+                    failures.append(
+                        f"{mode} {angle:g} deg reset class {row['source_node']}/{row['phase']}/"
+                        f"{row['measurement']}: {exc}"
+                    )
+                    continue
+                eps = float(rr["reset_metric_amplitude_fraction_upper"])
+                if eps > worst_eps:
+                    worst_eps = eps
+                    limiting = {
+                        "branch": row["branch"],
+                        "source_node": row["source_node"],
+                        "phase": row["phase"],
+                        "measurement": row["measurement"],
+                        "reset": rr,
+                    }
+                min_denom = min(min_denom, float(rr["cayley_composition_denominator_lower"]))
+                max_delta = max(max_delta, float(rr["correction_norm_upper"]))
+                max_q = max(max_q, float(rr["state_cayley_norm_upper"]))
+
+            modes[mode] = {
+                "dimension": 18 if mode == "H" else 21,
+                "candidate_attitude_angle_deg": angle,
+                "candidate_cayley_radius_upper": qc,
+                "metric_energy_limit_from_attitude_upper": W_angle,
+                "metric_energy_limit_from_reset_utility_upper": W_corr,
+                "source_complete_metric_energy_funnel_upper": W,
+                "maximum_state_cayley_norm_upper": max_q,
+                "maximum_shipping_attitude_correction_norm_upper": max_delta,
+                "minimum_cayley_composition_denominator_lower": min_denom,
+                "worst_reset_metric_amplitude_fraction_upper": worst_eps,
+                "worst_reset_metric_energy_fraction_upper": mul_up(worst_eps, worst_eps),
+                "limiting_reset_class": limiting,
+                "reset_defect_is_higher_order_in_metric_radius": True,
+            }
+        candidates.append({
+            "attitude_angle_deg": angle,
+            "outer_remainder_angle_rad_consumed": float(remainder["outer_angle_rad"]),
+            "modes": modes,
+        })
+
+    return {
+        "schema": SCHEMA,
+        "qualification": "OU3_P4_SOURCE_CORRELATED_CORRECTION_RESET_BUDGET",
+        "source_generated_not_trajectory_fit": True,
+        "trajectory_replay_used": False,
+        "filter_changed": False,
+        "declared_domain_changed": False,
+        "same_history_P3_metric_consumed": True,
+        "independent_cartesian_tau_sigma_R_S_extrema_used": False,
+        "canonical_P3_pass_required_before_P4_theorem_consumption": True,
+        "outer_0p8_rad_remainder_consumed": float(remainder["outer_angle_rad"]) == 0.80,
+        "accelerometer_corotated_aw_eta_zero_consumed": True,
+        "accelerometer_bias_eta_zero_consumed": True,
+        "kalman_gain_bound_identity": "K_theta S K_theta^T <= P_theta <= U_theta I",
+        "linear_innovation_metric_identity": "H^T S^-1 H <= P^-1",
+        "state_dependent_correction_bound": True,
+        "global_fixed_correction_cap_assumed": False,
+        "source_correlated_correction_norm_bound_supplied_here": True,
+        "exact_reset_transport_consumed": True,
+        "reset_inverse_operator_norm_upper": reset["reset_inverse_operator_norm_upper"],
+        "finite_operation_classes_scanned": finite_count,
+        "frozen_operation_classes_scanned": frozen_count,
+        "worst_correction_gain_by_mode_measurement": worst_gain,
+        "certificate_search_candidates": candidates,
+        "reset_defect_vanishes_quadratically_with_metric_radius": True,
+        "complete_H18_A21_word_established_here": False,
+        "P4_USABLE_CERTIFICATE_PROMOTED": False,
+        "P5_FINITE_CAPTURE_ESTABLISHED_HERE": False,
+        "next_obligation": (
+            "combine these same-source correction/reset budgets with the signed vector tangent forms, "
+            "S=0 linear forms, prediction/source-edge metric transport and recurrent H18/A21 word; "
+            "choose the widest candidate energy funnel for which the accumulated rho_H and rho_A are strictly below one"
+        ),
+        "failures": failures,
+    }
+
+
+def build(metric: dict, domain_path: Path = DEFAULT_DOMAIN) -> dict:
+    path = Path(domain_path).resolve()
+    domain = json.loads(path.read_text(encoding="utf-8"))
+    if domain.get("trajectory_fit") is not False:
+        raise RuntimeError("source-correlated reset budget must not be trajectory fitted")
+    return evaluate(metric, domain, VECTOR.build(), REMAINDER.build(path), RESET.build(path))
+
+
+def validate(d: dict) -> list[str]:
+    f = list(d.get("failures", []))
+    if d.get("schema") != SCHEMA:
+        f.append("schema mismatch")
+    if d.get("qualification") != "OU3_P4_SOURCE_CORRELATED_CORRECTION_RESET_BUDGET":
+        f.append("wrong qualification")
+    for key in (
+        "source_generated_not_trajectory_fit", "same_history_P3_metric_consumed",
+        "canonical_P3_pass_required_before_P4_theorem_consumption",
+        "outer_0p8_rad_remainder_consumed", "accelerometer_corotated_aw_eta_zero_consumed",
+        "accelerometer_bias_eta_zero_consumed", "state_dependent_correction_bound",
+        "source_correlated_correction_norm_bound_supplied_here", "exact_reset_transport_consumed",
+        "reset_defect_vanishes_quadratically_with_metric_radius",
+    ):
+        if d.get(key) is not True:
+            f.append(f"{key} is not true")
+    for key in (
+        "trajectory_replay_used", "filter_changed", "declared_domain_changed",
+        "independent_cartesian_tau_sigma_R_S_extrema_used", "global_fixed_correction_cap_assumed",
+        "complete_H18_A21_word_established_here", "P4_USABLE_CERTIFICATE_PROMOTED",
+        "P5_FINITE_CAPTURE_ESTABLISHED_HERE",
+    ):
+        if d.get(key) is not False:
+            f.append(f"{key} is not false")
+    if d.get("reset_inverse_operator_norm_upper") != 1.0:
+        f.append("exact reset inverse norm is not one")
+    if int(d.get("finite_operation_classes_scanned", 0)) != 800 * 26 * 2 * 2:
+        f.append("finite reset budget did not cover 800 x 26 x H/A x acc/mag")
+    if int(d.get("frozen_operation_classes_scanned", 0)) != 800 * 2 * 2:
+        f.append("frozen reset budget did not cover 800 x H/A x acc/mag")
+    candidates = d.get("certificate_search_candidates", [])
+    if [float(x.get("attitude_angle_deg", math.nan)) for x in candidates] != [30.0, 25.0, 20.0, 15.0]:
+        f.append("P4 certificate-search candidates changed")
+    for cand in candidates:
+        for mode in MODES:
+            row = cand.get("modes", {}).get(mode, {})
+            for key in (
+                "source_complete_metric_energy_funnel_upper",
+                "minimum_cayley_composition_denominator_lower",
+            ):
+                x = row.get(key)
+                if not isinstance(x, (int, float)) or isinstance(x, bool) or not math.isfinite(float(x)) or float(x) <= 0.0:
+                    f.append(f"{cand.get('attitude_angle_deg')} {mode}: {key} is not finite positive")
+            eps = row.get("worst_reset_metric_amplitude_fraction_upper")
+            if not isinstance(eps, (int, float)) or isinstance(eps, bool) or not math.isfinite(float(eps)) or float(eps) < 0.0:
+                f.append(f"{cand.get('attitude_angle_deg')} {mode}: reset amplitude fraction invalid")
+            delta = row.get("maximum_shipping_attitude_correction_norm_upper")
+            if not isinstance(delta, (int, float)) or float(delta) > RESET_CORRECTION_UTILITY_MAX_RAD:
+                f.append(f"{cand.get('attitude_angle_deg')} {mode}: correction utility range exceeded")
+    return list(dict.fromkeys(f))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--domain", type=Path, default=DEFAULT_DOMAIN)
+    ap.add_argument("--metric", type=Path, required=True)
+    ap.add_argument("--output", type=Path, required=True)
+    a = ap.parse_args()
+    metric = json.loads(a.metric.read_text(encoding="utf-8"))
+    d = build(metric, a.domain)
+    vf = validate(d)
+    d["validation_pass"] = not vf
+    d["validation_failures"] = vf
+    a.output.parent.mkdir(parents=True, exist_ok=True)
+    a.output.write_text(json.dumps(d, indent=2, sort_keys=True), encoding="utf-8")
+    print(json.dumps({
+        "status": "PASS" if not vf else "FAIL",
+        "finite_classes": d.get("finite_operation_classes_scanned"),
+        "frozen_classes": d.get("frozen_operation_classes_scanned"),
+        "worst_correction_gain": d.get("worst_correction_gain_by_mode_measurement"),
+        "candidates": d.get("certificate_search_candidates"),
+        "P4_promoted": d.get("P4_USABLE_CERTIFICATE_PROMOTED"),
+        "validation_failures": vf,
+    }, indent=2, sort_keys=True))
+    return 0 if not vf else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Purpose

This PR is deliberately narrower than #466. It must **not** become another open-ended P3→P4→P5 lemma/refinement loop.

Its job is:

1. make the frozen source-correlated canonical P3 backend actually reach a numerical verdict at the unchanged `1e-18` gate; and
2. **only if P3 passes**, run one structure-exact complete-word P4 feasibility calculation that decides whether the 0.80-rad theorem route is worth rigorous certification.

Full rigorous P4 construction and all P5 finite-capture work are out of scope for this PR unless the feasibility calculation first demonstrates a credible `rho_H<1`, `rho_A<1` route.

## Frozen theorem rules

These do not move in this PR:

- canonical P3 useful gate: `1e-18`;
- P2 interface: `OU3_P2_CORRELATED_STAGE_TRANSFER_V1`;
- same-history source correlation; no independent Cartesian `tau/sigma/R_S` extrema;
- H=18 and A=21 both required;
- no replay fitting;
- no operating-domain shrink solely to pass;
- no filter change to make the proof easier;
- lever arm remains disabled/zero in the current proof scope;
- vibration-guard proof branch remains dormant/transparent;
- P4 cannot consume a substitute for canonical P3;
- P5 remains blocked until canonical P4 genuinely contracts.

## Current observed failure — this is NOT a P3 numeric FAIL

The brittle one-ULP identity-floor test from #466 is fixed correctly. The focused canonical-P3 tests now pass.

The current head still does **not** reach the P3 margin calculation. Both `source-foundation` and `canonical-p3` fail inside:

`tools/ou3_p3_correlated_translation_segment.py`

with repeated

`Loewner prediction lower lost strict SPD; split x cell`.

The backend recursively subdivides the same `x` interval to the adaptive-depth limit and still loses strict SPD. Therefore the next action is **not** to increase subdivision depth or add another P4 bound. This is an enclosure-representation problem until proved otherwise.

The failing construction currently forms an absolute entrywise interval for

`F L F^T + Q`,

collapses it to a point Loewner lower by subtracting a row-radius `eps I`, and requires that lower to be strictly SPD at every 5-ms prediction. The integrated `S` channel has a very small one-sample process floor, so absolute-radius collapse can erase positivity even when the exact covariance family is SPD. More splitting is not automatically a remedy.

## Phase 1 — diagnose the P3 enclosure once

Use one deterministic representative failure first (currently source node 137 / gap 13 is already reproduced by tests).

For the first failing prediction record:

- `x` interval and subdivision depth;
- midpoint/center matrix;
- rigorous radius matrix / row-radius `eps`;
- `lambda_min(center)` and `eps/lambda_min(center)`;
- a high-precision point reference at the midpoint and interval endpoints for diagnosis only;
- which scaled coordinate/eigenvector is limiting.

### Stop rule

If subdivision shrinks the interval but the relative SPD margin does not improve materially, **stop subdividing**. Do not respond by increasing `MAX_ADAPTIVE_X_DEPTH`.

## Phase 2 — replace the structurally bad lower, not the theorem

Use a **relative / congruence-normalized Loewner enclosure** for the prediction or complete 13–26-sample segment instead of demanding a strong absolute point lower at every 5-ms step.

Preferred construction:

1. choose a well-conditioned point preconditioner from the segment/prediction midpoint;
2. transform the interval covariance family by congruence into normalized coordinates where the center is near identity;
3. certify a relative lower `B(x) >= alpha I`, `alpha>0`, using outward arithmetic / verified solves;
4. map that result back to the scalar or matrix floor actually needed by `common_boundary_floor`;
5. preserve Riccati monotonicity and the exact same P2-V1 source history.

The key objective is the **complete-segment floor** used by `common_boundary_floor`; a separately strong one-step SPD lower is not a theorem requirement unless the mathematics genuinely needs it.

Alternative constructions are acceptable only if they prove the same Loewner statement and demonstrably remove the absolute-conditioning failure. Entrywise clipping, optimistic PSD projection, replay-based tuning, or deeper blind subdivision are not acceptable.

## Phase 3 — obtain exactly one canonical P3 numerical verdict

After the enclosure backend is valid:

- run the source-complete P3 producer once over all 800 sources × 26 phases plus frozen-clock hold;
- always write/upload the diagnostic P3 artifacts before the workflow exits, even when the theorem gate is false;
- report explicitly:
  - translation worst margin and limiting source/phase/coordinate;
  - H margin;
  - A margin;
  - canonical worst H/A margin;
  - `P3_CANONICAL_PASS`;
  - fail reason if below `1e-18`.

### Decision gate

**A. Backend/enclosure still cannot produce a rigorous margin**

Fix only that mathematical backend. No P4 work.

**B. Rigorous P3 margin exists but `<1e-18`**

Identify the single limiting bound. One further tightening is allowed only when there is a written mathematical reason it attacks that limiter. Do not start another generic subdivision/constant-sharpening loop. If the source-faithful best formulation still stays below the useful gate, record P3 as FAIL and stop P4.

**C. H and A are both `>=1e-18`**

Freeze the exact P3 artifact, source-history digest, and P3→P4 metric handoff. No later P4 work may change them silently.

## Phase 4 — one P4 feasibility calculation, not another certificate stack

Only after case C, build a **diagnostic, non-promoting, structure-exact complete-word map**.

The diagnostic should compose the actual deployed operations over one legal recurrent source word:

`prediction -> linear S=0 updates -> accelerometer update/injection/reset -> magnetometer update/injection/reset -> ...`

using the frozen P3 metric/source history.

Use the exact structural identities already established in #466/#471 internally:

- Kalman prediction non-expansion in its information metric;
- exact Joseph information identity;
- co-rotated accelerometer `a_w` coordinate;
- exact magnetometer radial cancellation;
- exact quaternion/reset congruence;
- exact Cayley finite-angle geometry.

The existing `ou3_p4_source_correlated_reset_budget.py` and signed-vector coefficient code are **diagnostic lemmas only**. Do not extend them into another sequence of promotion stages before the complete-word ratio is known.

Compute

`rho_w = V_after(F_w(x)) / V_before(x)`

for H and A over the declared 0.80-rad domain/source language with high-precision matrix arithmetic. This feasibility pass is not proof and must not set canonical P4 flags.

It must report:

- worst `rho_H`, `rho_A`;
- limiting legal word/source/phase;
- maximizing state direction or generalized eigenvector;
- contribution of prediction, S, accel, mag, and reset to the limiting word;
- distance to `rho=1`.

### P4 feasibility stop rules

- If `rho << 1`: proceed in a **new PR** to rigorous outward-rounded complete-word certification.
- If `rho ≈ 1`: derive one targeted theorem improvement from the reported limiting direction before any rigorous interval implementation.
- If `rho > 1` even with essentially exact arithmetic and no interval pessimism: stop this 0.80-rad P4 formulation. Do not try to rescue it by sharpening unrelated constants; choose a different Lyapunov/theorem formulation.

## Explicitly out of scope for #471

- a new family of P4 micro-certificates;
- repeated reset-budget/correction-budget refinement before complete-word feasibility is known;
- P5 finite capture;
- changing the `1e-18` gate;
- shrinking the theorem domain to make numbers pass;
- changing the deployed filter;
- replay-fitted certificate parameters.

## Merge criteria for #471

This PR may merge only when:

1. the current Loewner-SPD recursion failure is replaced by a mathematically justified source-faithful enclosure;
2. canonical P3 emits an unambiguous rigorous numerical PASS/FAIL artifact at the unchanged `1e-18` gate;
3. if and only if P3 passes, the single complete-word P4 feasibility diagnostic above is recorded;
4. no P4/P5 theorem promotion is claimed unless its actual canonical gate is satisfied.

The purpose of this scope is to force a decision, not to continue indefinitely adding local inequalities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tooling to calculate and report source- and phase-correlated attitude-correction and exact-reset budgets across supported operating conditions.
  - Added validation and certificate generation for candidate attitude funnels and reset budgets.

- **Bug Fixes**
  - Reset budget calculations now reject energy values outside the candidate funnel instead of silently constraining them.
  - Improved separation and validation of residual and Jacobian information retention factors.
  - Corrected boundary handling in full-matrix translation processing.

- **Tests**
  - Expanded validation coverage for strict interval bounds and out-of-funnel reset requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->