### PR TITLE
OU-III: finite-tau_b full-21-state A21 cascade bridge

### DIFF
--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -1,51 +1,49 @@
 # OU-III proof research state
 
-## Handoff checkpoint
+## Current checkpoint
 
-Canonical source remains `COMPLETE_SEA3_NORMAL_LIVE_WORD`. Conditional complete-SEA3 P3 is closed and frozen at `delta=1e-18`. P4 is **OPEN** and P5 is **BLOCKED**. H18 and A21 are both required; H18->A21 remains a separate rectangular hybrid event. Zero lever arm and the dormant-transparent vibration branch remain the certified production branch.
+Canonical source remains `COMPLETE_SEA3_NORMAL_LIVE_WORD`. Conditional complete-SEA3 P3 is **closed and frozen** at `delta=1e-18`. P4 is **OPEN** and P5 is **BLOCKED**. H18 and A21 are both required; H18->A21 remains a separate rectangular hybrid event. Zero lever arm and the dormant-transparent vibration branch remain the certified production branch.
 
-The only production/proof-domain change made on PR #496 is the user-authorized accelerometer-bias projection-radius tightening from `0.5` to `0.4 m/s^2`. The declared startup/handoff accelerometer-bias error envelope is also `0.4 m/s^2`, while the Normal-Live active-bias interior bound is `0.35 m/s^2`, preserving a `0.05 m/s^2` projection margin. No other filter tuning, quality gate, source-language parameter, or P3 mathematics was changed.
+PR #496 is merged at `75f8ecc58bec654bb994ebcb7d74921355514544`. Continuation PR #498 is the active research branch for the paper-permitted finite-`tau_b`, full-21-state A21 route. No merge is authorized.
 
-The paper target remains the finite full-state source-indexed quadratic storage
+The only production/proof-domain change inherited from #496 is the user-authorized accelerometer-bias projection-radius tightening from `0.5` to `0.4 m/s^2`. The declared startup/handoff accelerometer-bias error envelope is `0.4 m/s^2`; the Normal-Live physical active-bias bound is `0.35 m/s^2`, leaving a strict `0.05 m/s^2` interior margin. No further filter tuning, source-language parameter change, quality-gate relaxation, or P3 change is permitted by this research route.
+
+The P4 target remains the finite full-state source-indexed quadratic storage
 
 `V(e,zeta)=e^T M(zeta)e`
 
-on one complete same-history SEA3 word, with a strict finite endpoint inequality, a finite every-prefix gain, and every-prefix chart/source-domain retention. A replay, point experiment, fitted endpoint metric, reduced-state coercivity test, or alternate source language cannot promote P4.
+on one complete same-history SEA3 word, with a strict finite endpoint inequality, a finite every-prefix gain, and every-prefix chart/source-domain retention. Point experiments, replay-fitted metrics, reduced-state coercivity, alternate source languages, selected-S words, independent tuner/R_S boxes, state elimination, packet-count nonlinear budgets, scalar correction radii, or marginal inverse-metric-floor arguments cannot promote P4.
 
-## Exact structural work retained on this checkpoint
+## Exact structural work retained
 
-The branch retains the theorem-facing algebra and execution machinery needed by a continuation PR:
+The retained theorem/execution machinery includes:
 
 - exact finite accelerometer coordinate shift with original shipping H/P/K/S and `H0 != H_u` at finite attitude error;
-- exact prediction transport with the literal full `F E_aw`, retaining v/p/S/a_w rows;
+- exact prediction transport with literal full `F E_aw`, including v/p/S/a_w rows;
 - exact Joseph/reset signed-information identity
   `Delta V = -I_y + E_eta + X_reset + E_reset`;
-- exact deployed Cayley reset transport and A21 `0.4 m/s^2` bias projection with generalized Jacobian;
-- every due S=0 event with actual applied anisotropic SpectralMSE `R_S` retained; S events have `eta=0` exactly and therefore contribute favorable information;
-- every valid accelerometer update, applicable vector update, full Q, covariance floors and immediate resets retained;
+- every due S=0 event with the **actual applied anisotropic SpectralMSE R_S**; S has `eta=0` exactly and therefore contributes favorable information with no nonlinear charge;
+- every valid Normal-Live accelerometer update, applicable vector update, full Q, covariance floors and immediate resets;
 - separate H18->A21 hybrid lift;
+- exact deployed Cayley reset transport and generalized A21 bias-projection branch;
 - outward interval/differential AD and generalized mean-value machinery for the exact nonlinear physical map;
-- complete-word accelerometer covariance channel and exact homogeneous Cayley residual-sector factorization;
-- the existing finite-`tau_b` A21 detectability module tied to complete SEA3, which closes the paper-level finite-bias detectability/UES hypothesis but explicitly does **not** close the canonical full 21x21 implementation-word P4 inequality.
+- complete-word accelerometer covariance channel and homogeneous Cayley residual-sector factorization;
+- finite-`tau_b` A21 detectability/UES support tied to complete SEA3.
 
-Do not replace these with selected-S words, independent tuner/R_S boxes, independent per-sample source boxes, packet-count nonlinear budgets, scalar correction radii, inverse-metric-floor arguments, state elimination, or replay-derived source families.
+Do not replace these with replay families, independent sample boxes, finite harmonic/grid surrogates, selected-S words, packet-count-times-worst-remainder bounds, correction balls, inverse-metric floors, `a_w` elimination, or any further proof-driven filter/domain tightening.
 
-## Authoritative single-observer linear evidence
+## Authoritative point evidence from #496
 
-The corrected single shipping observer owns one source/tuner/Riccati history and retains every operation. On the genuine PM+Stokes Hs=1.5 m history, the pre-0.4 legal 3-second point words were:
+The corrected single shipping observer owns one source/tuner/Riccati history and retains every operation. The genuine PM+Stokes Hs=1.5 m point diagnostics are falsification/debugging evidence only.
+
+Pre-0.4 legal 3-second linear words:
 
 - H18: `rho_linear=0.9998658024147671`, 600 predictions, 600 accelerometer updates, 137 actual-R_S S updates, 75 vector updates;
 - A21: `rho_linear=0.9958536807113242`, 600 predictions, 600 accelerometer updates, 108 actual-R_S S updates, 75 vector updates.
 
-Same-observer event ledgers reproduce those ratios within a few `1e-6` and telescope to roundoff. The old duplicate observer that staged tuner-commit data at the wrong boundary is retired; its older A21 rho values are stale.
+On the 0.4 head the 3-second physical reset-normalized diagnostic keeps zero-state parity. H18 contracts on every retained tested scale. A21 first crosses one at scale `8.0`; the worst retained-domain endpoint ratio is about `1.0860152320`. The 0.4 clamp is therefore a legitimate production/domain tightening, not a proof fix.
 
-On the 0.4 head, the 3-second physical reset-normalized diagnostic keeps strict zero-state parity. H18 remains contracting over every retained tested scale. A21 still first crosses one at scale `8.0`; the bias projection is inactive in the problematic cases, and the worst retained-domain endpoint ratio is about `1.0860152320`. Thus the 0.4 clamp is a legitimate production/domain tightening, not a proof fix.
-
-## 6-second and 9-second falsification result: longer-window route stopped
-
-The source-contiguous physical long-window diagnostic completed successfully in GitHub Actions run `34083473117` (`ou3-p4-physical-long-window-feasibility`), artifact `10004621877`, artifact SHA256 `8b3c1e3b83e6774895cf20770764609afd38e044131204c568d49d7f3544aa19`.
-
-It uses the same single shipping observer, the canonical source label, actual applied R_S, all accelerometer/S/vector events, strict zero-state parity, and no source/domain/filter substitution. It is explicitly non-promoting.
+The source-contiguous 6/9-second physical diagnostic is GitHub Actions run `34083473117`, artifact `10004621877`, SHA256 `8b3c1e3b83e6774895cf20770764609afd38e044131204c568d49d7f3544aa19`. It uses one shipping observer, complete event order, actual R_S and zero-state parity and is explicitly non-promoting.
 
 6-second result:
 
@@ -63,63 +61,127 @@ It uses the same single shipping observer, the canonical source label, actual ap
 - A21 worst retained physical rho `1.143708327664902`;
 - A21 worst prefix ratio `1.1653466626592186`.
 
-Therefore the proposed 3->6->9 second extension does **not** repair the finite A21 mechanism. Per the research protocol, stop the longer-window route here. Do not spend another iteration optimizing window length or point storage around this replay.
+The 3->6->9 longer-window tactic is stopped. Do not optimize window length further around this replay.
 
-## A21 mechanism and dead ends
+## A21 mechanism
 
-The finite A21 obstruction is primarily finite accelerometer curvature in a coupled attitude / latent-acceleration / accelerometer-bias cancellation direction. The exact lever-arm-off residual is
+The finite A21 obstruction is concentrated in a coupled attitude / latent-acceleration / accelerometer-bias cancellation direction. With lever arm disabled,
 
 `y = (E-I) f_hat + E R_hat delta_a_w + delta_b_a`,
 
-with first-order row
+while the first-order row is
 
 `H e = [c]_x f_hat + R_hat delta_a_w + delta_b_a`.
 
-These first-order terms can nearly cancel while second-order attitude curvature remains. The A21 bias projection is not active at the problematic scales, and reset terms are small; tightening reset bounds or eliminating a_w attacks the wrong mechanism.
+The first-order pieces can cancel while second-order attitude curvature remains. The genuine #496 long-window maximizing directions are strongly accelerometer-bias dominated in Euclidean direction energy: approximately **84.5% b_a at 6 s** and **89.0% b_a at 9 s**. This supports the finite-`tau_b` route, but does not justify a bias-only metric.
 
