### PR TITLE
P3: the whole-word lower is conditional on S firing, plus two scheduler fidelity fixes

### DIFF
--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -127,7 +127,45 @@ finite-state or monotone argument can quantify over legal histories.
 words rather than a local search: a finite-state or monotone quotient that bounds
 every legal word, not the best one a greedy descent can find.
 
-## Step 2: a floor justified against the other measurement channels
+## Closed-form whole-word margin: 800/800 nodes, interval-certified
+
+`tools/ou3_p3_closed_form_word_margin.py`. Both sides of the P3 comparison built
+in closed form from one endpoint-referenced observability Gramian, so neither
+steps a Riccati recursion -- which is what makes it survive interval arithmetic
+where three previous attempts died between 343 and 503 of 635 samples.
+
+| | value |
+| --- | --- |
+| source nodes evaluated / validated | **800 / 800** |
+| worst margin | **1.505e-05** |
+| clears the `1e-18` gate by | **13.18 orders** |
+| binding node / channel | 780 (`tau` in [8.386, 12.0]) on `v` |
+| S observations, ceiling / floor | 19 / 27 |
+
+Run under **current main's** clamps, `MAX_R_S = 400`, not #478's tightened ones,
+so the result does not depend on that PR landing. #478's clamps would improve it
+by a further 1.29 orders.
+
+Within each source cell the two sides take opposite endpoints -- the ceiling the
+fewest observations and weakest S measurement, the floor the most and strongest
+-- so both hold for every parameter value the cell admits. `R_S` comes from the
+deployed clamped SpectralMSE law rather than the free P2 cell range, and `P0`
+from the shipping constructor.
+
+Nine tests pin the contracts: cadence and `R_S` agree with the repo's own source
+parser and respect both clamps, the Gramian grows with observation count, the
+uninflated floor Gramian dominates the inflated ceiling one, floor never exceeds
+ceiling on any channel, a singular Gramian is reported rather than silently
+inverted, and `validate()` catches tampering with the gate or any
+non-promotion flag.
+
+**This is a margin, not a P3 verdict.** The canonical producer and gate remain
+the promotion authority; the artifact carries `certifies_theorem_stage: false`
+and cannot set a theorem flag. What remains between this and a certificate is
+the canonical producer wiring and mixed-source words, neither of which is
+blocked by the interval wall now that both sides are closed form.
+
+## How the floor is justified against the other measurement channels
 
 The defect in the first attempt -- a floor that ignored accelerometer information
 and so could be violated by the truth -- is closed by a structural argument

--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -127,6 +127,52 @@ finite-state or monotone argument can quantify over legal histories.
 words rather than a local search: a finite-state or monotone quotient that bounds
 every legal word, not the best one a greedy descent can find.
 
+## Stacked deficit accounting after PR #478
+
+Re-ran the ceiling under #478's tightened safety clamps. All figures are the
+binding `S` channel against the canonical segment floor 1.366e-20.
+
+| step | `S` ceiling (variance) | `delta` | orders short of `1e-18` |
+| --- | --- | --- | --- |
+| canonical today: 3-point, start-referenced, old clamps | 7.171e+09 | 1.91e-30 | **11.72** |
+| + endpoint referencing (#478's fix, and independently step 1 here) | 5.324e+07 | 2.57e-28 | 9.59 |
+| + N-point Gramian instead of 3-point (step 1 here) | 7.350e+04 | 1.86e-25 | 6.73 |
+| + #478's tightened safety clamps | 3.807e+03 | 3.59e-24 | **5.45** |
+
+**6.27 orders recovered; 5.45 remain, and they must come from the floor.** The
+earlier figure of 8.6 predates both #478's clamps and the ceiling work.
+
+### What #478's clamps change
+
+| constant | old | new | effect here |
+| --- | --- | --- | --- |
+| `MAX_TUNE_FREQ_HZ` | 1.5 | 1.2 | `tau` floor rises 0.3333 -> 0.4167 s |
+| `MAX_SIGMA_A` | 6.0 | 4.0 | less process noise at the corner |
+| `MAX_R_S` | 400 | 100 | 16x stronger worst-case `S` measurement |
+| `PSEUDO_UPDATE_PERIOD_MAX_S` | 0.25 | 0.15 | max S gap 33 -> 31 samples |
+| `kDynamicEmaHorizonMaxSec` | 30 | 35 | loosened, leaves the largest reference sea interior |
+
+Worth **1.29 orders** on the worst endpoint `S` ceiling on its own, taking it
+from 271.1 to 61.70 m.s. These are safety limits that no reference record
+approaches, so this is a theorem-envelope tightening rather than a deployed
+behaviour change -- but that claim is #478's to carry, and re-running the
+deterministic sim against it is still outstanding here.
+
+This ledger recorded the same corner as "unphysical but nearly free", measured at
+4x on `a_w` and 1.002x on v/p/S. That measurement was taken against the
+**broken** ceiling, where 1.29 orders was worth nothing against a 12.7-order
+deficit. Against the repaired ceiling it is a fifth of what remains. **The
+conclusion "not worth pursuing" was an artifact of the ceiling error**, and is
+withdrawn.
+
+### Endpoint referencing was found independently on both sides
+
+#478's covariance upper now states that the reconstructed `[v,p,S]` covariance
+"is already an endpoint covariance and MUST NOT be propagated forward through the
+word again". That is the same fix as step 1 here, reached separately. #478 keeps
+three selected observations; the N-point Gramian is worth a further 2.86 orders
+on top of it.
+
 ## PR #478 supersedes the starvation work here and hands Step 2 its input
 
 #478 repairs `set_pseudo_update_period_s` so a cadence retarget preserves

--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -127,7 +127,73 @@ finite-state or monotone argument can quantify over legal histories.
 words rather than a local search: a finite-state or monotone quotient that bounds
 every legal word, not the best one a greedy descent can find.
 
-## Why the certificate cannot be built as specified, and what does build
+## How to advance: P2's tau model is over-approximate, and that is the whole blocker
+
+Starvation is not a physical regime. It is an artifact of the P2 quotient letting
+`tau` jump anywhere inside a cell at every stage boundary, which the deployed
+chain cannot do.
+
+**Starvation is bit-exact.** Perturbing the resonant `tau` sequence by a single
+binary32 ulp at 24 of the 49 stages restores `S` firing, and the magnitude of the
+perturbation is irrelevant -- 1 ulp and 256 ulps break exactly the same 24
+positions. Only *which* stage is perturbed matters.
+
+**The deployed chain rate-limits `tau` by about 2.5 orders more than the
+resonance can tolerate.** Starvation needs the tuning frequency to alternate by
+1.1015e-3 relative every 13 samples = 65 ms, between #476's certified pair
+`0.05241831764578819` and `0.05247608572244644` Hz. But the deployed
+`WavePeriodEstimator` carries an exponentially weighted moment state with a
+horizon of **at least 20 s** (`min_horizon_sec = 20.0`,
+`moment_horizon_periods = 4.0`, up to `max_horizon_sec = 180.0`), plus a
+canonical log-period smoothing state on top:
+
+| estimator horizon | reachable fraction in one 65 ms stage | required moment-ratio swing |
+| --- | --- | --- |
+| 20 s (fastest allowed) | 3.24e-3 | 33.9 percent |
+| 40 s | 1.62e-3 | 67.8 percent |
+| 90 s | 7.22e-4 | 152.6 percent |
+| 180 s | 3.61e-4 | 305.1 percent |
+
+Even at the fastest allowed horizon the output moves only 3.2e-3 of the way to a
+new input per stage, so driving the required alternation demands a **34 percent
+relative swing in the moment ratio itself, every 65 ms, in exact antiphase, for
+49 consecutive stages, landing on binary32-exact values at each one**. The moment
+ratio is a ratio of spectral moments of wave acceleration and moves on wave
+timescales. Downstream of it the tuner EMA adds its own limit,
+`alpha = 1 - exp(-dt/adapt_sec) <= 0.095` per sample from the
+`adapt_sec >= 0.05 s` clamp.
+
+This is not a proof that the estimator cannot produce it, and it is not claimed
+as one. It is a measured statement that the deployed chain low-passes the
+required alternation by about 2.5 orders.
+
+### The route that needs no weakening
+
+1. Carry the deployed **`tau` slew limit** into the P2 source model as a parsed
+   source fact, exactly as the cadence ratio and clamps already are -- not a
+   domain shrink, because it is a property of the shipping code rather than a
+   restriction on the sea state.
+2. A slew-limited `tau` cannot hold the bit-exact 2-cycle, so zero-`S` words leave
+   the legal set.
+3. Every remaining legal word then has at least 19 `S` firings, so the `S`
+   observability Gramian is nonsingular and **a `P0`-free `Sigma_upper` exists
+   again**.
+4. The whole-word lower feasibility result below then applies as stated:
+   `delta ~ 3e-8`, clearing the `1e-18` gate by 10.5 orders.
+
+This keeps P3 uniform in initial covariance and needs no new declared entrance
+bound. It is preferred over the `P0`-bounded fallback recorded below, which
+remains available and clears by 12.7 orders but weakens what P3 asserts.
+
+**Next falsifiable experiment:** derive the per-stage `tau` slew bound from the
+estimator horizon and tuner EMA, add it to the P2 transition relation, and re-run
+the four-max witness and the starvation witness against it. **Predicted:** the
+resonant 2-cycle becomes illegal while #476's `[9,3,39,9]` label witness stays
+legal, since that one needs only ordinary cell-to-cell motion. **Falsified if**
+the slew bound is loose enough to still admit the 2-cycle, in which case the
+`P0`-bounded fallback is the remaining route.
+
+## Why a P0-free certificate cannot be built on the current legal word set
 
 `translation_upper` takes **no initial covariance**: it is `P0`-free by
 construction, which is exactly why it inverts a three-point observability

--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -552,12 +552,27 @@ The source-marker contracts do not close the gap either. They pin the update
 but nothing anywhere checks how `r` is defined.
 
 P4 would catch it, since it bounds the actual nonlinear state map `F_w`. P4 has
-never been reached because P3 blocks. So today **nothing in the certified chain
-verifies that the mean correction is stabilizing**; P1-P3 certify covariance
-behaviour only. Any future claim that the deployed filter is certified should
-state that limitation explicitly, and a cheap direct check of the innovation
-sign convention against each shipping update is worth adding independently of
-the P3/P4 work.
+never been reached because P3 blocks. So the certified chain does not verify
+that the mean correction is stabilizing; P1-P3 certify covariance behaviour only,
+and any claim that the deployed filter is certified should state that limitation.
+
+**Closed by direct test**, independently of the P3/P4 work:
+`tests/kalman_ou_iii/innovation_sign-test.cpp` pins that every shipping OU-III
+measurement update corrects the state *toward* its measurement. The invariant is
+sign-sensitive and gain-free: a correct linear Kalman update makes the posterior
+a convex combination of prior and measurement, so the corrected component lies in
+`[x-, z)` and can never move away from `z`. Covered: the `S = 0` integral
+pseudo-measurement, the position, velocity and vertical-velocity pseudo-updates,
+and the accelerometer attitude correction.
+
+The test was validated by negative control -- flipping the innovation sign in
+each of the four linear updates in turn, rebuilding, and confirming each flip is
+caught. Note the test Makefiles track the `.cpp` only, so a header edit needs
+`make -B`; without it the first negative-control pass silently ran a stale binary
+and reported four false passes. This does not affect CI, which builds clean.
+
+This closes the *sign* gap only. It does not make P1-P3 certify the mean, and it
+is not a substitute for P4.
 
 ## The translation ceiling credits 3 of the 19 to 602 S firings in a word
 

--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -127,7 +127,60 @@ finite-state or monotone argument can quantify over legal histories.
 words rather than a local search: a finite-state or monotone quotient that bounds
 every legal word, not the best one a greedy descent can find.
 
-## What canonical wiring actually requires: both sides, not one
+## The closed-form route CANNOT be fed to the canonical gate as it stands
+
+The chain exists on paper: `ou3_p3_p2_v1_full_state_join.build()` accepts a
+`translation_candidate`, and `ou3_p3_canonical_gate.build()` accepts a
+`p3_candidate`, so a parallel path could in principle let the **gate** render the
+verdict rather than this ledger asserting one. It cannot, and the reason is worth
+recording precisely.
+
+`TRANS.validate` requires 16 flags true. Audited against the closed-form
+construction, **6 can be claimed honestly, 1 is partial, and 9 cannot**:
+
+| can claim | cannot claim |
+| --- | --- |
+| `source_only` | `full_word_history_sufficient_quotient_consumed` |
+| `zero_lever_arm_branch` | `process_covariance_measurement_bounds_same_source_history` |
+| `dormant_transparent_vibration_guard_branch` | `same_history_covariance_evaluated_before_uniform_endpoint_envelope` |
+| `Riccati_order_monotonicity_used` | `full_4x4_translation_matrix_retained_inside_source_segments` |
+| `strongest_accelerometer_and_S_measurements_applied_every_sample` | `one_complete_segment_common_boundary_floor_used` |
+| `magnetometer_translation_jacobian_zero_on_declared_branch` | `older_process_covariance_discarded_at_each_boundary` |
+| | `all_finite_clock_sample_phases_covered` |
+| | `phase_26_is_next_stage_boundary_when_clock_advances` |
+| | `frozen_clock_absorbing_hold_branch_included` |
+
+plus the structural demands that `phase_samples == list(range(26))`,
+`endpoint_phase_count == 800*26`, and `boundary_floor` carry
+`all_800_sources_checked` with a strict `rho_z_identity_lower`.
+
+**The nine are not deficiencies in the closed-form bound. They describe the
+stepwise segment/phase architecture that it deliberately replaces.** There are no
+segment boundaries to discard covariance at, no 0..25 phase sweep because
+endpoint referencing removes that degree of freedom, and no same-history quotient
+because the mixed-word bound is deliberately cross-worst -- which is *stronger*,
+covering every legal word rather than one history at a time.
+
+Two are real scope limits rather than architecture mismatches, and should not be
+glossed with the rest: the construction is 3x3 on `(v, p, S)` and does not carry
+`a_w`, and the frozen-clock absorbing hold is not modelled.
+
+### Consequence
+
+Feeding the gate would require either setting flags that do not describe the
+construction, which is fabrication and is not an option, or revising the
+translation-candidate contract so it admits a closed-form architecture. The
+second is a proof-architecture decision for the project, not something this
+branch should do unilaterally: those flags encode real conservatism guarantees,
+and `older_process_covariance_discarded_at_each_boundary` in particular is a
+safety property whose closed-form analogue has to be argued, not dropped.
+
+**So this branch cannot produce a P3 verdict, and should not pretend the
+remaining work is plumbing.** What it can offer is a measured alternative
+construction with its own conservatism argument, for the project to accept or
+reject on the merits.
+
+## What replacing the canonical pair requires: both sides, not one
 
 Swapping the closed-form ceiling into the canonical producer alone does **not**
 reach the gate. The canonical floor is the limiter once the ceiling is repaired:

--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -93,42 +93,86 @@ but is not the limiter.
 ### What it does not invalidate
 
 * the `1e-18` canonical gate;
-* same-history P2-V1 source correlation and the envelope machinery, which is not
-  what broke;
+* ~~same-history P2-V1 source correlation and the envelope machinery, which is
+  not what broke~~ -- **withdrawn.** PR #476 showed the four-max summary admits
+  the full global adverse label `[9,3,39,9]` after only 101 samples, far inside
+  the 635-sample word, so at whole-word horizon the same-history *upper*
+  degenerates to the global one. Verified independently here: all six
+  transitions of `729 --16--> 568 --16--> 407 --18--> 246 --25--> 85 --13--> 74
+  --13--> 63` are legal P2 V1 edges. The source *language* stands; the four-max
+  quotient built on it does not;
 * the H/A attitude and bias floors, which are separate from translation;
 * the exact Joseph, Cayley, co-rotated accelerometer and reset identities;
 * the endpoint-only SPD result, which remains correct and is not the limiter.
 
 ### Next falsifiable experiment
 
-Extend the certified translation floor from one segment to a whole word, so that
-both sides of the master inequality are whole-word quantities, and credit the
-deployed `S` cadence in the ceiling at the same time.
+The horizon fix has two structural parts. PR #476 owns the second; this ledger
+entry owns the first.
 
-Requirements:
+1. **whole-word covariance lower**, valid for every admissible PSD initial
+   covariance and every legal source history;
+2. **time-ordered, duration-aware covariance upper** -- #476's lane, because the
+   four-max quotient it replaces is what broke.
 
-- the whole-word floor must be a valid **lower** bound over every admissible
-  source history and every admissible initial covariance, not a point recursion
-  -- this is the hard part, and is plausibly why the floor is a single zero-start
-  segment today;
-- keep the same-history P2-V1 envelope ordering, which is not what broke;
-- credit the `S` cadence per cell, using each cell's own `T_S` and word length;
-- report the floor, `Sigma_upper`, the recomputed `delta` and the binding channel.
+The lower must be certified over *mixed* legal words, not one source held for a
+word. The single-cell dwell measured below is a feasibility signal for it, not a
+substitute: it says the geometry has room, and says nothing about whether a
+finite-state or monotone argument can quantify over legal histories.
 
-**Predicted:** with both sides whole-word at the binding cell, `delta` reaches
-roughly `1e-4` to `1e-3` -- the point diagnostic gives 3.79e-4, binding on `p` --
-clearing the `1e-18` gate by about 14 orders.
-**Falsified if** a uniform whole-word floor cannot be certified over admissible
-histories, or if certifying it costs so much of the floor that `delta` stays
-below `1e-18`. Either outcome moves suspicion to the theorem formulation rather
-than to the bounds.
+**Predicted:** a whole-word lower certified over mixed legal words retains a
+`delta` within about two orders of the worst single-cell dwell, so above `1e-10`.
+**Falsified if** quantifying over mixed words costs more than that, in which case
+the loss is in the history quotient rather than the horizon, and the suspicion
+moves back to the source-correlation representation.
 
-Caveat: every number in this section is an mpmath point diagnostic at one tuner
-cell, with `P0`-independence checked at 40 and 55 decimal digits. None of it is a
-certificate. A rigorous replacement must hold uniformly over source-reachable
-cells and initial covariances, which is strictly more than a point recursion.
+## Whole-word lower feasibility (measured)
 
-Do not resume any shelved item before this experiment reports a number.
+`tools/ou3_p3_whole_word_lower_feasibility.py`, non-promoting point diagnostic.
+Canonical `delta` is same-history matched -- `phase_row` pairs node `t`'s floor
+image with `endpoint_phase_upper(t, ...)`, that same node's own upper, and then
+minimises over nodes. The analogue measured is, per source configuration, the
+horizon-matched ratio between the whole word propagated from `P = 0` and the same
+word propagated from a large initial covariance.
+
+Over all 800 physical source nodes at their adverse corner (slowest cadence,
+largest `sigma`, weakest `S`), holding each for the full 635-sample word:
+
+| | value |
+| --- | --- |
+| worst single-cell dwell | **3.51e-8** at node 729 (`tau = 12 s`, `sigma = 0.05`, `R_S = 400`, 19 firings, binds on `p`) |
+| clears the `1e-18` gate by | **10.55 orders** |
+| independent mpmath `dps=30` sweep | 3.50347e-08, agreeing to 0.24 percent |
+| best node | about 1.0 (node 390) |
+
+On #476's own adversarial witness extended to the word, the ordered ratio is
+2.00e-3 at the slowest-cadence corner and 3.88e-3 at the fastest, so the choice
+of `tau` within a cell is worth about 2x, not orders. Ordering *helps*: the worst
+fixed-source cell in that witness gives 3.5e-8 while the mixed word gives 2.0e-3,
+because a mixed word necessarily visits faster-cadence cells that fire `S` more
+often. The adversary for a lower is therefore dwelling, not mixing.
+
+**Scheduler correction to this ledger's own earlier numbers.** The cadence is
+tau-scaled *and* `set_pseudo_update_period_s` applies
+`elapsed = fmod(elapsed, new_period)` on every source commit, so the fixed-cell
+counts recorded above (19 at `tau = 12 s`, 602 at `tau = 0.333 s`) do not
+transfer to a changing-source word. The witness word fires **106** times at the
+fastest corner and **76** at the slowest -- neither equals any single cell's
+count. Fixed-cell counts remain valid only for a word spent entirely in one cell.
+
+**Numerical limits, surfaced rather than tuned away.** `P0 = infinity` is not
+representable in double precision, and two walls bracket the usable range: below
+the lower wall the word has not forgotten `P0`; above the upper wall the
+covariance-form update loses the endpoint to cancellation, the tell being that
+the endpoint *decreases* as `P0` grows, which the monotone Riccati map forbids.
+The gap between the walls moves across cells by about eight orders -- the
+accepted probe scale ranges 1e6 to 1e15 over the 800 nodes -- so no fixed probe
+pair serves all of them. The probe escalates relative to each word's own
+zero-start covariance until two consecutive probes agree, and reports the
+accepted scale and achieved spread per row.
+
+Not a certificate: point diagnostic at one corner per cell, double precision,
+`quantifies_over_legal_histories: false`, `certifies_theorem_stage: false`.
 
 ## Failure classification (historical, both blockers now cleared)
 

--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -127,6 +127,43 @@ finite-state or monotone argument can quantify over legal histories.
 words rather than a local search: a finite-state or monotone quotient that bounds
 every legal word, not the best one a greedy descent can find.
 
+## Step 2 computes but its floor is NOT yet justified -- do not build on it
+
+Closed-form floor from the same Gramian as the ceiling: information adds, so
+`Y_end <= Y0_propagated + G` and hence `P_end >= (Y0' + G)^-1`, with `P0` a
+shipping constant so `Y0` is bounded. No recursion, so the interval wall does not
+apply, and both inversions validate at all 15 cells.
+
+| tau | sigma | N | ceiling S | floor S | delta | vs `1e-18` |
+| --- | --- | --- | --- | --- | --- | --- |
+| 0.417 | 0.05 | 558 | 0.02041 | 0.02041 | **0.99947** | +18.0 |
+| 3.0 | 1.0 | 77 | 3.102 | 2.781 | 0.6639 | +17.8 |
+| 6.0 | 1.0 | 38 | 34.27 | 18.63 | 0.01436 | +16.2 |
+| 12.0 | 0.05 | 21 | 25.61 | 15.55 | **0.001683** | +15.2 |
+
+Worst `delta` 1.68e-3, nominally clearing the gate by 15.23 orders.
+
+**That number should not be trusted, and `delta ~ 0.999` at low `tau` is why.** A
+floor and a ceiling that agree to 0.05 percent are not two independent bounds --
+they are one construction differenced against itself. The floor here is the
+ceiling's own Gramian minus a prior term, so the agreement is an artifact of
+sharing `G`, not evidence that the covariance is pinned.
+
+**The concrete defect:** `G` counts only `S` observations. The deployed filter
+also runs accelerometer updates, which inform `v`, `p` and `S` through `a_w` and
+the cross-covariances. Extra information means smaller covariance, so the true
+`P` can fall **below** this floor, and a lower bound that the truth can violate
+is not a lower bound. The canonical floor starts from `P = 0` precisely to be
+safe against every information source, which is why it is 1.366e-20 and not
+this.
+
+So Step 2 is **not** done. What the computation does establish is narrower and
+still useful: the closed-form route survives interval arithmetic on both sides,
+and if a floor can be justified that credits the S observations at all, the
+geometry has ample room. Fixing it means bounding the information the other
+measurement channels can contribute, which is the real Step 2 and is not
+attempted here.
+
 ## Stacked deficit accounting after PR #478
 
 Re-ran the ceiling under #478's tightened safety clamps. All figures are the

--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -127,6 +127,65 @@ finite-state or monotone argument can quantify over legal histories.
 words rather than a local search: a finite-state or monotone quotient that bounds
 every legal word, not the best one a greedy descent can find.
 
+## Why the certificate cannot be built as specified, and what does build
+
+`translation_upper` takes **no initial covariance**: it is `P0`-free by
+construction, which is exactly why it inverts a three-point observability
+Gramian and is four orders loose. The looseness buys `P0`-independence.
+
+PR #476 certified, and this branch reproduced exactly, that **zero-`S` words are
+legal**. The proof domain has no GNSS -- `position_error_norm_upper_m` and
+`velocity_error_norm_upper_mps` are *entrance* bounds, not measurements -- so
+over a proof word the only translation measurement is `S = 0`. On a zero-`S`
+word, `v -> p -> S` is therefore a pure integrator chain **with no output at
+all**: structurally unobservable, covariance unbounded above as `P0` grows.
+
+**So no finite `P0`-free `Sigma_upper` exists over the current legal word set.**
+No amount of tightening, subdivision, ordering or enclosure work produces one;
+an unobservable state cannot be bounded without bounding where it started. This
+is why the whole-word lower result below is conditional, and it is a structural
+obstruction rather than a numerical one.
+
+### Measured: a P0-bounded formulation clears the gate by 12.7 orders
+
+Dropping `P0`-freedom and bounding the admissible initial covariance by the
+domain's declared entrance set -- velocity 5.0 m/s, position component
+`0.5*Hs <= 4.25` m, `||delta a_w|| <= 0.3 g` -- on the **starved** word itself:
+
+| assumed `S` entrance | `delta` | vs `1e-18` |
+| --- | --- | --- |
+| 13.5 m.s (`p_component * T_word`) | 4.86e-6 | clears by **12.69 orders** |
+| 63.5 m.s (`p_norm * T_word`, looser) | 1.16e-6 | clears by 12.06 orders |
+
+The worst single-cell dwell gives 4.10e-6, so starvation costs essentially
+nothing once `P0` is bounded. **The obstruction is the `P0`-freedom requirement,
+not the starvation.**
+
+The domain declares no entrance bound on `S`, the third integral, which is the
+channel that binds `delta`. That bound is **not load-bearing** and was not
+invented to make the proof close: the gate survives until an assumed `S`
+entrance of about `1e8 m.s`, against a physically meaningful 10--60 m.s, so
+there are six-plus orders of slack in the assumption itself.
+
+| assumed `S` entrance std | `delta` | |
+| --- | --- | --- |
+| 1e3 m.s | 5.87e-9 | clears by 9.77 orders |
+| 1e5 m.s | 5.87e-13 | clears by 5.77 orders |
+| 1e7 m.s | 5.87e-17 | clears by 1.77 orders |
+| 1e9 m.s | 5.87e-21 | **fails** by 2.23 orders |
+
+### What this costs
+
+A `P0`-bounded `Sigma_upper` is **weaker** than the present one: the theorem
+becomes conditional on the declared entrance set rather than uniform in initial
+covariance, and that must be stated wherever the result is claimed. It is not
+ad hoc -- P1 already hands off through that entrance box and P5 must prove
+capture into it -- but it is a real change to what P3 asserts, and it is a
+specification decision rather than something a proof tool may adopt on its own.
+
+Not a certificate: double-precision point diagnostic on two words, not interval
+arithmetic, and it does not quantify over all legal words.
+
 ## The whole-word lower result is conditional on S firing, which is not a theorem
 
 **PR #476 is ahead of this line of work and its result supersedes the headline

--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -122,9 +122,10 @@ finite-state or monotone argument can quantify over legal histories.
 
 **Predicted:** a whole-word lower certified over mixed legal words retains a
 `delta` within about two orders of the worst single-cell dwell, so above `1e-10`.
-**Falsified if** quantifying over mixed words costs more than that, in which case
-the loss is in the history quotient rather than the horizon, and the suspicion
-moves back to the source-correlation representation.
+**Result: survives** -- greedy adversarial descent reaches 2.97e-8, a factor of
+1.184 below the dwell. The remaining obligation is a *global* argument over legal
+words rather than a local search: a finite-state or monotone quotient that bounds
+every legal word, not the best one a greedy descent can find.
 
 ## Whole-word lower feasibility (measured)
 
@@ -141,9 +142,38 @@ largest `sigma`, weakest `S`), holding each for the full 635-sample word:
 | | value |
 | --- | --- |
 | worst single-cell dwell | **3.51e-8** at node 729 (`tau = 12 s`, `sigma = 0.05`, `R_S = 400`, 19 firings, binds on `p`) |
