### PR TITLE
Make main build again: unblock the evidence commit gate and clear clang-tidy

### DIFF
--- a/.github/workflows/ou-validation.yml
+++ b/.github/workflows/ou-validation.yml
@@ -317,7 +317,7 @@ jobs:
         run: |
           mkdir -p plots/kalman_ou_ii
           unzip -o sim-data-files.zip -d plots/kalman_ou_ii >/dev/null
-          make -C tests/validation test
+          make -C tests/validation evidence-test
 
   # Evidence regeneration is sharded: the full validation study is roughly
   # 840 twenty-minute simulator replays and robustness another ~310. It runs
@@ -529,7 +529,12 @@ jobs:
     needs: combine
     if: inputs.validation_mode == 'full'
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    # The contract run below is the long step here, and it grows with the
+    # evidence suite. Twenty minutes stopped covering it: the job was killed
+    # mid-suite on every main push from 2026-09-03 on, which left the branch
+    # with unpublished evidence and skipped the whole document build behind it.
+    # Sized for the suite plus the apt install and the retrying push.
+    timeout-minutes: 45
     permissions:
       contents: write
     steps:
@@ -667,9 +672,14 @@ jobs:
       # Run every sync/contract step first. Only then hash reports/results, so
       # the recorded results fingerprint describes the exact tree that will be
       # committed rather than a pre-validation intermediate tree.
+      #
+      # `evidence-test` is the whole suite minus the staged OU-III proof
+      # searches, which read source and tooling only and cannot be moved by a
+      # regenerated bundle. ou3-proof.yml owns those and gives them the hours
+      # they need; publishing evidence behind them is what timed this job out.
       - name: Check the manuscript against the regenerated evidence
         if: steps.published.outputs.already != 'true'
-        run: make -C tests/validation test
+        run: make -C tests/validation evidence-test
 
       - name: Record replay and results fingerprints
         if: steps.published.outputs.already != 'true'
@@ -716,6 +726,6 @@ jobs:
             python3 tools/ou_replay_fingerprint.py \
               --simulation-zip sim-data-files.zip \
               --check reports/ou_evidence_fingerprint.json
-            make -C tests/validation test
+            make -C tests/validation evidence-test
           done
           exit 1

--- a/src/kalman_ou_ii/Kalman3D_Wave_OU_II.h
+++ b/src/kalman_ou_ii/Kalman3D_Wave_OU_II.h
@@ -1942,7 +1942,7 @@ void Kalman3D_Wave_OU_II<T, with_gyro_bias, with_accel_bias>::measurement_update
     const Vector3 aw = xext.template segment<3>(OFF_AW);
     const Vector3 f_pred = R_wb() * (aw - g_world) + lever + ba_term;
 
-    const Vector3 f_meas = acc_meas;
+    const Vector3& f_meas = acc_meas;
     const Vector3 r = f_meas - f_pred;
 
     last_acc_diag_.r = r;

--- a/src/kalman_ou_iii/Kalman3D_Wave_OU_III.h
+++ b/src/kalman_ou_iii/Kalman3D_Wave_OU_III.h
@@ -1975,7 +1975,7 @@ void Kalman3D_Wave_OU_III<T, with_gyro_bias, with_accel_bias>::measurement_updat
     const Vector3 aw = xext.template segment<3>(OFF_AW);
     const Vector3 f_pred = R_wb() * (aw - g_world) + lever + ba_term;
 
-    const Vector3 f_meas = acc_meas;
+    const Vector3& f_meas = acc_meas;
     const Vector3 r = f_meas - f_pred;
 
     last_acc_diag_.r = r;