-Retired / forbidden rescue routes include:
+The nonlinear accelerometer residual has **no nonlinear b_a term**: b_a enters the physical residual exactly linearly. Thus finite-`tau_b` should be used to break the temporal `b_a`/`a_w`/attitude cancellation through the full same-history word, not charged as an artificial nonlinear bias remainder.
 
-- estimator-pair shadow promoted as theorem map;
-- raw or full-Phi endpoint optimization after their A21 finite-scale failures;
-- arbitrary single-map converse-metric fitting;
-- extending the failed physical replay to still longer windows merely to seek a green point;
-- reduced-state/Schur certificates or a_w elimination;
-- selected-S words or independent R_S/tuner schedules;
-- scalar Lipschitz, correction-radius, inverse-metric-floor, or packet-count-times-worst-remainder bounds;
-- further proof-driven filter/domain tightening beyond the authorized 0.4 change.
+## Finite projection lemma closed on #498
 
-## Correct next theorem route
+The shipping 0.4 m/s^2 accelerometer-bias projection is the Euclidean projection onto the closed ball `B_2(0,0.4)`. The theorem-domain true active bias satisfies `||b_true||<=0.35`, hence lies strictly inside the ball. Orthogonal projection onto a closed convex set is nonexpansive relative to every point in the set:
 
-The next PR should start from current main after this handoff and pursue the paper-permitted **finite-`tau_b`, full-21-state A21 cascade/detectability route**. This is qualitatively different from the failed endpoint/window experiments.
+`||Pi_B(x)-b_true||_2 <= ||x-b_true||_2`.
 
-The existing `tools/stability/ou3_sea3_a21_detectability_completion.py` already establishes the paper-level finite-bias detectability/UES hypothesis from:
+Therefore projection cannot increase finite physical bias-error norm. P4 does **not** need an adverse projection penalty, a correction-radius bound, or an assumption that the sampled projection branch is inactive. This is finite-error, not tangent-only.
 
-- complete-SEA3 H18 contraction;
-- exact finite residual-bias Gauss-Markov decay;
-- bounded full-state H18<->b_a coupling on the compact word;
-- full A21 process UCC;
-- no alternate estimator and no state elimination.
+## Fixed additive bias metric: falsified and retired
 
-However, that module deliberately remains fail-closed for the stronger canonical implementation-word bridge: `full_21x21_Omega_minus_delta_P_LDLT_closed_here = False` and `P4_MAY_CONSUME_P3 = False`.
+A natural diagnostic candidate was
 
-The next theorem-facing master inequality must therefore be a **full-rank 21-state** Lyapunov/cascade inequality that consumes the same complete-SEA3 source history and retains every actual shipping event/coupling. It must show how the finite-`tau_b` bias decay/detectability estimate combines with the H18 complete-word dissipation and the nonlinear accelerometer residual sector without eliminating `b_a`, `a_w`, or any cross terms. Only after that full-state bridge is quantitative and outward-certified should the universal nonlinear complete-word P4 endpoint/prefix enclosure resume.
+`M_alpha(P) = P^{-1} + alpha E_b^T E_b`,
 
-If the full-state finite-`tau_b` construction itself exposes a genuine admissible expanding direction that violates the paper-equivalent P4 inequality on the declared domain, report that obstruction directly rather than inventing a weaker certificate or shrinking the domain.
+with one fixed positive bias weight `alpha` and no state elimination. The genuine #496 A21 data falsify this tactic.
+
+For the selected worst nonlinear physical words, endpoint contraction requires approximately:
+
+- 6 s: `alpha >= 115346.17`;
+- 9 s: `alpha >= 86656.74`.
+
+But scanning **all legal A21 linear words already present in the same genuine artifacts** shows the largest fixed `alpha` preserving linear `rho<1` is only approximately:
+
+- 6 s: `alpha < 46392.08` (limiting legal word near `t0=1176.9927 s`);
+- 9 s: `alpha < 59331.27` (limiting legal word near `t0=125.9704 s`).
+
+At `alpha=100000`, legal linear words reach roughly `rho=1.10785` (6 s) and `rho=1.11385` (9 s). The nonlinear-repair lower bound and linear-contraction upper bound do not overlap. Per the research two-strike rule, **stop fixed additive bias weighting**. Do not retune alpha or replace it by a fixed diagonal bias congruence.
+
+This is a proof-method failure, not a counterexample to the paper-permitted source-indexed full-cross-term metric family.
+
+## Quantitative finite-tau_b comparison cascade on #498
+
+The existing `ou3_sea3_a21_detectability_completion.py` closes the paper-level finite-bias detectability/UES hypothesis using a triangular comparison observer
+
+`E_A = [[E_H,C_Hb],[0,Phi_b]]`
+
+but its old `N*K*L^N` C_Hb number is only a finiteness diagnostic and may not be consumed by P4.
+
+#498 now formulates the full-rank comparison storage
+
+`M_A(zeta)=diag(M_H(zeta),mu I3)`
+
+with target comparison gap `delta_A=5e-19` while leaving frozen P3 at `delta_H=1e-18`. If `c^2 >= ||M_H,+^(1/2) C_Hb||_2^2`, the exact two-block Schur condition is
+
+`c^2/mu < ((delta_H-delta_A)(beta_b-delta_A))/(1-delta_A)`.
+
+Strict gaps are stored directly; no binary64 `1-delta` comparison is used.
+
+The comparison C_Hb bound is now expressed without a suffix-norm product or packet-count nonlinear budget. Choose the H18 comparison observer with zero b_a correction row. Starting from `h_0=0`, the only direct linear b_a input to H18 is the accepted accelerometer residual. The exact Joseph identity gives
+
+`Delta V_H <= s_H b_j^T R_acc^{-1} b_j`,
+
+and the comparison bias follows exact homogeneous GM decay. Therefore
+
+`||C_Hb b_0||^2_{M_H,+} <= s_H lambda_max(R_acc^{-1}) sum_{j=1}^N exp(-2 j h_-/tau_b) ||b_0||^2`.
+
+The geometric sum is evaluated in closed form with outward-safe `expm1` arithmetic. Every valid accelerometer update remains present; S/vector/Q/floor/reset operations remain inside the complete H18 information word, including actual applied R_S. The resulting comparison-cascade Schur weight is represented logarithmically if very large rather than overflowed.
+
+This closes only the **triangular comparison-observer** quantitative cascade if its tests pass. It does **not** close the actual A21 Kalman word because the comparison observer deliberately has a zero bias correction row.
+
+## Actual A21 shipping bridge: current controlling obligation
+
+The next theorem object must retain the actual A21 Kalman bias correction row and all H18<->b_a covariance/metric cross terms. The fixed additive bias metric is ruled out, and the comparison observer cannot be relabeled as the shipping estimator.
+
+The preferred next route is a source-indexed **full-cross-term 21x21** word inequality / conditional-information construction that uses finite `tau_b` as temporal separation inside the complete same-history word:
+
+- b_a has exact finite GM decay;
+- b_a enters accelerometer residual linearly;
+- a_w/translation are tied to the complete S-chain, with every actual-R_S S event supplying favorable information and zero nonlinear charge;
+- attitude/gyro-bias are tied to recurring vector information;
+- all A21 Joseph cross terms and bias-row corrections remain in the joint matrix;
+- nonlinear accelerometer/vector/reset costs are compared against the joint signed information, not an event-count scalarization.
+
+The open bridge must either produce a source-uniform full 21x21 metric/information inequality for the **actual** A21 homogeneous word or expose a genuine admissible expanding direction. It may not shrink the domain or invent a weaker certificate.
+
+Only after this actual full-cross-term A21 linear bridge is quantitative and outward-certified should the universal nonlinear complete-word endpoint/prefix enclosure resume.
 
 ## Complete-source obligation still open
 
 The upstream complete-source contract still does not materialize the correlated finite-window SEA3 realization as an executable outward source family. Parameter compactness, RAO/moment envelopes, hard pathwise acceleration/body-rate caps, frontend parity, and adaptive-state rate/jump bounds do not replace a same-history transition for the correlated source state. P4 may not substitute independent per-sample boxes, a replay record, or a finite harmonic/grid surrogate.
 
-The continuation should first formulate the full-state finite-`tau_b` master inequality and determine exactly which source-correlated quantities it needs. Then extend the existing complete-SEA3 execution/source machinery only for those theorem quantities, rather than creating another surrogate proof language.
+The continuation should request from the complete-SEA3 machinery only the source-correlated quantities needed by the full-cross-term A21 inequality, rather than creating another proof language.
 
-## CI / evidence status at handoff
+## Retired / forbidden routes
 
-The long-window falsification workflow is green. Exact Cayley parity, the physical 3-second finite-map feasibility, A21-word, complete-word feasibility, and lever-arm-study workflows were also green on head `80140b762ab7bfd924d1d5dc279153e425a31612` when this handoff was prepared; several broader workflows were still running.
+Do not revisit:
 