-| clears the `1e-18` gate by | **10.55 orders** |
+| worst *mixed* legal word found | **2.97e-8** (greedy local search, 1.184x below the dwell) |
+| clears the `1e-18` gate by | **10.47 orders** |
 | independent mpmath `dps=30` sweep | 3.50347e-08, agreeing to 0.24 percent |
 | best node | about 1.0 (node 390) |
+
+**Dwelling is not the adversary -- hypothesis falsified.** This ledger predicted
+that mixing could only help a lower, because a mixed word necessarily visits
+faster-cadence cells. False. Greedy single-swap descent from the pure dwell at
+node 729 converged after four improving swaps:
+
+| round | swap | ratio |
+| --- | --- | --- |
+| 0 | pure dwell at 729 | 3.51191e-08 |
+| 1 | position 18 to node 649 | 3.14549e-08 |
+| 2 | position 17 to node 569 | 3.12656e-08 |
+| 3 | position 11 to node 649 | 2.96665e-08 |
+| 4 | position 24 to node 798 | 2.96635e-08 |
+| 5 | no legal single swap improves | converged |
+
+The worst legal word found uses four sources -- 569, 649, 729, 798, all high-`tau`
+high-`R_S` cells -- and is **1.184x** below the pure dwell, still clearing the
+gate by **10.47 orders**. So the recorded prediction (mixed words stay within
+about two orders, above `1e-10`) **survives**, while the stronger claim that the
+dwell *is* the adversary does not. Treat the dwell as a proxy good to about 20
+percent, not as the worst case.
+
+Two limits on that search. It is greedy single-swap and returns a **local**
+minimum, not the global worst legal word. And the legality constraint is far
+tighter than the self-loop result suggests: every one of the 800 nodes self-loops
+on all 14 gaps, so every dwell is a legal word, but only **75 of 3995**
+single-segment substitutions around a 729 dwell are legal, because `729 -> cand
+-> 729` usually is not.
 
 On #476's own adversarial witness extended to the word, the ordered ratio is
 2.00e-3 at the slowest-cadence corner and 3.88e-3 at the fastest, so the choice

--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -127,7 +127,44 @@ finite-state or monotone argument can quantify over legal histories.
 words rather than a local search: a finite-state or monotone quotient that bounds
 every legal word, not the best one a greedy descent can find.
 
-## Closed-form whole-word margin: 800/800 nodes, interval-certified
+## Mixed-source words are covered without enumeration
+
+The per-node rows pair one node's ceiling with its own floor, which is what
+canonical `delta` does but says nothing about a word that changes source
+mid-flight. Two monotonicity arguments close that without enumerating words:
+
+* **Ceiling.** The certified S recurrence puts an observation in every max-gap
+  window, so the worst a legal word can do is place them as late as possible in
+  each -- exactly the max-cadence dwell. Any other legal word has at least as
+  many observations, at least as close to the endpoint, hence a larger Gramian
+  and a smaller ceiling.
+* **Floor.** No word can carry more than one S observation per sample, and the
+  min-cadence dwell already attains that, since the cadence clamps to `h` there.
+  It is the most informative case and yields the smallest floor.
+
+| | ceiling | floor |
+| --- | --- | --- |
+| `tau` | 12.0 | 0.3333 |
+| `R_S` | 400 | 0.15 |
+| S observations | 19 | 635 (one per sample, the hard limit) |
+
+| channel | floor (var) | ceiling (var) | ratio |
+| --- | --- | --- | --- |
+| v | 2.510e-04 | 6.589e+04 | **3.809e-09** |
+| p | 6.727e-04 | 1.664e+05 | 4.043e-09 |
+| S | 3.169e-04 | 7.350e+04 | 4.311e-09 |
+
+**Mixed-word margin 3.81e-09, valid for every legal word, clearing the `1e-18`
+gate by 9.58 orders.** Binds on `v`. Strictly more pessimistic than the per-node
+1.505e-05 because it pairs cross-worst, and strictly more general.
+
+Four further tests pin it: the cross-worst pairing must not come out better than
+the same-history one, the ceiling must take the fewest observations while the
+floor takes the most, the floor must sit exactly at one observation per sample
+or it is not conservative, and `validate()` must reject a dropped
+source-changing claim.
+
+## Per-node margin: 800/800 nodes, interval-certified
 
 `tools/ou3_p3_closed_form_word_margin.py`. Both sides of the P3 comparison built
 in closed form from one endpoint-referenced observability Gramian, so neither

--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -127,6 +127,37 @@ finite-state or monotone argument can quantify over legal histories.
 words rather than a local search: a finite-state or monotone quotient that bounds
 every legal word, not the best one a greedy descent can find.
 