--- a/src/nlo/TimeVarGainNLO_Adapter.h
+++ b/src/nlo/TimeVarGainNLO_Adapter.h
@@ -82,7 +82,7 @@ public:
     struct Telemetry {
         R k1 = std::numeric_limits<R>::quiet_NaN();
         R k2 = std::numeric_limits<R>::quiet_NaN();
-        R kI = std::numeric_limits<R>::quiet_NaN();
+        R k_integral = std::numeric_limits<R>::quiet_NaN();
         R vartheta = std::numeric_limits<R>::quiet_NaN();
         R p0z_hat = std::numeric_limits<R>::quiet_NaN();
 
@@ -698,7 +698,7 @@ public:
 
         s.tvg.k1 = filter_.gainK1();
         s.tvg.k2 = filter_.gainK2();
-        s.tvg.kI = filter_.gainKI();
+        s.tvg.k_integral = filter_.gainKI();
         s.tvg.vartheta = filter_.gainVartheta();
         s.tvg.p0z_hat = filter_.integratedVerticalPositionState();
 

--- a/src/util/W3dSimCommon.cpp
+++ b/src/util/W3dSimCommon.cpp
@@ -1013,7 +1013,7 @@ static void write_tvg_nlo_csv_row(std::ofstream& ofs, const TvgNloFilterSnapshot
 
     ofs << "," << d.k1
         << "," << d.k2
-        << "," << d.kI
+        << "," << d.k_integral
         << "," << d.vartheta
         << "," << d.theta
         << "," << d.p0z_hat

--- a/src/util/W3dSimCommon.h
+++ b/src/util/W3dSimCommon.h
@@ -289,7 +289,7 @@ struct FilterSnapshot {
 struct TvgNloTelemetry {
     float k1 = NAN;
     float k2 = NAN;
-    float kI = NAN;
+    float k_integral = NAN;
     float vartheta = NAN;
     float theta = NAN;
     float p0z_hat = NAN;

--- a/tests/kalman_tfg/lie_group-test.cpp
+++ b/tests/kalman_tfg/lie_group-test.cpp
@@ -35,6 +35,7 @@
 #include <iostream>
 #include <random>
 #include <string>
+#include <string_view>
 
 namespace lie = ocean_imu::lie;
 
@@ -48,6 +49,17 @@ bool check(bool condition, const std::string& message) {
         ++failures;
     }
     return condition;
+}
+
+// Message builder for the per-angle loops below. Joining the tag, the failure
+// text and the angle with operator+ at the call site allocates an intermediate
+// string per message inside a loop, which is what
+// performance-inefficient-string-concatenation objects to.
+std::string tagged(const std::string& tag, std::string_view what, std::string_view at) {
+    std::string message;
+    message.reserve(tag.size() + what.size() + at.size());
+    message.append(tag).append(what).append(at);
+    return message;
 }
 
 template<typename T>
@@ -145,34 +157,34 @@ void test_so3(Sampler& s, T tol, const std::string& tag) {
 
         // Exp lands in SO(3).
         check(mat_close<T,3,3>(Matrix3(R * R.transpose()), Matrix3::Identity(), tol),
-              tag + ": Exp is not orthogonal" + at);
+              tagged(tag, ": Exp is not orthogonal", at));
         check(close<T>(R.determinant(), T(1), tol),
-              tag + ": Exp determinant != 1" + at);
+              tagged(tag, ": Exp determinant != 1", at));
 
         // Exp/Log round trip. Near pi the axis sign is ambiguous, so compare
         // through the rotation rather than through the vector.
         const Vector3 phi_back = lie::Log<T>(R);
         check(mat_close<T,3,3>(lie::Exp<T>(phi_back), R, tol),
-              tag + ": Exp/Log round trip" + at);
+              tagged(tag, ": Exp/Log round trip", at));
         if (angle < 3.0) {
             check(mat_close<T,3,1>(phi_back, phi, tol * T(10)),
-                  tag + ": Log did not recover the rotation vector" + at);
+                  tagged(tag, ": Log did not recover the rotation vector", at));
         }
 
         // J_l J_l^-1 = I.
         const Matrix3 Jl  = lie::left_jacobian<T>(phi);
         const Matrix3 Jli = lie::inv_left_jacobian<T>(phi);
         check(mat_close<T,3,3>(Matrix3(Jl * Jli), Matrix3::Identity(), tol * T(10)),
-              tag + ": J_l J_l^-1 != I" + at);
+              tagged(tag, ": J_l J_l^-1 != I", at));
 
         // J_r(phi) = J_l(-phi) = Exp(-phi) J_l(phi). This identity is what the
         // bias block of the group exponential rests on.
         check(mat_close<T,3,3>(lie::left_jacobian<T>(Vector3(-phi)),
                                Matrix3(lie::Exp<T>(Vector3(-phi)) * Jl), tol * T(10)),
-              tag + ": J_l(-phi) != Exp(-phi) J_l(phi)" + at);
+              tagged(tag, ": J_l(-phi) != Exp(-phi) J_l(phi)", at));
         check(mat_close<T,3,3>(lie::right_jacobian<T>(phi),
                                lie::left_jacobian<T>(Vector3(-phi)), tol),
-              tag + ": right_jacobian != J_l(-phi)" + at);
+              tagged(tag, ": right_jacobian != J_l(-phi)", at));
     }
 }
 
