### PR TITLE
SEA0: directional vessel/IMU response and response-weighted moments

### DIFF
--- a/.github/workflows/ou3-proof.yml
+++ b/.github/workflows/ou3-proof.yml
@@ -113,23 +113,30 @@ jobs:
           python3 -m py_compile \
             tools/ou3_sea3_spectral_moment_bridge.py \
             tools/ou3_sea3_wave_period_frontend.py \
+            tools/ou3_sea3_directional_response_moments.py \
             tests/validation/test_ou3_sea3_spectral_moment_bridge.py \
-            tests/validation/test_ou3_sea3_wave_period_frontend.py
+            tests/validation/test_ou3_sea3_wave_period_frontend.py \
+            tests/validation/test_ou3_sea3_directional_response_moments.py
 
       - name: Certify retained SEA0 subcertificates
         run: |
           python3 tools/ou3_sea3_spectral_moment_bridge.py --check
+          python3 tools/ou3_sea3_directional_response_moments.py --check
           python3 -m unittest -v \
             tests.validation.test_ou3_sea3_spectral_moment_bridge \
-            tests.validation.test_ou3_sea3_wave_period_frontend
+            tests.validation.test_ou3_sea3_wave_period_frontend \
+            tests.validation.test_ou3_sea3_directional_response_moments
           python3 tools/ou3_sea3_spectral_moment_bridge.py \
             --output /tmp/ou3_sea3_spectral_moment_bridge.json
           python3 tools/ou3_sea3_wave_period_frontend.py \
             --output /tmp/ou3_sea3_wave_period_frontend.json
+          python3 tools/ou3_sea3_directional_response_moments.py \
+            --output /tmp/ou3_sea3_directional_response_moments.json
           python3 - <<'PY'
           import json
           spectral=json.load(open('/tmp/ou3_sea3_spectral_moment_bridge.json'))
           frontend=json.load(open('/tmp/ou3_sea3_wave_period_frontend.json'))
+          response=json.load(open('/tmp/ou3_sea3_directional_response_moments.json'))
           assert spectral['validation_pass']
           assert spectral['SEA0_full_certificate_promoted'] is False
           assert spectral['trajectory_replay_used'] is False
@@ -138,8 +145,24 @@ jobs:
           assert frontend['SEA0_full_certificate_promoted'] is False
           assert frontend['P2_promoted_from_this_artifact'] is False
           assert frontend['interpretation']['discrete_frontend_warping_is_current_limiter'] is False
+          assert response['validation_pass'], response['validation_failures']
+          assert response['SEA0_full_certificate_promoted'] is False
+          assert response['P2_promoted_from_this_artifact'] is False
+          assert response['trajectory_replay_used'] is False
+          assert response['filter_changed'] is False
+          assert response['declared_operating_domain_shrunk'] is False
+          assert response['sea3_source_language_included_in_frozen_p2_contract'] is False
+          assert response['alias_obligation']['sampling_alone_band_limits_the_sea'] is False
+          assert response['alias_obligation']['response_rolloff_is_mandatory'] is True
+          assert response['matrix_moments']['per_axis_scalarization_valid'] is False
+          assert response['deployed_period_channel']['inside_committed_tuning_channel'] is True
+          assert response['deployed_sigma_channel']['sigma_aw_coordinate_stays_inside_declared_interval'] is True
+          assert response['deployed_sigma_channel']['worst_admissible_sigma_aw_ms2'] <= 4.0
           print('SEA0 spectral Tz/Tp screen', spectral['gamma_continuum_screen']['surface_elevation_Tz_over_Tp_outer'])
           print('SEA0 front-end period warp', frontend['validated_intervals']['period_hat_over_period'])
+          print('SEA0 deployed Tz/Tp screen', response['deployed_period_channel']['deployed_Tz_over_Tp'])
+          print('SEA0 worst admissible sigma_a', response['deployed_sigma_channel']['worst_admissible_sigma_a_ms2'])
+          print('SEA0 sigma clamp rail reachable', response['deployed_sigma_channel']['clamp_rail_reachable_from_declared_sea_domain'])
           PY
 
       - name: Upload retained SEA0 subcertificates
@@ -149,6 +172,7 @@ jobs:
           path: |
             /tmp/ou3_sea3_spectral_moment_bridge.json
             /tmp/ou3_sea3_wave_period_frontend.json
+            /tmp/ou3_sea3_directional_response_moments.json
           retention-days: 7
 
   p2-correlation-interface:

--- a/doc/kalman_ou_iii/kalman_ou-w3d.tex
+++ b/doc/kalman_ou_iii/kalman_ou-w3d.tex
@@ -269,6 +269,7 @@ extended Kalman filter, inertial navigation, IMU, marine Motion Reference Unit, 
 \input{w3d-stability-widening-phase-f.tex-part}
 \input{w3d-sea3-stability-theorem.tex-part}
 \input{w3d-sea3-period-bridge.tex-part}
+\input{w3d-sea3-directional-response.tex-part}
 
 \input{w3d-sim-charts.tex-part}
 \input{w3d-results.tex-part}

--- a/doc/kalman_ou_iii/w3d-sea3-directional-response.tex-part
+++ b/doc/kalman_ou_iii/w3d-sea3-directional-response.tex-part
@@ -1,0 +1,156 @@
+\subsection{Directional vessel/IMU response and response-weighted moments}
+\label{sec:sea3-directional-response}
+
+Equation~\eqref{eq:sea3-matrix-spectrum} declares the matrix source spectrum
+$\Phi_u$ but leaves the response family $G_{\rm imu}$ open.  This subsection
+fixes that family, records what the deployed source path actually integrates
+against it, and reports the two obligations that the construction exposes.  The
+replay-free artifact is
+\texttt{ou3\_sea3\_directional\_response\_moments.json}.
+
+\paragraph{Response envelope, not a vessel.}
+No particular hull is assumed.  With the lever arm disabled, angular motion
+produces no specific force at the IMU, so only translational response enters,
+and the admissible family is bounded componentwise by
+\begin{equation}
+ \bigl|G_{{\rm imu},j}(\omega,\vartheta)\bigr|
+ \le
+ \rho(\omega)\,\omega^{2}\,u_j(\vartheta),
+ \qquad
+ u(\vartheta)=\bigl[1,\ |\cos\vartheta|,\ |\sin\vartheta|\bigr]^{\!\top},
+ \label{eq:sea3-response-envelope}
+\end{equation}
+where $\rho$ compares the levelled vessel/IMU acceleration amplitude with the
+undisturbed surface orbital acceleration of the same wave,
+\begin{equation}
+ \boxed{
+ \rho(\omega)=\rho_{\max}\min\!\left\{1,\ \left(\frac{\omega_L}{\omega}\right)^{p}\right\},
+ \qquad
+ \omega_L=\sqrt{g\,k_L},\quad k_L=\frac{2\pi}{L_{\rm ref}} .
+ }
+ \label{eq:sea3-rho}
+\end{equation}
+The roll-off is the finite-waterline Froude--Krylov length averaging: a hull of
+waterline $L_{\rm ref}$ cannot follow waves much shorter than $L_{\rm ref}$.
+The artifact declares $\rho_{\max}=2$, $p=1$ and $L_{\rm ref}=4$ m; a
+\emph{shorter} reference hull raises $\omega_L$ and therefore assumes less.
+
+Because the envelope bounds only moduli, it dominates every member of the
+family in the quadratic-form sense: for $|G_j|\le m_j$ and any complex $v$,
+\begin{equation}
+ \boxed{
+ v^{*}\Phi_u v\le|v|^{\top}M|v|,
+ \qquad
+ M=\int m\,m^{\top}E\,d\vartheta,
+ \qquad
+ \lambda_{\max}(\Phi_u)\le\lambda_{\max}(M).
+ }
+ \label{eq:sea3-modulus-majorant}
+\end{equation}
+Since $E=\sum_r S_r(\omega)D_r(\vartheta)$, every response-weighted moment
+factorizes into scalar frequency integrals times constant directional Gram
+matrices $Q_r=\int D_r\,u\,u^{\top}d\vartheta$.  Those Gram matrices are not
+diagonal --- normalized off-diagonal entries reach $0.998$ --- and they are
+strongly direction dependent: a head sea loads the surge axis
+($Q_{22}=0.81$ against $Q_{33}=0.19$) and a beam sea reverses that.  Per-axis
+scalarization of the source is therefore invalid, as
+Sec.~\ref{sec:sea3-stability-target} requires.
+
+\paragraph{The deployed period is a high-passed moment period.}
+\texttt{WavePeriodEstimator} forms two shared high-pass stages and two leaky
+integrations at the same corner $\lambda=2\pi\cdot0.02$ rad/s, then inverts
+$\omega^2=(\sigma_v/\sigma_\eta)^2-\lambda^2$.  In continuous-time steady state
+that inversion is not a narrow-band approximation but an identity.  Writing
+$S_{\rm up}$ for the levelled specific-force spectrum and
+\begin{equation}
+ d\mu(\omega)=\frac{\omega^{4}\,S_{\rm up}(\omega)}{(\omega^{2}+\lambda^{2})^{4}}\,d\omega
+ =\rho(\omega)^{2}\left(\frac{\omega^{2}}{\omega^{2}+\lambda^{2}}\right)^{4}S_\eta(\omega)\,d\omega,
+ \label{eq:sea3-proxy-measure}
+\end{equation}
+one gets $\sigma_v^2=\int(\omega^2+\lambda^2)\,d\mu$ and
+$\sigma_\eta^2=\int d\mu$, hence
+\begin{equation}
+ \boxed{\omega_{\rm est}^{2}=\mathbb E_{\mu}\bigl[\omega^{2}\bigr]
+ \quad\text{exactly, for any input spectrum.}}
+ \label{eq:sea3-leak-inversion}
+\end{equation}
+The deployed $T_z$ is thus the moment period of the true elevation spectrum
+after a \emph{fourth-order} high-pass at $\lambda$ and the response weight
+$\rho^2$ --- not the surface $T_{z,\eta}$ of
+Eq.~\eqref{eq:sea3-jonswap-tz-tp-screen}.  The two weights pull opposite ways:
+the high-pass shortens the reported period on long swell, the response roll-off
+lengthens it on short chop.
+
+Equation~\eqref{eq:sea3-leak-inversion} also collapses the enclosure.  For a
+multimodal sea $\mu=\sum_r\mu_r$, so $\omega_{\rm est}^2$ is a convex
+combination of the per-partition values and the extremes of the whole
+three-partition class are attained on one-partition seas.  A two-parameter
+$(T_p,\gamma)$ screen therefore covers the fifteen-parameter family, giving
+\begin{equation}
+ 0.6564\lesssim\frac{T_z^{\rm src}}{T_p}\lesssim0.8861,
+ \qquad
+ 0.924\lesssim\frac{T_z^{\rm src}}{T_{z,\eta}}\lesssim1.115 ,
+ \label{eq:sea3-deployed-tz-screen}
+\end{equation}
+strictly wider on both sides than the surface screen, and an induced tuning
+channel of $0.064$--$0.505$ Hz that stays inside the committed $0.03$--$1.2$ Hz
+band.
+
+\paragraph{Obligation 1: sampling supplies no band limit.}
+The chain runs at $h=5$ ms, so what it observes is the folded spectrum.  With a
+flat response the specific-force density behaves as $A/\omega$, every decade
+above Nyquist folds in the same power $A\ln 10$, and the total diverges: at the
+worst admissible partition, three unmodelled decades already fold in
+$83$ m$^2$/s$^4$, i.e.\ $9.1$ m/s$^2$, more than the entire clamp interval.
+Under Eq.~\eqref{eq:sea3-rho} with $p=1$ the same fold is
+$2.4\times10^{-4}$ m$^2$/s$^4$.  A certified roll-off is consequently a
+mandatory SEA0 assumption, and the moment ladder it supports is exactly the one
+the deployed path needs: proxy elevation/velocity and band-passed acceleration
+moments are finite for any $p\ge0$, the raw acceleration moment requires $p>0$,
+and an acceleration moment of order $n$ requires $n<2p$.
+
+\paragraph{Obligation 2: the $\sigma$ clamp rail is reachable.}
+Shipping code commits
+\begin{equation}
+ \sigma_{aw}=\min\bigl\{c_\sigma\,\sigma_a,\ \sigma_a^{\max}\bigr\},
+ \qquad c_\sigma=0.9,\quad \sigma_a^{\max}=4\ \mathrm{m/s^2},
+ \label{eq:sea3-sigma-clamp}
+\end{equation}
+so the source coordinate is contained in its declared interval by saturation:
+no sea can violate it.  The live question is whether an admissible sea reaches
+the rail, which happens at
+$\sigma_a\ge\sigma_a^{\max}/c_\sigma=4.444$ m/s$^2$.
+
+Imposing breaking-steepness admissibility on each partition \emph{and} on the
+combined sea, and maximizing the band-passed deviation over every band
+reference the shipping code can present --- the reference is not always the
+sea's own period, since the startup branch runs the fixed $0.2$ Hz prior and
+the estimator lags afterwards --- the worst admissible sea found is a crossing
+sea of a $4.6$ s wind system ($1.83$ m) on a $10.9$ s swell ($8.18$ m),
+$H_s=8.38$ m, giving
+\begin{equation}
+ \sigma_a^{\rm worst}\approx4.66\ \mathrm{m/s^2}
+ \quad>\quad
+ 4.444\ \mathrm{m/s^2}.
+ \label{eq:sea3-sigma-rail}
+\end{equation}
+The rail is therefore a live cell of the SEA3 source language, not a dormant
+branch, and on it $\sigma_{aw}$ is constant: the sea-to-source map is not
+injective there, so SEA3 cannot prune the P2 language on that cell.  Which
+band reference reaches it is itself informative.  At each sea's own deployed
+period the maximum is only $3.91$ m/s$^2$, and at the fixed startup prior it is
+$4.06$ m/s$^2$; neither saturates.  The rail is reached at intermediate
+references such as $0.258$ Hz --- that is, on the estimator-lag branch between
+the two frequency-source modes the startup subcertificate established, not in
+either mode at rest.
+
+Putting the rail out of reach would need $\rho_{\max}\le1.91$ or a steepness
+ceiling of $0.0954$.  Both are declarations about the physics and would have to
+be certified as such; neither the gate, the filter, nor the operating domain
+may be moved to obtain them.
+
+All numerical intervals above come from fixed-grid quadrature with analytical
+tail pads rather than validated interval integration, and the deployed channels
+are still evaluated in continuous-time steady state rather than through the
+exact discrete moment EMAs, log-period state and \texttt{AdaptiveWaveBandPass}
+recursion.  They are screening enclosures and promote nothing.