+## Closed-form margin re-run under PR #478's clamp values
+
+Applied #478's clamps to a scratch copy of the source, re-ran the full 800-node
+tool, then restored `src/` (verified clean).
+
+| | main clamps | #478 clamps | gain |
+| --- | --- | --- | --- |
+| per-node worst | 1.505e-05 | **2.802e-04** | 1.27 orders |
+| mixed-word, all legal words | 3.809e-09 | **7.979e-08** | 1.32 orders |
+
+800/800 nodes validated in both runs. Under #478's clamps the per-node margin
+clears the `1e-18` gate by **14.45 orders** and the mixed-word bound by **10.90
+orders**. The binding node moves from 780 to 790 and the max S gap falls from 33
+to 31 samples.
+
+### `MAX_SIGMA_A` does not reach the proof tooling at all
+
+`ou3_source_reachable_matrix_p3.py:291` hardcodes
+`"sigma_aw_applied_safety": [0.05, 6.0]` instead of parsing `MAX_SIGMA_A` from
+the shipping header. So:
+
+* #478's `MAX_SIGMA_A` 6 -> 4 change is **invisible** to the proof chain, which
+  is part of why it measures at 0.00 orders;
+* the "#478 clamps" run above still used `sigma` up to 6.0, so it is conservative
+  -- the true figure under those clamps is slightly better than reported here;
+* it is a source-of-truth gap of exactly the kind that produced the
+  `PSEUDO_RATIO` defect recorded earlier in this ledger, where a hand-written
+  constant silently disagreed with the shipping one.
+
+Worth fixing on its own merits, independently of whether #478 lands.
+
 ## No clamp change can make canonical P3 pass
 
 Measured directly against `translation_upper`, since the canonical floor does not

--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -127,7 +127,75 @@ finite-state or monotone argument can quantify over legal histories.
 words rather than a local search: a finite-state or monotone quotient that bounds
 every legal word, not the best one a greedy descent can find.
 
-## How to advance: P2's tau model is over-approximate, and that is the whole blocker
+## The certificate needs NO new theorem conditions
+
+Earlier entries in this ledger asked whether a `P0`-bounded P3 would need a new
+declared entrance bound, and treated that as a specification decision. **It does
+not, and the framing was wrong.** `P0` is a shipping constant:
+
+```
+const T sigma_v0 = T(1.0);    // m/s
+const T sigma_p0 = T(20.0);   // m
+const T sigma_S0 = T(50.0);   // m.s
+set_initial_linear_uncertainty(sigma_v0, sigma_p0, sigma_S0);
+```
+
+with `a_w` seeded at `Sigma_aw_stat`. The `S` entrance bound this ledger called
+"undeclared" is declared: 50 m.s.
+
+### P2 is a Cartesian product over parameters the source computes jointly
+
+Two blockers, one cause. The P2 quotient ranges `(tau, sigma, R_S)` independently
+inside their cells, but the deployed code **derives** `R_S` from `tau` and
+`sigma` through the SpectralMSE law
+`R_S = coeff * q_eff^(1/14) * (sigma*tau^4)^(6/7) / sqrt(T_S)`:
+
+| tau | sigma | `R_S` the law gives | P2 cell max | reachable? |
+| --- | --- | --- | --- | --- |
+| 12 | 0.05 | **39.77** | 400 | no -- 10.1x below |
+| 12 | 1.0 | 518 -> clamped 400 | 400 | yes |
+| 3 | 0.05 | 0.686 | 400 | no |
+| 0.333 | 0.05 | 0.0010 -> clamped 0.15 | 400 | no |
+
+The adverse corner the covariance ceiling uses, `(tau=12, sigma=0.05, R_S=400)`,
+is **not reachable**. Likewise `tau` is slew-limited by the estimator moment
+horizon and the tuner EMA, which is what makes the starvation resonance
+unreachable. Both are properties of the shipping code, so importing them is a
+parsed source fact, not a domain shrink.
+
+### Measured: the word map has an invariant set, from source constants alone
+
+Iterating the joint word map `P <- max over law-consistent cells of
+word_map(cell, P)` from the declared `P0` converges in 81 iterations:
+
+| | v | p | S | a_w |
+| --- | --- | --- | --- | --- |
+| `P*` (variance) | 1578.4 | 10879 | 25699 | 35.80 |
+| as std | 39.7 m/s | 104 m | 160 m.s | 5.98 m/s^2 |
+
+`P*` is **invariant under every law-consistent cell** (verified, not argued), and
+
+    worst delta over all law-consistent cells = 1.26e-8
+    -> clears the canonical 1e-18 gate by 10.10 orders
+
+So `Sigma_upper = P*`. There is no new hypothesis, no new declared bound, and no
+weakening of what P3 asserts about initial covariance -- the theorem simply stops
+demanding `P0`-freedom, which its own word map never needed, and uses the
+invariant set instead. The `P0`-free Gramian inversion was a design choice in the
+proof, not a requirement of it.
+
+`P*` is large at the extreme corner because that corner is `sigma_aw = 6 m/s^2 =
+0.61 g` with `tau = 12 s`, already recorded above as unphysical; at
+`tau = 3, sigma = 1` the fixed point is v 2.3 m/s, p 3.2 m, S 2.6 m.s.
+
+**Still required:** starved words must be excluded, because with zero `S` firings
+the map has no fixed point at all -- `S` grows without bound. That is the `tau`
+slew argument below. Everything else is now measured.
+
+Not a certificate: double-precision point diagnostic over 15 cells at one word
+length, no interval arithmetic.
+
+## Supporting detail: P2's tau model is over-approximate
 
 Starvation is not a physical regime. It is an artifact of the P2 quotient letting
 `tau` jump anywhere inside a cell at every stage boundary, which the deployed

--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -127,6 +127,52 @@ finite-state or monotone argument can quantify over legal histories.
 words rather than a local search: a finite-state or monotone quotient that bounds
 every legal word, not the best one a greedy descent can find.
 
+## No clamp change can make canonical P3 pass
+
+Measured directly against `translation_upper`, since the canonical floor does not
+depend on the clamps. Canonical today is 11.72 orders short.
+
+| clamp change | worst upper `S` | `delta` | still short by | gain |
+| --- | --- | --- | --- | --- |
+| none (today) | 7.171e+09 | 1.905e-30 | 11.72 | -- |
+| `MAX_TUNE_FREQ_HZ` 1.5 -> 1.2 | 7.171e+09 | 1.905e-30 | 11.72 | **0.00** |
+| `MAX_SIGMA_A` 6 -> 4 | 7.168e+09 | 1.906e-30 | 11.72 | **0.00** |
+| `MAX_R_S` 400 -> 100 | 4.528e+08 | 3.017e-29 | 10.52 | 1.20 |
+| `PSEUDO_UPDATE_PERIOD_MAX` 0.25 -> 0.15 | 3.442e+09 | 3.968e-30 | 11.40 | 0.32 |
+| **all four (#478)** | 2.160e+08 | 6.324e-29 | **10.20** | 1.52 |
+
+And driving the dominant lever to absurdity does not help either -- `MAX_R_S`
+**saturates**:
+
+| `MAX_R_S` | `delta` | short by |
+| --- | --- | --- |
+| 100 | 3.017e-29 | 10.52 |
+| 10 | 1.456e-27 | 8.84 |
+| 1 | 2.761e-27 | 8.56 |
+| 0.15 (the minimum of its own range) | 2.786e-27 | **8.56** |
+
+**Taking `R_S` to the bottom of its declared range still leaves 8.56 orders.**
+
+### Why it saturates, and what that means
+
+`translation_upper` builds `rstack = 3 (rmax + s_nuis + s_proc)`. As `R_S` falls,
+`rmax` vanishes and the **process** corruption terms `s_nuis` and `s_proc`
+dominate. They do not depend on `R_S` at all, so the ceiling floors out.
+
+`translation_upper` is limited by process corruption, not by measurement noise.
+That is the same fact that made endpoint referencing worth 2.9 orders while
+crediting more observations was worth only 1.2: shortening the span over which
+process noise corrupts each observation is what pays, not strengthening the
+measurement.
+
+**Consequence for #478.** Its clamp tightening is worth 1.52 orders on the
+canonical margin and does not make P3 pass, so it has to be justified as
+theorem-envelope hygiene on its own merits rather than as a route to P3. Two of
+its four clamp moves -- `MAX_TUNE_FREQ_HZ` and `MAX_SIGMA_A` -- buy **nothing**
+here, 0.00 orders each.
+
+**Consequence generally: stop looking at clamps.** The deficit is structural.
+
 ## The closed-form route CANNOT be fed to the canonical gate as it stands
 
 The chain exists on paper: `ou3_p3_p2_v1_full_state_join.build()` accepts a

--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -127,7 +127,42 @@ finite-state or monotone argument can quantify over legal histories.
 words rather than a local search: a finite-state or monotone quotient that bounds
 every legal word, not the best one a greedy descent can find.
 
-## Whole-word lower feasibility (measured)
+## The whole-word lower result is conditional on S firing, which is not a theorem
+
+**PR #476 is ahead of this line of work and its result supersedes the headline
+below.** #476 certified that alternating two applied `tau` values *inside one
+source cell* drives the `S` firing count to **zero** across a whole 635-sample
+word. Reproduced here exactly, using the shipping binary32 scheduler:
+
+| word at node 720's cell, gap 13 | S firings |
+| --- | --- |
+| `tau` held at 9.533334732055664 | 24 |
+| `tau` held at 9.533475875854492 | 24 |
+| **alternating the two, same cell** | **0** |
+
+The two periods are 0.1300000101327896 and 0.13000193238258362, differing by
+1.92e-6 against a binary32 scheduler tolerance of 1.91e-6. Each stage boundary
+rebases the timer by `fmod` against the other period and the remainder never
+crosses.
+
+A word with no `S` firing never forgets its initial covariance. Measured on that
+word: `P0_independent = False` with a probe spread of 0.999, so the reported
+ratio 3.11e-17 is a finite-probe artifact and the true value tends to zero as
+`P0` grows. **No `P0`-independent whole-word lower exists for that word**, so the
+dwell figures below hold only under the assumption that `S` fires at all -- an
+assumption #476 showed is not implied by the current P2 quotient.
+
+**Two defects this exposed in the diagnostic here, both fixed.** The scheduler
+was transcribed in double precision, but the deployed MEKF is
+`Kalman3D_Wave_OU_III<float>`; the `periodic_update_due` tolerance is 1.9e-6 in
+binary32 against 3.6e-15 in double, and a double transcription cannot represent
+the starvation at all. And `PSEUDO_RATIO` was hand-written as `0.015/1.1`, while
+the C++ constant is a `constexpr float` quotient
+`f32(f32(0.015)/f32(1.1)) = 0.013636362738907337`; the two differ in the eighth
+digit, moving the period by 1.5e-8 s, which is decisive at this tolerance. The
+schedule constants are now parsed from the shipping header instead of restated.
+
+## Whole-word lower feasibility, conditional on S firing (measured)
 
 `tools/ou3_p3_whole_word_lower_feasibility.py`, non-promoting point diagnostic.
 Canonical `delta` is same-history matched -- `phase_row` pairs node `t`'s floor
@@ -143,6 +178,7 @@ largest `sigma`, weakest `S`), holding each for the full 635-sample word:
 | --- | --- |
 | worst single-cell dwell | **3.51e-8** at node 729 (`tau = 12 s`, `sigma = 0.05`, `R_S = 400`, 19 firings, binds on `p`) |
 | worst *mixed* legal word found | **2.97e-8** (greedy local search, 1.184x below the dwell) |