@@ -260,7 +272,7 @@ void test_exp_log(Sampler& s, typename Group::Scalar tol, const std::string& tag
         const Group g = Group::Exp_G(xi);
         const typename Group::Tangent back = Group::Log_G(g);
         if (!check(mat_close<T,Group::NX,1>(back, xi, tol * T(10)),
-                   tag + ": Exp_G/Log_G round trip" + at)) {
+                   tagged(tag, ": Exp_G/Log_G round trip", at))) {
             report(back, xi, "xi");
         }
 
@@ -271,7 +283,7 @@ void test_exp_log(Sampler& s, typename Group::Scalar tol, const std::string& tag
         check(mat_close<T,3,3>(h_back.R, h.R, tol) &&
               mat_close<T,3,Group::kWorldCols>(h_back.X, h.X, tol * T(10)) &&
               mat_close<T,3,Group::kBiasCols>(h_back.B, h.B, tol * T(10)),
-              tag + ": Log_G/Exp_G round trip" + at);
+              tagged(tag, ": Log_G/Exp_G round trip", at));
     }
 
     typename Group::Tangent zero;
@@ -589,12 +601,12 @@ void test_branch_seam(T tol, const std::string& tag) {
         const std::string at = " at angle " + std::to_string(static_cast<double>(angle));
 
         if (!check(mat_close<T,3,3>(lie::Exp<T>(phi), down(reference_exp(phi_ld)), tol),
-                   tag + ": Exp disagrees with the closed form" + at)) {
+                   tagged(tag, ": Exp disagrees with the closed form", at))) {
             report(lie::Exp<T>(phi), down(reference_exp(phi_ld)), "Exp");
         }
         if (!check(mat_close<T,3,3>(lie::left_jacobian<T>(phi),
                                     down(reference_left_jacobian(phi_ld)), tol),
-                   tag + ": left_jacobian disagrees with the closed form" + at)) {
+                   tagged(tag, ": left_jacobian disagrees with the closed form", at))) {
             report(lie::left_jacobian<T>(phi), down(reference_left_jacobian(phi_ld)), "J_l");
         }
         // The cotangent form is genuinely singular at t = 0; there the Taylor
@@ -602,7 +614,7 @@ void test_branch_seam(T tol, const std::string& tag) {
         if (angle > LD(1e-8)) {
             if (!check(mat_close<T,3,3>(lie::inv_left_jacobian<T>(phi),
                                         down(reference_inv_left_jacobian(phi_ld)), tol),
-                       tag + ": inv_left_jacobian disagrees with the closed form" + at)) {
+                       tagged(tag, ": inv_left_jacobian disagrees with the closed form", at))) {
                 report(lie::inv_left_jacobian<T>(phi),
                        down(reference_inv_left_jacobian(phi_ld)), "J_l^-1");
             }
@@ -610,7 +622,7 @@ void test_branch_seam(T tol, const std::string& tag) {
         check(mat_close<T,3,3>(
                   Matrix3(lie::left_jacobian<T>(phi) * lie::inv_left_jacobian<T>(phi)),
                   Matrix3::Identity(), tol * T(10)),
-              tag + ": J_l J_l^-1 != I" + at);
+              tagged(tag, ": J_l J_l^-1 != I", at));
     }
 }
 