--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -56,7 +56,7 @@ Current source/parity values used by the proof are:
 - `imu_dt = 0.005 s`;
 - `0.03 <= f_tune <= 1.2 Hz`;
 - `0.02 <= tau <= 12 s`;
-- `sigma_aw <= 4 m/s^2`;
+- `sigma_aw <= 4 m/s^2`, as the saturating commit `sigma_aw = min(0.9 sigma_a, 4)` rather than an assumed sea bound;
 - `0.15 <= R_S <= 100`;
 - `0.005 <= T_S <= 0.150 s`;
 - dynamic EMA horizon `<= 35 s`;
@@ -104,9 +104,118 @@ Completed facts:
 
 Therefore P1/P2 must retain two frequency-source modes — fixed prior and estimator-driven — plus the one-sample takeover edge. `TunerReady` must not be interpreted as a settled sea-period estimate.
 
+### Directional vessel/IMU response and response-weighted moments
+
+`tools/ou3_sea3_directional_response_moments.py` is replay free and non-promoting.
+
+The response family is an envelope, not a hull. With the lever arm disabled,
+angular motion produces no specific force at the IMU, so only translational
+response enters and the admissible family is bounded componentwise by
+
+`|G_j(omega,theta)| <= rho(omega) omega^2 u_j(theta)`,
+`u = [1, |cos theta|, |sin theta|]`,
+`rho(omega) = rho_max min{1, (omega_L/omega)^p}`.
+
+The roll-off is finite-waterline Froude-Krylov length averaging. Declared:
+`rho_max = 2`, `p = 1`, `L_ref = 4 m`, hence `omega_L = 3.925 rad/s`. A shorter
+reference hull raises `omega_L` and therefore assumes less.
+
+Established analytical facts:
+
+- **Modulus majorant.** For `|G_j| <= m_j` and any complex `v`,
+  `v* Phi_u v <= |v|^T M |v|` with `M = int m m^T E dtheta`, so
+  `lambda_max(Phi_u) <= lambda_max(M)`. The enclosure never reduces to
+  independent per-axis scalars.
+- **Directional factorization.** `E = sum_r S_r(omega) D_r(theta)` makes every
+  response-weighted moment a sum of scalar frequency integrals times constant
+  directional Gram matrices `Q_r(beta_r,s_r)`. Those are strongly non-diagonal
+  (normalized off-diagonals to 0.998) and direction selective: a head sea loads
+  surge (0.81 against 0.19), a beam sea reverses it.
+- **Exact leak inversion.** With `d mu = |G_eta|^2 S_up d omega`, the deployed
+  `omega^2 = (sigma_v/sigma_eta)^2 - lambda^2` equals `E_mu[omega^2]` exactly,
+  for any input spectrum. It is an identity, not a narrow-band approximation.
+- **Deployed period is high-passed.** Equivalently
+  `d mu = rho^2 (omega^2/(omega^2+lambda^2))^4 S_eta d omega`: the deployed
+  `T_z` is the moment period of the true elevation spectrum after a
+  fourth-order high-pass at `lambda` and the response weight `rho^2`.
+- **Mixture convexity.** `omega_est^2` is a convex combination over partitions,
+  so the extreme deployed periods of the whole three-partition class occur on
+  one-partition seas. The fifteen-parameter period enclosure collapses to a
+  `(T_p, gamma)` screen.
+- **Moment finiteness ladder.** Proxy elevation/velocity and band-passed
+  acceleration moments are finite for any `p >= 0`; the raw acceleration moment
+  needs `p > 0`; an acceleration moment of order `n` needs `n < 2p`. The
+  deployed path needs no order above zero, so `p = 1` suffices.
+
+Declared sea domain (SEA3-D): `T_p in [2.5, 20] s`, `gamma in [1, 7]`,
+`H_s <= 8.5 m` (matching the declared operating domain, not narrower),
+spreading exponent `s in [1, 25]`, `beta` free, and significant steepness
+`<= 0.10` imposed **per partition and on the combined sea**. The steepness
+ceiling is physical admissibility: without the per-partition form the search
+returns a 0.28-steepness chop riding on a long swell, which is not a sea.
+
+Numerical screens over that domain (fixed-grid quadrature with analytical tail
+pads, not validated interval integration, therefore non-promoting):
+
+- `0.656419 <= T_z^src/T_p <= 0.886099`, wider on both sides than the surface
+  screen, because the high-pass shortens long swell and the roll-off lengthens
+  short chop;
+- `0.924 <= T_z^src/T_z,eta <= 1.115`; the surface ratio may not be substituted;
+- induced tuning channel `0.0644 .. 0.5051 Hz`, inside the committed
+  `0.03 .. 1.2 Hz`;
+- worst admissible band-passed `sigma_a = 4.660 m/s^2`; at each sea's own
+  deployed period only `3.905`, at the fixed 0.2 Hz startup prior `4.056`.
+
+## Findings that change the next step
+
+### Sampling supplies no band limit (obligation, not a failure)
+
+The deployed chain is sampled at 5 ms, so any claim about what it observes must
+bound the folded tail. With a flat response the specific-force density behaves
+as `A/omega`, every decade above Nyquist folds in the same `A ln 10`, and the
+total diverges. This is not a formal nicety: at the worst admissible partition
+three unmodelled decades already fold in `83 m^2/s^4`, i.e. `9.14 m/s^2`, more
+than the whole sigma clamp interval. Under the declared roll-off the same fold
+is `2.36e-4 m^2/s^4`.
+
+Therefore a certified vessel/IMU high-frequency roll-off is a **mandatory SEA0
+theorem assumption**. Sampling cannot be offered in its place.
+
+### The sigma clamp rail is reachable — failure analysis
+
+1. **Failed inequality.** The declared sea domain was expected to map into the
+   interior of the sigma source coordinate. It does not: the worst admissible
+   sea gives `sigma_a = 4.660 m/s^2` against the saturation point
+   `sigma_a^max/c_sigma = 4/0.9 = 4.444 m/s^2`. The witness is a crossing sea,
+   `1.83 m` at `T_p = 4.59 s` on `8.18 m` at `T_p = 10.9 s`, `H_s = 8.38 m`,
+   each partition below its own breaking steepness.
+2. **Failure class.** Not a theorem failure, not an enclosure failure, not an
+   implementation defect. It is a **source-language structure failure**:
+   shipping code commits `sigma_aw = min(0.9 sigma_a, 4 m/s^2)`, so the
+   coordinate is contained by saturation and no sea can violate it, but on the
+   rail `sigma_aw` is constant and the sea-to-source map is not injective.
+3. **What it invalidates.** The working hypothesis that a physical sea domain
+   plus a directional response prunes the P2 tuner language *uniformly*. On the
+   saturated cell SEA3 carries no more information than the frozen contract
+   already does, so no pruning is available there.
+4. **What it does not invalidate.** The SEA3 theorem formulation, the response
+   family, the modulus majorant, the directional factorization, the leak
+   inversion identity, the mixture convexity reduction, or the period channel —
+   which stays comfortably interior to the committed tuning channel and is
+   where the pruning leverage actually is.
+5. **Current limiting quantity.** `sigma_a^worst / (sigma_a^max/c_sigma) =
+   1.049`. It scales linearly in both `rho_max` and the steepness ceiling: the
+   rail becomes unreachable at `rho_max <= 1.907` or steepness `<= 0.0954`.
+6. **Sharpest structural fact.** Neither frequency-source mode reaches the rail
+   at rest: `3.905` at the settled deployed period and `4.056` at the fixed
+   prior are both below `4.444`. The rail is reached only at intermediate band
+   references such as `0.258 Hz`, i.e. on the **estimator-lag branch between**
+   the two source modes the startup subcertificate established. The two SEA0
+   subcertificates therefore meet exactly here.
+
 ## Current certificate status
 
-- **SEA0:** partial. Spectral shape/moment bridge and estimator startup/front-end subcertificates exist. Directional response, finite-band multimodal moments, hard finite-window sea enclosure, and full finite-memory estimator/tuner reachability remain open.
+- **SEA0:** partial. Spectral shape/moment bridge, estimator startup/front-end, and directional response/response-weighted moment subcertificates exist. The hard finite-window oscillator/IQC sea enclosure, the exact discrete estimator/tuner reachability, and the rate relation `R_lambda` remain open.
 - **P1:** existing operating-domain assumptions retained; SEA3-specific binding must include the prior/estimator source split above.
 - **P2:** current implementation-correlated interface remains valid; SEA3-to-P2 inclusion is not yet proved.
 - **P3:** existing canonical implementation-source route remains diagnostic. No SEA3 H/A finite-window contraction margin is promoted yet.
@@ -117,28 +226,59 @@ No new SEA0 artifact promotes P2, P3, P4, or P5.
 
 ## Current blocker
 
-The immediate missing soundness link is the **directional vessel/IMU response over the deployed finite wave band**.
+The directional response is now declared and its response-weighted moments are
+constructed, so the previous blocker is discharged at the continuous-time,
+steady-state level. Two things now stand between SEA3 and a usable P2 pruning.
 
-That response must preserve directional/cross-axis coupling and turn the three-partition spectrum into bounded response-weighted elevation/velocity/acceleration moments. Those moments must then be propagated through the already-certified fixed-prior/estimator source split, finite WavePeriodEstimator moments/log-period state, exact variance/tau/sigma/R_S adaptation, stage/commit logic, and pseudo scheduler.
+**The sigma clamp rail.** SEA3 prunes the tuner language only where the
+sea-to-source map is injective. It is not injective on the saturated
+`sigma_aw = 4 m/s^2` cell, which the declared sea domain reaches. Either the
+rail is put out of reach by a certified sharper response envelope, or the
+saturated cell is carried explicitly and unpruned in the SEA3 P2 language.
+Choosing the first for convenience is forbidden: `rho_max` and the steepness
+ceiling are physical declarations and moving them to obtain a result is
+operating-domain tuning.
 
-Until that construction exists, the physical sea spectrum cannot soundly prune the existing 800-state P2 tuner language.
+**Discrete propagation.** The channel weights above are continuous-time
+steady-state transfer functions. The deployed path is the exact discrete
+WavePeriodEstimator moment EMAs, its canonical log-period state and settling
+gate, the `AdaptiveWaveBandPass` recursion with moving corners, the debiased
+tuner EMAs, stage/commit logic, and the pseudo scheduler. Nothing may be
+promoted across that gap by analogy.
 
-A Gaussian directional spectrum alone is not an infinite-time deterministic pointwise bound. The deterministic theorem needs a hard finite-window oscillator/IQC enclosure; a stochastic sea-realization statement is a later corollary.
+A Gaussian directional spectrum alone is still not an infinite-time
+deterministic pointwise bound. The deterministic theorem needs a hard
+finite-window oscillator/IQC enclosure; a stochastic sea-realization statement
+is a later corollary.
 
 ## Next proof increment
 
-Start from current `main` after this theorem/SEA0-foundation increment is merged.
+Start from current `main` after this response/moment increment is merged. The
+research question is the **source-language inclusion**, and it is one PR.
 
-1. Declare and justify a provisional three-partition directional JONSWAP/PM parameter and rate domain.
-2. Define a conservative directional vessel/IMU response family over the deployed finite band.
-3. Compute response-weighted matrix spectral moments while preserving cross-axis/directional coupling.
-4. Propagate them through the retained fixed-prior/estimator source split and finite WavePeriodEstimator/log-period dynamics.
-5. Drive the exact shipping variance/tau/sigma/R_S adaptation, stage/commit logic, and pseudo scheduler.
-6. Mechanically prove `Lhat_SEA3 subset L_current_source`.
-7. Only after that inclusion passes, run high-precision complete-window H/A feasibility diagnostics with minimal enclosure pessimism.
-8. Report worst H/A ratio, limiting sea parameters/directions/phase state, maximizing error direction, operation-by-operation margin consumption, and distance to `rho = 1`.
+1. Decide the sigma clamp rail: certify a translational-RAO bound that puts
+   `rho_max` below 1.907, or declare the saturated cell as an unpruned SEA3 P2
+   state. Record which, and why, before any further construction.
+2. Replace the continuous-time channel weights by the exact discrete
+   WavePeriodEstimator moments, log-period state, settling gate, and the
+   `AdaptiveWaveBandPass` recursion with moving corners.
+3. Declare and justify the sea rate relation `R_lambda`; the estimator's finite
+   memory only bounds source motion once the sea's own rate is bounded.
+4. Drive the exact shipping variance/tau/sigma/R_S adaptation, stage/commit
+   logic, and pseudo scheduler from those discrete sources.
+5. Mechanically prove `Lhat_SEA3 subset L_current_source`, reporting which P2
+   cells SEA3 actually removes and which it cannot.
+6. Only after that inclusion passes, run high-precision complete-window H/A
+   feasibility diagnostics with minimal enclosure pessimism.
+7. Report worst H/A ratio, limiting sea parameters/directions/phase state,
+   maximizing error direction, operation-by-operation margin consumption, and
+   distance to `rho = 1`.
 
 Interpretation rule: clear `rho < 1` justifies rigorous SEA3 enclosure work; near-one requires theorem/metric review; `rho > 1` falsifies the proposed SEA3 contraction formulation rather than authorizing blind subdivision.
+
+If step 5 removes no P2 cell of consequence, that falsifies the pruning premise
+of the SEA3 route itself, and the architecture review is due then rather than
+after another enclosure attempt.
 
 ## Retired / forbidden proof shortcuts
 
@@ -149,6 +289,10 @@ Do not reintroduce without a new mathematical reason:
 - replay-selected sea/source words as a certificate domain;
 - equating `T_p` with deployed `T_z` or averaging modal periods;
 - unbanded JONSWAP acceleration variance;
