### PR TITLE
[DUPLICATE] Continue OU-III P3 → P4 → P5 closure after #466

### DIFF
--- a/tests/validation/test_ou3_p3_p2_v1_stage_phase_translation.py
+++ b/tests/validation/test_ou3_p3_p2_v1_stage_phase_translation.py
@@ -25,8 +25,13 @@ class P2V1StagePhaseTranslationTests(unittest.TestCase):
         M = P._identity_floor(0.25)
         ok, _ = symmetric_positive_definite_ldlt(M)
         self.assertTrue(ok)
-        self.assertEqual(M[0][0].lo, 0.25)
-        self.assertEqual(M[0][1].lo, 0.0)
+        # _identity_floor uses outward-rounded point intervals.  The exact
+        # decimal value therefore only has to be enclosed; requiring its
+        # binary64 lower endpoint to equal 0.25 defeats the rigor contract.
+        self.assertLessEqual(M[0][0].lo, 0.25)
+        self.assertGreaterEqual(M[0][0].hi, 0.25)
+        self.assertLessEqual(M[0][1].lo, 0.0)
+        self.assertGreaterEqual(M[0][1].hi, 0.0)
 
     def test_certified_delta_matches_simple_diagonal_case(self):
         M = P._identity_floor(1.0)


### PR DESCRIPTION
Continuation from current main after PR #466.

Initial repair:
- fix the canonical-P3 CI regression caused by an exact binary64 equality assertion on an outward-rounded interval endpoint; the test now checks rigorous enclosure instead.

Proof work in this PR will continue the retained route without changing theorem gates, operating domain, or filter behavior:
- obtain the actual canonical P3 numerical verdict from the P2-V1 exact-history / stage-phase / precision-block producer;
- bind #466's exact Joseph/quaternion reset transport to the same source/phase P3 metric through a source-correlated energy-funnel correction bound;
- carry the signed vector Joseph forms through the complete H=18/A=21 recurrent word before scalarization;
- submit only a strict rho_H<1, rho_A<1 complete-word candidate to the frozen canonical P4 gate;
- only after canonical P4 passes, continue P5 to finite startup-to-inner-funnel capture.

No replay fitting, gate relaxation, operating-domain widening, or filter retuning is intended here.