+| **S-starved legal word (#476)** | **no P0-independent lower exists** -- the word never forgets `P0` |
 | clears the `1e-18` gate by | **10.47 orders** |
 | independent mpmath `dps=30` sweep | 3.50347e-08, agreeing to 0.24 percent |
 | best node | about 1.0 (node 390) |

--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -127,6 +127,40 @@ finite-state or monotone argument can quantify over legal histories.
 words rather than a local search: a finite-state or monotone quotient that bounds
 every legal word, not the best one a greedy descent can find.
 
+## What canonical wiring actually requires: both sides, not one
+
+Swapping the closed-form ceiling into the canonical producer alone does **not**
+reach the gate. The canonical floor is the limiter once the ceiling is repaired:
+
+| floor | ceiling | `delta` | vs `1e-18` |
+| --- | --- | --- | --- |
+| canonical | canonical (today) | 1.905e-30 | short by 11.72 |
+| canonical | closed form | 1.859e-25 | **short by 6.73** |
+| closed form | canonical | 4.419e-14 | clears by 4.65 |
+| closed form | closed form | 4.311e-09 | clears by 9.63 |
+
+So this is not a matter of plugging a better `Sigma_upper` into
+`phase_row`. The canonical floor is a stepwise zero-start segment quantity
+(1.366e-20 on `S`) and the closed-form floor is an information-form endpoint
+quantity (3.169e-04); they are different constructions and only the matched pair
+clears. Replacing both is a change to the producer's core rather than wiring
+into it, and it needs the canonical gate to render the verdict, not this module.
+
+### Floor premise verified on both measurement channels
+
+The floor rests on the other channels having no direct translation dependence.
+Checked in the source, not argued:
+
+* `measurement_update_acc_only` builds its innovation covariance from `OFF_TH`,
+  `OFF_AW`, `OFF_BA` and `OFF_BG` only;
+* `measurement_update_mag_only` (lines 2122-2198) references only
+  `P_th_th = Pext.block<3,3>(0,0)`. The `OFF_AW`/`OFF_BA` uses just below it
+  belong to `accelerometer_measurement_func`, which starts at 2199, not to the
+  magnetometer.
+
+Neither has `v`, `p` or `S` columns, so both reach translation solely through the
+cross-covariance with `a_w`, which is the channel the floor already accounts for.
+
 ## Mixed-source words are covered without enumeration
 
 The per-node rows pair one node's ceiling with its own floor, which is what

--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -127,7 +127,38 @@ finite-state or monotone argument can quantify over legal histories.
 words rather than a local search: a finite-state or monotone quotient that bounds
 every legal word, not the best one a greedy descent can find.
 
-## NO CERTIFICATE EXISTS. Everything in this ledger below is a diagnostic.
+## Step 1 SUCCEEDS: an interval-certified closed-form ceiling exists
+
+The first rigorous object in this line of work. Closed form, so the stepwise
+interval wall recorded below does not apply, and it **inverts cleanly in interval
+arithmetic at every cell tested** -- the 3x3 determinant never straddles zero.
+
+Construction: the S observations constrain the state at the **word endpoint**
+directly, each through the backward map `[(t_k - T_w)^2/2, (t_k - T_w), 1]` with
+its own process-corruption inflation, giving `G = sum_k h_k h_k' / R_eff,k` and
+`P_end <= G^-1`. No recursion, no `P0`.
+
+| construction | worst-case gain on the binding `S` channel |
+| --- | --- |
+| start-referenced, matching `translation_upper` | 1.24 orders |
+| **endpoint-referenced** | **4.10 orders** (up to 8.28) |
+
+**Endpoint-referencing is worth 2.9 orders on its own.** That is the more useful
+finding: `translation_upper`'s looseness is not mainly its three-point count. It
+builds the bound at word *start* and then free-runs the estimate through `F` for
+a whole word, and that free-running amplification dominates everything else. Two
+earlier comparisons in this ledger overstated the benefit of crediting the
+cadence because they compared unequal quantities -- bare `R_S` against
+`translation_upper`'s process-inflated `rstack`, and an at-start covariance
+against an at-endpoint one. Both are corrected here.
+
+**Where this leaves the deficit:** 12.7 orders needed, 4.10 delivered by the
+ceiling. **8.6 orders must come from the floor**, which is Step 2 and is not yet
+attempted. Step 1 retires the constructive risk on the ceiling only; it is not a
+P3 verdict, has not been run through the canonical producer, and quantifies over
+15 cells rather than 800.
+
+## NO CERTIFICATE EXISTS YET. Everything else in this ledger is a diagnostic.
 
 Stated plainly because the distinction was blurred: canonical P3 has never
 produced a passing artifact, and nothing in this branch is interval-certified.

--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -127,7 +127,61 @@ finite-state or monotone argument can quantify over legal histories.
 words rather than a local search: a finite-state or monotone quotient that bounds
 every legal word, not the best one a greedy descent can find.
 
-## Step 2 computes but its floor is NOT yet justified -- do not build on it
+## Step 2: a floor justified against the other measurement channels
+
+The defect in the first attempt -- a floor that ignored accelerometer information
+and so could be violated by the truth -- is closed by a structural argument
+rather than by a tighter number.
+
+**The accelerometer cannot drive v, p, S below their initial uncertainty.** Its
+measurement Jacobian has zero columns for `v`, `p`, `S`: the innovation
+covariance in `measurement_update_acc_only` references only `OFF_TH`, `OFF_AW`,
+`OFF_BA` and `OFF_BG`. It touches the translation states purely through the
+cross-covariance with `a_w`. And in the limiting case where `a_w` is known
+*exactly* for the whole word, `v(T) = v(0) + int a_w` still carries `v(0)`'s
+uncertainty, and likewise for `p` and `S`. The same holds for the magnetometer,
+which informs attitude only.
+
+So a floor safe against every other channel credits the `S` observations at their
+**full** strength and keeps the raw shipping prior:
+
+* `R_eff = rmax`, with **no** process inflation -- perfect `a_w` knowledge is the
+  most informative case, hence the smallest and therefore most conservative
+  floor;
+* the raw shipping `P0` rather than a propagated one, since propagation only adds
+  process noise and so only reduces information: `Y0_propagated <= Y0`, giving
+  `(Y0 + G)^-1 <= (Y0' + G)^-1 <= truth`.
+
+The ceiling keeps the pessimistic process-inflated `R_eff`. The two now differ by
+a real mechanism instead of by a shared term, and the tell-tale `delta ~ 0.999`
+is gone:
+
+| tau | sigma | N | ceiling S | floor S | delta |
+| --- | --- | --- | --- | --- | --- |
+| 0.417 | 0.05 | 558 | 0.02041 | 0.01909 | 0.4744 |
+| 0.417 | 4.0 | 558 | 0.03286 | 0.01909 | 0.003259 |
+| 3.0 | 0.05 | 77 | 0.2369 | 0.2331 | 0.9169 |
+| 6.0 | 4.0 | 38 | 50.37 | 23.54 | 0.0004839 |
+| 12.0 | 4.0 | 21 | 61.70 | 26.97 | **0.0002803** |
+
+**Worst `delta` = 2.80e-4, clearing the `1e-18` gate by 14.45 orders**, binding on
+`v` at `tau = 12`, `sigma = 4`, `R_S = 100`. Both inversions validate in interval
+arithmetic at all 15 cells.
+
+### What is still missing before this is a certificate
+
+* 15 cells, not the 800-node source partition;
+* single-source dwell words, not mixed legal words;
+* not run through the canonical P3 producer or its gate, which remain the
+  promotion authority;
+* the magnetometer argument is stated from the same structure but only the
+  accelerometer Jacobian was checked in the source.
+
+The construction is now closed-form on both sides, so none of these are blocked
+by the interval wall. They are enumeration and plumbing rather than open
+questions.
+
+## Superseded first attempt: a floor that shared the ceiling's Gramian
 
 Closed-form floor from the same Gramian as the ceiling: information adds, so
 `Y_end <= Y0_propagated + G` and hence `P_end >= (Y0' + G)^-1`, with `P0` a

--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -127,7 +127,56 @@ finite-state or monotone argument can quantify over legal histories.
 words rather than a local search: a finite-state or monotone quotient that bounds
 every legal word, not the best one a greedy descent can find.
 
-## The certificate needs NO new theorem conditions
+## NO CERTIFICATE EXISTS. Everything in this ledger below is a diagnostic.
+
+Stated plainly because the distinction was blurred: canonical P3 has never
+produced a passing artifact, and nothing in this branch is interval-certified.
+Every number recorded here is a double-precision or mpmath **point** evaluation,
+at 15 of 800 cells, at one word length. The artifacts say so themselves --
+`certifies_theorem_stage: false`, `interval_certified: false`,
+`quantifies_over_legal_histories: false`. They are useful for locating the
+limiter and for killing wrong hypotheses. They are not proof of anything.
+
+### Attempted and FALSIFIED: validated invariant upper by interval Riccati
+
+The natural rigorous construction was tried and does not work. The idea was
+sound: the Riccati word map is Loewner monotone, so certifying
+`D - W_c(D) >= 0` at the single box corner `D` certifies the whole box, meaning
+no covariance *box* need be propagated and only rounding accumulates.
+
+It still dies. Propagating the corner through one 635-sample word in interval
+arithmetic loses positivity of the measurement denominator partway through, even
+in **Joseph form** -- the covariance form dies within a few steps, since it
+subtracts two nearly equal large quantities whenever `R` is small against
+`P[S][S]`.
+
+| `x = h/tau` cell width | samples survived of 635 |
+| --- | --- |
+| 1.796e-04 (full cell) | 343 |
+| 2.806e-06 (64 subcells) | 434 |
+| 4.384e-08 (4096 subcells) | 503 |
+
+Narrowing `x` by 4096x buys 160 of the 292 missing steps, about 35 steps per 8x
+narrowing. Reaching 635 needs roughly `1e7` subcells against a budget already
+strained at 64. **This is the third independent time this project has hit the
+same wall**, and it is the same one already frozen in DEAD_ENDS as "recursive
+natural interval covariance boxes that forget the repeated scalar source
+parameter at every Riccati operation". Evaluating at a single corner does not
+escape it, because the transition itself is interval-valued through the `tau`
+cell.
+
+**Consequence: a rigorous whole-word upper cannot be built by stepwise interval
+propagation.** It has to be closed-form. The tractable candidate is an
+`N`-point observability-Gramian inversion -- structurally what
+`translation_upper` already does with three points, evaluated instead over all
+`N` firings the cadence actually delivers. That construction has no stepwise
+recursion, so the dependency wall above does not apply to it. Measured worth of
+crediting the real cadence, from the point diagnostics: 5.06 orders.
+
+The probe was removed rather than retained, matching how #476 handled its own
+falsified probes.
+
+## Point diagnostics: the certificate needs no new theorem conditions
 
 Earlier entries in this ledger asked whether a `P0`-bounded P3 would need a new
 declared entrance bound, and treated that as a specification decision. **It does

--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -127,6 +127,49 @@ finite-state or monotone argument can quantify over legal histories.
 words rather than a local search: a finite-state or monotone quotient that bounds
 every legal word, not the best one a greedy descent can find.
 
+## PR #478 supersedes the starvation work here and hands Step 2 its input
+
+#478 repairs `set_pseudo_update_period_s` so a cadence retarget preserves
+already-earned service credit instead of reducing elapsed time modulo the new
+period:
+
+```
+if (elapsed < period) return elapsed;          // preserve
+return std::nextafter(period, T(0));           // park just below the deadline
+```
+
+Verified here against this branch's own starvation witness, which #478's change
+kills outright:
+
+| retarget semantics | S firings over 635 samples |
+| --- | --- |
+| old `fmod` | **0** |
+| new progress-preserving | **24**, worst gap 27 |
+
+and the source-independent 33-sample bound reproduces exactly: the largest
+deployed period 0.16363635659217834 s over `h` is 32.727, so 33 samples, attained
+at `tau = 12`.
+
+**Consequences for this branch.**
+
+* The `tau` slew argument recorded below, and Step 0 of the plan built on it, are
+  **obsolete**. #478 makes S recurrence a property of the implementation rather
+  than something to be argued from the estimator's moment horizon. That is a
+  better outcome than the argument it replaces.
+* This branch concluded "no filter changes are warranted" on the evidence that
+  the firing rate is nominal under realistic jitter and starvation is
+  unreachable in practice. That was defensible but **it was the weaker call**:
+  #478 removes the latent fragility instead of arguing it is unreachable, and
+  gets a positive recurrence certificate for it.
+* `tools/ou3_p3_whole_word_lower_feasibility.py` mirrors the **old** `fmod`
+  retarget, and its four `StarvationWitness` tests assert that starvation
+  happens. Both must be re-pointed when #478 lands, or they will pin behaviour
+  the shipping code no longer has.
+
+**What Step 2 gains.** The closed-form floor needs a rigorous bound on the time
+since the last S firing. #478 certifies exactly that, source-independently, at
+**33 samples = 0.165 s**. Step 2 no longer has to derive it.
+
 ## Step 1 SUCCEEDS: an interval-certified closed-form ceiling exists
 
 The first rigorous object in this line of work. Closed form, so the stepwise

--- a/tests/kalman_ou_iii/Makefile
+++ b/tests/kalman_ou_iii/Makefile
@@ -21,7 +21,7 @@ LDFLAGS  =
 # Tell make to look for source files in src/util
 VPATH = $(REPO_ROOT)/src/util
 
-TARGETS = kalman_ou_iii-sim accel_vibration_guard-test imu_lever_arm-test ou3-certificate-sim ou3-information-certificate-sim ou3-neighborhood-sim kalman_ou_common-test aw_covariance_policy-test acc_bias_ou-test channel_freeze-test wave_period-test mag_hard_iron-test continuous_mag_hard_iron-test tuner_coupling-test tuner_schedule-test wave_band_sigma-test iss_contract-test rs_law-test startup_init-test
+TARGETS = kalman_ou_iii-sim accel_vibration_guard-test imu_lever_arm-test ou3-certificate-sim ou3-information-certificate-sim ou3-neighborhood-sim kalman_ou_common-test aw_covariance_policy-test acc_bias_ou-test channel_freeze-test wave_period-test mag_hard_iron-test continuous_mag_hard_iron-test tuner_coupling-test tuner_schedule-test wave_band_sigma-test iss_contract-test rs_law-test startup_init-test innovation_sign-test
 
 all: build test
 

--- a/tests/kalman_ou_iii/innovation_sign-test.cpp
+++ b/tests/kalman_ou_iii/innovation_sign-test.cpp
@@ -1,0 +1,160 @@
+// Pins that every shipping OU-III measurement update corrects the state TOWARD
+// its measurement.
+//
+// This closes a gap the certified P1-P3 chain cannot close by construction.  The
+// covariance update
+//
+//     P <- P - P C' (C P C' + R)^-1 C P
+//
+// never references the innovation, so a wrong-signed innovation would leave the
+// segment floor, Sigma_upper and the certified delta bit-identical while the
+// deployed filter drove its own state away from every measurement.  The
+// source-marker contracts pin the update *shape* -- "xext.noalias() += K * r;"
+// -- but nothing checks how r is defined.  P4 would catch it because it bounds
+// the nonlinear state map, but P4 has never been reached because P3 blocks.
+//
+// The invariant used here is sign-sensitive and gain-free: a correct linear
+// Kalman update makes the posterior a convex combination of the prior and the
+// measurement,
+//
+//     x+ = x- + K (z - H x-),   with the relevant gain block in [0, 1),
+//
+// so the corrected component must lie in the half-open interval [x-, z) and can
+// never move away from z.  Flipping the sign of r sends it the other way by
+// exactly the same magnitude, which every assertion below rejects.
+#define EIGEN_NON_ARDUINO
+#include <cmath>
+#include <iostream>
+#include <Eigen/Dense>
+#include <Eigen/Geometry>
+#define private public
+#include "kalman_ou_iii/Kalman3D_Wave_OU_III.h"
+#undef private
+
+using Filter = Kalman3D_Wave_OU_III<float>;
+using Vec3 = Eigen::Vector3f;
+
+// The offsets are private by default inside the class (they precede any access
+// specifier, so "#define private public" cannot reach them).  Restated locally,
+// matching ou3-certificate-sim.cpp, and guarded at runtime below against the
+// actual extended state size so the layout cannot drift silently.
+constexpr int kNX    = 21;   // 6 base (att_err + gyro bias) + v,p,S,a_w,b_acc
+constexpr int kOffV  = 6;
+constexpr int kOffP  = 9;
+constexpr int kOffS  = 12;
+
+static int fail(const char* m) { std::cerr << "FAIL: " << m << "\n"; return 1; }
+
+// Corrected value must move toward z and must not overshoot past it.
+static bool moved_toward(float prior, float post, float z, const char* what) {
+    const float d_before = std::fabs(z - prior);
+    const float d_after  = std::fabs(z - post);
+    if (!(d_after < d_before)) {
+        std::cerr << "  " << what << ": |z-post|=" << d_after
+                  << " did not shrink from |z-prior|=" << d_before
+                  << " (prior=" << prior << " post=" << post << " z=" << z << ")\n";
+        return false;
+    }
+    // Convexity: post lies between prior and z.
+    const float lo = std::min(prior, z), hi = std::max(prior, z);
+    if (post < lo - 1e-6f || post > hi + 1e-6f) {
+        std::cerr << "  " << what << ": post=" << post
+                  << " left the convex hull [" << lo << ", " << hi << "]\n";
+        return false;
+    }
+    return true;
+}
+
+static Filter make() {
+    Filter f(Vec3::Constant(0.0148f), Vec3::Constant(0.00157f), Vec3::Constant(0.25f),
+             1e-4f, 1e-6f, 1e-4f, 0.5f, 9.80665f);
+    // Give the translation blocks a well-conditioned prior so every gain is
+    // strictly positive and the direction of motion is unambiguous.
+    for (int i = 0; i < kNX; ++i) f.Pext(i, i) = std::max(f.Pext(i, i), 1.0f);
+    return f;
+}
+
+int main() {
+    int rc = 0;
+
+    // Layout guard: if the extended state changes size, every offset below is
+    // suspect and this test must be revisited rather than silently pass.
+    {
+        Filter probe = make();
+        if (probe.xext.size() != kNX) {
+            std::cerr << "  extended state is " << probe.xext.size()
+                      << " states, expected " << kNX << "\n";
+            return fail("OU-III extended state layout moved; offsets here are stale");
+        }
+    }
+
+    // ---- S = 0 integral pseudo-measurement: target is exactly zero ----
+    {
+        Filter f = make();
+        const Vec3 S0(0.7f, -1.3f, 2.1f);
+        f.xext.segment<3>(kOffS) = S0;
+        f.applyIntegralZeroPseudoMeas();
+        const Vec3 S1 = f.xext.segment<3>(kOffS);
+        for (int i = 0; i < 3; ++i)
+            if (!moved_toward(S0(i), S1(i), 0.0f, "applyIntegralZeroPseudoMeas"))
+                rc = fail("S=0 pseudo-measurement did not pull S toward zero");
+    }
+
+    // ---- position pseudo-measurement ----
+    {
+        Filter f = make();
+        const Vec3 p0(1.0f, -2.0f, 3.0f), z(-0.5f, 0.25f, -1.5f);
+        f.xext.segment<3>(kOffP) = p0;
+        f.measurement_update_position_pseudo(z, Vec3::Constant(0.3f));
+        const Vec3 p1 = f.xext.segment<3>(kOffP);
+        for (int i = 0; i < 3; ++i)
+            if (!moved_toward(p0(i), p1(i), z(i), "measurement_update_position_pseudo"))
+                rc = fail("position pseudo-measurement moved position away from z");
+    }
+
+    // ---- velocity pseudo-measurement ----
+    {
+        Filter f = make();
+        const Vec3 v0(0.9f, 1.4f, -0.6f), z(-0.2f, -1.1f, 0.8f);
+        f.xext.segment<3>(kOffV) = v0;
+        f.measurement_update_velocity_pseudo(z, Vec3::Constant(0.2f));
+        const Vec3 v1 = f.xext.segment<3>(kOffV);
+        for (int i = 0; i < 3; ++i)
+            if (!moved_toward(v0(i), v1(i), z(i), "measurement_update_velocity_pseudo"))
+                rc = fail("velocity pseudo-measurement moved velocity away from z");
+    }
+
+    // ---- vertical velocity pseudo-measurement (scalar path) ----
+    {
+        Filter f = make();
+        const int idx = kOffV + 2;
+        const float v0 = 1.7f, z = -0.4f;
+        f.xext(idx) = v0;
+        f.measurement_update_vert_velocity_pseudo(z, 0.25f);
+        if (!moved_toward(v0, f.xext(idx), z, "measurement_update_vert_velocity_pseudo"))
+            rc = fail("vertical velocity pseudo-measurement moved vz away from z");
+    }
+
+    // ---- accelerometer: a pure roll error must shrink, not grow ----
+    {
+        Filter f = make();
+        const float tilt = 0.20f;                  // rad, about x
+        f.qref = Eigen::Quaternionf(Eigen::AngleAxisf(tilt, Vec3::UnitX()));
+        f.qref.normalize();
+        // Specific force for a level vehicle, expressed in the body frame of the
+        // TRUE (level) attitude: gravity reaction along -z in NED.
+        const Vec3 acc_body(0.0f, 0.0f, -9.80665f);
+        f.measurement_update_acc_only(acc_body);
+        const float tilt_after =
+            2.0f * std::atan2(f.qref.vec().norm(), std::fabs(f.qref.w()));
+        if (!(tilt_after < tilt)) {
+            std::cerr << "  accelerometer: tilt grew from " << tilt
+                      << " to " << tilt_after << "\n";
+            rc = fail("accelerometer update did not reduce the attitude error");
+        }
+    }
+
+    if (rc == 0)
+        std::cout << "OU-III innovation sign: every shipping update corrects toward its measurement\n";
+    return rc;
+}

--- a/tests/kalman_ou_iii/run_tests.sh
+++ b/tests/kalman_ou_iii/run_tests.sh
@@ -16,3 +16,4 @@
 ./iss_contract-test
 ./rs_law-test
 ./startup_init-test
+./innovation_sign-test

--- a/tests/validation/test_ou3_p3_closed_form_word_margin.py
+++ b/tests/validation/test_ou3_p3_closed_form_word_margin.py
@@ -90,3 +90,36 @@ class NonPromotion(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class MixedWordBound(unittest.TestCase):
+    """The per-node rows say nothing about words that change source mid-flight."""
+
+    def test_mixed_word_bound_is_more_pessimistic_than_per_node(self):
+        k = M._consts()
+        mixed = M.mixed_word_margin(k)
+        self.assertTrue(mixed["validated"], mixed.get("reason"))
+        d = M.build(stride=401)
+        # Cross-worst pairing must not come out better than same-history pairing.
+        self.assertLessEqual(mixed["margin"], d["worst_margin"] * (1.0 + 1e-9))
+
+    def test_ceiling_takes_fewest_observations_and_floor_the_most(self):
+        k = M._consts()
+        m = M.mixed_word_margin(k)
+        self.assertLess(m["S_observations_ceiling"], m["S_observations_floor"])
+        self.assertGreater(m["tau_ceiling"], m["tau_floor"])
+        self.assertGreater(m["R_S_ceiling"], m["R_S_floor"])
+
+    def test_floor_attains_one_observation_per_sample(self):
+        k = M._consts()
+        m = M.mixed_word_margin(k)
+        # No legal word can beat one S observation per sample; the floor must
+        # already sit at that limit or the bound is not conservative.
+        self.assertEqual(m["S_observations_floor"], M.WORD_SAMPLES)
+
+    def test_validate_rejects_a_dropped_mixed_word_claim(self):
+        d = M.build(stride=401)
+        t = dict(d)
+        t["mixed_word_margin"] = dict(d["mixed_word_margin"])
+        t["mixed_word_margin"]["covers_source_changing_words"] = False
+        self.assertTrue(M.validate(t))

--- a/tests/validation/test_ou3_p3_closed_form_word_margin.py
+++ b/tests/validation/test_ou3_p3_closed_form_word_margin.py
@@ -1,5 +1,4 @@
 """Contracts for the closed-form whole-word translation margin."""
-import math
 import sys
 import unittest
 from pathlib import Path

--- a/tests/validation/test_ou3_p3_closed_form_word_margin.py
+++ b/tests/validation/test_ou3_p3_closed_form_word_margin.py
@@ -1,0 +1,93 @@
+"""Contracts for the closed-form whole-word translation margin."""
+import math
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+
+import ou3_p3_closed_form_word_margin as M  # noqa: E402
+import ou3_source_reachable_matrix_p3 as BASE  # noqa: E402
+
+
+class ShippingAgreement(unittest.TestCase):
+    def test_cadence_matches_the_repo_source_parser(self):
+        k = M._consts()
+        sched = BASE.source_schedule()
+        for tau in (0.4, 1.1, 3.0, 6.0, 12.0):
+            want = min(max(sched["pseudo_ratio"] * tau,
+                           sched["pseudo_min_s"]), sched["pseudo_max_s"])
+            self.assertEqual(M.cadence_s(tau, k), want)
+
+    def test_R_S_is_the_clamped_deployed_law_not_a_free_cell_range(self):
+        k = M._consts()
+        # The law derives R_S from tau and sigma; it must respect both clamps.
+        for tau, sigma in ((0.4, 0.05), (3.0, 1.0), (12.0, 4.0), (12.0, 6.0)):
+            rs = M.rs_target(tau, sigma, k)
+            self.assertGreaterEqual(rs, k["min_rs"])
+            self.assertLessEqual(rs, k["max_rs"])
+        # Monotone increasing in sigma and in tau, as the closed form requires.
+        self.assertLess(M.rs_target(3.0, 0.05, k), M.rs_target(3.0, 1.0, k))
+        self.assertLess(M.rs_target(1.1, 1.0, k), M.rs_target(6.0, 1.0, k))
+
+    def test_initial_covariance_is_the_shipping_constructor_value(self):
+        self.assertEqual((M.SIGMA_V0, M.SIGMA_P0, M.SIGMA_S0), (1.0, 20.0, 50.0))
+
+
+class ClosedFormStructure(unittest.TestCase):
+    def test_gramian_grows_with_more_observations(self):
+        k = M._consts()
+        # A faster cadence means more S observations, hence strictly more
+        # information in the S direction.
+        fast, n_fast = M._gramian(1.0, 1.0, 10.0, k, inflate=False)
+        slow, n_slow = M._gramian(12.0, 1.0, 10.0, k, inflate=False)
+        self.assertGreater(n_fast, n_slow)
+        self.assertGreater(fast[2][2].lo, slow[2][2].lo)
+
+    def test_uninflated_gramian_carries_more_information_than_inflated(self):
+        k = M._consts()
+        bare, _ = M._gramian(6.0, 1.0, 10.0, k, inflate=False)
+        infl, _ = M._gramian(6.0, 1.0, 10.0, k, inflate=True)
+        # The floor credits full-strength observations, so its Gramian dominates.
+        for i in range(3):
+            self.assertGreaterEqual(bare[i][i].lo, infl[i][i].lo)
+
+    def test_floor_never_exceeds_ceiling_on_any_channel(self):
+        k = M._consts()
+        import ou3_p4_source_node_cells as NODES
+        for node in NODES.build()["nodes"][::173]:
+            r = M.node_margin(node, k)
+            self.assertTrue(r["validated"], r.get("reason"))
+            for x in r["channel_ratios"]:
+                self.assertGreater(x, 0.0)
+                self.assertLessEqual(x, 1.0 + 1e-9)
+
+    def test_inversion_is_validated_not_assumed(self):
+        # A singular Gramian must be reported, never silently inverted.
+        G = [[M._I(0.0) for _ in range(3)] for _ in range(3)]
+        self.assertIsNone(M._inv3(G))
+
+
+class NonPromotion(unittest.TestCase):
+    def test_artifact_declares_what_it_is_and_is_not(self):
+        d = M.build(stride=401)
+        self.assertTrue(d["non_promoting"])
+        self.assertFalse(d["certifies_theorem_stage"])
+        self.assertTrue(d["interval_certified"])
+        self.assertFalse(d["stepwise_riccati_recursion_used"])
+        self.assertEqual(d["canonical_gate"], 1e-18)
+        self.assertEqual(M.validate(d), [])
+
+    def test_validate_rejects_a_tampered_gate_or_promotion_flag(self):
+        d = M.build(stride=401)
+        for key, bad in (("canonical_gate", 1e-12),
+                         ("certifies_theorem_stage", True),
+                         ("non_promoting", False),
+                         ("stepwise_riccati_recursion_used", True)):
+            t = dict(d)
+            t[key] = bad
+            self.assertTrue(M.validate(t), f"tampering with {key} was not caught")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/validation/test_ou3_p3_whole_word_lower_feasibility.py
+++ b/tests/validation/test_ou3_p3_whole_word_lower_feasibility.py
@@ -1,0 +1,108 @@
+from pathlib import Path
+import math
+import sys
+import unittest
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+sys.path.insert(0, str(TOOLS))
+
+import ou3_p3_whole_word_lower_feasibility as F
+
+
+class SchedulerSemantics(unittest.TestCase):
+    """The diagnostic is only meaningful if it reproduces the shipping scheduler."""
+
+    def test_cadence_is_tau_scaled_and_clamped(self):
+        self.assertAlmostEqual(F.cadence_s(1.1), 0.015, places=6)
+        # Both safety clamps are reachable from the declared tau envelope ends.
+        self.assertEqual(F.cadence_s(1.0e-6), F.PSEUDO_MIN_S)
+        self.assertEqual(F.cadence_s(1.0e6), F.PSEUDO_MAX_S)
+
+    def test_periodic_update_due_retains_remainder_and_never_fires_at_zero(self):
+        period, elapsed, fires = 0.02, 0.0, 0
+        for _ in range(100):
+            due, elapsed = F.periodic_update_due(F.DT_S, period, elapsed)
+            fires += int(due)
+            self.assertTrue(0.0 <= elapsed < period)
+        # DT_S is the binary32 5 ms, marginally below 0.005, so 100 samples
+        # span just under 0.5 s and yield 24 firings against a 20 ms period,
+        # not 25.  The remainder is retained rather than reset each time.
+        self.assertEqual(fires, 24)
+        due, _ = F.periodic_update_due(F.DT_S, 0.02, 0.0)
+        self.assertFalse(due)
+
+    def test_commit_period_rebases_the_timer(self):
+        # set_pseudo_update_period_s applies elapsed = fmod(elapsed, new_period),
+        # so a pending timer cannot survive a source commit unchanged.
+        self.assertAlmostEqual(F.commit_period(0.13, 0.05), 0.03, places=12)
+        self.assertEqual(F.commit_period(0.0, 0.05), 0.0)
+        with self.assertRaises(RuntimeError):
+            F.commit_period(float("nan"), 0.05)
+
+
+class WordPropagation(unittest.TestCase):
+    def test_zero_start_word_is_positive_and_covers_the_horizon(self):
+        segs = [(1.1, 0.5, 10.0, F.WORD_SAMPLES)]
+        P, fires, used = F.run_word(segs, [0.0, 0.0, 0.0, 0.0])
+        self.assertEqual(used, F.WORD_SAMPLES)
+        self.assertGreater(fires, 0)
+        for i in range(4):
+            self.assertTrue(math.isfinite(P[i][i]) and P[i][i] > 0.0)
+
+    def test_zero_start_stays_below_a_seeded_start(self):
+        # Riccati monotonicity in the initial covariance: P0 = 0 is a valid
+        # lower below every admissible PSD initial covariance.
+        segs = [(1.1, 0.5, 10.0, F.WORD_SAMPLES)]
+        lo, _, _ = F.run_word(segs, [0.0, 0.0, 0.0, 0.0])
+        hi, _, _ = F.run_word(segs, [1.0e6, 1.0e6, 1.0e6, 0.25])
+        for i in range(4):
+            self.assertLessEqual(lo[i][i], hi[i][i] * (1.0 + 1.0e-9))
+
+    def test_a_changing_source_word_does_not_reuse_a_fixed_cell_firing_count(self):
+        # The tau-scaled cadence and the fmod rebase mean a mixed word's firing
+        # count is not any single cell's count.
+        fixed_slow = F.run_word([(12.0, 0.05, 400.0, F.WORD_SAMPLES)], [0.0] * 4)[1]
+        fixed_fast = F.run_word([(0.3333, 0.05, 400.0, F.WORD_SAMPLES)], [0.0] * 4)[1]
+        mixed = F.run_word(
+            [(12.0, 0.05, 400.0, 100), (0.3333, 0.05, 400.0, 100)] * 4, [0.0] * 4)[1]
+        self.assertNotEqual(mixed, fixed_slow)
+        self.assertNotEqual(mixed, fixed_fast)
+        self.assertLess(fixed_slow, mixed)
+        self.assertLess(mixed, fixed_fast)
+
+
+class DiagnosticContract(unittest.TestCase):
+    def test_build_is_non_promoting_and_validates(self):
+        d = F.build(stride=211)
+        self.assertEqual(validate_ok(d), [])
+        self.assertTrue(d["non_promoting"])
+        self.assertFalse(d["certifies_theorem_stage"])
+        self.assertFalse(d["interval_certified"])
+        self.assertFalse(d["quantifies_over_legal_histories"])
+        self.assertEqual(d["canonical_gate"], 1.0e-18)
+        self.assertEqual(d["word_samples"], 635)
+
+    def test_validate_rejects_a_promoted_or_gate_moved_artifact(self):
+        d = F.build(stride=211)
+        for key, bad in (("non_promoting", False),
+                         ("certifies_theorem_stage", True),
+                         ("interval_certified", True),
+                         ("canonical_gate", 1.0e-12)):
+            broken = dict(d)
+            broken[key] = bad
+            self.assertTrue(F.validate(broken),
+                            f"validate() accepted a tampered {key}")
+
+    def test_every_row_forgets_its_initial_covariance(self):
+        d = F.build(stride=211)
+        for r in d["rows"]:
+            self.assertTrue(r["P0_independent"],
+                            f"node {r['source_node']} spread {r['P0_probe_relative_spread']}")
+
+
+def validate_ok(d):
+    return F.validate(d)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/validation/test_ou3_p3_whole_word_lower_feasibility.py
+++ b/tests/validation/test_ou3_p3_whole_word_lower_feasibility.py
@@ -106,3 +106,41 @@ def validate_ok(d):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class AdversarialDescent(unittest.TestCase):
+    """Single-cell dwell is not the adversary; the search must be able to say so."""
+
+    def test_descent_finds_a_cheaper_legal_word_and_reports_convergence(self):
+        # 0 -> {0,1}, 1 -> {0,1}, 2 unreachable. Node 1 scores lower.
+        graph = {0: {0, 1}, 1: {0, 1}}
+        score = {0: 1.0, 1: 0.5}
+
+        def successors(n):
+            return graph[n]
+
+        def ratio_fn(seq):
+            return min(score[n] for n in seq)
+
+        out = F.adversarial_descent([0, 0, 0], successors, ratio_fn)
+        self.assertTrue(out["converged"])
+        self.assertLess(out["ratio"], 1.0)
+        self.assertTrue(out["swaps"])
+        # Every retained word must stay legal under the injected graph.
+        for a, b in zip(out["word"], out["word"][1:]):
+            self.assertIn(b, successors(a))
+
+    def test_descent_respects_legality_and_can_find_nothing(self):
+        # A graph with only self-loops admits no swap at all.
+        graph = {0: {0}, 1: {1}}
+        out = F.adversarial_descent([0, 0, 0], lambda n: graph[n], lambda s: 1.0)
+        self.assertTrue(out["converged"])
+        self.assertEqual(out["swaps"], [])
+        self.assertEqual(out["word"], [0, 0, 0])
+
+    def test_history_is_non_increasing(self):
+        graph = {0: {0, 1, 2}, 1: {0, 1, 2}, 2: {0, 1, 2}}
+        score = {0: 1.0, 1: 0.7, 2: 0.4}
+        out = F.adversarial_descent([0, 0, 0], lambda n: graph[n],
+                                    lambda s: min(score[n] for n in s))
+        self.assertEqual(out["history"], sorted(out["history"], reverse=True))

--- a/tests/validation/test_ou3_p3_whole_word_lower_feasibility.py
+++ b/tests/validation/test_ou3_p3_whole_word_lower_feasibility.py
@@ -24,17 +24,23 @@ class SchedulerSemantics(unittest.TestCase):
             due, elapsed = F.periodic_update_due(F.DT_S, period, elapsed)
             fires += int(due)
             self.assertTrue(0.0 <= elapsed < period)
-        # DT_S is the binary32 5 ms, marginally below 0.005, so 100 samples
-        # span just under 0.5 s and yield 24 firings against a 20 ms period,
-        # not 25.  The remainder is retained rather than reset each time.
-        self.assertEqual(fires, 24)
+        # DT_S is the binary32 5 ms, marginally below 0.005, so 100 samples span
+        # just under 0.5 s.  The scheduler is binary32, where the tolerance is
+        # 16 * 2**-23 = 1.9e-6 rather than the 3.6e-15 of double, and that
+        # tolerance absorbs the shortfall: the 100th sample fires, giving 25.
+        # In a double-precision transcription the same word yields 24.  The
+        # difference is not cosmetic -- it is the same tolerance that decides
+        # S-firing starvation.
+        self.assertEqual(fires, 25)
         due, _ = F.periodic_update_due(F.DT_S, 0.02, 0.0)
         self.assertFalse(due)
 
     def test_commit_period_rebases_the_timer(self):
         # set_pseudo_update_period_s applies elapsed = fmod(elapsed, new_period),
         # so a pending timer cannot survive a source commit unchanged.
-        self.assertAlmostEqual(F.commit_period(0.13, 0.05), 0.03, places=12)
+        # Binary32: fmod(f32(0.13), f32(0.05)) is 0.0299999937, not 0.03.
+        self.assertAlmostEqual(F.commit_period(0.13, 0.05), 0.03, places=7)
+        self.assertEqual(F.commit_period(0.13, 0.05), F.f32(F.commit_period(0.13, 0.05)))
         self.assertEqual(F.commit_period(0.0, 0.05), 0.0)
         with self.assertRaises(RuntimeError):
             F.commit_period(float("nan"), 0.05)
@@ -144,3 +150,36 @@ class AdversarialDescent(unittest.TestCase):
         out = F.adversarial_descent([0, 0, 0], lambda n: graph[n],
                                     lambda s: min(score[n] for n in s))
         self.assertEqual(out["history"], sorted(out["history"], reverse=True))
+
+
+class StarvationWitness(unittest.TestCase):
+    """PR #476's zero-S word must be reproducible, or this tool is not conservative."""
+
+    # Certified in #476's artifact ou3-p3-tau-ema-scheduler-cycle-diagnostic.
+    TAU_LOW = 9.533334732055664
+    TAU_HIGH = 9.533475875854492
+    T_S_LOW = 0.1300000101327896
+    T_S_HIGH = 0.13000193238258362
+
+    def test_cadence_matches_the_certified_binary32_periods(self):
+        # A double-precision 0.015/1.1 ratio misses these by ~1.5e-8 s, which is
+        # enough to decide starvation against a 1.9e-6 tolerance.
+        self.assertEqual(F.cadence_s(self.TAU_LOW), self.T_S_LOW)
+        self.assertEqual(F.cadence_s(self.TAU_HIGH), self.T_S_HIGH)
+
+    def test_alternating_tau_starves_S_while_holding_it_does_not(self):
+        held = F.starvation_probe(self.TAU_LOW, self.TAU_LOW, 0.05, 400.0, gap=13)
+        self.assertFalse(held["starved"])
+        self.assertGreater(held["S_firings"], 0)
+        alt = F.starvation_probe(self.TAU_LOW, self.TAU_HIGH, 0.05, 400.0, gap=13)
+        self.assertTrue(alt["starved"])
+        self.assertEqual(alt["S_firings"], 0)
+
+    def test_a_starved_word_never_forgets_its_initial_covariance(self):
+        alt = F.starvation_probe(self.TAU_LOW, self.TAU_HIGH, 0.05, 400.0, gap=13)
+        self.assertFalse(alt["P0_independent"])
+        self.assertGreater(alt["P0_probe_relative_spread"], 0.5)
+
+    def test_build_records_that_the_dwell_result_is_conditional(self):
+        d = F.build(stride=401)
+        self.assertTrue(d["dwell_result_conditional_on_S_firing"])

--- a/tools/ou3_p3_closed_form_word_margin.py
+++ b/tools/ou3_p3_closed_form_word_margin.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Closed-form interval-certified whole-word translation margin.
+
+Both sides of the P3 comparison are built in closed form from one observability
+Gramian referenced to the covariance-word **endpoint**, so neither side steps a
+Riccati recursion.  That matters: this ledger records three independent failures
+of stepwise interval covariance propagation over a word, the last of which lost
+positivity between 343 and 503 of 635 samples even in Joseph form and even with
+the x cell narrowed 4096x.  Closed form is not an optimisation here, it is the
+only route that survives interval arithmetic.
+
+Ceiling (upper bound on P at the word endpoint)
+-----------------------------------------------
+Each S observation at lag ``ell`` from the endpoint constrains the endpoint state
+through ``[ell^2/2, ell, 1]``, with its own process-corruption inflation
+``R_eff = rmax + sigma^2 (ell^3/6)^2 + q_c ell^7/252``.  Then
+``P_end <= (sum_k h_k h_k' / R_eff,k)^-1``.  No ``P0`` appears, so the ceiling is
+independent of the initial covariance.
+
+Floor (lower bound on P at the word endpoint)
+---------------------------------------------
+The floor must survive every *other* measurement channel.  The accelerometer
+Jacobian has zero columns for ``v``, ``p`` and ``S`` -- ``measurement_update_acc_only``
+forms its innovation covariance from ``OFF_TH``, ``OFF_AW``, ``OFF_BA`` and
+``OFF_BG`` only -- so it reaches translation solely through the cross-covariance
+with ``a_w``; the magnetometer informs attitude alone.  In the limiting case
+where ``a_w`` is known *exactly* over the whole word, ``v(T) = v(0) + int a_w``
+still carries ``v(0)``'s uncertainty, and likewise ``p`` and ``S``.  So the floor
+credits the S observations at **full** strength (``R_eff = rmax``, no process
+inflation, the most informative case and hence the smallest floor) and adds the
+raw shipping prior information.  Propagation only injects process noise and so
+only reduces information, giving ``Y0_propagated <= Y0`` and therefore
+``(Y0 + G_full)^-1 <= truth``.
+
+Within one source cell the two sides take opposite endpoints -- the ceiling the
+fewest observations and weakest measurement, the floor the most and strongest --
+so both hold for every parameter value the cell admits.
+
+Non-promotion
+-------------
+This computes a margin.  It is **not** a P3 verdict: the canonical producer and
+gate remain the promotion authority, and this module cannot set a theorem flag.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+from pathlib import Path
+
+from ou3_interval import Interval
+import ou3_p4_source_node_cells as NODES
+import ou3_source_reachable_matrix_p3 as BASE
+
+REPO = Path(__file__).resolve().parents[1]
+DEFAULT_DOMAIN = REPO / "tools" / "ou3_proof_operating_domain.json"
+WRAPPER = REPO / "src" / "kalman_ou_iii" / "SeaStateFusionFilter_OU_III.h"
+SCHEMA = 1
+WORD_SAMPLES = 635
+GATE = 1.0e-18
+CHANNELS = ("v", "p", "S")
+
+# Shipping initial covariance, Kalman3D_Wave_OU_III constructor.
+SIGMA_V0, SIGMA_P0, SIGMA_S0 = 1.0, 20.0, 50.0
+
+
+def _I(x: float) -> Interval:
+    return Interval.point(float(x))
+
+
+def _consts() -> dict:
+    text = WRAPPER.read_text(encoding="utf-8")
+
+    def c(name: str) -> float:
+        m = re.search(r"constexpr float\s+" + name + r"\s*=\s*([0-9.eE+-]+)f", text)
+        if not m:
+            raise RuntimeError(f"shipping constant {name} not found")
+        return float(m.group(1))
+
+    # Cadence constants come from the repo's own source parser rather than a
+    # second regex here: PSEUDO_UPDATE_PERIOD_MIN_S_DEFAULT is FREQ_SMOOTHER_DT,
+    # not a literal, and source_schedule() already resolves the clamps and the
+    # constexpr-float ratio exactly as the shipping code computes them.
+    sched = BASE.source_schedule()
+    return {
+        "rs_coeff": c("R_S_MSE_COEFF_DEFAULT"),
+        "accel_density": c("R_S_ACCEL_NOISE_DENSITY_DEFAULT"),
+        "min_rs": c("MIN_R_S"),
+        "max_rs": c("MAX_R_S"),
+        "period_min": float(sched["pseudo_min_s"]),
+        "period_max": float(sched["pseudo_max_s"]),
+        "ratio": float(sched["pseudo_ratio"]),
+    }
+
+
+def cadence_s(tau: float, k: dict) -> float:
+    return min(max(k["ratio"] * float(tau), k["period_min"]), k["period_max"])
+
+
+def rs_target(tau: float, sigma: float, k: dict) -> float:
+    """Deployed SpectralMSE R_S, clamped exactly as the shipping code clamps it."""
+    q = (2.0 * k["accel_density"]) ** (1.0 / 14.0)
+    val = (k["rs_coeff"] * q * ((sigma * tau ** 4) ** (6.0 / 7.0))
+           / math.sqrt(cadence_s(tau, k)))
+    return min(max(val, k["min_rs"]), k["max_rs"])
+
+
+def _inv3(G):
+    """Interval 3x3 inverse; None when the determinant is not validated positive."""
+    d = (G[0][0] * (G[1][1] * G[2][2] - G[1][2] * G[2][1])
+         - G[0][1] * (G[1][0] * G[2][2] - G[1][2] * G[2][0])
+         + G[0][2] * (G[1][0] * G[2][1] - G[1][1] * G[2][0]))
+    if d.lo <= 0.0 <= d.hi:
+        return None
+    C = [[G[(i + 1) % 3][(j + 1) % 3] * G[(i + 2) % 3][(j + 2) % 3]
+          - G[(i + 1) % 3][(j + 2) % 3] * G[(i + 2) % 3][(j + 1) % 3]
+          for j in range(3)] for i in range(3)]
+    di = d.reciprocal()
+    return [[C[j][i] * di for j in range(3)] for i in range(3)]
+
+
+def _gramian(tau: float, sigma: float, rs: float, k: dict, *, inflate: bool):
+    """Endpoint-referenced S-observation Gramian over one covariance word."""
+    h = float(BASE.source_schedule()["dt_s"])
+    Tw = BASE.up(WORD_SAMPLES * h)
+    ts = cadence_s(tau, k)
+    n = int(Tw / ts)
+    if n < 3:
+        return None, n
+    fac = max(BASE.source_schedule()["R_S_axis_std_factors"])
+    rmax = BASE.up((rs * fac) ** 2)
+    qc = BASE.up(2.0 * sigma * sigma / tau)
+    G = [[Interval(0.0, 0.0) for _ in range(3)] for _ in range(3)]
+    for j in range(1, n + 1):
+        ell = Tw - j * ts
+        reff = rmax
+        if inflate:
+            reff = BASE.up(rmax + sigma * sigma * (ell ** 3 / 6.0) ** 2
+                           + qc * abs(ell) ** 7 / 252.0)
+        li = _I(BASE.up(ell))
+        hv = [li.square() * _I(0.5), li, _I(1.0)]
+        ri = _I(reff).reciprocal()
+        for a in range(3):
+            for b in range(3):
+                G[a][b] = G[a][b] + (hv[a] * hv[b]) * ri
+    return G, n
+
+
+def node_margin(node: dict, k: dict) -> dict:
+    """Margin for one source node, taking opposite cell endpoints on each side."""
+    tau_lo, tau_hi = float(node["tau_s"][0]), float(node["tau_s"][1])
+    sig_lo, sig_hi = (float(node["sigma_filter_committed_mps2"][0]),
+                      float(node["sigma_filter_committed_mps2"][1]))
+    # Ceiling: fewest observations and weakest S measurement in the cell.
+    rs_ceil = max(rs_target(tau_hi, sig_hi, k), rs_target(tau_hi, sig_lo, k))
+    Gc, n_ceil = _gramian(tau_hi, sig_hi, rs_ceil, k, inflate=True)
+    # Floor: most observations and strongest S measurement in the cell.
+    rs_floor = min(rs_target(tau_lo, sig_lo, k), rs_target(tau_lo, sig_hi, k))
+    Gf, n_floor = _gramian(tau_lo, sig_lo, rs_floor, k, inflate=False)
+    if Gc is None or Gf is None:
+        return {"source_node": int(node["index"]), "validated": False,
+                "reason": "fewer than three S observations in the word"}
+    for a, v0 in enumerate((SIGMA_V0 ** 2, SIGMA_P0 ** 2, SIGMA_S0 ** 2)):
+        Gf[a][a] = Gf[a][a] + _I(1.0 / v0)
+    Ci, Fi = _inv3(Gc), _inv3(Gf)
+    if Ci is None or Fi is None:
+        return {"source_node": int(node["index"]), "validated": False,
+                "reason": "interval inversion not validated"}
+    ratios = [abs(Fi[i][i].lo) / abs(Ci[i][i].hi) for i in range(3)]
+    idx = ratios.index(min(ratios))
+    return {"source_node": int(node["index"]), "validated": True,
+            "tau_s": [tau_lo, tau_hi], "R_S_ceiling": rs_ceil, "R_S_floor": rs_floor,
+            "S_observations_ceiling": n_ceil, "S_observations_floor": n_floor,
+            "channel_ratios": ratios, "margin": ratios[idx],
+            "binding_channel": CHANNELS[idx]}
+
+
+def build(domain_path: Path = DEFAULT_DOMAIN, *, stride: int = 1) -> dict:
+    k = _consts()
+    nodes = NODES.build()["nodes"]
+    rows = [node_margin(n, k) for n in nodes[::max(1, int(stride))]]
+    ok = [r for r in rows if r.get("validated")]
+    worst = min(ok, key=lambda r: r["margin"]) if ok else None
+    return {
+        "schema": SCHEMA,
+        "qualification": "OU3_P3_CLOSED_FORM_WHOLE_WORD_TRANSLATION_MARGIN",
+        "non_promoting": True,
+        "certifies_theorem_stage": False,
+        "interval_certified": True,
+        "stepwise_riccati_recursion_used": False,
+        "initial_covariance_from_shipping_constructor": [SIGMA_V0, SIGMA_P0, SIGMA_S0],
+        "R_S_from_deployed_clamped_SpectralMSE_law": True,
+        "canonical_gate": GATE,
+        "word_samples": WORD_SAMPLES,
+        "nodes_evaluated": len(rows),
+        "nodes_validated": len(ok),
+        "stride": int(stride),
+        "worst": worst,
+        "worst_margin": None if worst is None else worst["margin"],
+        "worst_clears_canonical_gate": bool(worst and worst["margin"] > GATE),
+        "rows": rows,
+    }
+
+
+def validate(d: dict) -> list[str]:
+    f: list[str] = []
+    if d.get("schema") != SCHEMA:
+        f.append("schema changed")
+    if d.get("non_promoting") is not True:
+        f.append("margin producer must remain non-promoting")
+    if d.get("certifies_theorem_stage") is not False:
+        f.append("margin producer must not claim a theorem stage")
+    if d.get("stepwise_riccati_recursion_used") is not False:
+        f.append("closed-form claim broken: a stepwise recursion was used")
+    if float(d.get("canonical_gate", 0.0)) != GATE:
+        f.append("canonical usefulness gate must remain exactly 1e-18")
+    if int(d.get("word_samples", 0)) != WORD_SAMPLES:
+        f.append("covariance word sample count changed")
+    if d.get("nodes_validated", 0) != d.get("nodes_evaluated", -1):
+        f.append("some source nodes did not validate")
+    for r in d.get("rows") or []:
+        if r.get("validated") and not (math.isfinite(r["margin"]) and r["margin"] > 0.0):
+            f.append(f"node {r['source_node']} produced a non-positive margin")
+            break
+    if not d.get("rows"):
+        f.append("no source nodes evaluated")
+    return list(dict.fromkeys(f))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--domain", type=Path, default=DEFAULT_DOMAIN)
+    ap.add_argument("--stride", type=int, default=1)
+    ap.add_argument("--output", type=Path, required=True)
+    a = ap.parse_args()
+    d = build(a.domain, stride=a.stride)
+    f = validate(d)
+    d["validation_pass"] = not f
+    d["validation_failures"] = f
+    a.output.parent.mkdir(parents=True, exist_ok=True)
+    a.output.write_text(json.dumps(d, indent=2, sort_keys=True), encoding="utf-8")
+    print(json.dumps({x: y for x, y in d.items() if x != "rows"}, indent=2, sort_keys=True))
+    return 0 if not f else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ou3_p3_closed_form_word_margin.py
+++ b/tools/ou3_p3_closed_form_word_margin.py
@@ -176,12 +176,57 @@ def node_margin(node: dict, k: dict) -> dict:
             "binding_channel": CHANNELS[idx]}
 
 
+def mixed_word_margin(k: dict) -> dict:
+    """Margin valid for every legal word, including source-changing ones.
+
+    The per-node rows pair one node's ceiling with its own floor, which is what
+    canonical ``delta`` does but says nothing about a word that changes source
+    mid-flight.  This bound needs no enumeration, by two monotonicity arguments:
+
+    * **Ceiling.** The certified S recurrence puts an observation in every
+      max-gap window, so the worst a legal word can do is place them as late as
+      possible in each -- exactly the max-cadence dwell.  Any other word has at
+      least as many observations, at least as close to the endpoint, hence a
+      larger Gramian and a smaller ceiling.
+    * **Floor.** No word can carry more than one S observation per sample, and
+      the min-cadence dwell already attains that, since the cadence clamps to
+      ``h`` there.  It is therefore the most informative case and yields the
+      smallest floor.
+
+    Pairing the two is cross-worst, so it is strictly more pessimistic than the
+    per-node pairing and strictly more general.
+    """
+    sched = BASE.source_schedule()
+    tau_lo, tau_hi = sched["tau_applied_invariant_s"]
+    sig_lo, sig_hi = sched["sigma_aw_applied_safety"]
+    Gc, n_ceil = _gramian(tau_hi, sig_hi, k["max_rs"], k, inflate=True)
+    Gf, n_floor = _gramian(tau_lo, sig_lo, k["min_rs"], k, inflate=False)
+    if Gc is None or Gf is None:
+        return {"validated": False, "reason": "fewer than three S observations"}
+    for a, v0 in enumerate((SIGMA_V0 ** 2, SIGMA_P0 ** 2, SIGMA_S0 ** 2)):
+        Gf[a][a] = Gf[a][a] + _I(1.0 / v0)
+    Ci, Fi = _inv3(Gc), _inv3(Gf)
+    if Ci is None or Fi is None:
+        return {"validated": False, "reason": "interval inversion not validated"}
+    ratios = [abs(Fi[i][i].lo) / abs(Ci[i][i].hi) for i in range(3)]
+    idx = ratios.index(min(ratios))
+    h = float(sched["dt_s"])
+    return {"validated": True, "tau_ceiling": tau_hi, "tau_floor": tau_lo,
+            "R_S_ceiling": k["max_rs"], "R_S_floor": k["min_rs"],
+            "S_observations_ceiling": n_ceil, "S_observations_floor": n_floor,
+            "max_S_gap_samples": math.ceil(cadence_s(tau_hi, k) / h),
+            "channel_ratios": ratios, "margin": ratios[idx],
+            "binding_channel": CHANNELS[idx],
+            "covers_source_changing_words": True}
+
+
 def build(domain_path: Path = DEFAULT_DOMAIN, *, stride: int = 1) -> dict:
     k = _consts()
     nodes = NODES.build()["nodes"]
     rows = [node_margin(n, k) for n in nodes[::max(1, int(stride))]]
     ok = [r for r in rows if r.get("validated")]
     worst = min(ok, key=lambda r: r["margin"]) if ok else None
+    mixed = mixed_word_margin(k)
     return {
         "schema": SCHEMA,
         "qualification": "OU3_P3_CLOSED_FORM_WHOLE_WORD_TRANSLATION_MARGIN",
@@ -199,6 +244,9 @@ def build(domain_path: Path = DEFAULT_DOMAIN, *, stride: int = 1) -> dict:
         "worst": worst,
         "worst_margin": None if worst is None else worst["margin"],
         "worst_clears_canonical_gate": bool(worst and worst["margin"] > GATE),
+        "mixed_word_margin": mixed,
+        "mixed_word_clears_canonical_gate": bool(mixed.get("validated")
+                                                 and mixed["margin"] > GATE),
         "rows": rows,
     }
 
@@ -225,6 +273,13 @@ def validate(d: dict) -> list[str]:
             break
     if not d.get("rows"):
         f.append("no source nodes evaluated")
+    m = d.get("mixed_word_margin") or {}
+    if not m.get("validated"):
+        f.append(f"mixed-word bound did not validate: {m.get('reason')}")
+    elif not (math.isfinite(m["margin"]) and m["margin"] > 0.0):
+        f.append("mixed-word margin is not positive finite")
+    elif m.get("covers_source_changing_words") is not True:
+        f.append("mixed-word bound no longer claims to cover source-changing words")
     return list(dict.fromkeys(f))
 
 

--- a/tools/ou3_p3_whole_word_lower_feasibility.py
+++ b/tools/ou3_p3_whole_word_lower_feasibility.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Feasibility diagnostic for a whole-word translation covariance *lower*.
+
+PR #476 established that the four-max "same-history" covariance upper is not a
+sufficient source-correlation quotient: a legal P2 V1 path attains the full
+global adverse label in 101 samples, far inside the 635-sample covariance word.
+Its recorded repair has two structural parts, and it claims only the second:
+
+1. a whole-word covariance **lower** valid for every admissible PSD initial
+   covariance and every legal source history;
+2. a time-ordered, duration-aware covariance **upper**.
+
+This module is evidence for part 1 and deliberately does not build part 2.
+
+What it measures
+----------------
+Canonical ``delta`` is same-history matched: ``phase_row`` pairs the floor image
+of source node ``t`` with ``endpoint_phase_upper(t, ...)``, that same node's own
+upper, and then minimises over nodes.  The analogue measured here is, per source
+configuration, the horizon-matched ratio
+
+    min_i  P_word[i,i](P0 = 0)  /  P_word[i,i](P0 = infinity on v,p,S)
+
+with both sides propagated over the *same* whole word under the *same* source
+parameters, so the ratio isolates how much of the word's covariance is forced by
+the word itself rather than inherited from the initial covariance.  A ratio far
+above the ``1e-18`` gate means a horizon-matched lower is not self-defeating; it
+does **not** certify one.
+
+Two source models are provided:
+
+``dwell``
+    Hold one physical source node for the whole word.  For a *lower* the natural
+    adversary is a word that never leaves the slowest-cadence, weakest-S cell,
+    because mixing in any faster-cadence cell only adds S information.
+
+``ordered``
+    Step a supplied legal ordered source word, carrying the shipping pseudo
+    timer across source commits.  ``set_pseudo_update_period_s`` applies
+    ``elapsed = fmod(elapsed, new_period)``, so fixed-cell firing counts cannot
+    be pasted onto a changing-source word.
+
+Non-promoting.  These are point diagnostics at one corner of each source cell,
+in double precision; they are not interval-certified, do not quantify over legal
+histories, and cannot set any theorem promotion flag.  The deployed filter,
+operating domain, P2 V1 source language and the canonical ``1e-18`` threshold
+are untouched.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+
+import ou3_p4_source_node_cells as NODES
+
+REPO = Path(__file__).resolve().parents[1]
+DEFAULT_DOMAIN = REPO / "tools" / "ou3_proof_operating_domain.json"
+SCHEMA = 1
+
+DT_S = 0.004999999888241291
+WORD_SAMPLES = 635
+PSEUDO_RATIO = 0.015 / 1.1
+PSEUDO_MIN_S = DT_S
+PSEUDO_MAX_S = 0.25
+CHANNELS = ("v", "p", "S", "a_w")
+GATE = 1.0e-18
+
+
+def cadence_s(tau: float) -> float:
+    """Deployed ``pseudo_update_period_for_`` including both safety clamps."""
+    return min(max(PSEUDO_RATIO * float(tau), PSEUDO_MIN_S), PSEUDO_MAX_S)
+
+
+def periodic_update_due(dt: float, period: float, elapsed: float):
+    """Exact port of ``ou_detail::periodic_update_due``."""
+    total = elapsed + dt
+    tol = 16.0 * sys.float_info.epsilon * max(1.0, period)
+    if total + tol < period:
+        return False, total
+    e = math.fmod(total, period) if total >= period else 0.0
+    if not (e >= 0.0) or not math.isfinite(e) or e >= period:
+        e = 0.0
+    return True, e
+
+
+def commit_period(elapsed: float, period: float) -> float:
+    """Exact port of ``set_pseudo_update_period_s``'s timer rebase."""
+    e = math.fmod(float(elapsed), float(period))
+    if not (math.isfinite(e) and 0.0 <= e < period):
+        raise RuntimeError("invalid fmod pseudo-timer state")
+    return e
+
+
+def _mm(A, B):
+    return [[sum(A[i][k] * B[k][j] for k in range(4)) for j in range(4)] for i in range(4)]
+
+
+def _sym(A):
+    B = [[float(x) for x in row] for row in A]
+    for i in range(4):
+        for j in range(i + 1, 4):
+            v = 0.5 * (B[i][j] + B[j][i])
+            B[i][j] = B[j][i] = v
+    return B
+
+
+def _transition_and_noise(tau: float, sigma: float, h: float):
+    """Exact discrete map of dv=a, dp=v, dS=p, da=-a/tau dt + sqrt(2 sig^2/tau) dW.
+
+    Series-summed rather than matrix-exponentiated so the module has no
+    numerical dependency beyond the standard library.
+    """
+    a = h / float(tau)
+    e = math.exp(-a)
+    # Integrals of the OU kernel against 1, t, t^2/2 over one sample.
+    t = float(tau)
+    i0 = t * (1.0 - e)
+    i1 = t * (h - i0)
+    i2 = t * (0.5 * h * h - i1)
+    Phi = [[1.0, 0.0, 0.0, i0],
+           [h, 1.0, 0.0, i1],
+           [0.5 * h * h, h, 1.0, i2],
+           [0.0, 0.0, 0.0, e]]
+    q = 2.0 * float(sigma) * float(sigma) / t
+    # Van Loan by direct quadrature: Q = int_0^h Phi(s) G q G' Phi(s)' ds with
+    # G = e_4.  Simpson on a fixed fine grid is exact enough for a diagnostic.
+    n = 64
+    Q = [[0.0] * 4 for _ in range(4)]
+    for k in range(n + 1):
+        s = h * k / n
+        w = (1.0 if k in (0, n) else (4.0 if k % 2 else 2.0)) * (h / n) / 3.0
+        es = math.exp(-s / t)
+        c0 = t * (1.0 - es)
+        c1 = t * (s - c0)
+        c2 = t * (0.5 * s * s - c1)
+        col = (c0, c1, c2, es)
+        for i in range(4):
+            for j in range(4):
+                Q[i][j] += w * q * col[i] * col[j]
+    return Phi, _sym(Q)
+
+
+def _measure_S(P, R: float):
+    den = P[2][2] + float(R)
+    if not (math.isfinite(den) and den > 0.0):
+        raise RuntimeError("S measurement denominator lost positivity")
+    c = [P[i][2] for i in range(4)]
+    return _sym([[P[i][j] - c[i] * c[j] / den for j in range(4)] for i in range(4)])
+
+
+def run_word(segments, P0_diag, *, word_samples: int = WORD_SAMPLES):
+    """Propagate ``P0_diag`` over ``segments`` = [(tau, sigma, R_S_std, gap)]."""
+    P = [[0.0] * 4 for _ in range(4)]
+    for i, x in enumerate(P0_diag):
+        P[i][i] = float(x)
+    elapsed = 0.0
+    fires = 0
+    used = 0
+    kernels: dict = {}
+    for (tau, sigma, rs_std, gap) in segments:
+        period = cadence_s(tau)
+        elapsed = commit_period(elapsed, period)
+        key = (round(float(tau), 12), round(float(sigma), 12))
+        if key not in kernels:
+            kernels[key] = _transition_and_noise(tau, sigma, DT_S)
+        Phi, Q = kernels[key]
+        R = float(rs_std) ** 2
+        PhiT = [list(r) for r in zip(*Phi)]
+        for _ in range(int(gap)):
+            if used >= word_samples:
+                break
+            M = _mm(_mm(Phi, P), PhiT)
+            P = _sym([[M[i][j] + Q[i][j] for j in range(4)] for i in range(4)])
+            used += 1
+            due, elapsed = periodic_update_due(DT_S, period, elapsed)
+            if due:
+                fires += 1
+                P = _measure_S(P, R)
+        if used >= word_samples:
+            break
+    return P, fires, used
+
+
+P0_SCALE_START = 1.0e3
+P0_SCALE_STEP = 1.0e3
+P0_SCALE_MAX = 1.0e15
+P0_TOLERANCE = 1.0e-4
+
+
+def _ratio(segments, sigma_for_aw: float):
+    """Horizon-matched ratio with an adaptive initial-covariance probe.
+
+    The upper side wants ``P0 = infinity`` on v, p and S, which double precision
+    cannot represent.  Two walls bracket the usable range and they move from cell
+    to cell:
+
+    * below the lower wall the word has not yet forgotten ``P0``, so the endpoint
+      still grows with it -- the slowest-cadence cells need more than 1e9;
+    * above the upper wall the covariance-form update loses the endpoint to
+      cancellation, and the tell is that the endpoint starts to *decrease* as
+      ``P0`` grows, which the monotone Riccati map forbids.
+
+    The gap between the walls spans about eight orders across the 800 source
+    cells, so no fixed probe pair serves all of them.  This escalates ``P0``
+    relative to the word's own zero-start covariance until two consecutive probes
+    agree, and stops early if monotonicity breaks.  The accepted scale and the
+    achieved spread are reported per row so a caller can see which wall a
+    non-converged row hit.
+    """
+    lo, fires, used = run_word(segments, [0.0, 0.0, 0.0, 0.0])
+    aw = float(sigma_for_aw) ** 2
+    base = [abs(lo[i][i]) for i in range(4)]
+    if any(not (math.isfinite(b) and b > 0.0) for b in base):
+        raise RuntimeError("zero-start whole-word lower lost positivity")
+
+    def probe(scale):
+        seed = [scale * base[0], scale * base[1], scale * base[2], aw]
+        return run_word(segments, seed)[0]
+
+    scale = P0_SCALE_START
+    prev = probe(scale)
+    best, spread, accepted, converged = prev, float("inf"), scale, False
+    while scale < P0_SCALE_MAX:
+        scale *= P0_SCALE_STEP
+        cur = probe(scale)
+        sp = 0.0
+        decreased = False
+        for i in range(4):
+            a, b = abs(prev[i][i]), abs(cur[i][i])
+            if not (math.isfinite(b) and b > 0.0):
+                decreased = True
+                break
+            sp = max(sp, abs(a - b) / max(a, b))
+            if b < a * (1.0 - P0_TOLERANCE):
+                decreased = True
+        if decreased:
+            # Upper wall: keep the last value produced below it.
+            break
+        best, spread, accepted = cur, sp, scale
+        if sp <= P0_TOLERANCE:
+            converged = True
+            break
+        prev = cur
+
+    r = [base[i] / abs(best[i][i]) for i in range(4)]
+    k = r.index(min(r))
+    return {"channel_ratios": r, "ratio": r[k], "binding_channel": CHANNELS[k],
+            "S_firings": fires, "samples": used,
+            "P0_probe_relative_spread": spread,
+            "P0_accepted_scale": accepted,
+            "P0_independent": bool(converged)}
+
+
+def _adverse_corner(node) -> tuple:
+    """Slowest cadence, largest sigma, weakest S measurement in the cell."""
+    return (float(node["tau_s"][1]),
+            float(node["sigma_filter_committed_mps2"][1]),
+            float(node["R_S_filter_std"][1]))
+
+
+def build(domain_path: Path = DEFAULT_DOMAIN, *, stride: int = 1) -> dict:
+    nodes = NODES.build()["nodes"]
+    rows = []
+    for node in nodes[::max(1, int(stride))]:
+        tau, sigma, rs = _adverse_corner(node)
+        res = _ratio([(tau, sigma, rs, WORD_SAMPLES)], sigma)
+        rows.append({"source_node": int(node["index"]),
+                     "tau_index": int(node["tau_index"]),
+                     "sigma_raw_index": int(node["sigma_raw_index"]),
+                     "R_S_index": int(node["R_S_index"]),
+                     "tau_s": tau, "sigma_aw": sigma, "R_S_filter_std": rs,
+                     **res})
+    rows.sort(key=lambda x: x["ratio"])
+    worst = rows[0] if rows else None
+    return {
+        "schema": SCHEMA,
+        "qualification": "OU3_P3_WHOLE_WORD_LOWER_FEASIBILITY_POINT_DIAGNOSTIC",
+        "non_promoting": True,
+        "certifies_theorem_stage": False,
+        "interval_certified": False,
+        "quantifies_over_legal_histories": False,
+        "source_model": "single_cell_dwell_adverse_corner",
+        "word_samples": WORD_SAMPLES,
+        "dt_s": DT_S,
+        "canonical_gate": GATE,
+        "nodes_evaluated": len(rows),
+        "stride": int(stride),
+        "worst": worst,
+        "worst_ratio": None if worst is None else worst["ratio"],
+        "worst_clears_canonical_gate": bool(worst is not None and worst["ratio"] > GATE),
+        "rows": rows,
+    }
+
+
+def validate(d: dict) -> list[str]:
+    f: list[str] = []
+    if d.get("schema") != SCHEMA:
+        f.append("schema changed")
+    for key in ("non_promoting", "interval_certified", "quantifies_over_legal_histories",
+                "certifies_theorem_stage"):
+        if key not in d:
+            f.append(f"missing honesty flag {key}")
+    if d.get("non_promoting") is not True:
+        f.append("diagnostic must remain non-promoting")
+    if d.get("certifies_theorem_stage") is not False:
+        f.append("diagnostic must not claim a theorem stage")
+    if d.get("interval_certified") is not False:
+        f.append("point diagnostic must not claim interval certification")
+    if float(d.get("canonical_gate", 0.0)) != GATE:
+        f.append("canonical usefulness gate must remain exactly 1e-18")
+    if int(d.get("word_samples", 0)) != WORD_SAMPLES:
+        f.append("covariance word sample count changed")
+    rows = d.get("rows") or []
+    if not rows:
+        f.append("no source rows evaluated")
+    for r in rows:
+        if not (math.isfinite(r["ratio"]) and r["ratio"] > 0.0):
+            f.append(f"node {r['source_node']} produced a non-positive ratio")
+            break
+        if r["binding_channel"] not in CHANNELS:
+            f.append(f"node {r['source_node']} reported an unknown binding channel")
+            break
+        if int(r["samples"]) != WORD_SAMPLES:
+            f.append(f"node {r['source_node']} did not cover the whole word")
+            break
+        if not r.get("P0_independent"):
+            f.append(f"node {r['source_node']} did not forget its initial covariance "
+                     f"(probe spread {r.get('P0_probe_relative_spread'):.3g})")
+            break
+    return list(dict.fromkeys(f))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--domain", type=Path, default=DEFAULT_DOMAIN)
+    ap.add_argument("--stride", type=int, default=1,
+                    help="evaluate every Nth source node (CI budget control)")
+    ap.add_argument("--output", type=Path, required=True)
+    a = ap.parse_args()
+    d = build(a.domain, stride=a.stride)
+    f = validate(d)
+    d["validation_pass"] = not f
+    d["validation_failures"] = f
+    a.output.parent.mkdir(parents=True, exist_ok=True)
+    a.output.write_text(json.dumps(d, indent=2, sort_keys=True), encoding="utf-8")
+    print(json.dumps({k: v for k, v in d.items() if k != "rows"}, indent=2, sort_keys=True))
+    return 0 if not f else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ou3_p3_whole_word_lower_feasibility.py
+++ b/tools/ou3_p3_whole_word_lower_feasibility.py
@@ -51,44 +51,71 @@ from __future__ import annotations
 import argparse
 import json
 import math
-import sys
+import struct
 from pathlib import Path
 
 import ou3_p4_source_node_cells as NODES
+import ou3_source_reachable_matrix_p3 as BASE
 
 REPO = Path(__file__).resolve().parents[1]
 DEFAULT_DOMAIN = REPO / "tools" / "ou3_proof_operating_domain.json"
 SCHEMA = 1
 
-DT_S = 0.004999999888241291
 WORD_SAMPLES = 635
-PSEUDO_RATIO = 0.015 / 1.1
-PSEUDO_MIN_S = DT_S
-PSEUDO_MAX_S = 0.25
 CHANNELS = ("v", "p", "S", "a_w")
 GATE = 1.0e-18
 
+# Scheduler constants are parsed from the shipping header rather than restated
+# here.  A hand-written PSEUDO_RATIO of 0.015/1.1 is *not* the deployed value:
+# the C++ constant is a constexpr float quotient, f32(f32(0.015)/f32(1.1)) =
+# 0.013636362738907337, against the double 0.013636363636363634.  The two differ
+# in the eighth digit, which moves the pseudo period by about 1.5e-8 s -- enough
+# to decide S-firing starvation, whose margin is of order the binary32 scheduler
+# tolerance 1.9e-6.
+_SCHED = BASE.source_schedule()
+DT_S = float(_SCHED["dt_s"])
+PSEUDO_RATIO = float(_SCHED["pseudo_ratio"])
+PSEUDO_MIN_S = float(_SCHED["pseudo_min_s"])
+PSEUDO_MAX_S = float(_SCHED["pseudo_max_s"])
+
+
+BINARY32_EPS = 2.0 ** -23
+
+
+def f32(x: float) -> float:
+    """Round to binary32.
+
+    The deployed MEKF is ``Kalman3D_Wave_OU_III<float>``, so every scheduler
+    quantity below is single precision.  This is not a cosmetic detail: the
+    ``periodic_update_due`` tolerance is ``16 * eps``, which is 1.9e-6 in
+    binary32 against 3.6e-15 in double, and S-firing starvation depends on that
+    tolerance being comparable to the separation between two pseudo periods
+    inside one source cell.  A double-precision transcription cannot represent
+    the starvation at all and therefore is not conservative.
+    """
+    return struct.unpack("f", struct.pack("f", x))[0]
+
 
 def cadence_s(tau: float) -> float:
-    """Deployed ``pseudo_update_period_for_`` including both safety clamps."""
-    return min(max(PSEUDO_RATIO * float(tau), PSEUDO_MIN_S), PSEUDO_MAX_S)
+    """Deployed ``pseudo_update_period_for_`` in binary32, including both clamps."""
+    return f32(min(max(f32(f32(PSEUDO_RATIO) * f32(tau)), PSEUDO_MIN_S), PSEUDO_MAX_S))
 
 
 def periodic_update_due(dt: float, period: float, elapsed: float):
-    """Exact port of ``ou_detail::periodic_update_due``."""
-    total = elapsed + dt
-    tol = 16.0 * sys.float_info.epsilon * max(1.0, period)
-    if total + tol < period:
+    """Exact binary32 port of ``ou_detail::periodic_update_due``."""
+    total = f32(elapsed + dt)
+    tol = f32(16.0 * BINARY32_EPS * max(1.0, period))
+    if f32(total + tol) < period:
         return False, total
-    e = math.fmod(total, period) if total >= period else 0.0
+    e = f32(math.fmod(total, period)) if total >= period else 0.0
     if not (e >= 0.0) or not math.isfinite(e) or e >= period:
         e = 0.0
     return True, e
 
 
 def commit_period(elapsed: float, period: float) -> float:
-    """Exact port of ``set_pseudo_update_period_s``'s timer rebase."""
-    e = math.fmod(float(elapsed), float(period))
+    """Exact binary32 port of ``set_pseudo_update_period_s``'s timer rebase."""
+    e = f32(math.fmod(f32(elapsed), f32(period)))
     if not (math.isfinite(e) and 0.0 <= e < period):
         raise RuntimeError("invalid fmod pseudo-timer state")
     return e
@@ -305,6 +332,40 @@ def range_of(seq):
     return sorted(set(seq))
 
 
+def starvation_probe(tau_low: float, tau_high: float, sigma: float, rs_std: float,
+                     *, gap: int = 13) -> dict:
+    """Check whether alternating two applied ``tau`` values starves the S update.
+
+    PR #476 found that alternating two applied ``tau`` values *inside one source
+    cell* can drive the S firing count to zero across the whole covariance word:
+    each stage boundary rebases the timer by ``fmod`` against a slightly
+    different period, and when the two periods differ by about the binary32
+    scheduler tolerance (1.9e-6) the accumulated remainder never crosses.  A word
+    with no S firing never forgets its initial covariance, so **no
+    P0-independent whole-word lower exists for it**.
+
+    This verifies a supplied witness pair; it does not search for one.  Finding
+    which cells admit a resonant pair needs the tau-EMA reachability argument,
+    which is #476's lane.  The pair is not near the cell endpoints -- #476's
+    witness separates the two taus by 1.4e-4 s inside a cell spanning 3.6 s -- so
+    a sweep that holds one corner per cell cannot see this and is therefore not
+    conservative.
+    """
+    n = math.ceil(WORD_SAMPLES / int(gap))
+    segs = [((tau_low if i % 2 == 0 else tau_high), sigma, rs_std, int(gap))
+            for i in range(n)]
+    _, fires, used = run_word(segs, [0.0, 0.0, 0.0, 0.0])
+    out = {"gap_samples": int(gap), "S_firings": fires, "samples": used,
+           "starved": fires == 0,
+           "period_low": cadence_s(tau_low), "period_high": cadence_s(tau_high)}
+    if fires == 0:
+        r = _ratio(segs, sigma)
+        out["ratio"] = r["ratio"]
+        out["P0_independent"] = r["P0_independent"]
+        out["P0_probe_relative_spread"] = r["P0_probe_relative_spread"]
+    return out
+
+
 def build(domain_path: Path = DEFAULT_DOMAIN, *, stride: int = 1) -> dict:
     nodes = NODES.build()["nodes"]
     rows = []
@@ -335,6 +396,12 @@ def build(domain_path: Path = DEFAULT_DOMAIN, *, stride: int = 1) -> dict:
         "worst": worst,
         "worst_ratio": None if worst is None else worst["ratio"],
         "worst_clears_canonical_gate": bool(worst is not None and worst["ratio"] > GATE),
+        # A cell that can starve S for a whole word admits a legal word that
+        # never forgets its initial covariance.  For such a word no
+        # P0-independent whole-word lower exists at all, so the dwell figures
+        # above are conditional on S firing, which PR #476 showed is not a
+        # theorem of the current P2 quotient.
+        "dwell_result_conditional_on_S_firing": True,
         "rows": rows,
     }
 

--- a/tools/ou3_p3_whole_word_lower_feasibility.py
+++ b/tools/ou3_p3_whole_word_lower_feasibility.py
@@ -261,6 +261,50 @@ def _adverse_corner(node) -> tuple:
             float(node["R_S_filter_std"][1]))
 
 
