### PR TITLE
OU-III: complete-SEA3 master nonlinear word proof

### DIFF
--- a/tools/stability/ou3_p4_complete_sea3_correction_information_bound.py
+++ b/tools/stability/ou3_p4_complete_sea3_correction_information_bound.py
@@ -21,6 +21,10 @@ The bounds here accept actual operation matrices. They create no alternative
 source and do not claim coverage of the complete SEA3 family. Uniform numeric
 radii remain null until reset/floor-complete source-correlated coverage closes.
 P3 is consumed unchanged and cannot be promoted by this module.
+
+The finite-angle rows consumed here are the invariant-coordinate rows already
+widened for the declared delta-a_w error domain.  The earlier physical-force-only
+rows are intentionally not accepted after the nominal-force correction.
 """
 from __future__ import annotations
 
@@ -36,8 +40,8 @@ import ou3_sea3_riccati_metric_p3 as P3
 
 REPO = Path(__file__).resolve().parents[2]
 DEFAULT_DOMAIN = REPO / "tools" / "stability" / "ou3_proof_operating_domain.json"
-SCHEMA = 3
-QUALIFICATION = "OU3_P4_COMPLETE_SEA3_OPERATION_CORRECTION_INFORMATION_BOUND_V3"
+SCHEMA = 4
+QUALIFICATION = "OU3_P4_COMPLETE_SEA3_OPERATION_CORRECTION_INFORMATION_BOUND_V4"
 
 
 def _checked_block(P: IntervalMatrix, indices: tuple[int, ...]) -> IntervalMatrix:
@@ -93,6 +97,10 @@ def defect_precision_trace_upper(P_J: IntervalMatrix, indices: tuple[int, ...]) 
 
 
 def _status(candidates: list[dict], p3_pass: bool) -> dict:
+    if [float(c.get("attitude_angle_deg", math.nan)) for c in candidates] != [30.0, 25.0, 20.0, 15.0]:
+        raise RuntimeError("widened invariant finite-angle rows missing or reordered")
+    if any(c.get("widened_for_declared_delta_aw_domain") is not True for c in candidates):
+        raise RuntimeError("un-widened finite-angle row reached correction-information consumer")
     modes = {}
     for mode, dimension in (("H", 18), ("A", 21)):
         modes[mode] = {
@@ -102,6 +110,9 @@ def _status(candidates: list[dict], p3_pass: bool) -> dict:
             "candidate_cells": [{
                 "candidate_attitude_angle_deg": float(c["attitude_angle_deg"]),
                 "candidate_cayley_norm_upper": float(c["cayley_norm_upper"]),
+                "candidate_e_eta_norm_upper_mps2": float(c["e_eta_norm_upper_mps2"]),
+                "candidate_force_upper_mps2_used": float(c["force_upper_mps2_used"]),
+                "widened_for_declared_delta_aw_domain": True,
                 "derived_metric_energy_radius_upper": None,
                 "candidate_metric_energy_ball_certified": False,
             } for c in candidates],
@@ -115,6 +126,8 @@ def _status(candidates: list[dict], p3_pass: bool) -> dict:
         "complete_SEA3_word_retained": True,
         "all_valid_accelerometer_updates_remain_in_complete_word": True,
         "all_due_S_updates_and_actual_RS_remain_in_complete_word": True,
+        "widened_invariant_finite_angle_rows_consumed": True,
+        "physical_force_only_candidate_rows_consumed": False,
         "same_operation_correction_information_identity_valid": True,
         "same_shipping_P_H_R_K_S_cell_required": True,
         "full_matrix_correction_inequality": "d d^T <= J K S K^T <= J P",
@@ -157,7 +170,8 @@ def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
     failures = P3.validate(p3) + INVARIANT.validate(invariant)
     if failures or p3["P3_CONDITIONAL_SEA3_PASS"] is not True:
         raise RuntimeError(f"unchanged conditional P3/invariant prerequisites failed: {failures}")
-    return _status(invariant["measurement_linearizing_shift_bounds_reused_without_widening"], True)
+    candidates = invariant["measurement_linearizing_shift_bounds_widened_for_declared_delta_aw_domain"]
+    return _status(candidates, True)
 
 
 def validate(d: dict) -> list[str]:
@@ -170,11 +184,13 @@ def validate(d: dict) -> list[str]:
         "P3_frozen_not_modified", "P3_conditional_complete_SEA3_consumed", "complete_SEA3_word_retained",
         "all_valid_accelerometer_updates_remain_in_complete_word",
         "all_due_S_updates_and_actual_RS_remain_in_complete_word",
+        "widened_invariant_finite_angle_rows_consumed",
         "same_operation_correction_information_identity_valid", "full_posterior_inverse_required_for_defect_cost",
     ):
         if d.get(key) is not True:
             failures.append(f"{key} is not true")
     for key in (
+        "physical_force_only_candidate_rows_consumed",
         "storage_is_original_physical_metric_isometry", "source_uniform_covariance_reset_and_floor_coverage_closed",
         "candidate_metric_energy_balls_derived", "reset_transport_correction_radius_source_closed",
         "source_indexed_e_eta_transition_closed_here", "complete_word_nonlinear_dissipation_closed_here",
@@ -201,6 +217,11 @@ def validate(d: dict) -> list[str]:
             q = row.get("candidate_cayley_norm_upper")
             if not isinstance(q, (int, float)) or not (math.isfinite(float(q)) and 0.0 < q < 1.0):
                 failures.append(f"{mode} candidate Cayley radius invalid")
+            e = row.get("candidate_e_eta_norm_upper_mps2")
+            if not isinstance(e, (int, float)) or not (math.isfinite(float(e)) and float(e) > 0.0):
+                failures.append(f"{mode} widened e_eta bound invalid")
+            if row.get("widened_for_declared_delta_aw_domain") is not True:
+                failures.append(f"{mode} un-widened finite-angle row consumed")
             if row.get("derived_metric_energy_radius_upper") is not None:
                 failures.append(f"{mode} unsupported numeric candidate radius")
             if row.get("candidate_metric_energy_ball_certified") is not False:

--- a/tools/stability/ou3_p4_complete_sea3_invariant_aw_coordinate.py
+++ b/tools/stability/ou3_p4_complete_sea3_invariant_aw_coordinate.py
@@ -66,11 +66,30 @@ transformed rather than altered, every due S=0 update and its actual applied
 SpectralMSE R_S remain in the same word and regularize the transformed a_w
 direction through the same information matrix.
 
+The nominal-force ceiling used below is NOT inferred from physical SEA3 alone.
+The declared Normal-Live source gives the true specific-force bound
+
+    ||a_true-g|| <= 13.80665 m/s^2,
+
+and the already-declared P4/startup perturbation domain gives
+
+    ||delta_a_w|| <= 2.941995 m/s^2.
+
+Since a_hat=a_true-delta_a_w,
+
+    ||a_hat-g|| <= 13.80665+2.941995 = 16.748645 m/s^2,
+    ||a_hat||   <= 16.748645+g       = 26.555295 m/s^2.
+
+Those are theorem-domain consequences, not replay extrema and not a new source
+assumption.  The pure-e_eta candidate rows inherited from the earlier helper
+were computed with the physical 13.80665 ceiling; this module outwardly widens
+them by the exact nominal/physical force ratio before they are reused.
+
 This producer deliberately remains fail-closed.  P4 still requires an
-operation-matched bound on transport of full epsilon_aw through the physical correction,
-quaternion injection/reset, prediction, and source change.  That transport must
-be charged to the same Joseph information decrease; no packet-count-times-worst
-remainder budget is admissible.
+operation-matched bound on transport of full epsilon_aw through the physical
+correction, quaternion injection/reset, prediction, and source change.  That
+transport must be charged to the same Joseph information decrease; no
+packet-count-times-worst remainder budget is admissible.
 """
 from __future__ import annotations
 
