### PR TITLE
Match the tightened OU-III caps across every mirror of them

### DIFF
--- a/tests/kalman_ou_iii/iss_contract-test.cpp
+++ b/tests/kalman_ou_iii/iss_contract-test.cpp
@@ -74,8 +74,8 @@ int main() {
         return fail("default PSD a_w covariance synchronization was disabled");
 
     if (!near(MIN_TAU_S, 0.02f) || !near(MAX_TAU_S, 12.0f) ||
-        !near(MAX_SIGMA_A, 6.0f) ||
-        !near(MIN_R_S, 0.15f) || !near(MAX_R_S, 400.0f) ||
+        !near(MAX_SIGMA_A, 4.0f) ||
+        !near(MIN_R_S, 0.15f) || !near(MAX_R_S, 100.0f) ||
         !near(ACC_NOISE_FLOOR_SIGMA_DEFAULT, 0.12f)) {
         return fail("OU-III wrapper clamps changed");
     }
@@ -108,7 +108,7 @@ int main() {
     }
 
     if (!near(PSEUDO_UPDATE_PERIOD_MIN_S_DEFAULT, 0.005f) ||
-        !near(PSEUDO_UPDATE_PERIOD_MAX_S_DEFAULT, 0.25f) ||
+        !near(PSEUDO_UPDATE_PERIOD_MAX_S_DEFAULT, 0.15f) ||
         !near(PSEUDO_UPDATE_TAU_RATIO_DEFAULT, 0.015f / 1.1f)) {
         return fail("OU-III pseudo-update cadence constants changed");
     }
@@ -121,8 +121,14 @@ int main() {
         std::min(std::max(PSEUDO_UPDATE_TAU_RATIO_DEFAULT * MAX_TAU_S,
                           PSEUDO_UPDATE_PERIOD_MIN_S_DEFAULT),
                  PSEUDO_UPDATE_PERIOD_MAX_S_DEFAULT);
-    if (!near(TS_at_tau_min, 0.005f) || TS_at_tau_max > 0.165f ||
-        TS_at_tau_max < 0.160f) {
+    // Both ends of the tau interval now saturate. The floor always did at
+    // tau_min; the ceiling does at tau_max, where the ratio alone asks for
+    // 163.6 ms and the 150 ms guard cuts it back. The guaranteed S-update
+    // recurrence the Live theorem quotes is therefore exactly [5, 150] ms.
+    if (!near(TS_at_tau_min, PSEUDO_UPDATE_PERIOD_MIN_S_DEFAULT) ||
+        !near(TS_at_tau_min, 0.005f) ||
+        !near(TS_at_tau_max, PSEUDO_UPDATE_PERIOD_MAX_S_DEFAULT) ||
+        !near(TS_at_tau_max, 0.15f)) {
         return fail("configured pseudo-update period left its bounded interval");
     }
 

--- a/tests/validation/test_ou_paper_code_parity.py
+++ b/tests/validation/test_ou_paper_code_parity.py
@@ -121,6 +121,33 @@ class OUPaperCodeParityTests(unittest.TestCase):
         self.assertIn("$[\\SI{0.5}{s},\\SI{6}{s}]$", self.ou3_impl)
         self.assertIn("$[\\SI{0.05}{s},\\SI{35}{s}]$", self.ou3_impl)
 
+    def test_ou3_iss_source_clamp_family_matches_the_header(self):
+        """The ISS section names the clamp family the machine certificate assumes.
+
+        Those clamps are the theorem's domain, not decoration: a retune that
+        moves a header constant without moving this paragraph leaves the
+        certificate quoting an envelope the implementation no longer enforces.
+        The same numbers are pinned on the C++ side by
+        tests/kalman_ou_iii/iss_contract-test.cpp.
+        """
+        for token in (
+            "MAX_TUNE_FREQ_HZ = 1.2f",
+            "MAX_SIGMA_A = 4.0f",
+            "MAX_R_S     = 100.0f",
+            "PSEUDO_UPDATE_PERIOD_MAX_S_DEFAULT = 0.15f",
+        ):
+            self.assertIn(token, self.ou3_wrap)
+        self.assertIn("kDynamicEmaHorizonMaxSec = 35.0f", self.limits)
+
+        for token in (
+            r"f_{\rm tune}\le\SI{1.2}{Hz}",
+            r"\sigma_{aw,k}^{\rm proc}\le\SI{4}{m/s^2}",
+            r"r_{S,k}\le\SI{100}{m.s}",
+            r"T_{S,k}\le\SI{0.15}{s}",
+            r"clamped at $\SI{35}{s}$",
+        ):
+            self.assertIn(token, self.ou3_iss)
+
     def test_ou3_candidate_emas_and_activation_hold_match_source(self):
         for token in (
             "ADAPT_TAU_SEA_PERIODS          = 0.40f",

--- a/tests/validation/test_record_conventions.py
+++ b/tests/validation/test_record_conventions.py
@@ -185,6 +185,35 @@ class DeployedLawMirrorTests(unittest.TestCase):
             places=6,
         )
 
+    def test_pseudo_update_cadence_bounds_match_the_filter_clamps(self):
+        """T_S sits under a square root in both laws, so its clamps are load bearing.
+
+        The mirror clips the pseudo-update period itself, so a ceiling that
+        drifts from the header silently moves r_S on every tau long enough to
+        reach it -- above 11 s for OU-III.  The two families carry the ceiling
+        independently, so pin both.
+        """
+        import ou_validation as validation
+
+        for bounds, header in (
+            (validation.OU_III_PSEUDO_PERIOD_BOUNDS_S, self.HEADER),
+            (validation.OU_II_PSEUDO_PERIOD_BOUNDS_S, self.HEADER_OU_II),
+        ):
+            with self.subTest(header=header.name):
+                # The floor is the IMU schedule itself, written as a rate.
+                rate = self._value_from(
+                    header, r"FREQ_SMOOTHER_DT\s*=\s*1\.0f\s*/\s*([0-9.]+)f"
+                )
+                self.assertAlmostEqual(bounds[0], 1.0 / rate, places=9)
+                self.assertAlmostEqual(
+                    bounds[1],
+                    self._value_from(
+                        header,
+                        r"PSEUDO_UPDATE_PERIOD_MAX_S_DEFAULT\s*=\s*([0-9.]+)f",
+                    ),
+                    places=6,
+                )
+
     def test_ou_ii_coefficients_match_the_filter_defaults(self):
         """OU-II's mirror has the same failure mode and had no test.
 

--- a/tools/ou_validation.py
+++ b/tools/ou_validation.py
@@ -742,14 +742,14 @@ def run_simulator(
 OU_III_RS_MSE_COEFF = 0.0538
 OU_III_RS_QEFF = 2.0 * (0.0148 ** 2) * (1.0 / 200.0)
 OU_III_PSEUDO_TAU_RATIO = 0.015 / 1.1
-OU_III_PSEUDO_PERIOD_BOUNDS_S = (1.0 / 200.0, 0.25)
+OU_III_PSEUDO_PERIOD_BOUNDS_S = (1.0 / 200.0, 0.15)
 OU_III_SIGMA_COEFF = 0.9
 OU_III_RS_COEFF = 17.112
 # sqrt(R_a): the accelerometer measurement-noise standard deviation the OU-III
 # base schedule uses as its acceleration scale.  Mirrors
 # R_S_ACCEL_NOISE_DENSITY_DEFAULT / FREQ_SMOOTHER_DT.
 OU_III_RS_ACCEL_SIGMA_MPS2 = 0.0148
-OU_III_RS_BOUNDS_MS = (0.15, 400.0)
+OU_III_RS_BOUNDS_MS = (0.15, 100.0)
 # The deployed OU-II law is PhysicalMSE:
 #     r_p = C_P q_eff^(1/10) sigma_a,B^(4/5) tau^(12/5) / sqrt(T_S),
 #     r_v = r_p / (C_P/C_V * tau),


### PR DESCRIPTION
`OU-III: tighten deployed proof envelope caps` (823275a) moved five deployed constants. The header is the golden source; three separate mirrors of those numbers were left behind, and two of them are hard CI failures.

| header constant | header | was |
| --- | --- | --- |
| `MAX_TUNE_FREQ_HZ` | `1.2f` | — |
| `MAX_SIGMA_A` | `4.0f` | `6.0f` in the ISS contract |
| `MAX_R_S` | `100.0f` | `400.0` in the Python mirror, `400.0f` in the ISS contract |
| `PSEUDO_UPDATE_PERIOD_MAX_S_DEFAULT` | `0.15f` | `0.25` in the Python mirror, `0.25f` in the ISS contract |
| `kDynamicEmaHorizonMaxSec` | `35.0f` | — |

## The two failures are stacked, and both have to be fixed together

**1. `tools/ou_validation.py`** — the fixed-tuning modes derive their frozen operating point from this mirror rather than reading it out of the filter, so a stale clamp scores every fixed mode at a point the deployed filter would never choose. This is what fails the main evidence job:

```
FAIL: test_rs_bounds_match_the_filter_clamps (test_record_conventions.DeployedLawMirrorTests)
AssertionError: 400.0 != 100.0 within 6 places (300.0 difference)
```

The cadence ceiling had no test at all, and it clips `T_S`, which sits under a square root in both laws — so it moves `r_S` for every `tau` above 11 s.

**2. `tests/kalman_ou_iii/iss_contract-test.cpp`** — the test that exists to stop the implementation-side hypotheses of the local ISS theorem from drifting had itself drifted. Built and run against `HEAD` before this PR:

```
FAIL: OU-III wrapper clamps changed
EXIT=1
```

It fails at line 76, ahead of every theorem check below it: the four-point observability determinant lemma, the contractive residual accel-bias OU block, the bounded-gap scheduler check. None of those were running.

This is why the two cannot be split. On main the native `build` matrix is gated on `ou-evidence` succeeding, and in run 8472 that job failed on the `MAX_R_S` mirror, so `build` — including the `kalman_ou_iii` job that runs this test — was **skipped**. Fixing only the Python mirror would unblock `ou-evidence` and then turn the native matrix red here instead, on its first run since 823275a.

A fourth assertion moves with them: at `tau_max` the ratio alone asks for 163.6 ms, so the 150 ms guard now *binds*. Both ends of the tau interval saturate and the guaranteed S-update recurrence is exactly [5, 150] ms. The old `[0.160, 0.165]` window is replaced by pins against the constants and their literals.

## Changes

- `tools/ou_validation.py` — `OU_III_RS_BOUNDS_MS` `400.0 -> 100.0`, `OU_III_PSEUDO_PERIOD_BOUNDS_S` ceiling `0.25 -> 0.15`.
- `tests/kalman_ou_iii/iss_contract-test.cpp` — take the header values for `MAX_SIGMA_A`, `MAX_R_S` and the cadence ceiling, and re-express the derived `T_S` interval around the now-binding 150 ms guard.
- `tests/validation/test_record_conventions.py` — pin both families' pseudo-update cadence bounds against `FREQ_SMOOTHER_DT` and `PSEUDO_UPDATE_PERIOD_MAX_S_DEFAULT`.
- `tests/validation/test_ou_paper_code_parity.py` — pin the ISS section's clamp family against the headers. `w3d-iss-stability.tex-part` was updated correctly by 823275a, but nothing was checking it, and it is the third independent copy of these numbers.

Deliberately unchanged: OU-II's own `MAX_SIGMA_A = 6.0f` and `PSEUDO_UPDATE_PERIOD_MAX_S_DEFAULT = 0.25f` (the tightening did not touch that header — its ISS contract builds and passes as-is), and `tools/ou_robustness_core.py`'s historical `(0.15, 400.0)` envelope, which archived bundles are restated against.

## Validation

- Whole OU-III native suite, built and run with sim data: `SUITE_EXIT=0`, 8/8 quality gates `PASS=1`, zero `PASS=0`. `OU-III local ISS implementation contract PASS`.
- `tests/kalman_ou_ii/iss_contract-test` built and run: passes.
- `evidence-test` set (`test_*.py` minus the staged P2–P5 proof searches), 342 tests: everything passes except six pre-existing failures, all the same thing — the committed evidence bundle's replay provenance is stale against `src/` (`replay dependency differs from replay provenance`). Those are what the full replay in `ou-evidence` regenerates and are not reachable from a branch.
- `ruff check` clean.

## Note on the remaining red

Every PR's `ou-validation` smoke job is currently red on that same stale provenance, at `ou_evidence_contract.py --auto`, before any test runs — this PR's included. The cause is the same circularity: main's evidence job replays, runs `evidence-test`, has been failing there, so the regenerated bundle is never committed and the stale one stays on main. The bundle can only be refreshed by the full replay on main once these failures are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BagaCcbzGV7qHHsyycavFq