+def adversarial_descent(seq, successors, ratio_fn, *, max_rounds: int = 8):
+    """Greedy single-swap descent toward the worst legal word.
+
+    ``successors(node)`` returns the legal successor set at the fixed gap and
+    ``ratio_fn(seq)`` scores a word.  Both are injected so this is testable
+    without building the P2 V1 runtime.
+
+    Single-cell dwell is *not* the adversary: mixing can beat it.  This finds by
+    how much.  It is a local search and returns a local minimum, never a proof of
+    the global worst legal word.
+    """
+    cur = list(seq)
+    best = ratio_fn(cur)
+    history = [best]
+    swaps = []
+    for _ in range(int(max_rounds)):
+        found = None
+        for pos in range(len(cur)):
+            prev = cur[pos - 1] if pos > 0 else None
+            nxt = cur[pos + 1] if pos + 1 < len(cur) else None
+            for cand in successors(prev) if prev is not None else range_of(cur):
+                if cand == cur[pos]:
+                    continue
+                if nxt is not None and nxt not in successors(cand):
+                    continue
+                trial = list(cur)
+                trial[pos] = cand
+                r = ratio_fn(trial)
+                if r < best * (1.0 - 1.0e-12):
+                    best, found = r, (pos, cand)
+        if found is None:
+            return {"word": cur, "ratio": best, "history": history,
+                    "swaps": swaps, "converged": True}
+        cur[found[0]] = found[1]
+        history.append(best)
+        swaps.append({"position": found[0], "node": found[1], "ratio": best})
+    return {"word": cur, "ratio": best, "history": history,
+            "swaps": swaps, "converged": False}
+
+
+def range_of(seq):
+    return sorted(set(seq))
+
+
 def build(domain_path: Path = DEFAULT_DOMAIN, *, stride: int = 1) -> dict:
     nodes = NODES.build()["nodes"]
     rows = []