-`ou-validation` is red for a known evidence-provenance reason, not because its numerical unit-test body found a new filter failure: `tools/ou_evidence_contract.py --auto` reports replay dependencies changed relative to committed validation/robustness provenance, including the OU-III filter and WavePeriodEstimator dependencies. Genuine validation/robustness evidence regeneration is therefore still required before a later proof PR is declared final/ready. Do not hand-edit provenance hashes.
+- estimator-pair shadow promoted as theorem map;
+- raw/full-Phi endpoint optimization after their A21 finite-scale failures;
+- arbitrary single-map converse-metric fitting;
+- longer replay windows merely to seek a green point;
+- fixed additive/diagonal bias metric after the no-overlap falsification above;
+- reduced-state/Schur certificates or a_w elimination;
+- selected-S words or independent R_S/tuner schedules;
+- scalar Lipschitz, correction-radius, inverse-metric-floor, or packet-count-times-worst-remainder bounds;
+- further proof-driven filter/domain tightening beyond the authorized 0.4 change.
 
-No claim is made that P4 or P5 is complete at this merge checkpoint.
+## CI / evidence
+
+At #496 handoff the genuine long-window diagnostic was green. Genuine validation/robustness replay evidence still requires regeneration before a future final/ready proof PR because committed provenance is stale after proof/filter dependency changes. Do not hand-edit provenance hashes.
+
+On #498, normal build passed on early heads. The new finite-`tau_b` bridge/projection/GM-energy modules require canonical proof/quality validation on the final head. `ou-validation` may remain red for the known stale evidence-provenance reason until genuine evidence is regenerated; numerical failures must still be investigated separately.
+
+No claim is made that P4 or P5 is complete.
 
 ## Continuation instruction
 
-Create a new PR from the merged main state. Read `AGENTS.md`, this file, the merged #496 handoff comment, `doc/kalman_ou_iii/w3d-sea3-stability-theorem.tex-part`, and `tools/stability/ou3_sea3_a21_detectability_completion.py` first. Keep P3 frozen at `delta=1e-18`; preserve complete same-history SEA3 and every actual-applied R_S update. Build the full-21-state finite-`tau_b` cascade/detectability bridge before adding further universal P4 enclosure machinery. P5 remains blocked until strict P4 closes.
+Continue on PR #498. Keep P3 frozen at `delta=1e-18`; preserve complete same-history SEA3 and every actual-applied R_S update. Validate the new comparison-cascade modules, but do not promote their comparison-observer metric to P4. Build the **actual A21 full-cross-term finite-tau_b shipping bridge** next. If it closes, attach the signed nonlinear complete-word sector and certify endpoint/prefix/domain retention. If it fails on a genuine admissible direction, record the obstruction directly. P5 remains blocked until strict P4 closes. No merge without explicit authorization.