--- a/tests/kalman_tfg/tfg_process_covariance-test.cpp
+++ b/tests/kalman_tfg/tfg_process_covariance-test.cpp
@@ -79,7 +79,8 @@ void test_full_gyro_and_bias_covariance() {
             Matrix3 B = Matrix3::Zero();
             for (int j = 0; j < 4; ++j)
                 B.noalias() += Prem(i,j) * (lie::skew<T>(Vector3(Xt.col(j))) * Rt);
-            M[static_cast<std::size_t>(k)].template block<3,3>(3*i,0) = B;
+            M[static_cast<std::size_t>(k)]
+                .template block<3,3>(3*static_cast<Eigen::Index>(i),0) = B;
         }
     }
     WorldMap tail = WorldMap::Zero();

--- a/tests/nlo/nlo-sim.cpp
+++ b/tests/nlo/nlo-sim.cpp
@@ -115,7 +115,7 @@ public:
 
         s.tvg.k1 = float(cs.tvg.k1);
         s.tvg.k2 = float(cs.tvg.k2);
-        s.tvg.kI = float(cs.tvg.kI);
+        s.tvg.k_integral = float(cs.tvg.k_integral);
         s.tvg.vartheta = float(cs.tvg.vartheta);
         s.tvg.theta = float(cs.tvg.theta);
         s.tvg.p0z_hat = float(cs.tvg.p0z_hat);