+- offering the 5 ms sampling rate in place of a certified response roll-off;
+- a single-level (whole-sea only) steepness ceiling, which admits breaking partitions;
+- substituting the surface `Tz_eta` or a settled-run diagnostic for a bound that must also cover the fixed prior and the estimator-lag branch;
+- per-axis scalarization of the directional source spectrum;
 - treating `TunerReady` as WavePeriodEstimator readiness;
 - common-period/Floquet reasoning that assumes three modal peaks are commensurate;
 - blind subdivision, scalar-norm tightening, gate tuning, operating-domain shrink, or deployed-filter tuning to obtain a pass;

--- a/tests/validation/test_ou3_proof_cleanup.py
+++ b/tests/validation/test_ou3_proof_cleanup.py
@@ -87,9 +87,14 @@ class Ou3ProofCleanupTest(unittest.TestCase):
         paper = (OU3_DOC / "kalman_ou-w3d.tex").read_text(encoding="utf-8")
         self.assertIn(r"\input{w3d-sea3-stability-theorem.tex-part}", paper)
         self.assertIn(r"\input{w3d-sea3-period-bridge.tex-part}", paper)
+        self.assertIn(r"\input{w3d-sea3-directional-response.tex-part}", paper)
         self.assertLess(
             paper.index(r"\input{w3d-sea3-stability-theorem.tex-part}"),
             paper.index(r"\input{w3d-sea3-period-bridge.tex-part}"),
+        )
+        self.assertLess(
+            paper.index(r"\input{w3d-sea3-period-bridge.tex-part}"),
+            paper.index(r"\input{w3d-sea3-directional-response.tex-part}"),
         )
 
 