--- a/tests/validation/test_ou3_p4_a21_bias_projection_nonexpansive.py
+++ b/tests/validation/test_ou3_p4_a21_bias_projection_nonexpansive.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import math
+import unittest
+
+import ou3_p4_a21_bias_projection_nonexpansive as PROJ
+
+
+class TestA21BiasProjectionNonexpansive(unittest.TestCase):
+    def test_interior_point_is_unchanged(self):
+        x = [0.1, -0.2, 0.05]
+        self.assertEqual(PROJ.project_ball(x, 0.4), x)
+
+    def test_exterior_point_projects_to_radius(self):
+        y = PROJ.project_ball([1.0, 2.0, -2.0], 0.4)
+        self.assertAlmostEqual(math.sqrt(sum(v * v for v in y)), 0.4, places=14)
+
+    def test_distance_to_any_interior_truth_cannot_increase(self):
+        truths = ([0.0, 0.0, 0.0], [0.35, 0.0, 0.0], [0.1, -0.2, 0.2])
+        estimates = ([1.2, -0.4, 0.7], [-1.0, 0.2, 0.1], [0.1, 0.1, 0.1])
+        for truth in truths:
+            self.assertLessEqual(math.sqrt(sum(v * v for v in truth)), 0.35 + 1e-15)
+            for estimate in estimates:
+                self.assertGreaterEqual(PROJ.distance_nonincrease(estimate, truth, 0.4), -1e-15)
+
+    def test_truth_outside_projection_ball_is_rejected(self):
+        with self.assertRaises(ValueError):
+            PROJ.distance_nonincrease([0.0, 0.0, 0.0], [0.41, 0.0, 0.0], 0.4)
+
+    def test_repository_contract(self):
+        d = PROJ.build()
+        self.assertEqual(PROJ.validate(d), [])
+        self.assertTrue(d["projection_bias_error_energy_nonincrease"])
+        self.assertTrue(d["projection_can_be_omitted_from_adverse_P4_bias_budget"])
+        self.assertFalse(d["projection_requires_correction_radius"])
+        self.assertFalse(d["projection_requires_inactive_branch_assumption"])
+        self.assertFalse(d["P4_promoted_here"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/validation/test_ou3_p4_a21_finite_bias_cascade_bridge.py
+++ b/tests/validation/test_ou3_p4_a21_finite_bias_cascade_bridge.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import math
+import unittest
+
+import ou3_p4_a21_finite_bias_cascade_bridge as BRIDGE
+
+
+class TestA21FiniteTauBCascadeBridge(unittest.TestCase):
+    def test_exact_schur_budget_is_strict(self):
+        dh = 1.0e-18
+        beta = 1.0e-3
+        da = 5.0e-19
+        lim = BRIDGE.cascade_g2_limit_conservative(dh, beta, da)
+        self.assertGreater(lim, 0.0)
+        g2 = 0.25 * lim
+        self.assertGreater(
+            BRIDGE.cascade_determinant_slack_lower(dh, beta, da, g2), 0.0
+        )
+
+    def test_target_must_be_below_both_diagonal_gaps(self):
+        with self.assertRaises(ValueError):
+            BRIDGE.cascade_g2_limit_conservative(1.0e-18, 1.0e-3, 1.0e-18)
+        with self.assertRaises(ValueError):
+            BRIDGE.cascade_g2_limit_conservative(1.0e-3, 1.0e-4, 1.0e-4)
+
+    def test_mu_logarithm_does_not_overflow(self):
+        x = BRIDGE.required_mu_log10(1.0e300, 1.0e-22)
+        self.assertTrue(math.isfinite(x))
+        self.assertGreater(x, 300.0)
+        self.assertEqual(BRIDGE.required_mu_log10(0.0, 1.0e-22), -math.inf)
+
+    def test_repository_build_is_fail_closed_at_joint_coupling(self):
+        d = BRIDGE.build()
+        self.assertEqual(d["canonical_source"], "COMPLETE_SEA3_NORMAL_LIVE_WORD")
+        self.assertEqual(d["P3_frozen_gate"], 1.0e-18)
+        self.assertTrue(d["P3_frozen_not_modified"])
+        self.assertTrue(d["actual_applied_R_S_retained"])
+        self.assertTrue(d["full_H18_state_retained_including_aw"])
+        self.assertTrue(d["full_ba_state_retained"])
+        self.assertFalse(d["packet_count_coupling_bound_consumed"])
+        self.assertFalse(d["joint_same_history_C_Hb_metric_bound_closed"])
+        self.assertIsNone(d["joint_C_Hb_c2_upper"])
+        self.assertFalse(d["full_rank_A21_cascade_metric_closed"])
+        self.assertFalse(d["P4_promoted_here"])
+        self.assertFalse(d["P5_may_start"])
+        self.assertEqual(BRIDGE.validate(d), [])
+
+    def test_metric_lower_is_full_matrix_not_marginal_inverse_floor(self):
+        d = BRIDGE.build()
+        m = d["H18_metric_equivalence"]
+        self.assertGreater(m["posterior_covariance_lambda_min_lower"], 0.0)
+        self.assertGreater(m["M_H_lambda_max_upper"], 0.0)
+        self.assertEqual(m["reset_sigma_min_lower"], 1.0)
+        self.assertFalse(m["reset_lower_bound_requires_correction_radius"])
+        self.assertFalse(m["marginal_inverse_metric_floor_inference_used"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/validation/test_ou3_p4_a21_finite_bias_cascade_energy_bound.py
+++ b/tests/validation/test_ou3_p4_a21_finite_bias_cascade_energy_bound.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import math
+import unittest
+
+import ou3_p4_a21_finite_bias_cascade_energy_bound as ENERGY
+
+
+class TestA21FiniteBiasCascadeEnergyBound(unittest.TestCase):
+    def test_geometric_decay_energy_is_strictly_below_packet_count(self):
+        n = 600
+        s = ENERGY.geometric_decay_energy_upper(n, 0.005, 5000.0)
+        self.assertGreater(s, 0.0)
+        self.assertLess(s, float(n))
+        # Slow 5000 s GM decay over 3 s is deliberately close to N, but still strict.
+        self.assertGreater(s, 599.0)
+
+    def test_bad_geometric_inputs_fail_closed(self):
+        with self.assertRaises(ValueError):
+            ENERGY.geometric_decay_energy_upper(0, 0.005, 5000.0)
+        with self.assertRaises(ValueError):
+            ENERGY.geometric_decay_energy_upper(600, 0.0, 5000.0)
+        with self.assertRaises(ValueError):
+            ENERGY.geometric_decay_energy_upper(600, 0.005, 0.0)
+
+    def test_sufficient_power10_has_explicit_decimal_slack(self):
+        p = ENERGY.sufficient_power10(26.01)
+        self.assertEqual(p, 28)
+        self.assertGreater(float(p), 26.01)
+
+    def test_repository_comparison_cascade_closes_but_shipping_bridge_stays_open(self):
+        d = ENERGY.build()
+        self.assertEqual(ENERGY.validate(d), [])
+        self.assertEqual(d["canonical_source"], "COMPLETE_SEA3_NORMAL_LIVE_WORD")
+        self.assertEqual(d["P3_frozen_gate"], 1.0e-18)
+        self.assertTrue(d["P3_frozen_not_modified"])
+        self.assertEqual(d["required_accelerometer_updates"], 600)
+        self.assertTrue(d["all_valid_accelerometer_updates_retained"])
+        self.assertTrue(d["every_due_S_update_with_actual_RS_retained_inside_H18_word"])
+        self.assertEqual(d["actual_RS_axis_factors"], [0.72, 0.72, 1.0])
+        self.assertTrue(d["comparison_cascade_Schur_condition_closed"])
+        self.assertTrue(d["comparison_observer_full_rank_21_state_metric_closed"])
+        self.assertFalse(d["actual_A21_shipping_bias_correction_row_consumed"])
+        self.assertFalse(d["actual_A21_shipping_H_b_cross_terms_closed"])
+        self.assertFalse(d["actual_A21_shipping_full_cross_term_metric_closed"])
+        self.assertFalse(d["P4_promoted_here"])
+        self.assertFalse(d["P5_may_start"])
+
+    def test_bound_does_not_reintroduce_retired_packet_or_suffix_routes(self):
+        d = ENERGY.build()
+        self.assertFalse(d["suffix_norm_product_used"])
+        self.assertFalse(d["N_times_worst_map_coupling_used"])
+        self.assertFalse(d["packet_count_nonlinear_remainder_multiplier_used"])
+        self.assertTrue(d["closed_form_same_word_bias_energy_used"])
+        self.assertFalse(d["state_elimination_used"])
+        self.assertFalse(d["a_w_elimination_used"])
+        self.assertGreater(d["joint_C_Hb_metric_c2_upper"], 0.0)
+        self.assertTrue(math.isfinite(d["mu_log10_required_upper"]))
+        self.assertGreater(d["mu_sufficient_power10"], d["mu_log10_required_upper"])
+        self.assertLess(d["c2_over_mu_to_g2_budget_ratio_upper"], 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/stability/ou3_p4_a21_bias_projection_nonexpansive.py
+++ b/tools/stability/ou3_p4_a21_bias_projection_nonexpansive.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Finite-error nonexpansiveness of the shipping A21 accelerometer-bias projection.
+
+The shipping MEKF projects the estimated accelerometer bias onto the Euclidean
+ball of radius ``acc_bias_limit_`` after state injection.  The declared Normal-
+Live theorem domain keeps the physical active bias strictly inside that ball.
+For every closed convex set C, the Euclidean projector Pi_C is firmly
+nonexpansive; in particular, for every y in C,
+
+    ||Pi_C(x)-y|| <= ||x-y||.
+
+Therefore the implemented 0.4 m/s^2 bias projection cannot increase the finite
+physical bias-error norm for any theorem-domain true bias (<=0.35 m/s^2).  No
+projection event needs an adverse scalar remainder or correction-radius charge
+in P4.  This is a finite-state fact, not a tangent-only claim.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+from pathlib import Path
+from typing import Sequence
+
+REPO = Path(__file__).resolve().parents[2]
+MEKF = REPO / "src" / "kalman_ou_iii" / "Kalman3D_Wave_OU_III.h"
+DEFAULT_DOMAIN = REPO / "tools" / "stability" / "ou3_proof_operating_domain.json"
+SCHEMA = 1
+QUALIFICATION = "OU3_P4_A21_ACCEL_BIAS_PROJECTION_FINITE_NONEXPANSIVE_V1"
+
+
+def _norm(x: Sequence[float]) -> float:
+    return math.sqrt(sum(float(v) * float(v) for v in x))
+
+
+def project_ball(x: Sequence[float], radius: float) -> list[float]:
+    r = float(radius)
+    if not (math.isfinite(r) and r > 0.0):
+        raise ValueError("projection radius must be finite positive")
+    y = [float(v) for v in x]
+    if not y or any(not math.isfinite(v) for v in y):
+        raise ValueError("projection input must be finite and nonempty")
+    n = _norm(y)
+    if n <= r:
+        return y
+    s = r / n
+    return [s * v for v in y]
+
+
+def distance_nonincrease(x: Sequence[float], truth: Sequence[float], radius: float) -> float:
+    if len(x) != len(truth) or not x:
+        raise ValueError("projection/truth dimension mismatch")
+    r = float(radius)
+    t = [float(v) for v in truth]
+    if any(not math.isfinite(v) for v in t) or _norm(t) > r:
+        raise ValueError("truth must lie in the projection ball")
+    p = project_ball(x, r)
+    before = _norm([float(a) - b for a, b in zip(x, t)])
+    after = _norm([a - b for a, b in zip(p, t)])
+    return before - after
+
+
+def _source_limit(text: str) -> float:
+    m = re.search(r"acc_bias_limit_\s*=\s*T\(([0-9.eE+-]+)\)", text)
+    if not m:
+        raise RuntimeError("cannot extract shipping acc_bias_limit_")
+    return float(m.group(1))
+
+
+def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
+    path = Path(domain_path).resolve()
+    domain = json.loads(path.read_text(encoding="utf-8"))
+    if domain.get("trajectory_fit") is not False:
+        raise RuntimeError("bias-projection theorem may not be trajectory fitted")
+    text = MEKF.read_text(encoding="utf-8")
+    radius = _source_limit(text)
+    active = float(domain["normal_live"]["active_accelerometer_bias_state_norm_upper_mps2"])
+    declared_projection = float(domain["normal_live"]["active_accelerometer_bias_projection_limit_mps2"])
+    parity = {
+        "shipping_projection_radius_matches_declared_domain": radius == declared_projection,
+        "projection_is_radial_Euclidean_ball_projection": (
+            "const T n = b.norm();" in text
+            and "if (n > acc_bias_limit_)" in text
+            and "b *= (acc_bias_limit_ / n);" in text
+        ),
+        "projection_called_after_state_injection": "project_acc_bias_();" in text,
+    }
+    if radius != 0.4 or declared_projection != 0.4:
+        raise RuntimeError("authorized shipping bias projection radius changed")
+    if not (math.isfinite(active) and 0.0 < active < radius and active == 0.35):
+        raise RuntimeError("Normal-Live active bias interior no longer equals authorized 0.35")
+    failures = [k for k, ok in parity.items() if not ok]
+    closed = not failures
+    return {
+        "schema": SCHEMA,
+        "qualification": QUALIFICATION,
+        "canonical_source": "COMPLETE_SEA3_NORMAL_LIVE_WORD",
+        "shipping_projection_radius_mps2": radius,
+        "declared_Normal_Live_true_bias_norm_upper_mps2": active,
+        "strict_interior_margin_mps2": radius - active,
+        "source_parity": parity,
+        "source_parity_failures": failures,
+        "mathematical_set": "closed Euclidean ball B_2(0,0.4)",
+        "finite_projection_identity": "||Pi_B(x)-b_true||_2 <= ||x-b_true||_2 for b_true in B",
+        "firm_nonexpansiveness_used": True,
+        "finite_error_not_tangent_only": True,
+        "projection_bias_error_energy_nonincrease": closed,
+        "projection_can_be_omitted_from_adverse_P4_bias_budget": closed,
+        "projection_requires_correction_radius": False,
+        "projection_requires_inactive_branch_assumption": False,
+        "point_diagnostic_projection_inactivity_required": False,
+        "state_elimination_used": False,
+        "filter_changed": False,
+        "declared_domain_changed": False,
+        "P4_promoted_here": False,
+        "P5_may_start": False,
+        "next_obligation": "compose finite-tau_b prediction decay and the same-word Joseph bias correction with the signed complete-word information ledger; projection adds no adverse bias-error term",
+    }
+
+
+def validate(d: dict) -> list[str]:
+    f: list[str] = []
+    if d.get("schema") != SCHEMA or d.get("qualification") != QUALIFICATION:
+        f.append("schema/qualification mismatch")
+    if d.get("canonical_source") != "COMPLETE_SEA3_NORMAL_LIVE_WORD":
+        f.append("canonical source changed")
+    for key in ("firm_nonexpansiveness_used", "finite_error_not_tangent_only", "projection_bias_error_energy_nonincrease", "projection_can_be_omitted_from_adverse_P4_bias_budget"):
+        if d.get(key) is not True:
+            f.append(f"{key} is not true")
+    for key in ("projection_requires_correction_radius", "projection_requires_inactive_branch_assumption", "point_diagnostic_projection_inactivity_required", "state_elimination_used", "filter_changed", "declared_domain_changed", "P4_promoted_here", "P5_may_start"):
+        if d.get(key) is not False:
+            f.append(f"{key} is not false")
+    if d.get("source_parity_failures"):
+        f.append("shipping projection source parity failed")
+    if not all(d.get("source_parity", {}).values()):
+        f.append("shipping projection source parity incomplete")
+    if float(d.get("shipping_projection_radius_mps2", math.nan)) != 0.4:
+        f.append("shipping projection radius changed")
+    active = float(d.get("declared_Normal_Live_true_bias_norm_upper_mps2", math.nan))
+    if active != 0.35 or not active < 0.4:
+        f.append("authorized Normal-Live bias interior changed")
+    if not float(d.get("strict_interior_margin_mps2", 0.0)) > 0.0:
+        f.append("projection interior margin is not strict")
+    return list(dict.fromkeys(f))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--domain", type=Path, default=DEFAULT_DOMAIN)
+    ap.add_argument("--output", type=Path, required=True)
+    args = ap.parse_args()
+    d = build(args.domain)
+    failures = validate(d)
+    d["validation_pass"] = not failures
+    d["validation_failures"] = failures
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(d, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"projection_radius": d["shipping_projection_radius_mps2"], "true_bias_upper": d["declared_Normal_Live_true_bias_norm_upper_mps2"], "finite_nonexpansive": d["projection_bias_error_energy_nonincrease"], "failures": failures}, indent=2, sort_keys=True))
+    return 0 if not failures else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/stability/ou3_p4_a21_finite_bias_cascade_bridge.py
+++ b/tools/stability/ou3_p4_a21_finite_bias_cascade_bridge.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Finite-tau_b full-21-state cascade bridge for canonical complete-SEA3 P4.
+
+This module is theorem-facing but deliberately fail-closed.  It formulates the
+full-rank active-bias cascade metric that the post-#496 ledger requires without
+using the retired longer-point-window route or the detectability helper's crude
+packet-count coupling estimate.
+
+Let the H18 complete-word map satisfy, in its source-indexed information metric,
+
+    ||E_H h||_{M_H+}^2 <= (1-delta_H) ||h||_{M_H-}^2,
+
+and let the residual accelerometer-bias homogeneous map satisfy
+
+    ||Phi_b b||^2 <= (1-beta_b) ||b||^2.
+
+For a full 21-state comparison map
+
+    E_A = [[E_H, C_Hb],
+           [  0, Phi_b]],
+
+use the full-rank block storage
+
+    M_A(zeta) = diag(M_H(zeta), mu I_3).
+
+If c^2 bounds ||M_H+^(1/2) C_Hb||_2^2 and g^2=c^2/mu, then a target
+0 < delta_A < min(delta_H,beta_b) is guaranteed by the exact 2x2 Schur test
+
+    g^2 < ((delta_H-delta_A)(beta_b-delta_A))/(1-delta_A).
+
+Because delta_A << binary64 epsilon, the implementation never evaluates
+1-delta_A as a proof of strictness.  It stores positive gaps and determinant
+slack directly.
+
+The missing object is intentionally explicit: a source-uniform JOINT bound on
+C_Hb over the same complete SEA3 word.  The older detectability helper reports
+a finite `N * L^N` style bound only to prove finiteness of a triangular observer;
+that packet-count bound is not consumed here and cannot promote P4.
+
+A fresh full-matrix covariance lower bound is also provided for the H18 endpoint
+metric.  It starts from the shipping full-process Q lower bound, pessimistically
+assimilates every same-sample S/accelerometer/magnetometer Joseph measurement,
+and uses the exact reset fact sigma_min(I+0.5[d]_x)=1.  Thus it does not infer
+an inverse metric floor from covariance marginals and does not require any
+correction-radius assumption.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+from pathlib import Path
+
+import ou3_full_process_ucc as PROCESS
+import ou3_sea3_a21_detectability_completion as ADET
+import ou3_sea3_dynamic_source_certificate as DYNAMIC
+import ou3_sea3_full_word_event_algebra as EVENT
+import ou3_sea3_h18_prior_free_completion as H18
+import ou3_sea3_riccati_metric_p3 as P3
+import ou3_sea3_windowed_vector_pe as PE
+
+REPO = Path(__file__).resolve().parents[2]
+WRAPPER = REPO / "src" / "kalman_ou_iii" / "SeaStateFusionFilter_OU_III.h"
+DEFAULT_DOMAIN = REPO / "tools" / "stability" / "ou3_proof_operating_domain.json"
+
+SCHEMA = 1
+QUALIFICATION = "OU3_P4_COMPLETE_SEA3_A21_FINITE_TAUB_FULL_STATE_CASCADE_BRIDGE_V1"
+P3_FROZEN_GATE = 1.0e-18
+TARGET_P4_CASCADE_GAP = 5.0e-19
+
+
+def down(x: float) -> float:
+    return math.nextafter(float(x), -math.inf)
+
+
+def up(x: float) -> float:
+    return math.nextafter(float(x), math.inf)
+
+
+def _positive(x: float, label: str) -> float:
+    y = float(x)
+    if not (math.isfinite(y) and y > 0.0):
+        raise RuntimeError(f"{label} must be finite positive, got {x!r}")
+    return y
+
+
+def cascade_g2_limit_conservative(delta_h: float, beta_b: float, delta_a: float) -> float:
+    """Conservative strict-cascade budget for g^2=c^2/mu."""
+    dh = _positive(delta_h, "delta_h")
+    bb = _positive(beta_b, "beta_b")
+    da = _positive(delta_a, "delta_a")
+    if not da < min(dh, bb):
+        raise ValueError("target cascade gap must be below both diagonal gaps")
+    a = down(dh - da)
+    b = down(bb - da)
+    if not (a > 0.0 and b > 0.0):
+        raise RuntimeError("cascade diagonal slack rounded nonpositive")
+    return down(a * b)
+
+
+def cascade_determinant_slack_lower(delta_h: float, beta_b: float, delta_a: float, g2_upper: float) -> float:
+    """Lower bound on det((1-delta_A)I - T^T T)."""
+    da = _positive(delta_a, "delta_a")
+    g2 = float(g2_upper)
+    if not (math.isfinite(g2) and g2 >= 0.0):
+        raise ValueError("g2 upper must be finite nonnegative")
+    a = down(_positive(delta_h, "delta_h") - da)
+    b = down(_positive(beta_b, "beta_b") - da)
+    return down(down(a * b) - up(g2))
+
+
+def required_mu_log10(c2_upper: float, g2_budget: float) -> float:
+    """Return log10(mu) sufficient for c^2/mu <= g2_budget."""
+    c2 = float(c2_upper)
+    g2 = _positive(g2_budget, "g2_budget")
+    if not (math.isfinite(c2) and c2 >= 0.0):
+        raise ValueError("c2 upper must be finite nonnegative")
+    if c2 == 0.0:
+        return -math.inf
+    return up(math.log10(c2) - math.log10(g2))
+
+
+def _axis_factors() -> list[float]:
+    text = WRAPPER.read_text(encoding="utf-8")
+    if "RSAdaptationLaw rs_law_ = RSAdaptationLaw::SpectralMSE;" not in text:
+        raise RuntimeError("cascade bridge requires deployed SpectralMSE R_S")
+    out = []
+    for name in ("R_S_x_factor_", "R_S_y_factor_"):
+        m = re.search(rf"float\s+{name}\s*=\s*([0-9.eE+-]+)f", text)
+        if not m:
+            raise RuntimeError(f"cannot extract deployed {name}")
+        out.append(float(m.group(1)))
+    return out + [1.0]
+
+
+def _measurement_variance_lower(std_xyz: list[float], label: str) -> float:
+    if len(std_xyz) != 3:
+        raise RuntimeError(f"{label} std must be length three")
+    return min(down(_positive(x, f"{label} std") ** 2) for x in std_xyz)
+
+
+def _h18_information_metric_upper(domain: dict, h18: dict, pe: dict, process: dict, dynamic: dict, event: dict) -> dict:
+    qh = _positive(process["modes"]["H"]["prediction_Q_lambda_min_lower"], "H18 Q lower")
+    live = domain["normal_live"]
+    fmax = _positive(live["specific_force_norm_upper_mps2"], "force upper")
+    mmax = _positive(live["magnetic_vector_norm_upper_uT"], "mag upper")
+    meas = pe["measurement_runtime"]
+    racc = _measurement_variance_lower(list(map(float, meas["accelerometer_std_mps2"])), "accelerometer")
+    rmag = _measurement_variance_lower(list(map(float, meas["magnetometer_std_uT"])), "magnetometer")
+    rs_base = _positive(dynamic["dynamic_invariant"]["R_S_applied"][0], "applied R_S lower")
+    factors = _axis_factors()
+    rs_std_min = down(rs_base * min(factors))
+    rs_var_min = down(rs_std_min * rs_std_min)
+    if not rs_var_min > 0.0:
+        raise RuntimeError("actual-applied R_S lower lost positivity")
+    info_s = up(1.0 / rs_var_min)
+    info_acc = up(up(fmax * fmax + 1.0) / racc)
+    info_mag = up(up(mmax * mmax) / rmag)
+    precision_upper = up(up(1.0 / qh) + up(info_s + up(info_acc + info_mag)))
+    pmin = down(1.0 / precision_upper)
+    if not pmin > 0.0:
+        raise RuntimeError("full H18 posterior covariance lower is not strict")
+    s_h = _positive(h18["same_word_diffuse_prior_covariance_upper"]["Pbar_trace_upper"], "H18 source-uniform covariance trace upper")
+    mplus = up(s_h / pmin)
+    if not (math.isfinite(mplus) and mplus > 0.0):
+        raise RuntimeError("H18 information metric upper is not finite")
+    reset = event["left_error_reset"]
+    reset_parity = bool(reset["same_full_matrix_margin_preserved_by_congruence"] and reset["small_angle_needed_for_nonsingularity"] is False and float(reset["determinant_lower"]) == 1.0)
+    return {
+        "normalization_s_H": s_h,
+        "prediction_Q_lambda_min_lower": qh,
+        "Racc_variance_lower": racc,
+        "Rmag_variance_lower": rmag,
+        "actual_applied_R_S_base_lower": rs_base,
+        "actual_applied_R_S_axis_factors": factors,
+        "actual_applied_R_S_variance_lower": rs_var_min,
+        "same_sample_information_spectral_upper": precision_upper - 1.0 / qh,
+        "posterior_covariance_lambda_min_lower": pmin,
+        "M_H_lambda_max_upper": mplus,
+        "M_H_lambda_min_lower_from_Pbar_trace_normalization": 1.0,
+        "Joseph_information_identity_used": True,
+        "every_possible_same_sample_measurement_assimilated_for_lower_bound": True,
+        "reset_source_parity_found": reset_parity,
+        "reset_sigma_min_lower": 1.0,
+        "reset_lower_bound_requires_correction_radius": False,
+        "PSD_covariance_floor_can_only_help_lower_bound": True,
+        "marginal_inverse_metric_floor_inference_used": False,
+    }
+
+
+def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
+    path = Path(domain_path).resolve()
+    domain = json.loads(path.read_text(encoding="utf-8"))
+    p3 = P3.build(path)
+    h18 = H18.build(path)
+    adet = ADET.build(path)
+    pe = PE.build(path)
+    process = PROCESS.build()
+    dynamic = DYNAMIC.build(path)
+    event = EVENT.build()
+    bad = {
+        "P3": P3.validate(p3), "H18": H18.validate(h18),
+        "A21_detectability": ADET.validate(adet), "PE": PE.validate(pe),
+        "process": PROCESS.validate(process), "dynamic": DYNAMIC.validate(dynamic),
+        "event_algebra": EVENT.validate(event),
+    }
+    bad = {k: v for k, v in bad.items() if v}
+    if bad:
+        raise RuntimeError(f"finite-tau_b cascade prerequisites failed: {bad}")
+    if p3["canonical_source"] != "COMPLETE_SEA3_NORMAL_LIVE_WORD":
+        raise RuntimeError("cascade bridge detached from canonical complete SEA3")
+    if p3["P3_CONDITIONAL_SEA3_PASS"] is not True:
+        raise RuntimeError("cascade bridge requires frozen conditional P3")
+    if float(p3["useful_gate"]) != P3_FROZEN_GATE:
+        raise RuntimeError("conditional P3 gate changed")
+    if domain.get("trajectory_fit") is not False:
+        raise RuntimeError("cascade bridge may not be trajectory fitted")
+    delta_h = float(p3["modes"]["H18"]["relative_Riccati_injection_margin_lower"])
+    if delta_h != P3_FROZEN_GATE:
+        raise RuntimeError("H18 P3 gap changed")
+    beta_b = _positive(adet["bias_homogeneous_energy_gap_lower"], "finite-tau_b bias energy gap")
+    delta_a = TARGET_P4_CASCADE_GAP
+    g2_limit = cascade_g2_limit_conservative(delta_h, beta_b, delta_a)
+    g2_budget = down(0.25 * g2_limit)
+    det_slack = cascade_determinant_slack_lower(delta_h, beta_b, delta_a, g2_budget)
+    if not (g2_budget > 0.0 and det_slack > 0.0):
+        raise RuntimeError("finite-tau_b cascade Schur budget is not strict")
+    metric = _h18_information_metric_upper(domain, h18, pe, process, dynamic, event)
+    if metric["reset_source_parity_found"] is not True:
+        raise RuntimeError("shipping reset source parity changed")
+    rejected_log_c = float(adet["triangular_detectability_observer"]["finite_coupling_log10_upper"])
+    return {
+        "schema": SCHEMA,
+        "qualification": QUALIFICATION,
+        "canonical_source": "COMPLETE_SEA3_NORMAL_LIVE_WORD",
+        "paper_storage_family": "M_A(zeta)=diag(M_H(zeta),mu*I3)",
+        "full_A21_dimension": 21, "H18_dimension": 18, "accelerometer_bias_dimension": 3,
+        "P3_frozen_gate": P3_FROZEN_GATE,
+        "P3_frozen_not_modified": True,
+        "P3_CONDITIONAL_SEA3_PASS_consumed": True,
+        "finite_tau_b_route": "ETA6_PLUS_FINITE_RESIDUAL_BIAS_CORRELATION",
+        "bias_energy_gap_lower": beta_b,
+        "target_P4_cascade_gap": delta_a,
+        "target_gap_stored_directly_not_as_1_minus_delta": True,
+        "cascade_master_inequality": "c2/mu < ((delta_H-delta_A)*(beta_b-delta_A))/(1-delta_A)",
+        "cascade_g2_limit_conservative_lower": g2_limit,
+        "cascade_g2_budget": g2_budget,
+        "cascade_determinant_slack_lower_if_budget_met": det_slack,
+        "H18_metric_equivalence": metric,
+        "actual_applied_R_S_retained": True,
+        "all_due_S_updates_remain_in_complete_word": True,
+        "all_valid_accelerometer_updates_remain_in_complete_word": True,
+        "asynchronous_vector_events_remain_in_complete_word": True,
+        "all_process_Q_and_covariance_floor_events_retained": True,
+        "immediate_resets_retained": True,
+        "full_H18_state_retained_including_aw": True,
+        "full_ba_state_retained": True,
+        "state_elimination_used": False,
+        "a_w_Schur_elimination_used": False,
+        "selected_S_word_used": False,
+        "independent_tuner_or_RS_box_used": False,
+        "trajectory_replay_used": False,
+        "finite_harmonic_or_grid_source_used": False,
+        "correction_radius_claim_used": False,
+        "inverse_metric_floor_claim_used": False,
+        "packet_count_coupling_bound_consumed": False,
+        "rejected_detectability_packet_count_log10_C_upper": rejected_log_c,
+        "joint_same_history_C_Hb_metric_bound_required": True,
+        "joint_same_history_C_Hb_metric_bound_closed": False,
+        "joint_C_Hb_c2_upper": None,
+        "mu_log10_required": None,
+        "full_rank_A21_cascade_metric_closed": False,
+        "nonlinear_residual_sector_attached": False,
+        "P4_promoted_here": False,
+        "P5_may_start": False,
+        "filter_changed": False,
+        "quality_gate_changed": False,
+        "next_obligation": "derive one source-uniform bound on ||M_H+^(1/2) C_Hb||^2 from the SAME complete-SEA3 word's joint Joseph/information geometry (including every actual-R_S S event), not from N*L^N; then choose finite mu from the certified Schur budget and attach the exact nonlinear residual sector",
+    }
+
+
+def validate(d: dict) -> list[str]:
+    f: list[str] = []
+    if d.get("schema") != SCHEMA or d.get("qualification") != QUALIFICATION:
+        f.append("schema/qualification mismatch")
+    if d.get("canonical_source") != "COMPLETE_SEA3_NORMAL_LIVE_WORD":
+        f.append("canonical source changed")
+    for key in ("P3_frozen_not_modified", "P3_CONDITIONAL_SEA3_PASS_consumed", "target_gap_stored_directly_not_as_1_minus_delta", "actual_applied_R_S_retained", "all_due_S_updates_remain_in_complete_word", "all_valid_accelerometer_updates_remain_in_complete_word", "asynchronous_vector_events_remain_in_complete_word", "all_process_Q_and_covariance_floor_events_retained", "immediate_resets_retained", "full_H18_state_retained_including_aw", "full_ba_state_retained", "joint_same_history_C_Hb_metric_bound_required"):
+        if d.get(key) is not True:
+            f.append(f"{key} is not true")
+    for key in ("state_elimination_used", "a_w_Schur_elimination_used", "selected_S_word_used", "independent_tuner_or_RS_box_used", "trajectory_replay_used", "finite_harmonic_or_grid_source_used", "correction_radius_claim_used", "inverse_metric_floor_claim_used", "packet_count_coupling_bound_consumed", "joint_same_history_C_Hb_metric_bound_closed", "full_rank_A21_cascade_metric_closed", "nonlinear_residual_sector_attached", "P4_promoted_here", "P5_may_start", "filter_changed", "quality_gate_changed"):
+        if d.get(key) is not False:
+            f.append(f"{key} is not false")
+    if float(d.get("P3_frozen_gate", math.nan)) != P3_FROZEN_GATE:
+        f.append("P3 gate changed")
+    da = d.get("target_P4_cascade_gap")
+    if not isinstance(da, (int, float)) or not (math.isfinite(float(da)) and 0.0 < float(da) < P3_FROZEN_GATE):
+        f.append("target cascade gap is not strict below frozen P3 gap")
+    for key in ("bias_energy_gap_lower", "cascade_g2_limit_conservative_lower", "cascade_g2_budget", "cascade_determinant_slack_lower_if_budget_met"):
+        x = d.get(key)
+        if not isinstance(x, (int, float)) or not (math.isfinite(float(x)) and float(x) > 0.0):
+            f.append(f"invalid positive cascade field {key}")
+    metric = d.get("H18_metric_equivalence", {})
+    for key in ("prediction_Q_lambda_min_lower", "Racc_variance_lower", "Rmag_variance_lower", "actual_applied_R_S_variance_lower", "posterior_covariance_lambda_min_lower", "M_H_lambda_max_upper", "M_H_lambda_min_lower_from_Pbar_trace_normalization", "reset_sigma_min_lower"):
+        x = metric.get(key)
+        if not isinstance(x, (int, float)) or not (math.isfinite(float(x)) and float(x) > 0.0):
+            f.append(f"invalid H18 metric field {key}")
+    for key in ("Joseph_information_identity_used", "every_possible_same_sample_measurement_assimilated_for_lower_bound", "reset_source_parity_found", "PSD_covariance_floor_can_only_help_lower_bound"):
+        if metric.get(key) is not True:
+            f.append(f"H18 metric property lost: {key}")
+    for key in ("reset_lower_bound_requires_correction_radius", "marginal_inverse_metric_floor_inference_used"):
+        if metric.get(key) is not False:
+            f.append(f"forbidden H18 metric shortcut re-entered: {key}")
+    if d.get("joint_C_Hb_c2_upper") is not None or d.get("mu_log10_required") is not None:
+        f.append("open joint C_Hb bound was populated without closure")
+    return list(dict.fromkeys(f))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--domain", type=Path, default=DEFAULT_DOMAIN)
+    ap.add_argument("--output", type=Path, required=True)
+    args = ap.parse_args()
+    d = build(args.domain)
+    failures = validate(d)
+    d["validation_pass"] = not failures
+    d["validation_failures"] = failures
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(d, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"target_gap": d["target_P4_cascade_gap"], "bias_gap": d["bias_energy_gap_lower"], "g2_budget": d["cascade_g2_budget"], "H18_metric_upper": d["H18_metric_equivalence"]["M_H_lambda_max_upper"], "joint_C_Hb_closed": d["joint_same_history_C_Hb_metric_bound_closed"], "P4_promoted": d["P4_promoted_here"], "failures": failures}, indent=2, sort_keys=True))
+    return 0 if not failures else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/stability/ou3_p4_a21_finite_bias_cascade_energy_bound.py
+++ b/tools/stability/ou3_p4_a21_finite_bias_cascade_energy_bound.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Quantitative complete-SEA3 finite-bias comparison-cascade energy bound.
+
+This closes the *comparison observer* C_Hb bound left open by
+``ou3_p4_a21_finite_bias_cascade_bridge`` without using the detectability
+helper's deliberately crude ``N*K*L^N`` estimate.
+
+Choose the H18 comparison observer to use the certified complete-SEA3 H18
+shipping information geometry and a zero accelerometer-bias correction row.
+For h_0=0 the only direct b_a forcing of that H18 observer is the accepted
+accelerometer residual.  The exact Joseph signed-energy identity gives
+
+    Delta V_H <= s_H b_j^T R_a^-1 b_j,
+
+while S=0 and vector events have no linear b_a residual input and tangent reset
+congruences preserve the H18 information energy.  The comparison bias state is
+not corrected and follows the exact shipping homogeneous GM law, so
+
+    ||b_j|| <= exp(-j h_-/tau_b) ||b_0||.
+
+Hence the whole 3 s bias-to-H coupling obeys the closed-form energy bound
+
+    ||C_Hb b_0||_{M_H,+}^2
+      <= s_H lambda_max(R_a^-1)
+         sum_{j=1}^N exp(-2 j h_-/tau_b) ||b_0||^2.
+
+The geometric sum is the actual finite-tau_b input energy over the required
+accepted accelerometer sequence.  It is not an N-times worst nonlinear
+remainder and contains no product of suffix norms.
+
+Combining this c^2 with the exact two-block Schur condition produces a finite
+full-rank quadratic metric for the *triangular comparison observer*.  This is a
+stronger quantitative detectability/UES bridge, but it is deliberately NOT yet
+a P4 metric for the actual A21 Kalman map: the actual shipping bias correction
+row and H<->b cross terms still need a theorem bridge or a direct source-uniform
+full-cross-term metric certificate.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+import ou3_p4_a21_finite_bias_cascade_bridge as BRIDGE
+import ou3_sea3_a21_detectability_completion as ADET
+import ou3_sea3_full_normal_live_word as WORD
+import ou3_sea3_riccati_metric_p3 as P3
+
+DEFAULT_DOMAIN = BRIDGE.DEFAULT_DOMAIN
+SCHEMA = 1
+QUALIFICATION = "OU3_P4_A21_FINITE_TAUB_COMPARISON_CASCADE_GM_ENERGY_V1"
+
+
+def down(x: float) -> float:
+    return math.nextafter(float(x), -math.inf)
+
+
+def up(x: float) -> float:
+    return math.nextafter(float(x), math.inf)
+
+
+def geometric_decay_energy_upper(n: int, h_lower: float, tau_b: float) -> float:
+    if n <= 0:
+        raise ValueError("sample count must be positive")
+    h = float(h_lower)
+    tau = float(tau_b)
+    if not (math.isfinite(h) and h > 0.0 and math.isfinite(tau) and tau > 0.0):
+        raise ValueError("h/tau must be finite positive")
+    a = down(2.0 * h / tau)
+    # q*(1-q^N)/(1-q), evaluated with expm1 to avoid cancellation near q=1.
+    q = up(math.exp(-a))
+    numerator = up(-math.expm1(-up(a * n)))
+    denominator = down(-math.expm1(-a))
+    if not denominator > 0.0:
+        raise RuntimeError("GM geometric denominator lost positivity")
+    return up(q * up(numerator / denominator))
+
+
+def sufficient_power10(log10_required: float) -> int:
+    x = float(log10_required)
+    if not math.isfinite(x):
+        raise ValueError("required logarithmic weight must be finite")
+    # One full decimal order of slack avoids depending on a rounded equality.
+    return int(math.ceil(x)) + 1
+
+
+def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
+    path = Path(domain_path).resolve()
+    bridge = BRIDGE.build(path)
+    p3 = P3.build(path)
+    adet = ADET.build(path)
+    word = WORD.build(path)
+    bad = {
+        "bridge": BRIDGE.validate(bridge),
+        "P3": P3.validate(p3),
+        "A21_detectability": ADET.validate(adet),
+        "word": WORD.validate(word),
+    }
+    bad = {k: v for k, v in bad.items() if v}
+    if bad:
+        raise RuntimeError(f"comparison-cascade prerequisites failed: {bad}")
+    if p3["canonical_source"] != "COMPLETE_SEA3_NORMAL_LIVE_WORD":
+        raise RuntimeError("comparison cascade detached from canonical complete SEA3")
+    if float(p3["useful_gate"]) != BRIDGE.P3_FROZEN_GATE:
+        raise RuntimeError("frozen P3 gate changed")
+
+    runtime = adet["active_bias_process"]
+    tau_b = float(runtime["tau_ba_s"])
+    # The literal complete word supplies the configured IMU dt enclosure and
+    # requires every valid Normal-Live accelerometer update.
+    h_bounds = word["configured_runtime"]["imu_dt_outward_interval_s"]
+    h_lower = float(h_bounds[0])
+    n_acc = int(word["imu_samples_upper"])
+    if n_acc <= 0 or word["all_Normal_Live_accelerometer_updates_required"] is not True:
+        raise RuntimeError("complete word no longer retains every accelerometer update")
+
+    gsum = geometric_decay_energy_upper(n_acc, h_lower, tau_b)
+    mh = bridge["H18_metric_equivalence"]
+    s_h = float(mh["normalization_s_H"])
+    racc = float(mh["Racc_variance_lower"])
+    if not (s_h > 0.0 and racc > 0.0):
+        raise RuntimeError("H18 normalization/Racc lower lost positivity")
+    c2 = up(up(s_h / racc) * gsum)
+    if not (math.isfinite(c2) and c2 > 0.0):
+        raise RuntimeError("GM energy C_Hb bound is not finite positive")
+
+    g2_budget = float(bridge["cascade_g2_budget"])
+    log_mu = BRIDGE.required_mu_log10(c2, g2_budget)
+    p10 = sufficient_power10(log_mu)
+    # mu=10^p10 is at least ten times the rounded required value, so
+    # c2/mu < 0.1*g2_budget < g2_budget, without materializing huge powers.
+    schur_ratio_upper = 0.1
+    comparison_closed = bool(
+        math.isfinite(log_mu)
+        and p10 > 0
+        and gsum > 0.0
+        and c2 > 0.0
+        and g2_budget > 0.0
+    )
+
+    return {
+        "schema": SCHEMA,
+        "qualification": QUALIFICATION,
+        "canonical_source": "COMPLETE_SEA3_NORMAL_LIVE_WORD",
+        "P3_frozen_gate": BRIDGE.P3_FROZEN_GATE,
+        "P3_frozen_not_modified": True,
+        "paper_active_bias_route": adet["paper_active_bias_route"],
+        "comparison_observer_form": "[[E_H,C_Hb],[0,Phi_b]]",
+        "comparison_observer_only_not_shipping_estimator": True,
+        "comparison_bias_correction_row_is_zero": True,
+        "H18_comparison_uses_complete_SEA3_shipping_information_geometry": True,
+        "same_complete_SEA3_word_used": True,
+        "word_horizon_s": float(word["word_horizon_s"]),
+        "required_accelerometer_updates": n_acc,
+        "all_valid_accelerometer_updates_retained": True,
+        "every_due_S_update_with_actual_RS_retained_inside_H18_word": True,
+        "actual_RS_axis_factors": mh["actual_applied_R_S_axis_factors"],
+        "actual_RS_regularization_not_replaced": True,
+        "tau_ba_s": tau_b,
+        "imu_dt_lower_s": h_lower,
+        "GM_bias_energy_geometric_sum_upper": gsum,
+        "GM_energy_sum_formula": "sum_{j=1}^N exp(-2*j*h_lower/tau_b)",
+        "H18_mode_global_normalization_s_H": s_h,
+        "Racc_variance_lower": racc,
+        "joint_C_Hb_metric_c2_upper": c2,
+        "C_Hb_bound_derivation": "exact Joseph bias-input supply plus closed-form GM energy",
+        "suffix_norm_product_used": False,
+        "N_times_worst_map_coupling_used": False,
+        "packet_count_nonlinear_remainder_multiplier_used": False,
+        "closed_form_same_word_bias_energy_used": True,
+        "cascade_g2_budget": g2_budget,
+        "mu_log10_required_upper": log_mu,
+        "mu_sufficient_decimal": f"1e{p10}",
+        "mu_sufficient_power10": p10,
+        "c2_over_mu_to_g2_budget_ratio_upper": schur_ratio_upper,
+        "comparison_cascade_Schur_condition_closed": comparison_closed,
+        "comparison_observer_full_rank_21_state_metric_closed": comparison_closed,
+        "full_ba_state_retained": True,
+        "full_H18_state_retained_including_aw": True,
+        "state_elimination_used": False,
+        "a_w_elimination_used": False,
+        "actual_A21_shipping_bias_correction_row_consumed": False,
+        "actual_A21_shipping_H_b_cross_terms_closed": False,
+        "actual_A21_shipping_full_cross_term_metric_closed": False,
+        "nonlinear_residual_sector_attached": False,
+        "P4_promoted_here": False,
+        "P5_may_start": False,
+        "filter_changed": False,
+        "declared_domain_changed": False,
+        "next_obligation": "bridge the quantitative finite-tau_b comparison-cascade storage to the ACTUAL A21 Kalman homogeneous word while retaining its bias correction row and H<->b cross terms, or construct the theorem-equivalent source-indexed full-cross-term metric directly; then attach the signed nonlinear complete-word sector",
+    }
+
+
+def validate(d: dict) -> list[str]:
+    f: list[str] = []
+    if d.get("schema") != SCHEMA or d.get("qualification") != QUALIFICATION:
+        f.append("schema/qualification mismatch")
+    if d.get("canonical_source") != "COMPLETE_SEA3_NORMAL_LIVE_WORD":
+        f.append("canonical source changed")
+    if float(d.get("P3_frozen_gate", math.nan)) != BRIDGE.P3_FROZEN_GATE:
+        f.append("P3 gate changed")
+    for key in (
+        "P3_frozen_not_modified",
+        "comparison_observer_only_not_shipping_estimator",
+        "comparison_bias_correction_row_is_zero",
+        "H18_comparison_uses_complete_SEA3_shipping_information_geometry",
+        "same_complete_SEA3_word_used",
+        "all_valid_accelerometer_updates_retained",
+        "every_due_S_update_with_actual_RS_retained_inside_H18_word",
+        "actual_RS_regularization_not_replaced",
+        "closed_form_same_word_bias_energy_used",
+        "comparison_cascade_Schur_condition_closed",
+        "comparison_observer_full_rank_21_state_metric_closed",
+        "full_ba_state_retained",
+        "full_H18_state_retained_including_aw",
+    ):
+        if d.get(key) is not True:
+            f.append(f"{key} is not true")
+    for key in (
+        "suffix_norm_product_used",
+        "N_times_worst_map_coupling_used",
+        "packet_count_nonlinear_remainder_multiplier_used",
+        "state_elimination_used",
+        "a_w_elimination_used",
+        "actual_A21_shipping_bias_correction_row_consumed",
+        "actual_A21_shipping_H_b_cross_terms_closed",
+        "actual_A21_shipping_full_cross_term_metric_closed",
+        "nonlinear_residual_sector_attached",
+        "P4_promoted_here",
+        "P5_may_start",
+        "filter_changed",
+        "declared_domain_changed",
+    ):
+        if d.get(key) is not False:
+            f.append(f"{key} is not false")
+    if d.get("paper_active_bias_route") != "ETA6_PLUS_FINITE_RESIDUAL_BIAS_CORRELATION":
+        f.append("active-bias theorem route changed")
+    for key in (
+        "word_horizon_s",
+        "tau_ba_s",
+        "imu_dt_lower_s",
+        "GM_bias_energy_geometric_sum_upper",
+        "H18_mode_global_normalization_s_H",
+        "Racc_variance_lower",
+        "joint_C_Hb_metric_c2_upper",
+        "cascade_g2_budget",
+        "mu_log10_required_upper",
+    ):
+        x = d.get(key)
+        if not isinstance(x, (int, float)) or not (math.isfinite(float(x)) and float(x) > 0.0):
+            f.append(f"invalid positive field {key}")
+    p = d.get("mu_sufficient_power10")
+    if not isinstance(p, int) or p <= 0 or d.get("mu_sufficient_decimal") != f"1e{p}":
+        f.append("invalid sufficient mu representation")
+    if float(d.get("c2_over_mu_to_g2_budget_ratio_upper", math.inf)) >= 1.0:
+        f.append("chosen comparison-cascade mu does not satisfy Schur budget")
+    if d.get("actual_RS_axis_factors") != [0.72, 0.72, 1.0]:
+        f.append("actual R_S anisotropy changed")
+    return list(dict.fromkeys(f))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--domain", type=Path, default=DEFAULT_DOMAIN)
+    ap.add_argument("--output", type=Path, required=True)
+    args = ap.parse_args()
+    d = build(args.domain)
+    failures = validate(d)
+    d["validation_pass"] = not failures
+    d["validation_failures"] = failures
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(d, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"C_Hb_c2_upper": d["joint_C_Hb_metric_c2_upper"], "mu_log10_required": d["mu_log10_required_upper"], "mu_sufficient": d["mu_sufficient_decimal"], "comparison_metric_closed": d["comparison_observer_full_rank_21_state_metric_closed"], "actual_shipping_bridge_closed": d["actual_A21_shipping_full_cross_term_metric_closed"], "P4_promoted": d["P4_promoted_here"], "failures": failures}, indent=2, sort_keys=True))
+    return 0 if not failures else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/stability/ou3_p4_a21_finite_bias_cascade_energy_bound.py
+++ b/tools/stability/ou3_p4_a21_finite_bias_cascade_energy_bound.py
@@ -42,6 +42,7 @@ import json
 import math
 from pathlib import Path
 