@@ -86,8 +105,37 @@ import ou3_sea3_complete_source as COMPLETE
 
 REPO = Path(__file__).resolve().parents[2]
 DEFAULT_DOMAIN = REPO / "tools" / "stability" / "ou3_proof_operating_domain.json"
-SCHEMA = 2
-QUALIFICATION = "OU3_P4_COMPLETE_SEA3_INVARIANT_AW_NORMAL_FORM_V2"
+SCHEMA = 3
+QUALIFICATION = "OU3_P4_COMPLETE_SEA3_INVARIANT_AW_NORMAL_FORM_V3"
+
+
+def _up_add(a: float, b: float) -> float:
+    return math.nextafter(float(a) + float(b), math.inf)
+
+
+def _widen_candidate_rows(rows: list[dict], physical_force: float, nominal_force: float) -> list[dict]:
+    if not (math.isfinite(physical_force) and physical_force > 0.0):
+        raise RuntimeError("invalid physical force ceiling")
+    if not (math.isfinite(nominal_force) and nominal_force >= physical_force):
+        raise RuntimeError("invalid nominal force ceiling")
+    ratio = math.nextafter(nominal_force / physical_force, math.inf)
+    out: list[dict] = []
+    for row in rows:
+        r = dict(row)
+        for key in (
+            "e_eta_norm_upper_mps2",
+            "e_eta_local_lipschitz_upper_mps2_per_cayley",
+        ):
+            value = float(r[key])
+            if not (math.isfinite(value) and value > 0.0):
+                raise RuntimeError(f"invalid inherited candidate bound {key}")
+            r[key] = math.nextafter(value * ratio, math.inf)
+        r["force_upper_mps2_used"] = nominal_force
+        r["inherited_physical_force_upper_mps2"] = physical_force
+        r["nominal_force_widening_ratio"] = ratio
+        r["widened_for_declared_delta_aw_domain"] = True
+        out.append(r)
+    return out
 
 
 def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