### PR DESCRIPTION
Continues from merged #475. **#476 is ahead of this line of work**, and this PR now leads with the correction its findings force rather than the number it originally reported.

## Superseded headline, stated first

This PR originally claimed a worst-case horizon-matched ratio of 2.97e-8, clearing the `1e-18` gate by 10.47 orders, as evidence that a whole-word covariance **lower** is viable. **That claim is conditional on the `S` pseudo-measurement firing at all, and #476 proved that is not a theorem of the current P2 quotient.**

#476 certified that alternating two applied `tau` values *inside one source cell* drives the `S` firing count to zero across a whole 635-sample word. Reproduced here exactly with the shipping binary32 scheduler:

| word at node 720's cell, gap 13 | S firings |
| --- | --- |
| `tau` held at 9.533334732055664 | 24 |
| `tau` held at 9.533475875854492 | 24 |
| **alternating the two, same cell** | **0** |

The periods are 0.1300000101327896 and 0.13000193238258362, differing by 1.92e-6 against a binary32 scheduler tolerance of 1.91e-6; each stage boundary rebases the timer by `fmod` against the other period and the remainder never crosses.

A word with no `S` firing never forgets its initial covariance. Measured on that word: `P0_independent = False`, probe spread **0.999**. The reported ratio 3.11e-17 is a finite-probe artifact and the true value tends to zero as `P0` grows. **No `P0`-independent whole-word lower exists for that word.**