+import ou3_full_process_ucc as PROCESS
 import ou3_p4_a21_finite_bias_cascade_bridge as BRIDGE
 import ou3_sea3_a21_detectability_completion as ADET
 import ou3_sea3_full_normal_live_word as WORD
@@ -91,11 +92,13 @@ def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
     p3 = P3.build(path)
     adet = ADET.build(path)
     word = WORD.build(path)
+    process = PROCESS.build()
     bad = {
         "bridge": BRIDGE.validate(bridge),
         "P3": P3.validate(p3),
         "A21_detectability": ADET.validate(adet),
         "word": WORD.validate(word),
+        "process": PROCESS.validate(process),
     }
     bad = {k: v for k, v in bad.items() if v}
     if bad:
@@ -107,12 +110,13 @@ def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
 
     runtime = adet["active_bias_process"]
     tau_b = float(runtime["tau_ba_s"])
-    # The literal complete word supplies the configured IMU dt enclosure and
-    # requires every valid Normal-Live accelerometer update.
-    h_bounds = word["configured_runtime"]["imu_dt_outward_interval_s"]
+    # The process certificate owns the configured outward IMU-dt interval; the
+    # literal word owns the requirement that every valid sample includes the
+    # accelerometer Joseph operation.  Keep those ownerships distinct.
+    h_bounds = process["configured_runtime"]["imu_dt_outward_interval_s"]
     h_lower = float(h_bounds[0])
     n_acc = int(word["imu_samples_upper"])