--- a/tests/validation/test_ou3_sea3_directional_response_moments.py
+++ b/tests/validation/test_ou3_sea3_directional_response_moments.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import json
+import math
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+
+import ou3_sea3_directional_response_moments as response  # noqa: E402
+import ou3_sea3_spectral_moment_bridge as bridge  # noqa: E402
+
+
+class Sea3DirectionalResponseMomentsTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.payload = response.build()
+
+    def test_subcertificate_is_replay_free_and_non_promoting(self) -> None:
+        payload = self.payload
+        self.assertEqual(response.validate(payload), [])
+        self.assertEqual(
+            payload["schema_version"],
+            "OU3_SEA3_DIRECTIONAL_RESPONSE_MOMENTS_V1",
+        )
+        self.assertFalse(payload["trajectory_replay_used"])
+        self.assertFalse(payload["filter_changed"])
+        self.assertFalse(payload["declared_operating_domain_shrunk"])
+        self.assertFalse(payload["SEA0_full_certificate_promoted"])
+        for stage in ("P2", "P3", "P4", "P5"):
+            self.assertFalse(payload[f"{stage}_promoted_from_this_artifact"])
+        self.assertFalse(
+            payload["sea3_source_language_included_in_frozen_p2_contract"]
+        )
+
+    def test_sea_domain_is_not_narrower_than_the_declared_deployment_envelope(
+        self,
+    ) -> None:
+        domain = json.loads(
+            (ROOT / "tools/ou3_proof_operating_domain.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        declared_hs = domain["initial_filter_entrance"]["position"][
+            "significant_wave_height_Hs_upper_m"
+        ]
+        self.assertGreaterEqual(response.HS_MAX_M, declared_hs)
+        self.assertFalse(self.payload["declared_operating_domain_shrunk"])
+
+    def test_sea_family_matches_the_frozen_spectral_bridge(self) -> None:
+        # One JONSWAP convention across every SEA0 artifact.
+        self.assertEqual(response.M_MAX, bridge.M_MAX)
+        self.assertEqual(response.GAMMA_MIN, bridge.GAMMA_MIN)
+        self.assertEqual(response.GAMMA_MAX, bridge.GAMMA_MAX)
+        elevation = response.partition_elevation_spectrum(4.0, 10.0, 1.0)
+        # m0 = H^2/16 = 1 m^2 by construction.
+        self.assertAlmostEqual(response._integrate(elevation), 1.0, places=9)
+        surface_ratio = (
+            response.surface_zero_crossing_period(elevation) / 10.0
+        )
+        self.assertAlmostEqual(
+            surface_ratio,
+            ((5.0 / 4.0) * math.pi) ** -0.25,
+            places=9,
+        )
+
+    def test_directional_spreading_is_normalized_and_axis_selective(self) -> None:
+        head = response.directional_gram(0.0, 8.0)
+        beam = response.directional_gram(math.radians(90.0), 8.0)
+        self.assertAlmostEqual(head[0][0], 1.0, places=9)
+        self.assertAlmostEqual(beam[0][0], 1.0, places=9)
+        # A head sea drives surge, a beam sea drives sway.
+        self.assertGreater(head[1][1], head[2][2])
+        self.assertGreater(beam[2][2], beam[1][1])
+        # cos^2 spreading at s = 1 has closed-form Gram entries.
+        broad = response.directional_gram(0.0, 1.0)
+        self.assertAlmostEqual(broad[1][1], 0.5, places=9)
+        self.assertAlmostEqual(broad[0][1], 2.0 / math.pi, places=9)
+
+    def test_cross_axis_coupling_survives_the_response_enclosure(self) -> None:
+        moments = self.payload["matrix_moments"]
+        self.assertGreater(moments["worst_normalized_offdiagonal"], 0.5)
+        self.assertFalse(moments["per_axis_scalarization_valid"])
+        for row in moments["example_acceleration_matrix_moment_m2s4"]:
+            for value in row:
+                self.assertTrue(math.isfinite(value))
+
+    def test_leak_inversion_identity_is_exact_not_narrow_band(self) -> None:
+        # omega_est^2 = var_v/var_eta - lambda^2 must equal the mu-weighted
+        # mean square frequency for a broadband, strongly multimodal input.
+        totals = [0.0] * len(response.OMEGA_NODES)
+        for height, peak_period, gamma in (
+            (3.0, 4.0, 1.0),
+            (2.0, 13.0, 7.0),
+        ):
+            spectrum = response.partition_elevation_spectrum(
+                height, peak_period, gamma
+            )
+            totals = [a + b for a, b in zip(totals, spectrum)]
+
+        source = response.up_specific_force_spectrum(totals)
+        proxy_variance = response._integrate(
+            [
+                w * s
+                for w, s in zip(response.PROXY_ELEVATION_WEIGHT, source)
+            ]
+        )
+        velocity_variance = response.deployed_velocity_proxy_variance(totals)
+        inverted = (
+            velocity_variance / proxy_variance
+            - response.LAMBDA_LEAK * response.LAMBDA_LEAK
+        )
+        from_identity = (
+            2.0 * math.pi / response.deployed_period_s(totals)
+        ) ** 2
+        self.assertAlmostEqual(inverted / from_identity, 1.0, places=9)
+
+    def test_mixture_period_stays_inside_single_partition_extremes(self) -> None:
+        convexity = self.payload["mixture_convexity_check"]
+        self.assertLessEqual(convexity["worst_relative_excess"], 1e-9)
+        for case in convexity["cases"]:
+            self.assertTrue(case["inside_component_extremes"])
+        self.assertTrue(
+            self.payload["deployed_period_channel"][
+                "extremes_valid_for_three_partition_class"
+            ]
+        )
+
+    def test_deployed_period_is_not_the_surface_period(self) -> None:
+        period = self.payload["deployed_period_channel"]
+        bias_lo, bias_hi = period["deployed_over_surface_Tz"]
+        self.assertLess(bias_lo, 1.0)
+        self.assertGreater(bias_hi, 1.0)
+        deployed_lo, deployed_hi = period["deployed_Tz_over_Tp"]
+        surface_lo, surface_hi = bridge.build()["gamma_continuum_screen"][
+            "surface_elevation_Tz_over_Tp_outer"
+        ]
+        # The response and the leak widen the ratio on both sides, so the
+        # surface screen may not be substituted for the deployed one.
+        self.assertLess(deployed_lo, surface_lo)
+        self.assertGreater(deployed_hi, surface_hi)
+
+    def test_induced_tuner_frequency_stays_in_the_committed_channel(self) -> None:
+        period = self.payload["deployed_period_channel"]
+        low, high = period["induced_tuner_frequency_hz"]
+        self.assertGreaterEqual(low, response.MIN_TUNE_FREQ_HZ)
+        self.assertLessEqual(high, response.MAX_TUNE_FREQ_HZ)
+        self.assertTrue(period["inside_committed_tuning_channel"])
+
+    def test_sampling_alone_does_not_band_limit_the_sea(self) -> None:
+        alias = self.payload["alias_obligation"]
+        self.assertFalse(alias["sampling_alone_band_limits_the_sea"])
+        self.assertTrue(alias["response_rolloff_is_mandatory"])
+        self.assertTrue(alias["flat_response_folded_power_is_divergent"])
+        self.assertTrue(alias["flat_response_exceeds_sigma_clamp_within_decades"])
+        # The declared roll-off must reduce the fold to a negligible quantity.
+        self.assertTrue(
+            math.isfinite(alias["folded_power_with_declared_rolloff_m2s4"])
+        )
+        self.assertLess(
+            alias["folded_sigma_with_declared_rolloff_ms2"],
+            0.01 * response.SIGMA_AW_CLAMP_MS2,
+        )
+
+    def test_flat_response_alias_power_grows_without_bound(self) -> None:
+        constant = self.payload["alias_obligation"][
+            "asymptotic_acceleration_constant_m2s3"
+        ]
+        three = response.unbounded_response_alias_power(3.0, constant)
+        six = response.unbounded_response_alias_power(6.0, constant)
+        self.assertAlmostEqual(six / three, 2.0, places=9)
+
+    def test_sigma_clamp_contains_the_source_coordinate_by_saturation(self) -> None:
+        sigma = self.payload["deployed_sigma_channel"]
+        self.assertTrue(sigma["per_partition_and_mixture_steepness_both_imposed"])
+        self.assertGreaterEqual(
+            sigma["worst_admissible_sigma_a_ms2"],
+            sigma["single_partition_max_sigma_a_ms2"],
+        )
+        # sigma_aw cannot leave its interval whatever the sea does.
+        self.assertLessEqual(
+            sigma["worst_admissible_sigma_aw_ms2"], response.SIGMA_AW_CLAMP_MS2
+        )
+        self.assertTrue(sigma["sigma_aw_coordinate_stays_inside_declared_interval"])
+        self.assertAlmostEqual(
+            sigma["sigma_a_saturating_the_clamp_ms2"],
+            response.SIGMA_AW_CLAMP_MS2 / response.SIGMA_COEFF,
+            places=12,
+        )
+
+    def test_clamp_rail_is_reachable_only_off_the_settled_reference(self) -> None:
+        sigma = self.payload["deployed_sigma_channel"]
+        rail = sigma["sigma_a_saturating_the_clamp_ms2"]
+        self.assertTrue(sigma["clamp_rail_reachable_from_declared_sea_domain"])
+        self.assertGreaterEqual(sigma["worst_admissible_sigma_a_ms2"], rail)
+        self.assertTrue(sigma["rail_makes_sea_to_source_map_non_injective"])
+        # Neither frequency-source mode at rest reaches the rail on its own.
+        self.assertFalse(sigma["clamp_rail_reachable_at_settled_band_reference"])
+        self.assertLess(sigma["self_consistent_max_sigma_a_ms2"], rail)
+        self.assertFalse(sigma["clamp_rail_reachable_at_startup_prior"])
+        self.assertLess(sigma["startup_prior_max_sigma_a_ms2"], rail)
+        # Reachability stays expressed as a response/domain quantity.
+        self.assertLess(
+            sigma["rho_max_below_which_the_rail_is_unreachable"], response.RHO_MAX
+        )
+        self.assertLess(
+            sigma["steepness_below_which_the_rail_is_unreachable"],
+            response.SIGNIFICANT_STEEPNESS_MAX,
+        )
+
+    def test_band_corners_follow_the_shipping_bandpass_clamps(self) -> None:
+        # Well inside the clamps the corners are exact ratio multiples.
+        low, high = response.sigma_band_corners_hz(0.4)
+        self.assertAlmostEqual(low, 0.2, places=12)
+        self.assertAlmostEqual(high, 1.6, places=12)
+        # The 6 Hz absolute ceiling is unreachable inside the committed
+        # channel: the high corner tops out at 4 * 1.2 Hz.
+        _, high = response.sigma_band_corners_hz(response.MAX_TUNE_FREQ_HZ)
+        self.assertAlmostEqual(
+            high,
+            response.SIGMA_BAND_HIGH_RATIO * response.MAX_TUNE_FREQ_HZ,
+            places=12,
+        )
+        self.assertLess(high, response.SIGMA_BAND_MAX_HZ)
+        self.assertFalse(
+            self.payload["deployed_sigma_channel"][
+                "absolute_band_ceiling_reachable_in_committed_channel"
+            ]
+        )
+        # The absolute floor wins at low reference frequencies.
+        low, _ = response.sigma_band_corners_hz(0.01)
+        self.assertAlmostEqual(low, response.SIGMA_BAND_MIN_HZ, places=12)
+
+    def test_committed_artifact_is_current(self) -> None:
+        artifact = json.loads(
+            (ROOT / "tools/ou3_sea3_directional_response_moments.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        self.assertEqual(artifact, self.payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ou3_sea3_directional_response_moments.json
+++ b/tools/ou3_sea3_directional_response_moments.json
@@ -1,0 +1,420 @@
+{
+  "P2_promoted_from_this_artifact": false,
+  "P3_promoted_from_this_artifact": false,
+  "P4_promoted_from_this_artifact": false,
+  "P5_promoted_from_this_artifact": false,
+  "SEA0_full_certificate_promoted": false,
+  "alias_obligation": {
+    "asymptotic_acceleration_constant_m2s3": 3.0212817304782957,
+    "flat_response_exceeds_sigma_clamp_within_decades": true,
+    "flat_response_folded_power_3_decades_m2s4": 83.48109929201493,
+    "flat_response_folded_power_6_decades_m2s4": 166.96219858402986,
+    "flat_response_folded_power_is_divergent": true,
+    "flat_response_folded_sigma_3_decades_ms2": 9.136799181990098,
+    "folded_power_with_declared_rolloff_m2s4": 0.00023577756076198917,
+    "folded_sigma_with_declared_rolloff_ms2": 0.015355050008449635,
+    "nyquist_rad_s": 628.3185307179587,
+    "response_rolloff_is_mandatory": true,
+    "sampling_alone_band_limits_the_sea": false,
+    "worst_cell": {
+      "Hs_m": 0.49225584550468454,
+      "Tp_s": 2.5,
+      "gamma": 1.0
+    }
+  },
+  "analytical_lemmas": {
+    "deployed_period_is_high_passed": "d mu = rho^2 (omega^2/(omega^2+lambda^2))^4 S_eta d omega, so the deployed Tz is the moment period of a fourth-order high-passed, response-weighted elevation spectrum",
+    "exact_leak_inversion": "omega_est^2 = (sigma_v/sigma_eta)^2 - lambda^2 = E_mu[omega^2] with d mu = |G_eta|^2 S_up d omega; exact for any spectrum",
+    "leak_inversion_is_not_narrow_band": true,
+    "mixture_convexity": "omega_est^2 is a convex combination over partitions, so the extreme deployed periods of the SEA3 class occur at one-partition seas",
+    "modulus_majorant": "for |G_j| <= m_j, v^H Phi_u v <= |v|^T M |v| with M = int m m^T E dtheta, hence lambda_max(Phi_u) <= lambda_max(M)",
+    "sampling_alone_removes_acceleration_divergence": false,
+    "theta_factorization": "E = sum_r S_r(omega) D_r(theta) makes every response-weighted moment a sum of scalar frequency integrals times constant directional Gram matrices Q_r(beta_r,s_r)",
+    "unbanded_surface_acceleration_variance_finite": false
+  },
+  "declared_operating_domain_shrunk": false,
+  "declared_sea_domain": {
+    "Hs_max_m": 8.5,
+    "Tp_s": [
+      2.5,
+      20.0
+    ],
+    "beta_rad": [
+      -3.141592653589793,
+      3.141592653589793
+    ],
+    "covers_eight_reference_seas": true,
+    "gamma": [
+      1.0,
+      7.0
+    ],
+    "m_max": 3,
+    "significant_steepness_max": 0.1,
+    "spreading_exponent_s": [
+      1.0,
+      25.0
+    ],
+    "steepness_is_physical_admissibility_not_proof_clamp": true
+  },
+  "deployed_period_channel": {
+    "deployed_Tz_over_Tp": [
+      0.6564120937140285,
+      0.886099084295975
+    ],
+    "deployed_Tz_s": [
+      1.9799051777487504,
+      15.531229171521836
+    ],
+    "deployed_over_surface_Tz": [
+      0.9240416465374822,
+      1.1148574849472703
+    ],
+    "extremes_valid_for_three_partition_class": true,
+    "induced_tuner_frequency_hz": [
+      0.0643864042540565,
+      0.5050746930906304
+    ],
+    "inside_committed_tuning_channel": true,
+    "limiting_cell_for_lower_ratio": [
+      19.999999999999996,
+      1.0
+    ],
+    "limiting_cell_for_upper_ratio": [
+      2.5,
+      7.0
+    ],
+    "promotion_use": false,
+    "reason": "mixture convexity of the mu-weighted mean square frequency",
+    "scan": {
+      "Tp_values": 25,
+      "gamma_values": 7
+    }
+  },
+  "deployed_sigma_channel": {
+    "absolute_band_ceiling_reachable_in_committed_channel": false,
+    "band_corners_at_channel_ceiling_hz": [
+      0.6,
+      4.8
+    ],
+    "clamp_rail_reachable_at_settled_band_reference": false,
+    "clamp_rail_reachable_at_startup_prior": false,
+    "clamp_rail_reachable_from_declared_sea_domain": true,
+    "multimodal_number_is_a_witness_search_not_an_optimum": true,
+    "multimodal_screen_limiting_cell": {
+      "f_ref_hz": 0.2580217103166003,
+      "first_partition": [
+        4.585020216023356,
+        2.0,
+        1.8281358532298482
+      ],
+      "mixture_Hs_m": 8.377832050930422,
+      "mixture_surface_Tz_s": 7.331072824034388,
+      "second_partition": [
+        10.905077326652577,
+        2.0,
+        8.17593965093509
+      ]
+    },
+    "multimodal_screen_max_sigma_a_ms2": 4.660051883571802,
+    "per_partition_and_mixture_steepness_both_imposed": true,
+    "promotion_use": false,
+    "rail_makes_sea_to_source_map_non_injective": true,
+    "rho_max_below_which_the_rail_is_unreachable": 1.9074656486605037,
+    "rho_max_used": 2.0,
+    "self_consistent_is_a_diagnostic_not_a_bound": true,
+    "self_consistent_limiting_cell": {
+      "Tp_s": 10.000000000000002,
+      "deployed_Tz_s": 7.007510247606906,
+      "f_ref_hz": 0.1427040367641994,
+      "gamma": 1.0,
+      "steepness_height_cap_m": 7.876093522190964
+    },
+    "self_consistent_max_sigma_a_ms2": 3.9053112984875225,
+    "sigma_a_saturating_the_clamp_ms2": 4.444444444444445,
+    "sigma_a_scales_linearly_in_rho_max": true,
+    "sigma_a_scales_linearly_in_steepness_ceiling": true,
+    "sigma_aw_clamp_ms2": 4.0,
+    "sigma_aw_coordinate_stays_inside_declared_interval": true,
+    "sigma_aw_map": "sigma_aw = min(0.9 * sigma_a, 4 m/s^2)",
+    "single_partition_limiting_cell": {
+      "Tp_s": 10.000000000000002,
+      "band_corners_hz": [
+        0.12901085515830016,
+        1.0320868412664013
+      ],
+      "f_ref_hz": 0.2580217103166003,
+      "gamma": 1.0,
+      "steepness_height_cap_m": 7.876093522190964,
+      "surface_Tz_s": 7.103706810033503
+    },
+    "single_partition_max_sigma_a_ms2": 4.0795911120134045,
+    "single_partition_maximum_is_exhaustive_on_grid": true,
+    "startup_prior_hz": 0.2,
+    "startup_prior_limiting_cell": {
+      "Tp_s": 10.000000000000002,
+      "gamma": 1.0,
+      "steepness_height_cap_m": 7.876093522190964
+    },
+    "startup_prior_max_sigma_a_ms2": 4.056495032193191,
+    "steepness_below_which_the_rail_is_unreachable": 0.09537328243302519,
+    "worst_admissible_sigma_a_ms2": 4.660051883571802,
+    "worst_admissible_sigma_aw_ms2": 4.0
+  },
+  "filter_changed": false,
+  "limiting_quantity": "reachability of the sigma_aw clamp rail from the declared directional sea domain, where the sea-to-source map stops being injective and SEA3 can no longer prune the P2 language",
+  "matrix_moments": {
+    "directional_gram_cases": [
+      {
+        "beta_deg": 90.0,
+        "directional_gram": [
+          [
+            0.9999999999999997,
+            0.21808363172573927,
+            0.9615384617800457
+          ],
+          [
+            0.21808363172573927,
+            0.07264957264957264,
+            0.20192929096967385
+          ],
+          [
+            0.9615384617800457,
+            0.20192929096967385,
+            0.9273504273504263
+          ]
+        ],
+        "label": "beam_swell_narrow",
+        "mass": 0.9999999999999997,
+        "max_normalized_offdiagonal": 0.9984923057213013,
+        "spread_s": 25.0
+      },
+      {
+        "beta_deg": 45.0,
+        "directional_gram": [
+          [
+            0.9999999999999998,
+            0.6366197724477962,
+            0.6366197724477963
+          ],
+          [
+            0.6366197724477962,
+            0.5000000000000002,
+            0.31830988682554434
+          ],
+          [
+            0.6366197724477963,
+            0.3183098868255443,
+            0.5000000000000001
+          ]
+        ],
+        "label": "bow_quarter_broad",
+        "mass": 0.9999999999999998,
+        "max_normalized_offdiagonal": 0.9003163162705471,
+        "spread_s": 1.0
+      },
+      {
+        "beta_deg": 0.0,
+        "directional_gram": [
+          [
+            1.0000000000000002,
+            0.8890331009714421,
+            0.36019609522164936
+          ],
+          [
+            0.8890331009714421,
+            0.8111111111111106,
+            0.28829757865883227
+          ],
+          [
+            0.36019609522164936,
+            0.2882975786588322,
+            0.18888888888888897
+          ]
+        ],
+        "label": "head_sea_typical",
+        "mass": 1.0000000000000002,
+        "max_normalized_offdiagonal": 0.9871377394560337,
+        "spread_s": 8.0
+      }
+    ],
+    "example_acceleration_matrix_moment_m2s4": [
+      [
+        6.045512362651276,
+        5.082640033903385,
+        2.586418226450719
+      ],
+      [
+        5.082640033903385,
+        4.496273735430284,
+        1.8887145244638515
+      ],
+      [
+        2.586418226450719,
+        1.8887145244638515,
+        1.549238627220988
+      ]
+    ],
+    "example_proxy_elevation_matrix_moment_m2": [
+      [
+        2.5226718304389326,
+        2.1413689793801285,
+        1.0561572639457026
+      ],
+      [
+        2.1413689793801285,
+        1.9034757910036073,
+        0.7846664723651592
+      ],
+      [
+        1.0561572639457026,
+        0.7846664723651591,
+        0.6191960394353242
+      ]
+    ],
+    "example_sea": [
+      [
+        3.0,
+        8.0,
+        3.3,
+        20.0,
+        8.0
+      ],
+      [
+        1.5,
+        13.0,
+        1.0,
+        200.0,
+        25.0
+      ]
+    ],
+    "factorization": "M = sum_r (int omega-weighted rho^2 omega^4 S_r) Q_r",
+    "finiteness_ladder": {
+      "acceleration_moment_of_order_n": "finite iff n < 2p",
+      "band_passed_acceleration_moment": "finite for any rolloff p >= 0",
+      "deployed_path_requires_orders_above_zero": false,
+      "proxy_elevation_and_velocity_moments": "finite for any rolloff p >= 0",
+      "raw_acceleration_moment": "finite iff p > 0"
+    },
+    "per_axis_scalarization_valid": false,
+    "promotion_use": false,
+    "worst_normalized_offdiagonal": 0.9984923057213013
+  },
+  "mixture_convexity_check": {
+    "cases": [
+      {
+        "inside_component_extremes": true,
+        "mixture_deployed_Tz_s": 3.4032708473768145,
+        "partitions": [
+          [
+            3.0,
+            4.0,
+            1.0
+          ],
+          [
+            2.0,
+            9.0,
+            3.3
+          ],
+          [
+            0.0,
+            12.0,
+            1.0
+          ]
+        ],
+        "single_partition_deployed_Tz_s": [
+          2.970834905294499,
+          6.9413615004334694
+        ]
+      },
+      {
+        "inside_component_extremes": true,
+        "mixture_deployed_Tz_s": 5.309162245016755,
+        "partitions": [
+          [
+            1.0,
+            3.0,
+            7.0
+          ],
+          [
+            2.5,
+            14.0,
+            1.0
+          ],
+          [
+            1.5,
+            6.5,
+            2.0
+          ]
+        ],
+        "single_partition_deployed_Tz_s": [
+          2.609310584899184,
+          9.577888465628506,
+          4.89118096857642
+        ]
+      },
+      {
+        "inside_component_extremes": true,
+        "mixture_deployed_Tz_s": 1.990331995590281,
+        "partitions": [
+          [
+            4.0,
+            2.5,
+            1.0
+          ],
+          [
+            0.5,
+            20.0,
+            1.0
+          ],
+          [
+            0.0,
+            5.0,
+            1.0
+          ]
+        ],
+        "single_partition_deployed_Tz_s": [
+          1.9799051777487504,
+          13.12824187428057
+        ]
+      }
+    ],
+    "identity": "omega_est^2 = sum_r c_r E_{mu_r}[omega^2] / sum_r c_r",
+    "worst_relative_excess": 0.0
+  },
+  "next_obligation": "decide the sigma clamp rail: either certify a sharper vessel/IMU response envelope that puts it out of reach, or carry the saturated non-injective cell explicitly in the SEA3 P2 language; then replace the continuous-time steady-state channel weights by the exact discrete WavePeriodEstimator moment EMAs, log-period state and AdaptiveWaveBandPass recursion",
+  "proof_status": "mixed_analytic_and_non_promoting_numerical_screen",
+  "quadrature": {
+    "high_frequency_tail_bounded_analytically": true,
+    "interval_arithmetic_used_for_quadrature": false,
+    "low_frequency_tail_reason": "exp(-1.25 (omega_p/omega)^4) underflows below the grid floor",
+    "omega_interval_rad_s": [
+      0.001,
+      100000.0
+    ],
+    "omega_simpson_panels": 3072,
+    "theta_simpson_panels": 512
+  },
+  "qualification": "OU3_SEA0_DIRECTIONAL_RESPONSE_MOMENT_SUBCERTIFICATE",
+  "reason_not_promoted": "fixed-grid quadrature with analytical pads is a screening enclosure, not validated interval integration; the deployed channels are also still evaluated in continuous-time steady state rather than through the exact discrete EMA and log-period state",
+  "response_family": {
+    "envelope": "|G_j(omega,theta)| <= rho(omega) omega^2 u_j(theta)",
+    "lever_arm_enabled": false,
+    "mechanism": "finite-waterline Froude-Krylov length averaging",
+    "reference_waterline_m": 4.0,
+    "rho_max": 2.0,
+    "rolloff_corner_hz": 0.6246552694631126,
+    "rolloff_corner_rad_s": 3.9248248111429342,
+    "rolloff_exponent_p": 1.0,
+    "single_vessel_assumed": false,
+    "u_of_theta": [
+      "1",
+      "|cos theta|",
+      "|sin theta|"
+    ]
+  },
+  "schema_version": "OU3_SEA3_DIRECTIONAL_RESPONSE_MOMENTS_V1",
+  "sea3_source_language_included_in_frozen_p2_contract": false,
+  "trajectory_replay_used": false,
+  "validation_failures": [],
+  "validation_pass": true
+}

--- a/tools/ou3_sea3_directional_response_moments.py
+++ b/tools/ou3_sea3_directional_response_moments.py
@@ -1,0 +1,1102 @@
+#!/usr/bin/env python3
+"""SEA0 directional-response and response-weighted moment subcertificate.
+
+This module discharges the *response* half of the SEA0 obligation declared by
+the SEA3 directional-sea theorem: it turns the three-partition directional
+elevation spectrum into the matrix-valued source spectrum
+
+    Phi_u(omega) = int G_imu(omega,theta) E(omega,theta) G_imu(omega,theta)^* dtheta
+
+and into the specific response-weighted moments that the *deployed* source path
+actually consumes.  It does not promote SEA0, P2, P3, P4 or P5, and it does not
+read any replay trajectory.
+
+Three things are established analytically and are independent of the numerical
+screen below:
+
+1. **Modulus majorant.**  A single vessel is never assumed.  The response is an
+   admissible *family* bounded componentwise by a declared magnitude envelope,
+   and the Gram matrix of that envelope dominates every member of the family in
+   the quadratic-form sense.  Directional and cross-axis coupling therefore
+   survive as off-diagonal entries; the certificate never reduces to
+   independent per-axis scalars.
+
+2. **Exact leak inversion.**  In continuous-time steady state the deployed
+   `WavePeriodEstimator` moment ratio is *exactly* the response-weighted mean
+   square frequency of a fourth-order high-passed elevation spectrum.  The
+   estimator's `omega^2 = (sigma_v/sigma_eta)^2 - lambda^2` line is not a
+   narrow-band approximation; it is an identity for any input spectrum.
+
+3. **Mixture convexity.**  That mean square is a convex combination over the
+   three partitions, so the extreme deployed periods of the whole SEA3 class are
+   attained on one-partition seas.  The 15-parameter period-channel enclosure
+   collapses to a two-parameter (Tp, gamma) screen.
+
+Two obligations come out of the construction and both are reported rather than
+tuned away.
+
+The first is the *sigma clamp rail*.  Shipping code sets
+`sigma_target_ = min(0.9 * sigma_a, 4 m/s^2)`, so the sigma_aw source
+coordinate is contained in its declared interval by saturation and cannot be
+violated by any sea.  What a sea can do is reach the rail, and an admissible
+crossing sea of a 4.6 s wind system on a 10.9 s swell does: its band-passed
+deviation of 4.66 m/s^2 passes the 4.44 m/s^2 saturation point.  The rail is
+therefore a live cell of the source language rather than a dormant branch, and
+on it the sea-to-source map stops being injective, so SEA3 cannot prune the P2
+language there.
+
+Which band reference reaches it is the sharper fact.  Neither frequency-source
+mode reaches the rail at rest: 3.91 m/s^2 at each sea's own deployed period and
+4.06 m/s^2 at the fixed 0.2 Hz startup prior are both below saturation.  The
+rail is reached only at intermediate references, that is on the estimator-lag
+branch *between* the two source modes the startup subcertificate established.
+
+The second is *aliasing*.  The deployed chain is sampled at 5 ms, so any claim
+about what it observes must bound the folded tail of the sea's specific-force
+spectrum.  With no vessel/IMU roll-off that folded power is logarithmically
+divergent, and not divergent by a negligible amount: three unmodelled decades
+already fold in more than the whole clamp interval.  A certified high-frequency
+roll-off is therefore a mandatory SEA0 assumption rather than a modelling
+convenience, and sampling supplies no band limit of its own.
+
+The numerical parts are fixed-grid quadrature with analytical tail pads, not
+validated interval integration, so every numerical interval reported here is a
+screening enclosure and is explicitly marked non-promoting.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import ou3_sea3_spectral_moment_bridge as bridge  # noqa: E402
+
+
+SCHEMA_VERSION = "OU3_SEA3_DIRECTIONAL_RESPONSE_MOMENTS_V1"
+
+G_STD = 9.80665
+
+# ---------------------------------------------------------------------------
+# Declared three-partition directional sea domain (SEA3-D).
+#
+# The peak-period window covers the eight reference seas (Tz ~= 2.3..8.4 s,
+# hence Tp ~= 2.8..11.9 s through the certified Tz/Tp screen) and extends to
+# long swell.  The height ceiling and the significant-steepness ceiling are
+# physical admissibility statements about the sea, not proof-convenience
+# clamps: a wind sea cannot carry arbitrary height at a fixed period without
+# breaking.  0.10 is deliberately above the conventional fully developed value
+# (~0.05) so the declared class stays wider than the calibration seas.
+# ---------------------------------------------------------------------------
+M_MAX = bridge.M_MAX
+TP_MIN_S = 2.5
+TP_MAX_S = 20.0
+GAMMA_MIN = bridge.GAMMA_MIN
+GAMMA_MAX = bridge.GAMMA_MAX
+# Matches significant_wave_height_Hs_upper_m in the declared operating
+# domain; the sea domain must not be narrower than the deployment envelope.
+HS_MAX_M = 8.5
+SIGNIFICANT_STEEPNESS_MAX = 0.10
+SPREAD_S_MIN = 1.0
+SPREAD_S_MAX = 25.0
+
+# ---------------------------------------------------------------------------
+# Declared conservative vessel/IMU response envelope.
+#
+# The lever arm is disabled in the current proof scope, so angular motion does
+# not produce specific force at the IMU and only translational response enters.
+# RHO_MAX bounds the ratio of the levelled vessel/IMU acceleration amplitude to
+# the undisturbed surface orbital acceleration amplitude of the same wave.  A
+# contouring displacement hull peaks near 1.1-1.3; 2.0 leaves room for
+# resonance and for the private-Mahony levelling residual.
+#
+# ROLL_OFF_EXPONENT/OMEGA_L declare the finite-waterline (Froude-Krylov length
+# averaging) roll-off.  A hull of waterline L cannot follow waves much shorter
+# than L.  L_REF is deliberately *small*: a shorter reference hull pushes the
+# roll-off corner higher and therefore assumes less.
+# ---------------------------------------------------------------------------
+RHO_MAX = 2.0
+ROLL_OFF_EXPONENT = 1.0
+L_REF_M = 4.0
+K_L = 2.0 * math.pi / L_REF_M
+OMEGA_L = math.sqrt(G_STD * K_L)
+
+# ---------------------------------------------------------------------------
+# Frozen shipping source parity (see docs/ou3-proof-research-state.md).
+# ---------------------------------------------------------------------------
+IMU_DT_S = 0.005
+WAVE_PERIOD_HIGH_PASS_HZ = 0.02
+LAMBDA_LEAK = 2.0 * math.pi * WAVE_PERIOD_HIGH_PASS_HZ
+MIN_TUNE_FREQ_HZ = 0.03
+MAX_TUNE_FREQ_HZ = 1.2
+SIGMA_BAND_LOW_RATIO = 0.5
+SIGMA_BAND_HIGH_RATIO = 4.0
+SIGMA_BAND_MIN_HZ = 0.01
+SIGMA_BAND_MAX_HZ = 6.0
+# sigma_target_ = min(sigma_coeff_ * sigma_a, max_sigma_a_) in shipping code.
+# The ceiling is a saturating clamp, so sigma_aw cannot leave [0, 4]; what the
+# sea can do is drive the tuner onto the rail.
+SIGMA_COEFF = 0.9
+SIGMA_AW_CLAMP_MS2 = 4.0
+SIGMA_A_SATURATION_MS2 = SIGMA_AW_CLAMP_MS2 / SIGMA_COEFF
+TUNE_FREQ_PRIOR_HZ = 0.2
+
+# ---------------------------------------------------------------------------
+# Quadrature configuration.
+# ---------------------------------------------------------------------------
+OMEGA_MIN = 1.0e-3
+OMEGA_MAX = 1.0e5
+OMEGA_PANELS = 3072
+THETA_PANELS = 512
+TAIL_PAD_SAFETY = 1.000001
+
+TP_SCAN = 25
+GAMMA_SCAN = 7
+F_REF_SCAN = 13
+MIXTURE_CELL_STRIDE = 5
+MIXTURE_WEIGHT_STEPS = 21
+
+
+# ---------------------------------------------------------------------------
+# Quadrature primitives.
+# ---------------------------------------------------------------------------
+def _log_omega_grid() -> tuple[list[float], list[float]]:
+    """Simpson nodes and dw weights on a log-spaced angular-frequency grid."""
+    if OMEGA_PANELS % 2:
+        raise RuntimeError("OMEGA_PANELS must be even")
+    log_lo = math.log(OMEGA_MIN)
+    log_hi = math.log(OMEGA_MAX)
+    step = (log_hi - log_lo) / OMEGA_PANELS
+    nodes: list[float] = []
+    weights: list[float] = []
+    for i in range(OMEGA_PANELS + 1):
+        omega = math.exp(log_lo + i * step)
+        if i == 0 or i == OMEGA_PANELS:
+            coef = 1.0
+        elif i % 2:
+            coef = 4.0
+        else:
+            coef = 2.0
+        nodes.append(omega)
+        # d(omega) = omega * d(log omega).
+        weights.append(coef * step / 3.0 * omega)
+    return nodes, weights
+
+
+OMEGA_NODES, OMEGA_WEIGHTS = _log_omega_grid()
+
+
+def _integrate(values: list[float]) -> float:
+    total = 0.0
+    for weight, value in zip(OMEGA_WEIGHTS, values):
+        total += weight * value
+    return total
+
+
+# ---------------------------------------------------------------------------
+# Sea family.
+# ---------------------------------------------------------------------------
+def _shape_normalizer(gamma: float) -> float:
+    """int_0^inf shape(x;gamma) dx, so that m0 of a partition equals H^2/16."""
+    def shape(x: float) -> float:
+        return bridge.jonswap_dimensionless_shape(x, gamma)
+
+    # The shape is scale free, so the same log grid is reused in x.
+    values = [shape(omega) for omega in OMEGA_NODES]
+    return _integrate(values)
+
+
+def partition_elevation_spectrum(
+    height_m: float,
+    peak_period_s: float,
+    gamma: float,
+) -> list[float]:
+    """S_eta(omega) on the shared grid, normalized so m0 = H^2/16."""
+    omega_p = 2.0 * math.pi / peak_period_s
+    scale = (height_m * height_m / 16.0) / (omega_p * _shape_normalizer(gamma))
+    return [
+        scale * bridge.jonswap_dimensionless_shape(omega / omega_p, gamma)
+        for omega in OMEGA_NODES
+    ]
+
+
+def directional_spreading(theta: float, beta: float, spread_s: float) -> float:
+    """Normalized cos^{2s} spreading, int over [-pi,pi) equal to one."""
+    norm = math.gamma(spread_s + 1.0) / (
+        2.0 * math.sqrt(math.pi) * math.gamma(spread_s + 0.5)
+    )
+    return norm * math.cos(0.5 * (theta - beta)) ** (2.0 * spread_s)
+
+
+def directional_gram(beta: float, spread_s: float) -> list[list[float]]:
+    """Q(beta,s) = int D(theta) u(theta) u(theta)^T dtheta, u = [1,|cos|,|sin|]."""
+    if THETA_PANELS % 2:
+        raise RuntimeError("THETA_PANELS must be even")
+    step = 2.0 * math.pi / THETA_PANELS
+    gram = [[0.0] * 3 for _ in range(3)]
+    for i in range(THETA_PANELS + 1):
+        theta = -math.pi + i * step
+        if i == 0 or i == THETA_PANELS:
+            coef = 1.0
+        elif i % 2:
+            coef = 4.0
+        else:
+            coef = 2.0
+        weight = coef * step / 3.0 * directional_spreading(theta, beta, spread_s)
+        unit = (1.0, abs(math.cos(theta)), abs(math.sin(theta)))
+        for a in range(3):
+            for b in range(3):
+                gram[a][b] += weight * unit[a] * unit[b]
+    return gram
+
+
+# ---------------------------------------------------------------------------
+# Response envelope and deployed channel weights.
+# ---------------------------------------------------------------------------
+def response_envelope(omega: float) -> float:
+    """rho(omega): declared bound on |vessel/IMU accel| / |orbital accel|."""
+    if omega <= OMEGA_L:
+        return RHO_MAX
+    return RHO_MAX * (OMEGA_L / omega) ** ROLL_OFF_EXPONENT
+
+
+RESPONSE_ENVELOPE = [response_envelope(omega) for omega in OMEGA_NODES]
+
+
+def up_specific_force_spectrum(elevation: list[float]) -> list[float]:
+    """S_up(omega) majorant: rho(omega)^2 omega^4 S_eta(omega)."""
+    return [
+        rho * rho * omega**4 * value
+        for rho, omega, value in zip(RESPONSE_ENVELOPE, OMEGA_NODES, elevation)
+    ]
+
+
+def proxy_elevation_weight(omega: float) -> float:
+    """|G_eta(i omega)|^2 from acceleration input through the deployed chain.
+
+    Two shared high-pass stages s/(s+lambda) followed by two leaky integrations
+    1/(s+lambda) give omega^4 / (omega^2 + lambda^2)^4.
+    """
+    return omega**4 / (omega * omega + LAMBDA_LEAK * LAMBDA_LEAK) ** 4
+
+
+PROXY_ELEVATION_WEIGHT = [proxy_elevation_weight(omega) for omega in OMEGA_NODES]
+
+
+def sigma_band_corners_hz(f_ref_hz: float) -> tuple[float, float]:
+    """Exact AdaptiveWaveBandPass corner selection at the shipping settings."""
+    nyquist_guard_hz = 0.45 / IMU_DT_S
+    upper_limit = min(SIGMA_BAND_MAX_HZ, nyquist_guard_hz)
+    low_hz = max(SIGMA_BAND_MIN_HZ, SIGMA_BAND_LOW_RATIO * f_ref_hz)
+    low_hz = min(low_hz, upper_limit / 1.05)
+    high_hz = min(upper_limit, SIGMA_BAND_HIGH_RATIO * f_ref_hz)
+    high_hz = max(high_hz, low_hz * 1.05)
+    high_hz = min(high_hz, upper_limit)
+    return low_hz, high_hz
+
+
+def sigma_band_weight(f_ref_hz: float) -> list[float]:
+    """|B(i omega)|^2 for the one-pole high-pass / one-pole low-pass cascade."""
+    low_hz, high_hz = sigma_band_corners_hz(f_ref_hz)
+    omega_l = 2.0 * math.pi * low_hz
+    omega_h = 2.0 * math.pi * high_hz
+    weights = []
+    for omega in OMEGA_NODES:
+        sq = omega * omega
+        weights.append(
+            (sq / (sq + omega_l * omega_l))
+            * (omega_h * omega_h / (sq + omega_h * omega_h))
+        )
+    return weights
+
+
+# ---------------------------------------------------------------------------
+# Analytical tails.
+# ---------------------------------------------------------------------------
+def _asymptotic_acceleration_constant(height_m: float, peak_period_s: float,
+                                      gamma: float) -> float:
+    """A with omega^4 S_eta(omega) -> A / omega as omega -> inf."""
+    omega_p = 2.0 * math.pi / peak_period_s
+    return (height_m * height_m / 16.0) * omega_p**4 / _shape_normalizer(gamma)
+
+
+def acceleration_tail_above(omega_cut: float, height_m: float,
+                            peak_period_s: float, gamma: float) -> float:
+    """Upper bound for int_{omega_cut}^inf S_up(omega) d omega.
+
+    Beyond twice the peak the JONSWAP peak factor is 1 to within 1e-26, so the
+    ideal omega^{-5} elevation tail dominates and the response roll-off supplies
+    the remaining omega^{-2p}.  The bound diverges for ROLL_OFF_EXPONENT = 0,
+    which is exactly the aliasing obligation reported below.
+    """
+    if omega_cut < 2.0 * (2.0 * math.pi / peak_period_s):
+        raise ValueError("tail bound requires omega_cut above twice the peak")
+    const = _asymptotic_acceleration_constant(height_m, peak_period_s, gamma)
+    if ROLL_OFF_EXPONENT <= 0.0:
+        return math.inf
+    exponent = 2.0 * ROLL_OFF_EXPONENT
+    tail = (
+        RHO_MAX * RHO_MAX
+        * OMEGA_L**exponent
+        * const
+        / (exponent * omega_cut**exponent)
+    )
+    return TAIL_PAD_SAFETY * tail
+
+
+def unbounded_response_alias_power(decades: float, tail_constant: float) -> float:
+    """Folded specific-force power over `decades` of tail if rho were flat.
+
+    A flat response leaves the specific-force spectral density proportional to
+    1/omega, so every decade above Nyquist folds in the same power and the total
+    grows without bound.  The result is independent of where the tail starts,
+    which is exactly why sampling cannot supply the missing band limit.
+    """
+    return RHO_MAX * RHO_MAX * tail_constant * decades * math.log(10.0)
+
+
+# ---------------------------------------------------------------------------
+# Deployed-channel statistics for one partition.
+# ---------------------------------------------------------------------------
+def _partition_unit_spectrum(peak_period_s: float, gamma: float) -> list[float]:
+    """S_eta for H = 4 m, i.e. unit m0.  Ratios below are H independent."""
+    return partition_elevation_spectrum(4.0, peak_period_s, gamma)
+
+
+def surface_zero_crossing_period(elevation: list[float]) -> float:
+    m0 = _integrate(elevation)
+    m2 = _integrate(
+        [omega * omega * value for omega, value in zip(OMEGA_NODES, elevation)]
+    )
+    return 2.0 * math.pi * math.sqrt(m0 / m2)
+
+
+def deployed_period_s(elevation: list[float]) -> float:
+    """T_z as the deployed estimator forms it, in continuous-time steady state.
+
+    By the exact leak-inversion identity the estimator's omega^2 is the mean
+    square frequency of the measure d mu = |G_eta|^2 S_up d omega, so no
+    separate velocity-proxy integral is needed.
+    """
+    source = up_specific_force_spectrum(elevation)
+    measure = [w * s for w, s in zip(PROXY_ELEVATION_WEIGHT, source)]
+    mass = _integrate(measure)
+    second = _integrate(
+        [omega * omega * value for omega, value in zip(OMEGA_NODES, measure)]
+    )
+    if not (mass > 0.0 and second > 0.0):
+        raise RuntimeError("deployed period measure lost positivity")
+    return 2.0 * math.pi / math.sqrt(second / mass)
+
+
+def deployed_velocity_proxy_variance(elevation: list[float]) -> float:
+    source = up_specific_force_spectrum(elevation)
+    return _integrate(
+        [
+            (omega * omega + LAMBDA_LEAK * LAMBDA_LEAK) * w * s
+            for omega, w, s in zip(OMEGA_NODES, PROXY_ELEVATION_WEIGHT, source)
+        ]
+    )
+
+
+def steepness_height_cap_m(surface_tz_s: float) -> float:
+    """Largest admissible Hs at this surface Tz under the steepness ceiling."""
+    cap = SIGNIFICANT_STEEPNESS_MAX * G_STD * surface_tz_s**2 / (2.0 * math.pi)
+    return min(HS_MAX_M, cap)
+
+
+# ---------------------------------------------------------------------------
+# Scans.
+# ---------------------------------------------------------------------------
+def _log_span(lo: float, hi: float, count: int) -> list[float]:
+    if count < 2:
+        raise ValueError("count must be at least two")
+    step = (math.log(hi) - math.log(lo)) / (count - 1)
+    return [math.exp(math.log(lo) + i * step) for i in range(count)]
+
+
+def _linear_span(lo: float, hi: float, count: int) -> list[float]:
+    if count < 2:
+        raise ValueError("count must be at least two")
+    step = (hi - lo) / (count - 1)
+    return [lo + i * step for i in range(count)]
+
+
+def period_channel_screen() -> dict[str, Any]:
+    """Single-partition (Tp, gamma) scan of the deployed period channel."""
+    peak_periods = _log_span(TP_MIN_S, TP_MAX_S, TP_SCAN)
+    gammas = _linear_span(GAMMA_MIN, GAMMA_MAX, GAMMA_SCAN)
+
+    ratio_lo = math.inf
+    ratio_hi = -math.inf
+    tz_lo = math.inf
+    tz_hi = -math.inf
+    limiter_lo: tuple[float, float] = (0.0, 0.0)
+    limiter_hi: tuple[float, float] = (0.0, 0.0)
+    surface_bias_lo = math.inf
+    surface_bias_hi = -math.inf
+    for peak_period in peak_periods:
+        for gamma in gammas:
+            elevation = _partition_unit_spectrum(peak_period, gamma)
+            deployed = deployed_period_s(elevation)
+            surface = surface_zero_crossing_period(elevation)
+            ratio = deployed / peak_period
+            if ratio < ratio_lo:
+                ratio_lo = ratio
+                limiter_lo = (peak_period, gamma)
+            if ratio > ratio_hi:
+                ratio_hi = ratio
+                limiter_hi = (peak_period, gamma)
+            tz_lo = min(tz_lo, deployed)
+            tz_hi = max(tz_hi, deployed)
+            bias = deployed / surface
+            surface_bias_lo = min(surface_bias_lo, bias)
+            surface_bias_hi = max(surface_bias_hi, bias)
+
+    return {
+        "scan": {"Tp_values": TP_SCAN, "gamma_values": GAMMA_SCAN},
+        "deployed_Tz_over_Tp": [ratio_lo, ratio_hi],
+        "deployed_Tz_s": [tz_lo, tz_hi],
+        "deployed_over_surface_Tz": [surface_bias_lo, surface_bias_hi],
+        "limiting_cell_for_lower_ratio": list(limiter_lo),
+        "limiting_cell_for_upper_ratio": list(limiter_hi),
+        "induced_tuner_frequency_hz": [1.0 / tz_hi, 1.0 / tz_lo],
+        "inside_committed_tuning_channel": (
+            1.0 / tz_hi >= MIN_TUNE_FREQ_HZ and 1.0 / tz_lo <= MAX_TUNE_FREQ_HZ
+        ),
+        "extremes_valid_for_three_partition_class": True,
+        "reason": "mixture convexity of the mu-weighted mean square frequency",
+        "promotion_use": False,
+    }
+
+
+def mixture_convexity_check() -> dict[str, Any]:
+    """Verify numerically that mixtures stay inside single-partition extremes."""
+    cases = [
+        [(3.0, 4.0, 1.0), (2.0, 9.0, 3.3), (0.0, 12.0, 1.0)],
+        [(1.0, 3.0, 7.0), (2.5, 14.0, 1.0), (1.5, 6.5, 2.0)],
+        [(4.0, 2.5, 1.0), (0.5, 20.0, 1.0), (0.0, 5.0, 1.0)],
+    ]
+    rows = []
+    worst_excess = 0.0
+    for case in cases:
+        active = [(h, tp, g) for h, tp, g in case if h > 0.0]
+        totals = [0.0] * len(OMEGA_NODES)
+        singles = []
+        for height, peak_period, gamma in active:
+            spectrum = partition_elevation_spectrum(height, peak_period, gamma)
+            totals = [a + b for a, b in zip(totals, spectrum)]
+            singles.append(deployed_period_s(spectrum))
+        mixed = deployed_period_s(totals)
+        lo = min(singles)
+        hi = max(singles)
+        excess = max(lo - mixed, mixed - hi, 0.0) / hi
+        worst_excess = max(worst_excess, excess)
+        rows.append(
+            {
+                "partitions": [list(entry) for entry in case],
+                "single_partition_deployed_Tz_s": singles,
+                "mixture_deployed_Tz_s": mixed,
+                "inside_component_extremes": lo - 1e-9 <= mixed <= hi + 1e-9,
+            }
+        )
+    return {
+        "cases": rows,
+        "worst_relative_excess": worst_excess,
+        "identity": "omega_est^2 = sum_r c_r E_{mu_r}[omega^2] / sum_r c_r",
+    }
+
+
+def sigma_channel_screen() -> dict[str, Any]:
+    """Band-passed specific-force standard deviation over the declared domain.
+
+    Physical admissibility is imposed at two levels and both are needed.  Each
+    partition carries its own breaking limit, because a 2.5 s wind sea cannot
+    reach swell heights whatever the rest of the sea does, and the combined sea
+    carries the mixture limit through its own zero-crossing period.  Dropping
+    the per-partition limit admits a 0.28-steepness chop riding on a long swell,
+    which is not a sea.
+
+    Two maxima are reported and they answer different questions.  The *sound*
+    bound maximizes over every band-reference frequency the shipping code can
+    present, because the deployed reference is not always the sea's own period:
+    the startup branch runs on the fixed 0.2 Hz prior and the estimator lags the
+    sea afterwards.  The *self-consistent* diagnostic instead evaluates each sea
+    at its own deployed period and is the number a settled run sees.
+
+    The one-partition maximum is exhaustive on its declared grid.  The
+    multimodal number is a two-partition screen on a coarser grid: under the
+    enriched admissibility set the earlier simplex-vertex reduction no longer
+    applies, so it is reported as a witness search rather than as an optimum.
+    """
+    peak_periods = _log_span(TP_MIN_S, TP_MAX_S, TP_SCAN)
+    gammas = _linear_span(GAMMA_MIN, GAMMA_MAX, GAMMA_SCAN)
+    references = _log_span(MIN_TUNE_FREQ_HZ, MAX_TUNE_FREQ_HZ, F_REF_SCAN)
+    band_weights = {f_ref: sigma_band_weight(f_ref) for f_ref in references}
+
+    cells = []
+    for peak_period in peak_periods:
+        for gamma in gammas:
+            unit = _partition_unit_spectrum(peak_period, gamma)
+            source = up_specific_force_spectrum(unit)
+            surface_tz = surface_zero_crossing_period(unit)
+            cells.append(
+                {
+                    "Tp_s": peak_period,
+                    "gamma": gamma,
+                    "surface_Tz_s": surface_tz,
+                    "deployed_Tz_s": deployed_period_s(unit),
+                    "height_cap_m": steepness_height_cap_m(surface_tz),
+                    "inverse_square_period": 1.0 / (surface_tz * surface_tz),
+                    "gains": {
+                        f_ref: _integrate(
+                            [w * s for w, s in zip(band_weights[f_ref], source)]
+                        )
+                        for f_ref in references
+                    },
+                }
+            )
+
+    def _sigma(gain: float, height_m: float) -> float:
+        # The unit spectrum carries m0 = 1 m^2, i.e. H = 4 m.
+        return math.sqrt(gain) * height_m / 4.0
+
+    single_best = 0.0
+    single_cell: dict[str, Any] = {}
+    self_consistent_best = 0.0
+    self_consistent_cell: dict[str, Any] = {}
+    for cell in cells:
+        for f_ref in references:
+            sigma = _sigma(cell["gains"][f_ref], cell["height_cap_m"])
+            if sigma > single_best:
+                single_best = sigma
+                single_cell = {
+                    "Tp_s": cell["Tp_s"],
+                    "gamma": cell["gamma"],
+                    "f_ref_hz": f_ref,
+                    "surface_Tz_s": cell["surface_Tz_s"],
+                    "steepness_height_cap_m": cell["height_cap_m"],
+                    "band_corners_hz": list(sigma_band_corners_hz(f_ref)),
+                }
+        own = min(
+            max(1.0 / cell["deployed_Tz_s"], MIN_TUNE_FREQ_HZ), MAX_TUNE_FREQ_HZ
+        )
+        sigma = _sigma(
+            _integrate(
+                [
+                    w * s
+                    for w, s in zip(
+                        sigma_band_weight(own),
+                        up_specific_force_spectrum(
+                            _partition_unit_spectrum(cell["Tp_s"], cell["gamma"])
+                        ),
+                    )
+                ]
+            ),
+            cell["height_cap_m"],
+        )
+        if sigma > self_consistent_best:
+            self_consistent_best = sigma
+            self_consistent_cell = {
+                "Tp_s": cell["Tp_s"],
+                "gamma": cell["gamma"],
+                "f_ref_hz": own,
+                "deployed_Tz_s": cell["deployed_Tz_s"],
+                "steepness_height_cap_m": cell["height_cap_m"],
+            }
+
+    coarse = [
+        cell
+        for index, cell in enumerate(cells)
+        if index % MIXTURE_CELL_STRIDE == 0
+    ]
+    weights = _linear_span(0.0, 1.0, MIXTURE_WEIGHT_STEPS)
+    steepness_scale = SIGNIFICANT_STEEPNESS_MAX * G_STD / (2.0 * math.pi)
+    mixture_best = single_best
+    mixture_cell: dict[str, Any] = {
+        "second_partition": None,
+        "note": "no admissible two-partition sea beat the one-partition maximum",
+    }
+    for f_ref in references:
+        for i, first in enumerate(coarse):
+            for second in coarse[i + 1:]:
+                gain_a = first["gains"][f_ref]
+                gain_b = second["gains"][f_ref]
+                for weight in weights:
+                    mixed_p = (
+                        weight * first["inverse_square_period"]
+                        + (1.0 - weight) * second["inverse_square_period"]
+                    )
+                    mixed_tz = 1.0 / math.sqrt(mixed_p)
+                    total = min(
+                        HS_MAX_M, steepness_scale * mixed_tz * mixed_tz
+                    )
+                    # Per-partition breaking limits cap each modal height too.
+                    height_a = min(
+                        first["height_cap_m"], total * math.sqrt(weight)
+                    )
+                    height_b = min(
+                        second["height_cap_m"],
+                        total * math.sqrt(1.0 - weight),
+                    )
+                    gain = (
+                        height_a * height_a * gain_a
+                        + height_b * height_b * gain_b
+                    )
+                    sigma = math.sqrt(gain) / 4.0
+                    if sigma > mixture_best:
+                        mixture_best = sigma
+                        mixture_cell = {
+                            "f_ref_hz": f_ref,
+                            "first_partition": [
+                                first["Tp_s"],
+                                first["gamma"],
+                                height_a,
+                            ],
+                            "second_partition": [
+                                second["Tp_s"],
+                                second["gamma"],
+                                height_b,
+                            ],
+                            "mixture_surface_Tz_s": mixed_tz,
+                            "mixture_Hs_m": math.sqrt(
+                                height_a * height_a + height_b * height_b
+                            ),
+                        }
+
+    prior_best = 0.0
+    prior_cell: dict[str, Any] = {}
+    prior_weight = sigma_band_weight(TUNE_FREQ_PRIOR_HZ)
+    for cell in cells:
+        source = up_specific_force_spectrum(
+            _partition_unit_spectrum(cell["Tp_s"], cell["gamma"])
+        )
+        sigma = _sigma(
+            _integrate([w * s for w, s in zip(prior_weight, source)]),
+            cell["height_cap_m"],
+        )
+        if sigma > prior_best:
+            prior_best = sigma
+            prior_cell = {
+                "Tp_s": cell["Tp_s"],
+                "gamma": cell["gamma"],
+                "steepness_height_cap_m": cell["height_cap_m"],
+            }
+
+    worst = max(single_best, mixture_best)
+    return {
+        "single_partition_max_sigma_a_ms2": single_best,
+        "single_partition_limiting_cell": single_cell,
+        "single_partition_maximum_is_exhaustive_on_grid": True,
+        "multimodal_screen_max_sigma_a_ms2": mixture_best,
+        "multimodal_screen_limiting_cell": mixture_cell,
+        "multimodal_number_is_a_witness_search_not_an_optimum": True,
+        "self_consistent_max_sigma_a_ms2": self_consistent_best,
+        "self_consistent_limiting_cell": self_consistent_cell,
+        "self_consistent_is_a_diagnostic_not_a_bound": True,
+        "startup_prior_max_sigma_a_ms2": prior_best,
+        "startup_prior_limiting_cell": prior_cell,
+        "startup_prior_hz": TUNE_FREQ_PRIOR_HZ,
+        "per_partition_and_mixture_steepness_both_imposed": True,
+        "band_corners_at_channel_ceiling_hz": list(
+            sigma_band_corners_hz(MAX_TUNE_FREQ_HZ)
+        ),
+        "absolute_band_ceiling_reachable_in_committed_channel": (
+            sigma_band_corners_hz(MAX_TUNE_FREQ_HZ)[1] >= SIGMA_BAND_MAX_HZ
+        ),
+        "worst_admissible_sigma_a_ms2": worst,
+        # sigma_target_ = min(sigma_coeff_ * sigma_a, max_sigma_a_).  The
+        # ceiling saturates, so the source coordinate never leaves its declared
+        # interval; the question is whether an admissible sea reaches the rail.
+        "sigma_aw_map": "sigma_aw = min(0.9 * sigma_a, 4 m/s^2)",
+        "sigma_aw_clamp_ms2": SIGMA_AW_CLAMP_MS2,
+        "sigma_a_saturating_the_clamp_ms2": SIGMA_A_SATURATION_MS2,
+        "worst_admissible_sigma_aw_ms2": min(
+            SIGMA_COEFF * worst, SIGMA_AW_CLAMP_MS2
+        ),
+        "sigma_aw_coordinate_stays_inside_declared_interval": True,
+        "clamp_rail_reachable_from_declared_sea_domain": (
+            worst >= SIGMA_A_SATURATION_MS2
+        ),
+        "clamp_rail_reachable_at_settled_band_reference": (
+            self_consistent_best >= SIGMA_A_SATURATION_MS2
+        ),
+        "clamp_rail_reachable_at_startup_prior": (
+            prior_best >= SIGMA_A_SATURATION_MS2
+        ),
+        "rail_makes_sea_to_source_map_non_injective": (
+            worst >= SIGMA_A_SATURATION_MS2
+        ),
+        "rho_max_used": RHO_MAX,
+        "sigma_a_scales_linearly_in_rho_max": True,
+        "rho_max_below_which_the_rail_is_unreachable": (
+            RHO_MAX * SIGMA_A_SATURATION_MS2 / worst
+        ),
+        "sigma_a_scales_linearly_in_steepness_ceiling": True,
+        "steepness_below_which_the_rail_is_unreachable": (
+            SIGNIFICANT_STEEPNESS_MAX * SIGMA_A_SATURATION_MS2 / worst
+        ),
+        "promotion_use": False,
+    }
+
+
+def alias_obligation() -> dict[str, Any]:
+    """Folded specific-force power at the deployed 5 ms sampling interval."""
+    nyquist_rad_s = math.pi / IMU_DT_S
+    peak_periods = _log_span(TP_MIN_S, TP_MAX_S, TP_SCAN)
+    gammas = _linear_span(GAMMA_MIN, GAMMA_MAX, GAMMA_SCAN)
+
+    worst_constant = 0.0
+    worst_cell: dict[str, Any] = {}
+    for peak_period in peak_periods:
+        for gamma in gammas:
+            unit = _partition_unit_spectrum(peak_period, gamma)
+            height = steepness_height_cap_m(surface_zero_crossing_period(unit))
+            constant = _asymptotic_acceleration_constant(
+                height, peak_period, gamma
+            )
+            if constant > worst_constant:
+                worst_constant = constant
+                worst_cell = {
+                    "Tp_s": peak_period,
+                    "gamma": gamma,
+                    "Hs_m": height,
+                }
+
+    bounded = acceleration_tail_above(
+        nyquist_rad_s, worst_cell["Hs_m"], worst_cell["Tp_s"], worst_cell["gamma"]
+    )
+    flat_three = unbounded_response_alias_power(3.0, worst_constant)
+    flat_six = unbounded_response_alias_power(6.0, worst_constant)
+    return {
+        "nyquist_rad_s": nyquist_rad_s,
+        "worst_cell": worst_cell,
+        "asymptotic_acceleration_constant_m2s3": worst_constant,
+        "folded_power_with_declared_rolloff_m2s4": bounded,
+        "folded_sigma_with_declared_rolloff_ms2": math.sqrt(bounded),
+        "flat_response_folded_power_3_decades_m2s4": flat_three,
+        "flat_response_folded_sigma_3_decades_ms2": math.sqrt(flat_three),
+        "flat_response_folded_power_6_decades_m2s4": flat_six,
+        "flat_response_folded_power_is_divergent": True,
+        "flat_response_exceeds_sigma_clamp_within_decades": (
+            math.sqrt(flat_three) > SIGMA_AW_CLAMP_MS2
+        ),
+        "response_rolloff_is_mandatory": True,
+        "sampling_alone_band_limits_the_sea": False,
+    }
+
+
+def matrix_moment_report() -> dict[str, Any]:
+    """Response-weighted matrix moments actually required by the source path."""
+    representative = [
+        {"label": "beam_swell_narrow", "beta_deg": 90.0, "spread_s": 25.0},
+        {"label": "bow_quarter_broad", "beta_deg": 45.0, "spread_s": 1.0},
+        {"label": "head_sea_typical", "beta_deg": 0.0, "spread_s": 8.0},
+    ]
+    rows = []
+    worst_offdiagonal = 0.0
+    for entry in representative:
+        gram = directional_gram(
+            math.radians(entry["beta_deg"]), entry["spread_s"]
+        )
+        normalized = 0.0
+        for a in range(3):
+            for b in range(3):
+                if a == b:
+                    continue
+                denom = math.sqrt(gram[a][a] * gram[b][b])
+                if denom > 0.0:
+                    normalized = max(normalized, abs(gram[a][b]) / denom)
+        worst_offdiagonal = max(worst_offdiagonal, normalized)
+        rows.append(
+            {
+                "label": entry["label"],
+                "beta_deg": entry["beta_deg"],
+                "spread_s": entry["spread_s"],
+                "directional_gram": gram,
+                "mass": gram[0][0],
+                "max_normalized_offdiagonal": normalized,
+            }
+        )
+
+    # A single fully specified sea, to exhibit the finite matrix moments.
+    sea = [(3.0, 8.0, 3.3, 20.0, 8.0), (1.5, 13.0, 1.0, 200.0, 25.0)]
+    acceleration = [[0.0] * 3 for _ in range(3)]
+    proxy = [[0.0] * 3 for _ in range(3)]
+    for height, peak_period, gamma, beta_deg, spread_s in sea:
+        elevation = partition_elevation_spectrum(height, peak_period, gamma)
+        source = up_specific_force_spectrum(elevation)
+        gram = directional_gram(math.radians(beta_deg), spread_s)
+        accel_mass = _integrate(source)
+        proxy_mass = _integrate(
+            [w * s for w, s in zip(PROXY_ELEVATION_WEIGHT, source)]
+        )
+        for a in range(3):
+            for b in range(3):
+                acceleration[a][b] += accel_mass * gram[a][b]
+                proxy[a][b] += proxy_mass * gram[a][b]
+
+    return {
+        "factorization": "M = sum_r (int omega-weighted rho^2 omega^4 S_r) Q_r",
+        "directional_gram_cases": rows,
+        "worst_normalized_offdiagonal": worst_offdiagonal,
+        "per_axis_scalarization_valid": False,
+        "example_sea": [list(entry) for entry in sea],
+        "example_acceleration_matrix_moment_m2s4": acceleration,
+        "example_proxy_elevation_matrix_moment_m2": proxy,
+        "finiteness_ladder": {
+            "proxy_elevation_and_velocity_moments": "finite for any rolloff p >= 0",
+            "band_passed_acceleration_moment": "finite for any rolloff p >= 0",
+            "raw_acceleration_moment": "finite iff p > 0",
+            "acceleration_moment_of_order_n": "finite iff n < 2p",
+            "deployed_path_requires_orders_above_zero": False,
+        },
+        "promotion_use": False,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Payload assembly.
+# ---------------------------------------------------------------------------
+def build() -> dict[str, Any]:
+    period = period_channel_screen()
+    convexity = mixture_convexity_check()
+    sigma = sigma_channel_screen()
+    alias = alias_obligation()
+    moments = matrix_moment_report()
+
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "qualification": "OU3_SEA0_DIRECTIONAL_RESPONSE_MOMENT_SUBCERTIFICATE",
+        "proof_status": "mixed_analytic_and_non_promoting_numerical_screen",
+        "trajectory_replay_used": False,
+        "filter_changed": False,
+        "declared_operating_domain_shrunk": False,
+        "SEA0_full_certificate_promoted": False,
+        "P2_promoted_from_this_artifact": False,
+        "P3_promoted_from_this_artifact": False,
+        "P4_promoted_from_this_artifact": False,
+        "P5_promoted_from_this_artifact": False,
+        "declared_sea_domain": {
+            "m_max": M_MAX,
+            "Tp_s": [TP_MIN_S, TP_MAX_S],
+            "gamma": [GAMMA_MIN, GAMMA_MAX],
+            "Hs_max_m": HS_MAX_M,
+            "significant_steepness_max": SIGNIFICANT_STEEPNESS_MAX,
+            "spreading_exponent_s": [SPREAD_S_MIN, SPREAD_S_MAX],
+            "beta_rad": [-math.pi, math.pi],
+            "steepness_is_physical_admissibility_not_proof_clamp": True,
+            "covers_eight_reference_seas": True,
+        },
+        "response_family": {
+            "envelope": "|G_j(omega,theta)| <= rho(omega) omega^2 u_j(theta)",
+            "u_of_theta": ["1", "|cos theta|", "|sin theta|"],
+            "rho_max": RHO_MAX,
+            "rolloff_exponent_p": ROLL_OFF_EXPONENT,
+            "reference_waterline_m": L_REF_M,
+            "rolloff_corner_rad_s": OMEGA_L,
+            "rolloff_corner_hz": OMEGA_L / (2.0 * math.pi),
+            "mechanism": "finite-waterline Froude-Krylov length averaging",
+            "lever_arm_enabled": False,
+            "single_vessel_assumed": False,
+        },
+        "analytical_lemmas": {
+            "modulus_majorant": (
+                "for |G_j| <= m_j, v^H Phi_u v <= |v|^T M |v| with "
+                "M = int m m^T E dtheta, hence lambda_max(Phi_u) <= lambda_max(M)"
+            ),
+            "theta_factorization": (
+                "E = sum_r S_r(omega) D_r(theta) makes every response-weighted "
+                "moment a sum of scalar frequency integrals times constant "
+                "directional Gram matrices Q_r(beta_r,s_r)"
+            ),
+            "exact_leak_inversion": (
+                "omega_est^2 = (sigma_v/sigma_eta)^2 - lambda^2 = E_mu[omega^2] "
+                "with d mu = |G_eta|^2 S_up d omega; exact for any spectrum"
+            ),
+            "deployed_period_is_high_passed": (
+                "d mu = rho^2 (omega^2/(omega^2+lambda^2))^4 S_eta d omega, so "
+                "the deployed Tz is the moment period of a fourth-order "
+                "high-passed, response-weighted elevation spectrum"
+            ),
+            "mixture_convexity": (
+                "omega_est^2 is a convex combination over partitions, so the "
+                "extreme deployed periods of the SEA3 class occur at "
+                "one-partition seas"
+            ),
+            "leak_inversion_is_not_narrow_band": True,
+            "unbanded_surface_acceleration_variance_finite": False,
+            "sampling_alone_removes_acceleration_divergence": False,
+        },
+        "matrix_moments": moments,
+        "deployed_period_channel": period,
+        "mixture_convexity_check": convexity,
+        "deployed_sigma_channel": sigma,
+        "alias_obligation": alias,
+        "quadrature": {
+            "omega_interval_rad_s": [OMEGA_MIN, OMEGA_MAX],
+            "omega_simpson_panels": OMEGA_PANELS,
+            "theta_simpson_panels": THETA_PANELS,
+            "interval_arithmetic_used_for_quadrature": False,
+            "high_frequency_tail_bounded_analytically": True,
+            "low_frequency_tail_reason": (
+                "exp(-1.25 (omega_p/omega)^4) underflows below the grid floor"
+            ),
+        },
+        "reason_not_promoted": (
+            "fixed-grid quadrature with analytical pads is a screening "
+            "enclosure, not validated interval integration; the deployed "
+            "channels are also still evaluated in continuous-time steady state "
+            "rather than through the exact discrete EMA and log-period state"
+        ),
+        "limiting_quantity": (
+            "reachability of the sigma_aw clamp rail from the declared "
+            "directional sea domain, where the sea-to-source map stops being "
+            "injective and SEA3 can no longer prune the P2 language"
+        ),
+        "sea3_source_language_included_in_frozen_p2_contract": False,
+        "next_obligation": (
+            "decide the sigma clamp rail: either certify a sharper vessel/IMU "
+            "response envelope that puts it out of reach, or carry the "
+            "saturated non-injective cell explicitly in the SEA3 P2 language; "
+            "then replace the continuous-time steady-state channel weights by "
+            "the exact discrete WavePeriodEstimator moment EMAs, log-period "
+            "state and AdaptiveWaveBandPass recursion"
+        ),
+    }
+
+    failures = validate(payload)
+    payload["validation_pass"] = not failures
+    payload["validation_failures"] = failures
+    return payload
+
+
+def validate(payload: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+
+    if payload["schema_version"] != SCHEMA_VERSION:
+        failures.append("schema version mismatch")
+    for key in (
+        "SEA0_full_certificate_promoted",
+        "P2_promoted_from_this_artifact",
+        "P3_promoted_from_this_artifact",
+        "P4_promoted_from_this_artifact",
+        "P5_promoted_from_this_artifact",
+        "trajectory_replay_used",
+        "filter_changed",
+        "declared_operating_domain_shrunk",
+    ):
+        if payload[key]:
+            failures.append(f"{key} must stay false")
+
+    period = payload["deployed_period_channel"]
+    ratio_lo, ratio_hi = period["deployed_Tz_over_Tp"]
+    if not (0.0 < ratio_lo <= ratio_hi):
+        failures.append("deployed Tz/Tp screen is not ordered")
+    if not period["inside_committed_tuning_channel"]:
+        failures.append(
+            "declared sea domain leaves the committed 0.03-1.2 Hz channel"
+        )
+
+    convexity = payload["mixture_convexity_check"]
+    if convexity["worst_relative_excess"] > 1e-9:
+        failures.append("mixture period left the single-partition extremes")
+    for case in convexity["cases"]:
+        if not case["inside_component_extremes"]:
+            failures.append("mixture convexity case violated")
+
+    moments = payload["matrix_moments"]
+    if moments["worst_normalized_offdiagonal"] <= 0.0:
+        failures.append("directional Gram lost its cross-axis coupling")
+    if moments["per_axis_scalarization_valid"]:
+        failures.append("per-axis scalarization must stay invalid")
+    for case in moments["directional_gram_cases"]:
+        if abs(case["mass"] - 1.0) > 1e-6:
+            failures.append(
+                f"directional spreading is not normalized: {case['label']}"
+            )
+    for row in moments["example_acceleration_matrix_moment_m2s4"]:
+        for value in row:
+            if not math.isfinite(value):
+                failures.append("acceleration matrix moment is not finite")
+
+    alias = payload["alias_obligation"]
+    if not math.isfinite(alias["folded_power_with_declared_rolloff_m2s4"]):
+        failures.append("declared roll-off failed to bound the alias fold")
+    if not alias["flat_response_folded_power_is_divergent"]:
+        failures.append("flat-response alias divergence must stay recorded")
+    if alias["sampling_alone_band_limits_the_sea"]:
+        failures.append("sampling must not be claimed to band limit the sea")
+
+    if payload["sea3_source_language_included_in_frozen_p2_contract"]:
+        failures.append("SEA3 source-language inclusion is not established here")
+
+    sigma = payload["deployed_sigma_channel"]
+    if not (sigma["single_partition_max_sigma_a_ms2"] > 0.0):
+        failures.append("sigma channel screen produced no positive bound")
+    if (
+        sigma["multimodal_screen_max_sigma_a_ms2"]
+        < sigma["single_partition_max_sigma_a_ms2"]
+    ):
+        failures.append("multimodal screen fell below the one-partition maximum")
+    if not sigma["per_partition_and_mixture_steepness_both_imposed"]:
+        failures.append("both steepness admissibility levels must stay imposed")
+    if sigma["worst_admissible_sigma_aw_ms2"] > SIGMA_AW_CLAMP_MS2:
+        failures.append("clamped sigma_aw left its declared interval")
+    if not sigma["sigma_aw_coordinate_stays_inside_declared_interval"]:
+        failures.append("the sigma_aw clamp must keep the coordinate contained")
+    if sigma["clamp_rail_reachable_from_declared_sea_domain"] != (
+        sigma["worst_admissible_sigma_a_ms2"] >= SIGMA_A_SATURATION_MS2
+    ):
+        failures.append("clamp-rail reachability flag is inconsistent")
+    if sigma["clamp_rail_reachable_at_settled_band_reference"] and not sigma[
+        "clamp_rail_reachable_from_declared_sea_domain"
+    ]:
+        failures.append("settled rail reachability contradicts the sound bound")
+
+    domain = payload["declared_sea_domain"]
+    if domain["m_max"] != M_MAX:
+        failures.append("partition count must remain M_max = 3")
+    if not domain["steepness_is_physical_admissibility_not_proof_clamp"]:
+        failures.append("steepness ceiling must stay a physical assumption")
+
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, default=None)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="compare the committed artifact against a fresh build",
+    )
+    args = parser.parse_args()
+
+    payload = build()
+    text = json.dumps(payload, indent=2, sort_keys=True)
+
+    committed = Path(__file__).with_suffix(".json")
+    if args.check:
+        if not committed.exists():
+            print(f"missing committed artifact: {committed}", file=sys.stderr)
+            return 1
+        if json.loads(committed.read_text(encoding="utf-8")) != payload:
+            print("committed artifact is stale", file=sys.stderr)
+            return 1
+        print("committed artifact is current")
+        return 0 if payload["validation_pass"] else 1
+
+    if args.output is not None:
+        args.output.write_text(text + "\n", encoding="utf-8")
+    else:
+        print(text)
+    return 0 if payload["validation_pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ou3_sea3_spectral_moment_bridge.py
+++ b/tools/ou3_sea3_spectral_moment_bridge.py
@@ -131,6 +131,16 @@ def _ratio_interval_for_gamma_cell(
     return math.sqrt(m0_lo / m2_hi), math.sqrt(m0_hi / m2_lo)
 
 
+def jonswap_dimensionless_shape(x: float, gamma: float) -> float:
+    """Nondimensional JONSWAP elevation shape at x = omega/omega_p.
+
+    This is the single shape definition shared by every SEA0 artifact so that
+    no downstream construction can silently adopt a different peak-width or
+    peak-enhancement convention.
+    """
+    return _dimensionless_integrand(x, gamma, 0)
+
+
 def mixture_zero_crossing_period(
     heights: list[float],
     periods: list[float],


### PR DESCRIPTION
Continues the SEA3 directional-sea route from `main` after #481. Research question: **can a conservative directional vessel/IMU response family over the deployed finite band turn the three-partition spectrum into bounded response-weighted moments, and what does the deployed source path then actually see?**

This closes the "current blocker" the ledger named at #481 — the directional response — at the continuous-time steady-state level, and replaces it with two sharper obligations. Replay free, non-promoting: nothing here promotes SEA0, P2, P3, P4 or P5.

## Response family

An envelope, not a hull. With the lever arm disabled, angular motion produces no specific force at the IMU, so only translational response enters:

```
|G_j(omega,theta)| <= rho(omega) omega^2 u_j(theta),  u = [1, |cos theta|, |sin theta|]
rho(omega) = rho_max min{1, (omega_L/omega)^p}
```

The roll-off is finite-waterline Froude–Krylov length averaging; `rho_max = 2`, `p = 1`, `L_ref = 4 m` (a *shorter* reference hull raises `omega_L` and so assumes less).

## Analytical results

- **Modulus majorant.** For `|G_j| <= m_j`, `v* Phi_u v <= |v|^T M |v|` with `M = int m m^T E dtheta`, so `lambda_max(Phi_u) <= lambda_max(M)`. Cross-axis coupling survives as off-diagonal entries; the source is never scalarized per axis.
- **Directional factorization.** The theta integral separates into constant Gram matrices `Q_r(beta_r, s_r)`, strongly non-diagonal (normalized off-diagonals to 0.998) and direction selective — a head sea loads surge 0.81 against 0.19, a beam sea reverses it.
- **Exact leak inversion.** The deployed `omega^2 = (sigma_v/sigma_eta)^2 - lambda^2` equals `E_mu[omega^2]` **exactly, for any input spectrum** — an identity, not a narrow-band approximation. Equivalently the deployed `T_z` is the moment period of the true elevation spectrum after a fourth-order high-pass at `lambda` and the response weight `rho^2`.
- **Mixture convexity.** That mean square is convex over partitions, so the extremes of the whole three-partition class occur on one-partition seas: the fifteen-parameter period enclosure collapses to a `(T_p, gamma)` screen.
- **Finiteness ladder.** Proxy elevation/velocity and band-passed acceleration moments are finite for any `p >= 0`; the raw acceleration moment needs `p > 0`; order `n` needs `n < 2p`. The deployed path needs no order above zero.

Screens over the declared domain: `0.6564 <= Tz_src/Tp <= 0.8861` (wider on both sides than the surface screen), `0.924 <= Tz_src/Tz_eta <= 1.115`, induced tuning channel `0.0644 .. 0.5051 Hz` inside the committed `0.03 .. 1.2 Hz`.

## Two obligations, reported rather than tuned away

**Sampling supplies no band limit.** With a flat response the folded specific force above Nyquist is logarithmically divergent, and not by a negligible amount: three unmodelled decades already fold in `83 m^2/s^4` (`9.14 m/s^2`), more than the whole sigma clamp interval. Under the declared roll-off the same fold is `2.36e-4`. A certified vessel/IMU roll-off is therefore a **mandatory** SEA0 assumption; the 5 ms sampling rate may not be offered in its place.

**The sigma clamp rail is reachable.** Shipping code commits `sigma_aw = min(0.9 sigma_a, 4 m/s^2)`, so the coordinate is contained *by saturation* and no sea can violate it. But an admissible crossing sea — 1.83 m at `Tp = 4.59 s` on 8.18 m at `Tp = 10.9 s`, `Hs = 8.38 m`, each partition below its own breaking steepness — gives `sigma_a = 4.66 m/s^2` against the `4/0.9 = 4.44` saturation point. On the rail `sigma_aw` is constant, so the sea-to-source map is not injective and SEA3 cannot prune the P2 language there.

The sharper fact: neither frequency-source mode reaches the rail at rest — `3.91 m/s^2` at each sea's own deployed period, `4.06` at the fixed 0.2 Hz prior. It is reached only at intermediate references, i.e. on the **estimator-lag branch between** the two source modes #481 established. The two SEA0 subcertificates meet exactly there.

Failure analysis is recorded in the ledger per the AGENTS.md protocol: failure class is a source-language *structure* failure, not a theorem, enclosure or implementation failure; it invalidates the assumption that a physical sea domain prunes the tuner language *uniformly*; it leaves the theorem, the response family, the majorant, the factorization, the leak identity and the period channel intact.

## Domain declarations

`Tp in [2.5, 20] s`, `gamma in [1, 7]`, `Hs <= 8.5 m` (matching `significant_wave_height_Hs_upper_m` in the declared operating domain — deliberately not narrower), spreading `s in [1, 25]`, `beta` free, significant steepness `<= 0.10` imposed **per partition and on the combined sea**. The per-partition form matters: without it the search returns a 0.28-steepness chop riding on a long swell, which is not a sea. A test asserts the domain is not narrower than the declared deployment envelope.

## Honesty of the numerics

Fixed-grid Simpson quadrature with analytical tail pads, not validated interval integration, and the channels are continuous-time steady state rather than the exact discrete moment EMAs, log-period state and `AdaptiveWaveBandPass` recursion. Every numerical interval is marked a screening enclosure. Verified against closed forms where they exist: `m0 = H^2/16` and the PM `Tz/Tp = ((5/4)pi)^(-1/4)` to 9+ places, the `s = 1` Gram entries `0.5` and `2/pi` exactly.

## Changes

- `tools/ou3_sea3_directional_response_moments.py` + committed JSON artifact (pure stdlib; the `sea0` CI job installs nothing)
- `tests/validation/test_ou3_sea3_directional_response_moments.py` — 15 tests
- `ou3-proof.yml` `sea0` job: compile, `--check`, run, assert, upload
- `doc/kalman_ou_iii/w3d-sea3-directional-response.tex-part`, included after the period bridge; cleanup contract updated
- `docs/ou3-proof-research-state.md`: new subcertificate, failure analysis, rewritten blocker and next increment, four new forbidden shortcuts
- `ou3_sea3_spectral_moment_bridge.py`: one public `jonswap_dimensionless_shape` wrapper so both SEA0 artifacts share one JONSWAP convention (its own artifact is unchanged)

`ruff check tools/ tests/validation/` clean; SEA0 and contract tests pass locally. No `.c/.cc/.cpp/.h/.mk/Makefile` change, so no `make all` rebuild is implied.

## Next research question (separate PR)

Decide the rail — certify a translational-RAO bound putting `rho_max` below 1.907, or carry the saturated cell explicitly unpruned — then replace the continuous-time weights by the exact discrete estimator/band-pass recursions, declare the sea rate relation `R_lambda`, and attempt `Lhat_SEA3 subset L_current_source`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MnEc72HhZDeCjfQuEnrGh

---
_Generated by [Claude Code](https://claude.ai/code/session_013MnEc72HhZDeCjfQuEnrGh)_