@@ -322,7 +322,7 @@ static void print_tvg_nlo_vertical_summary(const TvgNloSimulationRunResult& resu
 
     std::cout << "tvg_k1=" << d.k1
               << ", tvg_k2=" << d.k2
-              << ", tvg_kI=" << d.kI
+              << ", tvg_kI=" << d.k_integral
               << ", tvg_vartheta=" << d.vartheta << "\n";
 
     std::cout << "tvg_theta=" << d.theta

--- a/tests/validation/Makefile
+++ b/tests/validation/Makefile
@@ -1,4 +1,13 @@
-.PHONY: build publication-sync evidence-contract test clean
+.PHONY: build publication-sync evidence-contract test evidence-test clean
+
+# The staged OU-III proof searches. Each of these modules is minutes of
+# interval arithmetic and the set is around three quarters of an hour, which is
+# why ou3-proof.yml runs them in jobs that budget one to two hours each. They
+# read source and tooling only: no bundle this repository publishes can change
+# their verdict. `evidence-test` therefore leaves them to the workflow that
+# owns them, and runs every contract that does depend on the evidence tree.
+PROOF_SEARCH_TESTS := $(wildcard test_ou3_p2_*.py test_ou3_p3_*.py test_ou3_p4_*.py test_ou3_p5_*.py)
+EVIDENCE_TESTS := $(filter-out $(PROOF_SEARCH_TESTS),$(wildcard test_*.py))
 
 build:
 	python3 -m py_compile ../../tools/*.py test_*.py
@@ -14,6 +23,9 @@ evidence-contract: publication-sync
 
 test: evidence-contract
 	python3 -m unittest discover -v -p 'test_*.py'
+
+evidence-test: evidence-contract
+	python3 -m unittest -v $(EVIDENCE_TESTS:.py=)
 
 clean:
 	rm -rf __pycache__ ../../tools/__pycache__

--- a/tests/validation/test_workflow_contract.py
+++ b/tests/validation/test_workflow_contract.py
@@ -6,6 +6,8 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ou-validation.yml"
 BRANCH_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ou-full-evidence-branch.yml"
 BUILD_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "build.yml"
+PROOF_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ou3-proof.yml"
+VALIDATION_MAKEFILE = REPO_ROOT / "tests" / "validation" / "Makefile"
 
 
 def _mapping_child_keys(text, section):
@@ -73,7 +75,7 @@ class WorkflowContractTests(unittest.TestCase):
 
         self.assertLess(check, commit)
         gate = workflow[check:commit]
-        self.assertIn("make -C tests/validation test", gate)
+        self.assertIn("make -C tests/validation evidence-test", gate)
         self.assertNotIn("continue-on-error", gate)
 
     def test_validation_publication_is_aligned_before_bundle_upload(self):
@@ -103,7 +105,7 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("replay_required=false", gate)
         self.assertIn("replay_required=true", gate)
         self.assertIn("complete results tree", gate)
-        self.assertIn("make -C tests/validation test", gate)
+        self.assertIn("make -C tests/validation evidence-test", gate)
 
         regen_header = workflow[regenerate:workflow.index("    runs-on:", regenerate)]
         self.assertIn("needs: fingerprint", regen_header)
@@ -161,9 +163,53 @@ class WorkflowContractTests(unittest.TestCase):
 
         rebase = loop.index("git pull --rebase")
         fingerprint = loop.index("tools/ou_replay_fingerprint.py")
-        validate = loop.index("make -C tests/validation test")
+        validate = loop.index("make -C tests/validation evidence-test")
         self.assertLess(rebase, fingerprint)
         self.assertLess(fingerprint, validate)
+
+    def test_evidence_gate_is_the_suite_without_the_proof_searches(self):
+        """What the publication gate runs, and why it is not the whole suite.
+
+        The staged OU-III proof searches are three quarters of an hour of
+        interval arithmetic and read source and tooling only: no bundle this
+        repository publishes can move their verdict. Running them inside the
+        twenty-minute commit job is what killed it mid-suite on every main push
+        from 2026-09-03 on, leaving the branch with unpublished evidence and
+        skipping the document build behind it. ou3-proof.yml owns them and
+        budgets hours; `test` still runs everything for a local full pass and
+        for the pull-request smoke gate.
+        """
+        makefile = VALIDATION_MAKEFILE.read_text(encoding="utf-8")
+        self.assertIn(
+            "PROOF_SEARCH_TESTS := $(wildcard test_ou3_p2_*.py test_ou3_p3_*.py "
+            "test_ou3_p4_*.py test_ou3_p5_*.py)",
+            makefile,
+        )
+        self.assertIn(
+            "EVIDENCE_TESTS := $(filter-out $(PROOF_SEARCH_TESTS),"
+            "$(wildcard test_*.py))",
+            makefile,
+        )
+        self.assertIn("evidence-test: evidence-contract", makefile)
+        self.assertIn("test: evidence-contract", makefile)
+        self.assertIn("python3 -m unittest discover -v -p 'test_*.py'", makefile)
+
+        # Most of the skipped modules are named in the proof workflow. The few
+        # that are not stay covered because the pull-request smoke gate runs
+        # the whole suite, so nothing here drops out of CI entirely.
+        proof = PROOF_WORKFLOW.read_text(encoding="utf-8")
+        directory = REPO_ROOT / "tests" / "validation"
+        skipped = sorted(
+            path.stem
+            for prefix in ("p2", "p3", "p4", "p5")
+            for path in directory.glob(f"test_ou3_{prefix}_*.py")
+        )
+        self.assertTrue(skipped)
+        self.assertTrue(any(name in proof for name in skipped))
+
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        smoke = workflow[workflow.index("  validate:"):workflow.index("  fingerprint:")]
+        self.assertIn("make -C tests/validation test", smoke)
 
     def test_commit_job_validates_against_the_regenerated_commit(self):
         """The bundles are made at github.sha, so the gate must see that tree.


### PR DESCRIPTION
Main has not produced a document build since 2026-09-02, and `quality-gates` has been red on every push. Two independent causes, both fixed here.

## 1. The evidence commit job was being killed mid-suite

`build.yml` calls `ou-validation.yml` in full mode on main, and `build` runs only when that call succeeds. Its `commit` job carried `timeout-minutes: 20`, and its step *"Check the manuscript against the regenerated evidence"* ran `make -C tests/validation test` — the entire validation suite, which now includes the staged OU-III proof searches.

Those searches are about three quarters of an hour on their own: run 33823481819's `source-foundation` job took 46 minutes for the same modules, which is why `ou3-proof.yml` gives them 60- and 120-minute jobs. Inside a 20-minute cap the step never finished:

| run | commit job | step outcome |
| --- | --- | --- |
| 33823481833 (`babeb61`) | 01:47:48 → 02:08:03 | cancelled, mid `test_ou3_p3_canonical_gate` |
| 33788825660 (`5d4721f`) | 18:43:03 → 19:03:19 | cancelled, same step |
| 33779059387, 33765857413 | same | same |

Every one of those runs then skipped `build` and `release` outright, so no PDF was cut and no evidence was published.

The proof searches read source and tooling only — no bundle this repository publishes can move their verdict, and `ou3-proof.yml` owns them. So the evidence gates now run a new `evidence-test` target: the suite minus the four staged proof prefixes. 235 tests, under two seconds. The commit job's cap goes to 45 minutes so the gate has room as the evidence suite grows.

The same substitution fixes the `fingerprint` job's "Verify reusable committed evidence" step, which ran the full suite inside a 45-minute cap and would have hit the identical wall the first time the committed evidence was reusable.

`make -C tests/validation test` still runs everything and is what the pull-request smoke gate runs, so the four proof modules `ou3-proof.yml` does not name by hand stay covered. `test_workflow_contract.py` pinned the old target string in three places; those are updated and a new test pins the split and the reason for it.

## 2. clang-tidy: 24 diagnostics with `WarningsAsErrors: '*'`

Four findings, none of which changes a computed value:

- **`tests/kalman_tfg/lie_group-test.cpp`** — thirteen messages built as `tag + "..." + at` inside the per-angle loops, one intermediate string per message. A small `tagged` helper appends the three pieces into one reserved buffer.
- **`src/kalman_ou_ii/Kalman3D_Wave_OU_II.h`, `src/kalman_ou_iii/Kalman3D_Wave_OU_III.h`** — `const Vector3 f_meas = acc_meas;` copies a vector read once on the next line. Now a reference, so the name still says what the quantity is without the copy.
- **`src/util/W3dSimCommon.h`** and its three users — the telemetry field `kI` is genuinely confusable with the `k1` two lines above it. Renamed to `k_integral`. The CSV column and the console label stay `tvg_kI`, so the plots and every committed record parse exactly as before.
- **`tests/kalman_tfg/tfg_process_covariance-test.cpp`** — `3*i` computed in `int` and widened to `Eigen::Index`; the cast is now explicit.

## Verification

- `tools/quality_gates.sh clang-tidy` — **clean** (was 24 diagnostics)
- `tools/quality_gates.sh warnings` — clean, 52 translation units
- `tools/quality_gates.sh python` — ruff and py_compile clean
- `lie_group-test` and `tfg_process_covariance-test` both pass
- `evidence-test` module set: 235 tests, no failures beyond the ones this checkout already had before the change (missing numpy locally, and the stale committed evidence described below)
- `tfg-validation` is green on this branch

## Two things to expect on this PR

**The ou-validation smoke gate will fail at the evidence contract.** Four replay-closure headers on main already differ from the committed replay provenance — `SeaStateFusionFilterCommon.h`, both `SeaStateFusionFilter_OU_*.h`, and `KalmanWaveDirection.h`, left over from the ODR work in ec4e097 — because the job that restamps them is exactly the one that has been timing out. The two OU filter headers and `W3dSimCommon.h` touched here join that set. Regenerating is the sanctioned route for closure-header changes (ec4e097's own commit message says so), and the first main push after this lands does it automatically. If you would rather see the gate green before merging, dispatching `ou-full-evidence-branch.yml` on this branch will restamp provenance here instead.

**`ou3-proof` / `canonical-p3` will still be red.** Its certificate build hits the 120-minute cap, on main and here alike — this PR only triggers that workflow because the diff touches `src/kalman_ou_iii/**`. That is the open research computation and PR #478 is actively working it ("ci: accelerate canonical P3 certificate build"), so nothing here touches `ou3-proof.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgEZU3fTpzUciyewrboZj5

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgEZU3fTpzUciyewrboZj5)_