-    if n_acc <= 0 or word["all_Normal_Live_accelerometer_updates_required"] is not True:
+    if n_acc <= 0 or word["every_valid_imu_sample_requires_accelerometer_Joseph"] is not True:
         raise RuntimeError("complete word no longer retains every accelerometer update")
 
     gsum = geometric_decay_energy_upper(n_acc, h_lower, tau_b)


### PR DESCRIPTION
## Continuation checkpoint

Continue from merged #496 / `main` `75f8ecc58bec654bb994ebcb7d74921355514544` on the paper-permitted finite-`tau_b` active accelerometer-bias route.

This PR keeps conditional complete-SEA3 P3 frozen at `delta=1e-18`, preserves `COMPLETE_SEA3_NORMAL_LIVE_WORD`, every valid accelerometer update, every due S=0 update with the actual applied anisotropic SpectralMSE `R_S`, asynchronous vector events, full Q/covariance-floor events, immediate resets, H18/A21 dimensions and the separate H->A hybrid. It does not change filter code or numerical quality gates and does not merge without explicit authorization.

## First theorem checkpoint

The new full-rank cascade storage is

`M_A(zeta)=diag(M_H(zeta), mu I3)`

for the finite-`tau_b` comparison cascade `[[E_H,C_Hb],[0,Phi_b]]`. For target P4 cascade gap `delta_A=5e-19`, the exact Schur condition is

`c^2/mu < ((delta_H-delta_A)(beta_b-delta_A))/(1-delta_A)`.

Strictness is stored as positive gap/determinant slack; the code never evaluates `1-delta_A` as a binary64 proof.

A fresh full-matrix H18 covariance lower / information-metric upper is derived from the shipping full-process Q lower, bounded same-sample Joseph information, and the exact reset fact `sigma_min(I+0.5[d]_x)=1`. This does **not** use the withdrawn marginal inverse-metric-floor or correction-radius claims.

The bridge is intentionally fail-closed at one remaining linear object: a source-uniform same-history bound on `||M_H+^(1/2) C_Hb||^2`. The older detectability helper's crude `N*L^N` coupling estimate is explicitly rejected and is not consumed by the proof. The next step is to derive that coupling from the complete word's joint Joseph/information geometry, retaining every actual-`R_S` S event, then choose finite `mu` and attach the exact nonlinear residual sector.

P4 remains OPEN. P5 remains BLOCKED.