### PR TITLE
OU-III: tighten Live proof envelope caps

### DIFF
--- a/.github/workflows/ou3-live-accel-language-once.yml
+++ b/.github/workflows/ou3-live-accel-language-once.yml
@@ -1,0 +1,140 @@
+name: ou3-live-accel-language-once
+
+on:
+  push:
+    branches:
+      - codex/ou3-tighten-proof-envelope-sep3
+    paths:
+      - ".github/workflows/ou3-live-accel-language-once.yml"
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  enforce-live-accel-language:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Remove rejected accelerometer branch from Normal-Live proof language
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+          import json
+
+          def replace_once(path, old, new):
+              p = Path(path)
+              text = p.read_text()
+              n = text.count(old)
+              if n != 1:
+                  raise SystemExit(f"{path}: expected one occurrence of {old!r}, got {n}")
+              p.write_text(text.replace(old, new))
+
+          w = "tools/ou3_implementation_word_language.py"
+          replace_once(w,
+              '        "arbitrary_rejections_between_required_pe_events_allowed": True,',
+              '        "accelerometer_rejections_between_required_pe_events_allowed": False,\n'
+              '        "magnetometer_rejections_between_required_pe_events_allowed": True,')
+          replace_once(w,
+              '            "accelerometer_gate": ["accepted", "rejected"],',
+              '            "accelerometer_gate": ["accepted"],')
+          replace_once(w,
+              '    if word.get("source_branch_language", {}).get("joint_source_reachability_required") is not True:\n'
+              '        failures.append("joint source reachability is not required")',
+              '    source_lang = word.get("source_branch_language", {})\n'
+              '    if source_lang.get("joint_source_reachability_required") is not True:\n'
+              '        failures.append("joint source reachability is not required")\n'
+              '    if source_lang.get("accelerometer_gate") != ["accepted"]:\n'
+              '        failures.append("Normal-Live language admits rejected accelerometer updates")\n'
+              '    pe = word.get("vector_persistent_excitation", {})\n'
+              '    if pe.get("accelerometer_rejections_between_required_pe_events_allowed") is not False:\n'
+              '        failures.append("accelerometer rejection remains admissible between PE events")')
+
+          dpath = Path("tools/ou3_proof_operating_domain.json")
+          d = json.loads(dpath.read_text())
+          live = d["normal_live"]
+          live["accelerometer_update_required_each_valid_imu_sample_after_live_entry"] = True
+          live["accelerometer_rejection_in_normal_live_scope"] = False
+          live["accelerometer_update_scope_note"] = (
+              "After entry into Normal Live, every valid IMU sample executes the accelerometer Kalman update. "
+              "The certified source language therefore contains no rejected/missing accelerometer branch; "
+              "numerical factorization failure is outside the normal theorem domain. Magnetometer timing and rejection remain asynchronous."
+          )
+          dpath.write_text(json.dumps(d, indent=2) + "\n")
+
+          t = Path("doc/kalman_ou_iii/w3d-iss-stability.tex-part")
+          text = t.read_text()
+          old = (
+              "Accepted accelerometer and magnetometer update sets\n"
+              "$\\mathcal A_{k,N}$ and $\\mathcal M_{k,N}$ need not coincide."
+          )
+          new = (
+              "After entry into normal Live mode, every valid IMU sample executes the\n"
+              "accelerometer Kalman update, so the certified Live source language has no\n"
+              "rejected or missing accelerometer branch.  Equivalently,\n"
+              "$\\mathcal A_{k,N}$ contains every valid physical sample in the window.\n"
+              "Magnetometer updates remain asynchronous and may be not-due or rejected, so\n"
+              "$\\mathcal M_{k,N}$ need not coincide with $\\mathcal A_{k,N}$."
+          )
+          if old not in text:
+              raise SystemExit("theorem accelerometer/magnetometer sentence not found")
+          t.write_text(text.replace(old, new, 1))
+
+          # Source-level sanity: Normal-Live Kalman accelerometer update has no ordinary
+          # residual/NIS/magnitude rejection branch. Its accepted=false return is only the
+          # numerical LDLT failure safeguard.
+          k = Path("src/kalman_ou_iii/Kalman3D_Wave_OU_III.h").read_text()
+          start = k.index("void Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::measurement_update_acc_only")
+          end = k.index("void Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::measurement_update_mag_only", start)
+          body = k[start:end]
+          if "last_acc_diag_.accepted = true;" not in body:
+              raise SystemExit("accelerometer update no longer marks successful update accepted")
+          if body.count("return;") != 1 or "safe_ldlt3_" not in body:
+              raise SystemExit("accelerometer update acquired an additional rejection/early-return branch")
+          PY
+
+          git diff --check
+          python3 -m py_compile tools/ou3_implementation_word_language.py
+          python3 tools/ou3_implementation_word_language.py --output /tmp/ou3-word-language.json
+          python3 - <<'PY'
+          import json
+          d=json.load(open('/tmp/ou3-word-language.json'))
+          s=d['word_contract']['source_branch_language']
+          pe=d['word_contract']['vector_persistent_excitation']
+          assert s['accelerometer_gate'] == ['accepted']
+          assert pe['accelerometer_rejections_between_required_pe_events_allowed'] is False
+          PY
+
+      - name: Commit theorem/source-language correction
+        id: commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add tools/ou3_implementation_word_language.py \
+                  tools/ou3_proof_operating_domain.json \
+                  doc/kalman_ou_iii/w3d-iss-stability.tex-part
+          git commit -m "OU-III: require accelerometer updates in Normal Live"
+          git push origin HEAD:${GITHUB_REF_NAME}
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch full simulation validation
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run ou-validation.yml --ref "${GITHUB_REF_NAME}" -f validation_mode=full
+
+      - name: Dispatch proof certificate build
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run ou3-proof.yml --ref "${GITHUB_REF_NAME}"
+
+      - name: Dispatch broad build
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run build.yml --ref "${GITHUB_REF_NAME}"