## Two real defects this exposed in the diagnostic, both fixed

1. **The scheduler was transcribed in double precision.** The deployed MEKF is `Kalman3D_Wave_OU_III<float>`. `periodic_update_due`'s tolerance is `16 * 2**-23 = 1.9e-6` in binary32 against 3.6e-15 in double, so a double transcription **cannot represent the starvation at all** and was not conservative.
2. **`PSEUDO_RATIO` was hand-written as `0.015/1.1`.** The C++ constant is a `constexpr float` quotient, `f32(f32(0.015)/f32(1.1)) = 0.013636362738907337`, against the double `0.013636363636363634`. The eighth-digit difference moves the pseudo period by 1.5e-8 s, which is decisive at a 1.9e-6 tolerance. Schedule constants are now parsed from the shipping header instead of restated.

With both fixed, `cadence_s` reproduces #476's certified periods bit-for-bit.

## What survives

The conditional result still stands *as a conditional result*, and is worth keeping because it bounds what a non-starved word can give:

| | value |
| --- | --- |
| worst single-cell dwell, 800 nodes at adverse corner | 3.51e-8 (node 729, binds `p`) |
| worst mixed legal word found (greedy local search) | 2.97e-8, 1.184x below the dwell |
| independent mpmath `dps=30` cross-check of the dwell | 3.50347e-08, agreeing to 0.24 percent |
| **S-starved legal word** | **no `P0`-independent lower exists** |