@@ -113,13 +161,16 @@ def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
         raise RuntimeError("canonical complete SEA3 source changed")
 
     live = domain["normal_live"]
+    handoff = domain["startup"]["physical_handoff_coordinate_bounds"]
     g = float(domain["startup"]["gravity_mps2"])
-    fmax = float(live["specific_force_norm_upper_mps2"])
-    if not (math.isfinite(g) and g > 0.0 and math.isfinite(fmax) and fmax > 0.0):
-        raise RuntimeError("invalid gravity/specific-force theorem bounds")
-    # Since f_hat=R_hat(a_hat-g), orthogonality gives
-    # ||a_hat|| <= ||a_hat-g||+||g|| <= fmax+g.
-    ahat = math.nextafter(fmax + g, math.inf)
+    true_force = float(live["specific_force_norm_upper_mps2"])
+    delta_aw = float(handoff["latent_acceleration_error_norm_upper_mps2"])
+    if not all(math.isfinite(x) and x > 0.0 for x in (g, true_force, delta_aw)):
+        raise RuntimeError("invalid gravity/true-force/delta-aw theorem bounds")
+
+    nominal_force = _up_add(true_force, delta_aw)
+    nominal_aw = _up_add(nominal_force, g)
+    rows = _widen_candidate_rows(awlin["candidate_cells"], true_force, nominal_force)
 
     return {
         "schema": SCHEMA,
@@ -134,16 +185,30 @@ def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
         "complete_SEA3_word_retained": True,
         "all_valid_accelerometer_updates_remain_in_complete_word": True,
         "all_due_S_updates_and_actual_RS_remain_in_complete_word": True,
-        "source_nominal_aw_norm_upper_mps2": ahat,
-        "nominal_aw_bound_is_conditional_on_nominal_force_bound": True,
-        "nominal_force_bound_inherited_from_physical_SEA3_proved": False,
+        "nominal_force_derivation": {
+            "true_specific_force_upper_mps2": true_force,
+            "declared_delta_aw_error_upper_mps2": delta_aw,
+            "nominal_specific_force_upper_mps2": nominal_force,
+            "gravity_mps2": g,
+            "nominal_aw_norm_upper_mps2": nominal_aw,
+            "identity": "a_hat=a_true-delta_a_w",
+            "triangle_inequality": "||a_hat-g||<=||a_true-g||+||delta_a_w||",
+            "uses_complete_SEA3_physical_source_bound": True,
+            "uses_already_declared_P4_error_domain": True,
+            "new_source_assumption_added": False,
+            "replay_extrema_used": False,
+        },
+        "source_nominal_specific_force_upper_mps2": nominal_force,
+        "source_nominal_aw_norm_upper_mps2": nominal_aw,
+        "nominal_force_bound_from_complete_SEA3_plus_declared_error_domain_proved": True,
+        "nominal_force_bound_from_physical_SEA3_alone_claimed": False,
         "shipping_Joseph_binding_closed": False,
         "shipping_Joseph_binding_scope": "SOURCE_UNIFORM_NONLINEAR_TRANSPORT",
         "linear_triangular_coordinate": {
             "w_lin": "delta_a_w+B*c",
             "B_c": "R_hat^T*[c]x*R_hat*a_hat",
             "B_matrix": "-R_hat^T*[R_hat*a_hat]x",
-            "B_operator_norm_upper_mps2_per_cayley": ahat,
+            "B_operator_norm_upper_mps2_per_cayley": nominal_aw,
             "T_B_unit_triangular": True,
             "T_B_determinant_exact": 1.0,
             "T_B_nonsingular": True,
@@ -179,7 +244,8 @@ def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
             "nonlinear_displacement_is_full_aw_shift": True,
             "first_order_wave_attitude_term_removed_from_remainder": True,
         },
-        "measurement_linearizing_shift_bounds_reused_without_widening": awlin["candidate_cells"],
+        "measurement_linearizing_shift_bounds_reused_without_widening": False,
+        "measurement_linearizing_shift_bounds_widened_for_declared_delta_aw_domain": rows,
         "reused_candidate_bounds_cover_pure_e_eta_only": True,
         "full_nonlinear_coordinate_displacement_bounded_here": False,
         "standalone_eta_Rinv_packet_budget_used": False,
@@ -206,6 +272,7 @@ def validate(d: dict) -> list[str]:
         "complete_SEA3_word_retained",
         "all_valid_accelerometer_updates_remain_in_complete_word",
         "all_due_S_updates_and_actual_RS_remain_in_complete_word",
+        "nominal_force_bound_from_complete_SEA3_plus_declared_error_domain_proved",
         "transformed_attitude_column_depends_only_on_gravity",
         "wave_acceleration_attitude_cross_term_is_linear_coordinate_coupling",
         "actual_RS_information_matrix_retained_under_congruence",
@@ -214,7 +281,7 @@ def validate(d: dict) -> list[str]:
         if d.get(key) is not True:
             f.append(f"{key} is not true")
     for key in (
-        "nominal_force_bound_inherited_from_physical_SEA3_proved",
+        "nominal_force_bound_from_physical_SEA3_alone_claimed",
         "shipping_Joseph_binding_closed",
         "trajectory_replay_used",
         "filter_changed",
@@ -225,9 +292,34 @@ def validate(d: dict) -> list[str]:
         "complete_source_correlated_transport_defect_closed_here",
         "full_nonlinear_coordinate_displacement_bounded_here",
         "P4_promoted_here",
+        "measurement_linearizing_shift_bounds_reused_without_widening",
     ):
         if d.get(key) is not False:
             f.append(f"{key} is not false")
+
+    force = d.get("nominal_force_derivation", {})
+    for key in (
+        "uses_complete_SEA3_physical_source_bound",
+        "uses_already_declared_P4_error_domain",
+    ):
+        if force.get(key) is not True:
+            f.append(f"nominal-force derivation {key} is not true")
+    for key in ("new_source_assumption_added", "replay_extrema_used"):
+        if force.get(key) is not False:
+            f.append(f"nominal-force derivation {key} is not false")
+    true_force = float(force.get("true_specific_force_upper_mps2", math.nan))
+    delta_aw = float(force.get("declared_delta_aw_error_upper_mps2", math.nan))
+    nominal_force = float(force.get("nominal_specific_force_upper_mps2", math.nan))
+    g = float(force.get("gravity_mps2", math.nan))
+    nominal_aw = float(force.get("nominal_aw_norm_upper_mps2", math.nan))
+    if not all(math.isfinite(x) and x > 0.0 for x in (true_force, delta_aw, nominal_force, g, nominal_aw)):
+        f.append("nominal-force derivation contains invalid values")
+    else:
+        if nominal_force < true_force + delta_aw:
+            f.append("nominal specific-force ceiling dropped declared delta-aw error")
+        if nominal_aw < nominal_force + g:
+            f.append("nominal aw ceiling dropped gravity")
+
     tri = d.get("linear_triangular_coordinate", {})
     for key in ("T_B_unit_triangular", "T_B_nonsingular", "T_B_inverse_exact"):
         if tri.get(key) is not True:
@@ -235,8 +327,9 @@ def validate(d: dict) -> list[str]:
     if float(tri.get("T_B_determinant_exact", math.nan)) != 1.0:
         f.append("triangular coordinate determinant changed")
     B = float(tri.get("B_operator_norm_upper_mps2_per_cayley", math.nan))
-    if not (math.isfinite(B) and B > 0.0):
+    if not (math.isfinite(B) and B >= nominal_aw):
         f.append("triangular B norm bound invalid")
+
     metric = d.get("moving_metric_congruence", {})
     for key in (
         "innovation_covariance_S_invariant",
@@ -248,6 +341,7 @@ def validate(d: dict) -> list[str]:
     for key in ("condition_number_multiplier_used", "group_isotropic_metric_assumption_used"):
         if metric.get(key) is not False:
             f.append(f"forbidden moving metric shortcut {key} enabled")
+
     exact = d.get("exact_finite_angle_coordinate", {})
     for key in (
         "nonlinear_displacement_is_full_aw_shift",
@@ -255,9 +349,15 @@ def validate(d: dict) -> list[str]:
     ):
         if exact.get(key) is not True:
             f.append(f"exact finite-angle coordinate {key} is not true")
-    rows = d.get("measurement_linearizing_shift_bounds_reused_without_widening", [])
+
+    rows = d.get("measurement_linearizing_shift_bounds_widened_for_declared_delta_aw_domain", [])
     if [r.get("attitude_angle_deg") for r in rows] != [30.0, 25.0, 20.0, 15.0]:
         f.append("finite-angle candidate cells changed")
+    for row in rows:
+        if row.get("widened_for_declared_delta_aw_domain") is not True:
+            f.append("finite-angle row not widened for declared delta-aw domain")
+        if float(row.get("force_upper_mps2_used", math.nan)) < nominal_force:
+            f.append("finite-angle row uses insufficient nominal force ceiling")
     return list(dict.fromkeys(f))
 
 
@@ -273,6 +373,9 @@ def main() -> int:
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(json.dumps(d, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     print(json.dumps({
+        "true_specific_force_upper_mps2": d["nominal_force_derivation"]["true_specific_force_upper_mps2"],
+        "declared_delta_aw_error_upper_mps2": d["nominal_force_derivation"]["declared_delta_aw_error_upper_mps2"],
+        "nominal_specific_force_upper_mps2": d["source_nominal_specific_force_upper_mps2"],
         "source_nominal_aw_norm_upper_mps2": d["source_nominal_aw_norm_upper_mps2"],
         "gravity_only_attitude_column": d["transformed_attitude_column_depends_only_on_gravity"],
         "actual_RS_retained": d["actual_RS_information_matrix_retained_under_congruence"],

--- a/tools/stability/ou3_p4_complete_sea3_measurement_linearizing_aw_coordinate.py
+++ b/tools/stability/ou3_p4_complete_sea3_measurement_linearizing_aw_coordinate.py
@@ -35,8 +35,20 @@ u=A phi and b=G^-1 xi the signed ledger is
     V_plus-V_minus=-J+2 u^T P_J^-1 b+b^T P_J^-1 b.
 
 The same full inverse, including all cross terms, must be used for both
-terms; a marginal covariance lower bound cannot replace it. Source transition,
-prediction, hybrid events and the complete H18/A21 word remain obligations.
+terms; a marginal covariance lower bound cannot replace it.
+
+For a physical prediction z_plus=F z+rho_p, the corresponding identity is
+
+    Phi_plus=F Phi+xi_p,
+    xi_p=rho_p+E_aw epsilon_plus-F E_aw epsilon_minus.
+
+The last term includes v,p,S components: F E_aw is not E_aw. Those components
+are precisely part of the coupling to the retained S=0/R_S regularizer. For a
+source-only step use its actual map; for H18->A21 use the actual rectangular
+lift J and separate covariance/initialization operation, not an H18 ceiling.
+The evaluator below performs only this algebra. Same-history source admission,
+physical defects, covariance/hybrid binding and complete-word dissipation are
+not established by it.
 Candidate bounds below bound ONLY e_eta, not epsilon_aw. No promotion occurs.
 """
 from __future__ import annotations
@@ -46,7 +58,9 @@ import json
 import math
 from pathlib import Path
 
-from ou3_interval import up
+from ou3_interval import (
+    Interval, IntervalMatrix, matrix_add, matrix_mul, matrix_sub, up,
+)
 import ou3_p4_complete_sea3_accelerometer_operation_coordinate as ACC
 import ou3_p4_complete_sea3_vector_remainder_geometry as GEOM
 import ou3_p4_exact_reset_transport as RESET
@@ -56,6 +70,47 @@ REPO = Path(__file__).resolve().parents[2]
 DEFAULT_DOMAIN = REPO / "tools" / "stability" / "ou3_proof_operating_domain.json"
 SCHEMA = 2
 QUALIFICATION = "OU3_P4_COMPLETE_SEA3_MEASUREMENT_LINEARIZING_AW_COORDINATE_V2"
+
+
+def evaluate_full_shift_transport(
+    linear_map: IntervalMatrix,
+    physical_defect: IntervalMatrix,
+    epsilon_before: IntervalMatrix,
+    epsilon_after: IntervalMatrix,
+) -> IntervalMatrix:
+    """Transport the full shift through one supplied physical operation.
+
+    For z_after=L z_before+r, this returns
+    xi=r+E_aw,out epsilon_after-L E_aw,in epsilon_before.
+    For correction/reset, z_before here is t=z-d and Phi_before is A Phi;
+    L=G. For prediction L=F, NOT G or I. The v,p,S rows of F E_aw must
+    survive. An H18-to-A21 lift is rectangular and must be supplied literally.
+
+    Both shifts include (Q_aw-I) delta_a_w. The supplied map/defect/shifts
+    must come from the SAME physical event. Shape checks establish neither
+    that provenance nor SEA3 membership, and this routine emits no certificate.
+    Covariance transport and actual applied R_S belong to the unchanged word.
+    """
+    n_out = len(linear_map)
+    n_in = len(linear_map[0]) if linear_map else 0
+    if (n_out, n_in) not in ((18, 18), (21, 21), (21, 18)):
+        raise ValueError("linear_map must be H18, A21, or the 21x18 H-to-A lift")
+    for name, value, rows, cols in (
+        ("linear_map", linear_map, n_out, n_in),
+        ("physical_defect", physical_defect, n_out, 1),
+        ("epsilon_before", epsilon_before, 3, 1),
+        ("epsilon_after", epsilon_after, 3, 1),
+    ):
+        if len(value) != rows or any(len(row) != cols for row in value):
+            raise ValueError(f"{name} must have shape {rows}x{cols}")
+        if any(not isinstance(x, Interval) or not (math.isfinite(x.lo) and math.isfinite(x.hi))
+               or x.lo > x.hi for row in value for x in row):
+            raise ValueError(f"{name} must contain finite intervals")
+    before = [[Interval.point(0.0)] for _ in range(n_in)]
+    after = [[Interval.point(0.0)] for _ in range(n_out)]
+    before[15:18] = [row[:] for row in epsilon_before]
+    after[15:18] = [row[:] for row in epsilon_after]
+    return matrix_add(physical_defect, matrix_sub(after, matrix_mul(linear_map, before)))
 
 
 def _candidate(row: dict, force_upper: float) -> dict:
@@ -171,6 +226,21 @@ def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
             "reset_covariance_congruence_exact": not RESET.validate(reset) and bool(reset["exact_reset_congruence_identity"]),
             "G_inverse_operator_norm_exact": float(reset["reset_inverse_operator_norm_upper"]),
         },
+        "prediction_shift_transport": {
+            "physical_map": "z_plus=F*z+rho_p",
+            "phi_plus": "F*Phi+xi_p",
+            "xi_p": "rho_p+E_aw*epsilon_plus-F*E_aw*epsilon_minus",
+            "full_v_p_S_aw_prediction_columns_required": True,
+            "reset_only_shift_difference_valid_for_prediction": False,
+            "source_uniform_prediction_defect_closed": False,
+        },
+        "hybrid_shift_transport": {
+            "physical_map": "z_A_plus=J_HA*z_H+rho_HA",
+            "xi_HA": "rho_HA+E_aw_A*epsilon_A_plus-J_HA*E_aw_H*epsilon_H_minus",
+            "actual_rectangular_lift_and_covariance_seed_required": True,
+            "H18_ceiling_reused_for_A21": False,
+            "source_uniform_hybrid_defect_closed": False,
+        },
         "source_indexed_shift_must_persist_across_complete_word": True,
         "packetwise_shift_reset_to_zero_allowed": False,
         "complete_SEA3_source_transition_must_drive_e_plus_minus": True,
@@ -254,6 +324,20 @@ def validate(d: dict) -> list[str]:
         f.append("reset covariance congruence is not exact")
     if float(tr.get("G_inverse_operator_norm_exact", math.inf)) != 1.0:
         f.append("reset inverse norm changed")
+    prediction = d.get("prediction_shift_transport", {})
+    if prediction.get("xi_p") != "rho_p+E_aw*epsilon_plus-F*E_aw*epsilon_minus":
+        f.append("prediction dropped the full F E_aw shift transport")
+    if prediction.get("full_v_p_S_aw_prediction_columns_required") is not True:
+        f.append("prediction lost its coupling into the S regularizer")
+    for key in ("reset_only_shift_difference_valid_for_prediction", "source_uniform_prediction_defect_closed"):
+        if prediction.get(key) is not False:
+            f.append(f"prediction {key} is not false")
+    hybrid = d.get("hybrid_shift_transport", {})
+    if hybrid.get("actual_rectangular_lift_and_covariance_seed_required") is not True:
+        f.append("hybrid transport detached from its actual lift/covariance seed")
+    for key in ("H18_ceiling_reused_for_A21", "source_uniform_hybrid_defect_closed"):
+        if hybrid.get(key) is not False:
+            f.append(f"hybrid {key} is not false")
     rows = d.get("candidate_cells", [])
     if [r.get("attitude_angle_deg") for r in rows] != [30.0, 25.0, 20.0, 15.0]:
         f.append("candidate finite-angle cells changed")


### PR DESCRIPTION
Continuation from current main `b5c313074ca0dbf30cb12a88e91d2a59ca8559b4` after #494.

This is the clean theorem line for P4/P5. It does not continue the replay/frozen-shadow optimization work from #495/#496. Salvaged only independently valid corrections: original shipping-H full `epsilon_aw`, full prediction `F E_aw` transport including v/p/S/a_w, literal H18->A21 lift, and the declared-error-domain nominal-force correction.

Immutable constraints:
- canonical source `COMPLETE_SEA3_NORMAL_LIVE_WORD`;
- conditional P3 frozen at `delta=1e-18`;
- no production filter, quality-gate, or proof-domain changes;
- preserve every valid accelerometer, asynchronous vector event, covariance floor, immediate reset, and every due S=0 update with actual applied SpectralMSE R_S and deployed `[0.72,0.72,1]` factors;
- no replay/finite-harmonic source, independent source/tuner/R_S boxes, selected-S replacement word, packet-count remainder, correction-radius revival, or metric-floor shortcut;
- P4/P5 remain open until the universal complete-word nonlinear inequality closes.

Next commit will be a single master-word P4 consumer of the existing complete-SEA3 P3 information/R_S/Cayley results. No merge without explicit authorization.