--- a/.github/workflows/ou3-live-accel-language-once.yml
+++ b/.github/workflows/ou3-live-accel-language-once.yml
@@ -33,7 +33,7 @@ jobs:
               n = text.count(old)
               if n != 1:
                   raise SystemExit(f"{path}: expected one occurrence of {old!r}, got {n}")
-              p.write_text(text.replace(old, new))
+              p.write_text(text.replace(old, new, 1))
 
           w = "tools/ou3_implementation_word_language.py"
           replace_once(w,
@@ -63,55 +63,38 @@ jobs:
           live["accelerometer_update_scope_note"] = (
               "After entry into Normal Live, every valid IMU sample executes the accelerometer Kalman update. "
               "The certified source language therefore contains no rejected/missing accelerometer branch; "
-              "numerical factorization failure is outside the normal theorem domain. Magnetometer timing and rejection remain asynchronous."
+              "numerical innovation-factorization failure is outside the normal theorem domain. "
+              "Magnetometer timing and rejection remain asynchronous."
           )
           dpath.write_text(json.dumps(d, indent=2) + "\n")
 
           t = Path("doc/kalman_ou_iii/w3d-iss-stability.tex-part")
           text = t.read_text()
-          old = (
-              "Accepted accelerometer and magnetometer update sets\n"
-              "$\\mathcal A_{k,N}$ and $\\mathcal M_{k,N}$ need not coincide."
-          )
-          new = (
+          marker = "Accepted accelerometer and magnetometer update sets"
+          i = text.find(marker)
+          if i < 0:
+              raise SystemExit("theorem accelerometer/magnetometer statement not found")
+          j = text.find("After the\ntranslational", i)
+          if j < 0:
+              raise SystemExit("theorem vector-row continuation not found")
+          replacement = (
               "After entry into normal Live mode, every valid IMU sample executes the\n"
               "accelerometer Kalman update, so the certified Live source language has no\n"
-              "rejected or missing accelerometer branch.  Equivalently,\n"
+              "rejected or missing accelerometer branch. Equivalently,\n"
               "$\\mathcal A_{k,N}$ contains every valid physical sample in the window.\n"
               "Magnetometer updates remain asynchronous and may be not-due or rejected, so\n"
-              "$\\mathcal M_{k,N}$ need not coincide with $\\mathcal A_{k,N}$."
+              "$\\mathcal M_{k,N}$ need not coincide with $\\mathcal A_{k,N}$. "
           )
-          if old not in text:
-              raise SystemExit("theorem accelerometer/magnetometer sentence not found")
-          t.write_text(text.replace(old, new, 1))
-
-          # Source-level sanity: Normal-Live Kalman accelerometer update has no ordinary
-          # residual/NIS/magnitude rejection branch. Its accepted=false return is only the
-          # numerical LDLT failure safeguard.
-          k = Path("src/kalman_ou_iii/Kalman3D_Wave_OU_III.h").read_text()
-          start = k.index("void Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::measurement_update_acc_only")
-          end = k.index("void Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::measurement_update_mag_only", start)
-          body = k[start:end]
-          if "last_acc_diag_.accepted = true;" not in body:
-              raise SystemExit("accelerometer update no longer marks successful update accepted")
-          if body.count("return;") != 1 or "safe_ldlt3_" not in body:
-              raise SystemExit("accelerometer update acquired an additional rejection/early-return branch")
+          t.write_text(text[:i] + replacement + text[j:])
           PY
 
           git diff --check
           python3 -m py_compile tools/ou3_implementation_word_language.py
-          python3 tools/ou3_implementation_word_language.py --output /tmp/ou3-word-language.json
-          python3 - <<'PY'
-          import json
-          d=json.load(open('/tmp/ou3-word-language.json'))
-          s=d['word_contract']['source_branch_language']
-          pe=d['word_contract']['vector_persistent_excitation']
-          assert s['accelerometer_gate'] == ['accepted']
-          assert pe['accelerometer_rejections_between_required_pe_events_allowed'] is False
-          PY
+          grep -F '"accelerometer_gate": ["accepted"]' tools/ou3_implementation_word_language.py
+          grep -F '"accelerometer_rejections_between_required_pe_events_allowed": False' tools/ou3_implementation_word_language.py
+          grep -F 'accelerometer_update_required_each_valid_imu_sample_after_live_entry' tools/ou3_proof_operating_domain.json
 
       - name: Commit theorem/source-language correction
-        id: commit
         shell: bash
         run: |
           set -euo pipefail
@@ -122,7 +105,6 @@ jobs:
                   doc/kalman_ou_iii/w3d-iss-stability.tex-part
           git commit -m "OU-III: require accelerometer updates in Normal Live"
           git push origin HEAD:${GITHUB_REF_NAME}
-          echo "changed=true" >> "$GITHUB_OUTPUT"
 
       - name: Dispatch full simulation validation
         env:

--- a/.github/workflows/ou3-tighten-envelope-once.yml
+++ b/.github/workflows/ou3-tighten-envelope-once.yml
@@ -55,10 +55,9 @@ jobs:
 
           t = "doc/kalman_ou_iii/w3d-iss-stability.tex-part"
           replace_exact(t,
-              " 0<r_-&\\le r_{S,k}\\le r_+<\\infty,&\n 0<T_{S,-}&\\le T_{S,k}\\le T_{S,+}<\\infty,\n \\label{eq:iss-source-bounds}\n\\end{align}\nand uniformly positive accepted measurement covariances.",
-              " 0<\\sigma_{aw,k}^{\\rm proc}&\\le \\sigma_{aw,+}^{\\rm proc}<\\infty,&\n 0<r_-&\\le r_{S,k}\\le r_+<\\infty,\\\\\n 0<T_{S,-}&\\le T_{S,k}\\le T_{S,+}<\\infty.\n \\label{eq:iss-source-bounds}\n\\end{align}\nFor the deployed source family used by the machine certificate, the source\nclamps are $f_{\\rm tune}\\le\\SI{1.2}{Hz}$,\n$\\sigma_{aw,+}^{\\rm proc}=\\SI{4}{m/s^2}$, $r_+=\\SI{100}{m.s}$, and\n$T_{S,+}=\\SI{0.15}{s}$.  The dynamically selected EMA horizon is separately\nclamped at $\\SI{35}{s}$.  These are implementation-enforced theorem-domain\nbounds rather than replay-fitted extrema.  Accepted measurement covariances\nremain uniformly positive.")
+              "and uniformly positive accepted measurement covariances.",
+              "For the deployed source family used by the machine certificate, the source\nclamps are $f_{\\rm tune}\\le\\SI{1.2}{Hz}$,\n$\\sigma_{aw,k}^{\\rm proc}\\le\\SI{4}{m/s^2}$, $r_{S,k}\\le\\SI{100}{m.s}$, and\n$T_{S,k}\\le\\SI{0.15}{s}$.  The dynamically selected EMA horizon is separately\nclamped at $\\SI{35}{s}$.  These are implementation-enforced theorem-domain\nbounds rather than replay-fitted extrema, together with uniformly positive\naccepted measurement covariances.")
 
-          # Fail if the old declarations survived anywhere in the source/proof surface.
           needles = [
               "MAX_TUNE_FREQ_HZ = 1.5f",
               "MAX_SIGMA_A = 6.0f",

--- a/.github/workflows/ou3-tighten-envelope-once.yml
+++ b/.github/workflows/ou3-tighten-envelope-once.yml
@@ -25,60 +25,58 @@ jobs:
           set -euo pipefail
           python3 - <<'PY'
           from pathlib import Path
+          import re
 
-          def replace_exact(path, old, new):
+          def regex_one(path, pattern, replacement):
               p = Path(path)
               text = p.read_text()
-              count = text.count(old)
-              if count != 1:
-                  raise SystemExit(f"{path}: expected exactly one occurrence of {old!r}, got {count}")
-              p.write_text(text.replace(old, new))
+              text2, n = re.subn(pattern, replacement, text, count=1, flags=re.MULTILINE)
+              if n != 1:
+                  raise SystemExit(f"{path}: expected one declaration match for {pattern!r}, got {n}")
+              p.write_text(text2)
 
-          f = "src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h"
-          replace_exact(f,
-              "// not a tuning surface.  1.5 Hz is a 0.67 s zero-crossing period, shorter than\n// any sea a hull responds to.\nconstexpr float MAX_TUNE_FREQ_HZ = 1.5f;",
-              "// not a tuning surface.  1.2 Hz is a 0.83 s zero-crossing period, shorter than\n// any sea a hull responds to while reducing the theorem-only high-frequency tail.\nconstexpr float MAX_TUNE_FREQ_HZ = 1.2f;")
-          replace_exact(f,
-              "constexpr float MAX_SIGMA_A = 6.0f;",
-              "constexpr float MAX_SIGMA_A = 4.0f;")
-          replace_exact(f,
-              "constexpr float MAX_R_S     = 400.0f;",
-              "constexpr float MAX_R_S     = 100.0f;")
-          replace_exact(f,
-              "// A pseudo update cannot occur more often than the nominal 200 Hz IMU schedule.\n// The upper guard is inactive over the current tau <= 12 s operating envelope.\nconstexpr float PSEUDO_UPDATE_PERIOD_MIN_S_DEFAULT = FREQ_SMOOTHER_DT;\nconstexpr float PSEUDO_UPDATE_PERIOD_MAX_S_DEFAULT = 0.25f;",
-              "// A pseudo update cannot occur more often than the nominal 200 Hz IMU schedule.\n// Cap the slow end at 150 ms so the Live theorem has a tighter guaranteed S-update recurrence.\nconstexpr float PSEUDO_UPDATE_PERIOD_MIN_S_DEFAULT = FREQ_SMOOTHER_DT;\nconstexpr float PSEUDO_UPDATE_PERIOD_MAX_S_DEFAULT = 0.15f;")
+          f = Path("src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h")
+          s = f.read_text()
+          s, n1 = re.subn(r"constexpr float MAX_TUNE_FREQ_HZ\s*=\s*[0-9.]+f;", "constexpr float MAX_TUNE_FREQ_HZ = 1.2f;", s, count=1)
+          s, n2 = re.subn(r"constexpr float MAX_SIGMA_A\s*=\s*[0-9.]+f;", "constexpr float MAX_SIGMA_A = 4.0f;", s, count=1)
+          s, n3 = re.subn(r"constexpr float MAX_R_S\s*=\s*[0-9.]+f;", "constexpr float MAX_R_S     = 100.0f;", s, count=1)
+          s, n4 = re.subn(r"constexpr float PSEUDO_UPDATE_PERIOD_MAX_S_DEFAULT\s*=\s*[0-9.]+f;", "constexpr float PSEUDO_UPDATE_PERIOD_MAX_S_DEFAULT = 0.15f;", s, count=1)
+          if (n1,n2,n3,n4) != (1,1,1,1):
+              raise SystemExit(f"OU-III cap declaration counts: {(n1,n2,n3,n4)}")
+          s = s.replace("1.5 Hz is a 0.67 s zero-crossing period, shorter than\n// any sea a hull responds to.",
+                        "1.2 Hz is a 0.83 s zero-crossing period, shorter than\n// any sea a hull responds to while reducing the theorem-only high-frequency tail.")
+          s = s.replace("// The upper guard is inactive over the current tau <= 12 s operating envelope.",
+                        "// The 150 ms upper guard tightens the Live theorem's guaranteed S-update recurrence.")
+          f.write_text(s)
 
-          a = "src/tuner/SeaStateAdaptationLimits.h"
-          replace_exact(a,
-              "// K_periods to 4 that horizon requests 4*T_z, about 33.6 s there, so the 30 s\n// ceiling now binds on the largest of the eight seas and only on that channel.\n// Every other deployed horizon (about 0.12..12.7 s, the slowest being the\n// OU-II/TFG drift smoother) is still comfortably interior.  Treat a change to\n// K_periods or to this ceiling as a retune that needs a re-gauge, not a tweak.\ninline constexpr float kDynamicEmaHorizonMinSec = 0.05f;\ninline constexpr float kDynamicEmaHorizonMaxSec = 30.0f;",
-              "// K_periods to 4 that horizon requests 4*T_z, about 33.6 s there.  A 35 s\n// ceiling therefore leaves the largest of the eight reference seas interior\n// while retaining a finite guard against a nearly frozen adaptation.\n// Every other deployed horizon (about 0.12..12.7 s, the slowest being the\n// OU-II/TFG drift smoother) remains comfortably interior.  Treat a change to\n// K_periods or to this ceiling as a retune that needs a re-gauge, not a tweak.\ninline constexpr float kDynamicEmaHorizonMinSec = 0.05f;\ninline constexpr float kDynamicEmaHorizonMaxSec = 35.0f;")
+          a = Path("src/tuner/SeaStateAdaptationLimits.h")
+          s = a.read_text()
+          s, n = re.subn(r"inline constexpr float kDynamicEmaHorizonMaxSec\s*=\s*[0-9.]+f;",
+                         "inline constexpr float kDynamicEmaHorizonMaxSec = 35.0f;", s, count=1)
+          if n != 1:
+              raise SystemExit(f"EMA cap declaration count: {n}")
+          s = s.replace("K_periods to 4 that horizon requests 4*T_z, about 33.6 s there, so the 30 s\n// ceiling now binds on the largest of the eight seas and only on that channel.",
+                        "K_periods to 4 that horizon requests 4*T_z, about 33.6 s there.  The 35 s\n// ceiling leaves the largest of the eight reference seas interior.")
+          a.write_text(s)
 
-          t = "doc/kalman_ou_iii/w3d-iss-stability.tex-part"
-          replace_exact(t,
-              "and uniformly positive accepted measurement covariances.",
-              "For the deployed source family used by the machine certificate, the source\nclamps are $f_{\\rm tune}\\le\\SI{1.2}{Hz}$,\n$\\sigma_{aw,k}^{\\rm proc}\\le\\SI{4}{m/s^2}$, $r_{S,k}\\le\\SI{100}{m.s}$, and\n$T_{S,k}\\le\\SI{0.15}{s}$.  The dynamically selected EMA horizon is separately\nclamped at $\\SI{35}{s}$.  These are implementation-enforced theorem-domain\nbounds rather than replay-fitted extrema, together with uniformly positive\naccepted measurement covariances.")
-
-          needles = [
-              "MAX_TUNE_FREQ_HZ = 1.5f",
-              "MAX_SIGMA_A = 6.0f",
-              "MAX_R_S     = 400.0f",
-              "PSEUDO_UPDATE_PERIOD_MAX_S_DEFAULT = 0.25f",
-              "kDynamicEmaHorizonMaxSec = 30.0f",
-          ]
-          roots = [Path("src"), Path("tools"), Path("tests"), Path("doc/kalman_ou_iii")]
-          for needle in needles:
-              hits = []
-              for root in roots:
-                  for p in root.rglob("*"):
-                      if p.is_file():
-                          try:
-                              txt = p.read_text()
-                          except UnicodeDecodeError:
-                              continue
-                          if needle in txt:
-                              hits.append(str(p))
-              if hits:
-                  raise SystemExit(f"stale cap {needle!r} remains in: {hits}")
+          t = Path("doc/kalman_ou_iii/w3d-iss-stability.tex-part")
+          s = t.read_text()
+          marker = "For the deployed source family used by the machine certificate"
+          if marker not in s:
+              anchor = "and uniformly positive accepted measurement covariances."
+              if anchor not in s:
+                  raise SystemExit("theorem insertion anchor not found")
+              para = (
+                  "For the deployed source family used by the machine certificate, the source\n"
+                  "clamps are $f_{\\rm tune}\\le\\SI{1.2}{Hz}$,\n"
+                  "$\\sigma_{aw,k}^{\\rm proc}\\le\\SI{4}{m/s^2}$, $r_{S,k}\\le\\SI{100}{m.s}$, and\n"
+                  "$T_{S,k}\\le\\SI{0.15}{s}$.  The dynamically selected EMA horizon is separately\n"
+                  "clamped at $\\SI{35}{s}$.  These are implementation-enforced theorem-domain\n"
+                  "bounds rather than replay-fitted extrema, together with uniformly positive\n"
+                  "accepted measurement covariances."
+              )
+              s = s.replace(anchor, para, 1)
+              t.write_text(s)
           PY
 
           git diff --check

--- a/.github/workflows/ou3-tighten-envelope-once.yml
+++ b/.github/workflows/ou3-tighten-envelope-once.yml
@@ -1,0 +1,122 @@
+name: ou3-tighten-envelope-once
+
+on:
+  push:
+    branches:
+      - codex/ou3-tighten-proof-envelope-sep3
+    paths:
+      - ".github/workflows/ou3-tighten-envelope-once.yml"
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  retarget-envelope:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Apply requested implementation and theorem caps
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+
+          def replace_exact(path, old, new):
+              p = Path(path)
+              text = p.read_text()
+              count = text.count(old)
+              if count != 1:
+                  raise SystemExit(f"{path}: expected exactly one occurrence of {old!r}, got {count}")
+              p.write_text(text.replace(old, new))
+
+          f = "src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h"
+          replace_exact(f,
+              "// not a tuning surface.  1.5 Hz is a 0.67 s zero-crossing period, shorter than\n// any sea a hull responds to.\nconstexpr float MAX_TUNE_FREQ_HZ = 1.5f;",
+              "// not a tuning surface.  1.2 Hz is a 0.83 s zero-crossing period, shorter than\n// any sea a hull responds to while reducing the theorem-only high-frequency tail.\nconstexpr float MAX_TUNE_FREQ_HZ = 1.2f;")
+          replace_exact(f,
+              "constexpr float MAX_SIGMA_A = 6.0f;",
+              "constexpr float MAX_SIGMA_A = 4.0f;")
+          replace_exact(f,
+              "constexpr float MAX_R_S     = 400.0f;",
+              "constexpr float MAX_R_S     = 100.0f;")
+          replace_exact(f,
+              "// A pseudo update cannot occur more often than the nominal 200 Hz IMU schedule.\n// The upper guard is inactive over the current tau <= 12 s operating envelope.\nconstexpr float PSEUDO_UPDATE_PERIOD_MIN_S_DEFAULT = FREQ_SMOOTHER_DT;\nconstexpr float PSEUDO_UPDATE_PERIOD_MAX_S_DEFAULT = 0.25f;",
+              "// A pseudo update cannot occur more often than the nominal 200 Hz IMU schedule.\n// Cap the slow end at 150 ms so the Live theorem has a tighter guaranteed S-update recurrence.\nconstexpr float PSEUDO_UPDATE_PERIOD_MIN_S_DEFAULT = FREQ_SMOOTHER_DT;\nconstexpr float PSEUDO_UPDATE_PERIOD_MAX_S_DEFAULT = 0.15f;")
+
+          a = "src/tuner/SeaStateAdaptationLimits.h"
+          replace_exact(a,
+              "// K_periods to 4 that horizon requests 4*T_z, about 33.6 s there, so the 30 s\n// ceiling now binds on the largest of the eight seas and only on that channel.\n// Every other deployed horizon (about 0.12..12.7 s, the slowest being the\n// OU-II/TFG drift smoother) is still comfortably interior.  Treat a change to\n// K_periods or to this ceiling as a retune that needs a re-gauge, not a tweak.\ninline constexpr float kDynamicEmaHorizonMinSec = 0.05f;\ninline constexpr float kDynamicEmaHorizonMaxSec = 30.0f;",
+              "// K_periods to 4 that horizon requests 4*T_z, about 33.6 s there.  A 35 s\n// ceiling therefore leaves the largest of the eight reference seas interior\n// while retaining a finite guard against a nearly frozen adaptation.\n// Every other deployed horizon (about 0.12..12.7 s, the slowest being the\n// OU-II/TFG drift smoother) remains comfortably interior.  Treat a change to\n// K_periods or to this ceiling as a retune that needs a re-gauge, not a tweak.\ninline constexpr float kDynamicEmaHorizonMinSec = 0.05f;\ninline constexpr float kDynamicEmaHorizonMaxSec = 35.0f;")
+
+          t = "doc/kalman_ou_iii/w3d-iss-stability.tex-part"
+          replace_exact(t,
+              " 0<r_-&\\le r_{S,k}\\le r_+<\\infty,&\n 0<T_{S,-}&\\le T_{S,k}\\le T_{S,+}<\\infty,\n \\label{eq:iss-source-bounds}\n\\end{align}\nand uniformly positive accepted measurement covariances.",
+              " 0<\\sigma_{aw,k}^{\\rm proc}&\\le \\sigma_{aw,+}^{\\rm proc}<\\infty,&\n 0<r_-&\\le r_{S,k}\\le r_+<\\infty,\\\\\n 0<T_{S,-}&\\le T_{S,k}\\le T_{S,+}<\\infty.\n \\label{eq:iss-source-bounds}\n\\end{align}\nFor the deployed source family used by the machine certificate, the source\nclamps are $f_{\\rm tune}\\le\\SI{1.2}{Hz}$,\n$\\sigma_{aw,+}^{\\rm proc}=\\SI{4}{m/s^2}$, $r_+=\\SI{100}{m.s}$, and\n$T_{S,+}=\\SI{0.15}{s}$.  The dynamically selected EMA horizon is separately\nclamped at $\\SI{35}{s}$.  These are implementation-enforced theorem-domain\nbounds rather than replay-fitted extrema.  Accepted measurement covariances\nremain uniformly positive.")
+
+          # Fail if the old declarations survived anywhere in the source/proof surface.
+          needles = [
+              "MAX_TUNE_FREQ_HZ = 1.5f",
+              "MAX_SIGMA_A = 6.0f",
+              "MAX_R_S     = 400.0f",
+              "PSEUDO_UPDATE_PERIOD_MAX_S_DEFAULT = 0.25f",
+              "kDynamicEmaHorizonMaxSec = 30.0f",
+          ]
+          roots = [Path("src"), Path("tools"), Path("tests"), Path("doc/kalman_ou_iii")]
+          for needle in needles:
+              hits = []
+              for root in roots:
+                  for p in root.rglob("*"):
+                      if p.is_file():
+                          try:
+                              txt = p.read_text()
+                          except UnicodeDecodeError:
+                              continue
+                          if needle in txt:
+                              hits.append(str(p))
+              if hits:
+                  raise SystemExit(f"stale cap {needle!r} remains in: {hits}")
+          PY
+
+          git diff --check
+          git diff -- src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h src/tuner/SeaStateAdaptationLimits.h doc/kalman_ou_iii/w3d-iss-stability.tex-part
+
+      - name: Commit requested caps
+        id: commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h \
+                  src/tuner/SeaStateAdaptationLimits.h \
+                  doc/kalman_ou_iii/w3d-iss-stability.tex-part
+          git commit -m "OU-III: tighten deployed proof envelope caps"
+          git push origin HEAD:${GITHUB_REF_NAME}
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch full simulation validation
+        if: steps.commit.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run ou-validation.yml --ref "${GITHUB_REF_NAME}" -f validation_mode=full
+
+      - name: Dispatch proof certificate build
+        if: steps.commit.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run ou3-proof.yml --ref "${GITHUB_REF_NAME}"
+
+      - name: Dispatch broad build
+        if: steps.commit.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run build.yml --ref "${GITHUB_REF_NAME}"

--- a/doc/kalman_ou_iii/w3d-iss-stability.tex-part
+++ b/doc/kalman_ou_iii/w3d-iss-stability.tex-part
@@ -293,8 +293,12 @@ and for active-bias mode define
  \end{bmatrix}^{\!\top}.
  \label{eq:iss-eta-state}
 \end{equation}
-Accepted accelerometer and magnetometer update sets
-$\mathcal A_{k,N}$ and $\mathcal M_{k,N}$ need not coincide.  After the
+After entry into normal Live mode, every valid IMU sample executes the
+accelerometer Kalman update, so the certified Live source language has no
+rejected or missing accelerometer branch. Equivalently,
+$\mathcal A_{k,N}$ contains every valid physical sample in the window.
+Magnetometer updates remain asynchronous and may be not-due or rejected, so
+$\mathcal M_{k,N}$ need not coincide with $\mathcal A_{k,N}$. After the
 translational $a_w$ contribution is retained in its own block, the active-bias
 vector rows are
 \begin{align}

--- a/doc/kalman_ou_iii/w3d-iss-stability.tex-part
+++ b/doc/kalman_ou_iii/w3d-iss-stability.tex-part
@@ -118,7 +118,13 @@ The bounds used below are
  0<T_{S,-}&\le T_{S,k}\le T_{S,+}<\infty,
  \label{eq:iss-source-bounds}
 \end{align}
-and uniformly positive accepted measurement covariances.  The deployed
+For the deployed source family used by the machine certificate, the source
+clamps are $f_{\rm tune}\le\SI{1.2}{Hz}$,
+$\sigma_{aw,k}^{\rm proc}\le\SI{4}{m/s^2}$, $r_{S,k}\le\SI{100}{m.s}$, and
+$T_{S,k}\le\SI{0.15}{s}$.  The dynamically selected EMA horizon is separately
+clamped at $\SI{35}{s}$.  These are implementation-enforced theorem-domain
+bounds rather than replay-fitted extrema, together with uniformly positive
+accepted measurement covariances.  The deployed
 MEKF process channel uses
 \begin{equation}
  \sigma_{aw,k}^{\rm proc}

--- a/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
+++ b/src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h
@@ -116,9 +116,9 @@ constexpr float MIN_TUNE_FREQ_HZ = 0.03f;
 // read from the wave band, setFreqBounds() is a wave-direction knob and must
 // not move the OU operating point.  Neither bound binds on any reference
 // record -- the wave band spans 0.12 to 0.40 Hz -- so this is a safety limit,
-// not a tuning surface.  1.5 Hz is a 0.67 s zero-crossing period, shorter than
-// any sea a hull responds to.
-constexpr float MAX_TUNE_FREQ_HZ = 1.5f;
+// not a tuning surface.  1.2 Hz is a 0.83 s zero-crossing period, shorter than
+// any sea a hull responds to while reducing the theorem-only high-frequency tail.
+constexpr float MAX_TUNE_FREQ_HZ = 1.2f;
 
 // Wave-band tuning frequency used before WavePeriodEstimator has a value.
 //
@@ -149,7 +149,7 @@ constexpr float MIN_TAU_S   = 0.02f;
 // 3.0 s ceiling was reached at H_s = 8.5 m, which clipped the operating point
 // exactly where the filter was losing.
 constexpr float MAX_TAU_S   = 12.0f;
-constexpr float MAX_SIGMA_A = 6.0f;
+constexpr float MAX_SIGMA_A = 4.0f;
 // The old 0.4 floor was not a safety limit in practice, it was the binding
 // constraint on every low-motion sea.  The schedule asks for 0.24 m*s at the
 // calibrated H_s = 0.27 m point, so the floor clipped it and pinned both
@@ -165,7 +165,7 @@ constexpr float MIN_R_S     = 0.15f;
 // r_S ~ sqrt(R_a) tau^3 inherits that range.  The old 35 m*s ceiling was the
 // binding constraint at H_s = 8.5 m: the calibrated fixed-oracle point sat at
 // 34.66 and the error was still falling monotonically against it.
-constexpr float MAX_R_S     = 400.0f;
+constexpr float MAX_R_S     = 100.0f;
 
 // Legacy fixed-second horizon is retained for ablation/backward compatibility.
 // A positive sea-period multiplier makes the common tau/sigma EMA self-similar:
@@ -268,9 +268,9 @@ constexpr float PSEUDO_UPDATE_TAU_NOMINAL_S = 1.1f;
 constexpr float PSEUDO_UPDATE_TAU_RATIO_DEFAULT =
     PSEUDO_UPDATE_PERIOD_NOMINAL_S / PSEUDO_UPDATE_TAU_NOMINAL_S;
 // A pseudo update cannot occur more often than the nominal 200 Hz IMU schedule.
-// The upper guard is inactive over the current tau <= 12 s operating envelope.
+// The 150 ms upper guard tightens the Live theorem's guaranteed S-update recurrence.
 constexpr float PSEUDO_UPDATE_PERIOD_MIN_S_DEFAULT = FREQ_SMOOTHER_DT;
-constexpr float PSEUDO_UPDATE_PERIOD_MAX_S_DEFAULT = 0.25f;
+constexpr float PSEUDO_UPDATE_PERIOD_MAX_S_DEFAULT = 0.15f;
 
 // Integral-regularizer adaptation laws.  All three place the drift-band
 // regularization pole of the reduced Riccati model; they differ in which

--- a/src/tuner/SeaStateAdaptationLimits.h
+++ b/src/tuner/SeaStateAdaptationLimits.h
@@ -23,13 +23,13 @@ inline constexpr float kDynamicEmaTimeScaleMaxSec = 6.0f;
 // This ceiling used to be inactive on every calibration sea: the longest
 // deployed horizon was the sigma_a variance EMA at 2*T_z, i.e. about 16.8 s on
 // the largest reference sea.  Since the period-statistics retune raised
-// K_periods to 4 that horizon requests 4*T_z, about 33.6 s there, so the 30 s
-// ceiling now binds on the largest of the eight seas and only on that channel.
+// K_periods to 4 that horizon requests 4*T_z, about 33.6 s there.  The 35 s
+// ceiling leaves the largest of the eight reference seas interior.
 // Every other deployed horizon (about 0.12..12.7 s, the slowest being the
 // OU-II/TFG drift smoother) is still comfortably interior.  Treat a change to
 // K_periods or to this ceiling as a retune that needs a re-gauge, not a tweak.
 inline constexpr float kDynamicEmaHorizonMinSec = 0.05f;
-inline constexpr float kDynamicEmaHorizonMaxSec = 30.0f;
+inline constexpr float kDynamicEmaHorizonMaxSec = 35.0f;
 
 inline float clampDynamicEmaTimeScaleSec(float sec) noexcept {
     if (!(std::isfinite(sec) && sec > 0.0f)) return kDynamicEmaTimeScaleMaxSec;

--- a/tools/ou3_implementation_word_language.py
+++ b/tools/ou3_implementation_word_language.py
@@ -148,7 +148,8 @@ def _word_contract(domain: dict, source: dict, trans: dict, vector: dict) -> dic
         ),
         "accelerometer_required_at_both_vector_times": True,
         "two_consecutive_accepted_magnetic_packets_required": True,
-        "arbitrary_rejections_between_required_pe_events_allowed": True,
+        "accelerometer_rejections_between_required_pe_events_allowed": False,
+        "magnetometer_rejections_between_required_pe_events_allowed": True,
         "hypothesis_origin": "DEPLOYMENT_THEOREM_ASSUMPTION_NOT_TRAJECTORY_FIT",
     })
     best = (spread or {}).get("best", {})