Also verified independently along the way:

- #476's four-max witness `729 --16--> 568 --16--> 407 --18--> 246 --25--> 85 --13--> 74 --13--> 63` is legal end-to-end, 101 samples;
- all 800 nodes self-loop on all 14 gaps, so every single-cell dwell **is** a legal word — checked rather than assumed, since the dwell headline rested on it;
- only 75 of 3995 single-segment substitutions around a 729 dwell are legal, because `729 -> cand -> 729` usually is not.

**Hypothesis falsified along the way:** I predicted mixing could only help a lower, since a mixed word visits faster-cadence cells. False — greedy descent beat the pure dwell by 1.184x using sources 569/649/729/798.

## Corrections to my own merged #475

- the claim that same-history P2 V1 correlation "is not what broke" is **withdrawn**; #476 disproved it;
- #475's fixed-cell firing counts (19 at `tau = 12 s`, 602 at `tau = 0.333 s`) do not transfer to changing-source words. The witness word fires 76–106 times. They remain valid only within a single cell.

## Non-promotion contract

Stdlib-only. The artifact carries `non_promoting: true`, `certifies_theorem_stage: false`, `interval_certified: false`, `quantifies_over_legal_histories: false`, and now `dwell_result_conditional_on_S_firing: true`. `validate()` fails if any flag is tampered with or the canonical `1e-18` threshold is moved.

16 tests, green. Four pin the starvation witness: the certified binary32 periods, starvation under alternation but not under holding, the loss of `P0`-independence on a starved word, and that `build()` records the conditionality. Two earlier tests encoded double-precision expectations and now assert the binary32 truth with the reason recorded in each.

## Next experiment

Not another lower against a quotient that admits starved words. The open question is upstream, and it is #476's: whether the canonical `WavePeriodEstimator` log-period state excludes the resonant `tau` sequence, or whether the theorem architecture must tolerate zero-`S` words outright. This PR's contribution is the measured conditional bound and a scheduler transcription faithful enough to see the starvation.

## Merge note

The ledger edit is surgical because #476 rewrites `docs/ou3-proof-research-state.md` wholesale; whichever lands second needs a small manual resolution there. The tool and test are new files and do not collide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUsVmRfaxHPUuhf7P9jPj7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated OU-III research notes with revised covariance analyses, scheduler corrections, diagnostic results, and clarified certificate limitations.
  * Documented whole-word feasibility, starvation conditions, measurement-update validation, and updated firing-bound results.

* **Tests**
  * Added coverage confirming measurement updates move state estimates toward their measurements.
  * Added validation for scheduler timing, covariance propagation, mixed-source behavior, adversarial word selection, and starvation scenarios.
  * Integrated the new measurement-update and whole-word feasibility checks into standard test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->