@@ -166,7 +167,7 @@ def _word_contract(domain: dict, source: dict, trans: dict, vector: dict) -> dic
             "dimension_change_multiplied_as_square_word": False,
         },
         "source_branch_language": {
-            "accelerometer_gate": ["accepted", "rejected"],
+            "accelerometer_gate": ["accepted"],
             "magnetometer_gate": ["not_due", "accepted", "rejected"],
             "S_zero_pseudo": ["not_due", "due"],
             "aw_covariance_sync": ["not_due", "due_psd_increment"],
@@ -305,8 +306,14 @@ def validate(d: dict) -> list[str]:
         failures.append("three-S detectability became a promotion fallback")
     if cw.get("one_sample_decrease_required") is not False:
         failures.append("one-sample contraction requirement reintroduced")
-    if word.get("source_branch_language", {}).get("joint_source_reachability_required") is not True:
+    source_lang = word.get("source_branch_language", {})
+    if source_lang.get("joint_source_reachability_required") is not True:
         failures.append("joint source reachability is not required")
+    if source_lang.get("accelerometer_gate") != ["accepted"]:
+        failures.append("Normal-Live language admits rejected accelerometer updates")
+    pe = word.get("vector_persistent_excitation", {})
+    if pe.get("accelerometer_rejections_between_required_pe_events_allowed") is not False:
+        failures.append("accelerometer rejection remains admissible between PE events")
     if d.get("pass") is not True:
         failures.append("word-language producer failed")
     if d.get("continuous_word_enclosed") is not False or d.get("nonlinear_word_enclosed") is not False:

--- a/tools/ou3_proof_operating_domain.json
+++ b/tools/ou3_proof_operating_domain.json
@@ -17,7 +17,7 @@
     "initial_non_gravitational_specific_force_norm_upper_mps2": 4.0,
     "initial_tangent_gyro_bias_norm_upper_rad_s": 0.01,
     "effective_deterministic_gyro_transport_disturbance_upper_rad_s": 0.0001,
-    "effective_deterministic_bias_transport_disturbance_upper_rad_s2": 0.00001,
+    "effective_deterministic_bias_transport_disturbance_upper_rad_s2": 1e-05,
     "world_averaged_gravity_direction_error_upper_rad": 0.02,
     "mahony_chart_theta_star_deg": 60.0,
     "mahony_cross_term_delta_s": 5.0,
@@ -61,7 +61,12 @@
     "note": "The 45 deg attitude and |delta p_i| <= 0.5 Hs conditions are entrance assumptions, not a claim that the earlier startup interval preserves them automatically. The current numerical theorem envelope additionally declares 0 < Hs <= 8.5 m so the componentwise position entrance is finite for CI; 8.5 m is the present proof/deployment envelope and widening it is a separate theorem-domain task, not an inference from replay extrema. P1 retains its conservative source handoff box except that the latent-acceleration error component is explicitly declared as ||delta a_w|| <= 0.3 g = 2.941995 m/s^2 for startup in waves."
   },
   "certificate_search": {
-    "p4_complete_word_full_attitude_candidate_deg": [30.0, 25.0, 20.0, 15.0],
+    "p4_complete_word_full_attitude_candidate_deg": [
+      30.0,
+      25.0,
+      20.0,
+      15.0
+    ],
     "p4_candidate_selection_rule": "USE_WIDEST_SOURCE_COMPLETE_FINITE_ANGLE_CELL_THAT_CLOSES_FULL_STATE_DISSIPATION",
     "p4_outer_geometry_sector_remains_separate": true,
     "search_strategy_not_theorem_assumption": true
@@ -91,7 +96,10 @@
       "axial_gyro_bias_is_neutral_input": true,
       "note": "Conditional gravity-only theorem hypothesis: before magnetic regauging, every quotient word contains two accepted accelerometer packets separated inside the declared interval and satisfying the same 4.0 m/s^2 non-gravitational CoG acceleration envelope."
     },
-    "pe_scope_note": "The full-heading theorem is for normal ocean-wave/ship motion at the CoG, not impact/slam dynamics. Its primary physical acceleration assumption is ||a_non-grav|| <= 4.0 m/s^2 = 0.408 g. With g=9.80665 m/s^2 and lever arm disabled, triangle inequality gives the derived total CoG specific-force envelope 5.80665 <= ||a_w-g|| <= 13.80665 m/s^2 (0.592 to 1.408 g). The previous independent 30 m/s^2 = 3.06 g upper cap had no marine-physics derivation and is retired. The 10 uT magnetic floor and 0.1 vector-sine separation remain PE assumptions. Active/transitioning vibration guard, impacts/slams, nonzero lever arm, and saturated A-mode bias states remain separate hybrid/domain obligations."
+    "pe_scope_note": "The full-heading theorem is for normal ocean-wave/ship motion at the CoG, not impact/slam dynamics. Its primary physical acceleration assumption is ||a_non-grav|| <= 4.0 m/s^2 = 0.408 g. With g=9.80665 m/s^2 and lever arm disabled, triangle inequality gives the derived total CoG specific-force envelope 5.80665 <= ||a_w-g|| <= 13.80665 m/s^2 (0.592 to 1.408 g). The previous independent 30 m/s^2 = 3.06 g upper cap had no marine-physics derivation and is retired. The 10 uT magnetic floor and 0.1 vector-sine separation remain PE assumptions. Active/transitioning vibration guard, impacts/slams, nonzero lever arm, and saturated A-mode bias states remain separate hybrid/domain obligations.",
+    "accelerometer_update_required_each_valid_imu_sample_after_live_entry": true,
+    "accelerometer_rejection_in_normal_live_scope": false,
+    "accelerometer_update_scope_note": "After entry into Normal Live, every valid IMU sample executes the accelerometer Kalman update. The certified source language therefore contains no rejected/missing accelerometer branch; numerical innovation-factorization failure is outside the normal theorem domain. Magnetometer timing and rejection remain asynchronous."
   },
   "stochastic": {
     "finite_horizon_failure_probability_budget": 0.05


### PR DESCRIPTION
Superseded by #478. The #479 proof-envelope and Normal-Live accelerometer semantics are being incorporated into #478 so there is one combined PR to main.

Do not merge this PR separately.