### PR TITLE
OU-III P4: add full-state finite-tau_b joint-sector bridge

### DIFF
--- a/.github/workflows/ou3-proof.yml
+++ b/.github/workflows/ou3-proof.yml
@@ -337,7 +337,8 @@ jobs:
       - name: Build canonical finite-state endpoint and prefix P4 gate
         run: |
           python3 tools/stability/ou3_sea3_riccati_metric_p4.py \
-            --output /tmp/ou3_sea3_riccati_metric_p4.json
+            --output /tmp/ou3_sea3_riccati_metric_p4.json \
+            --joint-sector-output /tmp/ou3_p4_complete_sea3_joint_sector_master.json
 
       - name: Test complete-SEA3 finite physical P4 contract
         working-directory: tests/validation
@@ -352,9 +353,11 @@ jobs:
           import json
           m = json.load(open('/tmp/ou3_p4_complete_sea3_phi_differential_metric.json'))
           r = json.load(open('/tmp/ou3_p4_complete_sea3_reset_gauge_attachment.json'))
+          j = json.load(open('/tmp/ou3_p4_complete_sea3_joint_sector_master.json'))
           d = json.load(open('/tmp/ou3_sea3_riccati_metric_p4.json'))
           assert m['validation_pass'], m['validation_failures']
           assert r['validation_pass'], r['validation_failures']
+          assert j['validation_pass'], j['validation_failures']
           assert d['validation_pass'], d['validation_failures']
           assert r['zero_error_P3_to_physical_P4_tangent_attachment_closed'] is True
           assert r['finite_error_nonlinear_reset_transport_closed_here'] is False
@@ -369,6 +372,21 @@ jobs:
           assert d['prefix_chart_and_source_domain_retention_required'] is True
           assert d['same_complete_SEA3_word_required'] is True
           assert d['all_due_S_updates_with_actual_applied_RS_required'] is True
+          assert j['P3_delta_required'] == 1e-18
+          assert j['full_A21_finite_taub_P3_margin_required'] is True
+          assert j['canonical_full_matrix_P3_consumed'] is True
+          assert j['finite_taub_A21_detectability_consumed'] is True
+          assert j['finite_taub_detectability_used_as_standalone_P4_promotion'] is False
+          assert j['all_due_S_updates_with_actual_applied_RS_remain_in_suffix'] is True
+          assert j['actual_RS_provenance_preserved'] is True
+          assert j['all_21_state_cross_terms_retained'] is True
+          assert j['terminal_full_augmented_interval_LDLT_available'] is True
+          assert j['same_history_quadratic_graph_sector_assembler_available'] is True
+          assert j['arbitrary_joint_nondiagonal_sector_weights_retained'] is True
+          assert j['per_event_scalar_sector_required'] is False
+          assert d['full_state_joint_sector_master_available'] is True
+          assert d['A21_finite_taub_full_matrix_P3_required'] is True
+          assert d['A21_finite_taub_detectability_consumed'] is True
           assert d['differential_AD_used_only_for_finite_map_enclosure'] is True
           assert d['differential_pullback_used_as_replacement_P4'] is False
           assert d['packet_count_remainder_budget_used'] is False
@@ -377,12 +395,14 @@ jobs:
           assert d['correction_radius_claim_used'] is False
           assert d['inverse_metric_floor_claim_used'] is False
           assert d['source_uniform_complete_word_generalized_Jacobian_enclosed'] is False
+          assert d['source_uniform_same_history_joint_sector_closed'] is False
+          assert d['source_uniform_full_augmented_LDLT_closed'] is False
           assert d['source_uniform_endpoint_finite_map_closed'] is False
           assert d['source_uniform_prefix_gain_closed'] is False
           assert d['source_uniform_prefix_domain_retention_closed'] is False
           assert d['P4_CANONICAL_PASS'] is False
           assert d['P5_MAY_START'] is False
-          print('Finite physical-map architecture contracts pass; source-uniform endpoint/prefix P4 and P5 remain OPEN.')
+          print('Finite physical-map and joint-sector bridge contracts pass; source-uniform endpoint/prefix P4 and P5 remain OPEN.')
           PY
 
       - name: Upload canonical finite-state P4 artifacts
@@ -393,5 +413,6 @@ jobs:
             /tmp/ou3_p4_cayley_sector_certificate.json
             /tmp/ou3_p4_complete_sea3_phi_differential_metric.json
             /tmp/ou3_p4_complete_sea3_reset_gauge_attachment.json
+            /tmp/ou3_p4_complete_sea3_joint_sector_master.json
             /tmp/ou3_sea3_riccati_metric_p4.json
           retention-days: 7

--- a/doc/kalman_ou_iii/w3d-sea3-stability-theorem.tex-part
+++ b/doc/kalman_ou_iii/w3d-sea3-stability-theorem.tex-part
@@ -234,6 +234,39 @@ where $D_{s,k}$ and $D_{n,k}$ are hard energies over the window beginning at
 $k$.  No one-sample decrease of $V$ is required; growth inside an oscillation
 is allowed.
 
+For the homogeneous finite-state part of one complete shipping word, write
+$\Phi_N=M_W\Phi_0+d_W$, $J_N=P_N^{-1}$, and
+$D_W=J_0-M_W^\top J_N M_W$.  Retain the nonlinear residual, reset, boundary,
+and projection history as one same-history coordinate $w_W$, without splitting
+it into independent event radii, so that $d_W=B_W w_W$.  Then the exact endpoint
+energy difference is the full augmented quadratic form
+\begin{equation}
+ V_N-V_0
+ =
+ \begin{bmatrix}\Phi_0\\w_W\end{bmatrix}^{\!\top}
+ \underbrace{\begin{bmatrix}
+ -D_W & M_W^\top J_NB_W\\
+ B_W^\top J_NM_W & B_W^\top J_NB_W
+ \end{bmatrix}}_{L_W}
+ \begin{bmatrix}\Phi_0\\w_W\end{bmatrix}.
+ \label{eq:sea3-joint-word-master}
+\end{equation}
+If the correlated nonlinear graph is enclosed by quadratic sectors
+$z_W^\top\Pi_jz_W\ge0$, $z_W=[\Phi_0^\top,w_W^\top]^\top$, it is sufficient
+to find nonnegative multipliers $\lambda_j$ for which the outward full-matrix
+test
+\begin{equation}
+ \boxed{-\left(L_W+\sum_j\lambda_j\Pi_j\right)\succ0}
+ \label{eq:sea3-joint-word-sector-test}
+\end{equation}
+holds.  In active accelerometer-bias mode this test is on the full 21-state
+matrix and retains finite-$\tau_b$ bias decay and every state cross term.  Each
+suffix in $B_W$ contains every later shipping event, in particular each due
+$S=0$ update with the actual applied anisotropic $R_S$.  Thus
+Eq.~\eqref{eq:sea3-joint-word-sector-test} may neither eliminate $a_w$ or
+$b_a$ nor replace the same-history graph by a packet-count or independent-box
+bound.
+
 Endpoint contraction alone is not sufficient for a full-sample ISS claim.
 P4 must additionally certify a uniform prefix-gain inequality: there exist
 finite nonnegative constants $\kappa_V,\kappa_s,\kappa_n$ such that for every

--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -88,11 +88,10 @@ Retired / forbidden rescue routes include:
 - scalar Lipschitz, correction-radius, inverse-metric-floor, or packet-count-times-worst-remainder bounds;
 - further proof-driven filter/domain tightening beyond the authorized 0.4 change.
 
-## Correct next theorem route
+## Retained finite-`tau_b` premise
 
-The next PR should start from current main after this handoff and pursue the paper-permitted **finite-`tau_b`, full-21-state A21 cascade/detectability route**. This is qualitatively different from the failed endpoint/window experiments.
-
-The existing `tools/stability/ou3_sea3_a21_detectability_completion.py` already establishes the paper-level finite-bias detectability/UES hypothesis from:
+`tools/stability/ou3_sea3_a21_detectability_completion.py` establishes the
+paper-level finite-bias detectability/UES hypothesis from:
 
 - complete-SEA3 H18 contraction;
 - exact finite residual-bias Gauss-Markov decay;
@@ -100,26 +99,83 @@ The existing `tools/stability/ou3_sea3_a21_detectability_completion.py` already 
 - full A21 process UCC;
 - no alternate estimator and no state elimination.
 
-However, that module deliberately remains fail-closed for the stronger canonical implementation-word bridge: `full_21x21_Omega_minus_delta_P_LDLT_closed_here = False` and `P4_MAY_CONSUME_P3 = False`.
+Its stronger implementation-word flags remain deliberately false. The joint
+master consumes this result only through the validated canonical P3 chain; it
+does not promote the comparison observer or replace the full A21 matrix test.
 
-The next theorem-facing master inequality must therefore be a **full-rank 21-state** Lyapunov/cascade inequality that consumes the same complete-SEA3 source history and retains every actual shipping event/coupling. It must show how the finite-`tau_b` bias decay/detectability estimate combines with the H18 complete-word dissipation and the nonlinear accelerometer residual sector without eliminating `b_a`, `a_w`, or any cross terms. Only after that full-state bridge is quantitative and outward-certified should the universal nonlinear complete-word P4 endpoint/prefix enclosure resume.
+## Current hypothesis
 
-If the full-state finite-`tau_b` construction itself exposes a genuine admissible expanding direction that violates the paper-equivalent P4 inequality on the declared domain, report that obstruction directly rather than inventing a weaker certificate or shrinking the domain.
+Use the exact complete-word endpoint identity and the full 21-state finite-`tau_b`
+P3/detectability result to build one correlated nonlinear graph-sector master.
+For `z=[x;w_W]`, the controlling matrix is
+`L_W=[[-D_W,M_W^T J_N B_W],[B_W^T J_N M_W,B_W^T J_N B_W]]`.
+Admissible graph sectors `z^T Pi_j z>=0` enter only through the full
+S-procedure test `-(L_W+sum lambda_j Pi_j)>0`; the same construction is
+required at every prefix.
+
+## Evidence and current limiter
+
+P3 was recomputed with the deployed `0.4 m/s^2` accelerometer-bias projection
+limit: H18 and A21 retain `delta=1e-18`, the first active A21 bias full-matrix
+margin is `1.2499987189052501e-9`, and the H18 worst interval LDLT pivot is
+`4.987499868870966e-14`. `P3_DEPLOYMENT_PASS` remains false only for the
+separate physical-language inclusion obligation.
+
+The canonical 6 s A21 payload has a strict small-error margin
+(`rho=0.9911176` at scale `0.125`) but crosses one at scale `7.5` and
+reaches `1.1357229` at the retained-domain boundary. The finite-`tau_b`
+detectability rerun passes with bias energy gap `1.1992803e-3` and
+asymptotic A21 gap `1e-18`. Thus linear bias decay is not the limiter;
+the limiter is the correlated attitude/`a_w`/`b_a` accelerometer curvature.
+
+## Failed approaches / DEAD_ENDS
+
+On the same canonical payload, diagonal bias precision, fixed-frame and
+source-framed `a_w`/`b_a` cross penalties, and separate latent diagonal
+energies all failed after their allowed refinement. The closest result was
+`rho_linear=0.996797290`, `rho_finite=1.00009035805` at
+`(beta_aw,beta_b)=(500,310000)`. Do not resume metric-grid tuning.
+
+## Retained facts, alternatives, and next experiment
+
+Retain the complete same-history source, frozen P3 `delta=1e-18`, full H18/A21
+states and cross terms, exact Cayley/reset residuals, all valid accelerometer
+and vector events, and every due S event with actual applied `R_S` inside its
+suffix. Packetwise radii, state elimination, replay fitting, and further
+domain/filter changes remain forbidden.
+
+The remaining alternatives are a dense source-structured storage LMI, a
+path-dependent joint storage, or direct falsification of a source-uniform
+inner funnel. The next falsifiable experiment is to materialize only the
+same-history state/residual selectors needed by the master, lift the exact
+Cayley and A21 projection bounds into dense graph sectors, and evaluate the
+full augmented matrix first on the canonical point word. Proceed to outward
+source-uniform LDLT only if that non-promoting matrix diagnostic is below one.
 
 ## Complete-source obligation still open
 
 The upstream complete-source contract still does not materialize the correlated finite-window SEA3 realization as an executable outward source family. Parameter compactness, RAO/moment envelopes, hard pathwise acceleration/body-rate caps, frontend parity, and adaptive-state rate/jump bounds do not replace a same-history transition for the correlated source state. P4 may not substitute independent per-sample boxes, a replay record, or a finite harmonic/grid surrogate.
 
-The continuation should first formulate the full-state finite-`tau_b` master inequality and determine exactly which source-correlated quantities it needs. Then extend the existing complete-SEA3 execution/source machinery only for those theorem quantities, rather than creating another surrogate proof language.
+The full-state master now identifies the needed quantities: same-history prefix
+state selectors, stacked nonlinear residual selectors, reset/boundary terms,
+and the A21 projection graph. Extend the existing complete-SEA3 execution only
+to materialize those quantities, rather than creating another source language.
 
-## CI / evidence status at handoff
+## Current CI / evidence status
 
-The long-window falsification workflow is green. Exact Cayley parity, the physical 3-second finite-map feasibility, A21-word, complete-word feasibility, and lever-arm-study workflows were also green on head `80140b762ab7bfd924d1d5dc279153e425a31612` when this handoff was prepared; several broader workflows were still running.
+The exact `source-foundation` command passes 73 tests. The 0.4 P3 recomputation,
+finite-`tau_b` detectability rerun, canonical P4 integration, and all 91 P4
+discovery tests pass. `make all` is locally blocked before compilation because
+this environment has neither `/usr/include/eigen3/Eigen/Dense` nor a vendored
+Eigen tree; the build command and include policy were not changed.
 
 `ou-validation` is red for a known evidence-provenance reason, not because its numerical unit-test body found a new filter failure: `tools/ou_evidence_contract.py --auto` reports replay dependencies changed relative to committed validation/robustness provenance, including the OU-III filter and WavePeriodEstimator dependencies. Genuine validation/robustness evidence regeneration is therefore still required before a later proof PR is declared final/ready. Do not hand-edit provenance hashes.
 
-No claim is made that P4 or P5 is complete at this merge checkpoint.
+No claim is made that P4 or P5 is complete.
 
-## Continuation instruction
+## Promotion boundary
 
-Create a new PR from the merged main state. Read `AGENTS.md`, this file, the merged #496 handoff comment, `doc/kalman_ou_iii/w3d-sea3-stability-theorem.tex-part`, and `tools/stability/ou3_sea3_a21_detectability_completion.py` first. Keep P3 frozen at `delta=1e-18`; preserve complete same-history SEA3 and every actual-applied R_S update. Build the full-21-state finite-`tau_b` cascade/detectability bridge before adding further universal P4 enclosure machinery. P5 remains blocked until strict P4 closes.
+The master and graph-sector machinery are non-promoting. P4 remains open until
+the source-uniform endpoint and every-prefix augmented LDLT plus domain
+retention close on the same complete SEA3 history. P5 remains blocked until
+strict canonical P4 contraction closes.

--- a/tests/kalman_ou_iii/ou3_p4_physical_finite_map_feasibility.py
+++ b/tests/kalman_ou_iii/ou3_p4_physical_finite_map_feasibility.py
@@ -13,7 +13,8 @@ applied R_S from that source word.
 The finite state is the paper's true-minus-estimated physical Cayley error.  It
 is propagated by the existing theorem-facing physical prediction and Joseph
 event functions.  A21 uses homogeneous source true residual bias zero and the
-shipping 0.5 m/s^2 projection; the full delta-b_a error coordinate is retained.
+projection radius read from the current proof domain; the full delta-b_a error
+coordinate is retained.
 
 Before any finite ratio is reported, the zero-state physical Jacobian cocycle
 must reproduce the reset-normalized linear cocycle.  This is a point

--- a/tests/kalman_ou_iii/ou3_p4_physical_long_window_feasibility.py
+++ b/tests/kalman_ou_iii/ou3_p4_physical_long_window_feasibility.py
@@ -20,12 +20,9 @@ from __future__ import annotations
 
 import argparse
 import json
-import math
 import os
 from pathlib import Path
 import subprocess
-
-import numpy as np
 
 import ou3_p4_complete_sea3_word_feasibility as WORD
 import ou3_p4_physical_finite_map_feasibility as BASE

--- a/tests/validation/test_ou3_p4_complete_sea3_joint_sector_master.py
+++ b/tests/validation/test_ou3_p4_complete_sea3_joint_sector_master.py
@@ -1,0 +1,116 @@
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools" / "stability"))
+
+from ou3_interval import Interval, matrix_point  # noqa: E402
+import ou3_p4_complete_sea3_joint_sector_master as mod  # noqa: E402
+
+
+class CompleteSea3JointSectorMasterTests(unittest.TestCase):
+    def test_master_matrix_is_exact_endpoint_energy_identity(self):
+        D = matrix_point([[0.75]])
+        M = matrix_point([[0.5]])
+        J = matrix_point([[1.0]])
+        B = matrix_point([[0.1]])
+        master = mod.master_quadratic_matrix(D, M, J, B)
+
+        x = 0.4
+        w = -0.3
+        direct = -0.75 * x * x + 2.0 * (0.5 * x) * (0.1 * w) + (0.1 * w) ** 2
+        value = mod.quadratic_value(master, [Interval.point(x), Interval.point(w)])
+        self.assertTrue(value.contains(direct))
+        self.assertTrue(master[0][0].contains(-0.75))
+        self.assertTrue(master[0][1].contains(0.05))
+        self.assertTrue(master[1][1].contains(0.01))
+
+    def test_full_augmented_sprocedure_closes_strict_fixture(self):
+        master = mod.master_quadratic_matrix(
+            matrix_point([[0.75]]),
+            matrix_point([[0.5]]),
+            matrix_point([[1.0]]),
+            matrix_point([[0.1]]),
+        )
+        # The graph sector is 0.01*x^2-w^2 >= 0, i.e. |w| <= 0.1|x|.
+        sector = mod.quadratic_graph_sector(
+            matrix_point([[1.0, 0.0]]),
+            matrix_point([[0.01]]),
+            matrix_point([[0.0, 1.0]]),
+            matrix_point([[1.0]]),
+        )
+        closed, pivots = mod.certify_strict_joint_sector_domination(
+            master, [sector], [0.02]
+        )
+        self.assertTrue(closed)
+        self.assertGreater(min(pivots), 0.0)
+
+    def test_sprocedure_rejects_invalid_multipliers_or_dimensions(self):
+        master = matrix_point([[-1.0, 0.0], [0.0, -1.0]])
+        sector = matrix_point([[1.0, 0.0], [0.0, -1.0]])
+        with self.assertRaises(ValueError):
+            mod.joint_sector_sprocedure_matrix(master, [sector], [-0.1])
+        with self.assertRaises(ValueError):
+            mod.joint_sector_sprocedure_matrix(master, [matrix_point([[1.0]])], [0.1])
+        with self.assertRaises(ValueError):
+            mod.joint_sector_sprocedure_matrix(master, [sector], [])
+
+    def test_contract_retains_source_p3_full_state_and_actual_rs(self):
+        channel = mod.CHANNEL.build()
+        residual = mod.RESIDUAL.build()
+        signed = {"joint_complete_word_signed_information_composition_available": True}
+        p3 = {
+            "P3_CONDITIONAL_SEA3_PASS": True,
+            "conditional_composition": {
+                "A21_finite_bias_correlation_route_consumed": True,
+                "A21_detectability_completion_closed": True,
+                "A21_paper_UES_hypotheses_closed": True,
+                "A21_comparison_observer_is_proof_only_not_alternate_estimator": True,
+                "A21_uses_eta9_packet_shortcut": False,
+                "A21_detectability_asymptotic_word_energy_gap_lower": 1.0e-18,
+                "A21_bias_homogeneous_contraction_gap_lower": 0.001,
+            },
+            "modes": {
+                "H18": {
+                    "Omega_minus_delta_P_full_matrix_closed": True,
+                    "relative_Riccati_injection_margin_lower": 1.0e-18,
+                },
+                "A21": {
+                    "Omega_minus_delta_P_full_matrix_closed": True,
+                    "relative_Riccati_injection_margin_lower": 1.0e-18,
+                },
+            },
+        }
+        with (
+            patch.object(mod.SIGNED, "validate", return_value=[]),
+            patch.object(mod.P3, "validate", return_value=[]),
+        ):
+            d = mod.build(
+                channel_contract=channel,
+                residual_contract=residual,
+                signed_contract=signed,
+                p3_contract=p3,
+            )
+        self.assertEqual(mod.validate(d), [])
+        self.assertEqual(d["canonical_source"], "COMPLETE_SEA3_NORMAL_LIVE_WORD")
+        self.assertEqual(d["P3_delta_required"], 1.0e-18)
+        self.assertEqual(d["full_state_dimensions"], {"H18": 18, "A21": 21})
+        self.assertTrue(d["full_A21_finite_taub_P3_margin_required"])
+        self.assertTrue(d["canonical_full_matrix_P3_consumed"])
+        self.assertTrue(d["finite_taub_A21_detectability_consumed"])
+        self.assertTrue(d["detectability_comparison_observer_only"])
+        self.assertFalse(d["finite_taub_detectability_used_as_standalone_P4_promotion"])
+        self.assertTrue(d["actual_RS_provenance_preserved"])
+        self.assertTrue(d["all_21_state_cross_terms_retained"])
+        self.assertTrue(d["same_history_quadratic_graph_sector_assembler_available"])
+        self.assertTrue(d["arbitrary_joint_nondiagonal_sector_weights_retained"])
+        self.assertFalse(d["per_event_scalar_sector_required"])
+        self.assertFalse(d["source_uniform_same_history_joint_sector_closed"])
+        self.assertFalse(d["source_uniform_full_augmented_LDLT_closed"])
+        self.assertFalse(d["P4_promoted_here"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/validation/test_ou3_p4_complete_word_endpoint_transport.py
+++ b/tests/validation/test_ou3_p4_complete_word_endpoint_transport.py
@@ -125,15 +125,17 @@ class CompleteWordEndpointTransportTests(unittest.TestCase):
         self.assertFalse(d["inverse_metric_floor_claim_used"])
         self.assertFalse(d["P4_promoted_here"])
 
-    def test_endpoint_storage_is_not_the_canonical_p4_architecture(self):
+    def test_endpoint_transport_is_subordinate_to_canonical_finite_state_p4(self):
         d = P4.build()
         self.assertEqual(P4.validate(d), [])
         self.assertEqual(
             d["canonical_P4_architecture"],
-            "FULL_STATE_COMPLETE_SEA3_DIFFERENTIAL_PULLBACK",
+            "FINITE_STATE_COMPLETE_SEA3_QUADRATIC_ENDPOINT_AND_PREFIX",
         )
-        self.assertFalse(d["finite_Phi_storage_used_as_Lyapunov_function"])
-        self.assertFalse(d["finite_raw_endpoint_storage_used_as_P4_certificate"])
+        self.assertEqual(d["paper_Lyapunov_function"], "V(e,zeta)=e^T M(zeta)e")
+        self.assertTrue(d["finite_state_endpoint_dissipation_required"])
+        self.assertTrue(d["finite_state_prefix_gain_required"])
+        self.assertFalse(d["differential_pullback_used_as_replacement_P4"])
         self.assertFalse(d["P4_CANONICAL_PASS"])
         self.assertFalse(d["P5_MAY_START"])
 

--- a/tests/validation/test_ou3_sea3_full_word_source_identity.py
+++ b/tests/validation/test_ou3_sea3_full_word_source_identity.py
@@ -16,12 +16,16 @@ class Sea3FullWordSourceIdentityTest(unittest.TestCase):
         d = gate.build()
         self.assertEqual(gate.validate(d), [])
         self.assertEqual(d["canonical_source"], "COMPLETE_SEA3_NORMAL_LIVE_WORD")
-        self.assertTrue(d["same_complete_SEA3_word_used_for_H18_and_A21"])
-        self.assertTrue(d["same_xs_lambda_drives_entire_word"])
+        self.assertTrue(d["same_complete_SEA3_execution_continues_across_H_to_A"])
+        self.assertTrue(d["same_xs_lambda_drives_entire_execution"])
+        self.assertFalse(d["same_three_second_same_mode_word_used_for_H18_and_A21"])
+        self.assertTrue(d["H_to_A_is_separate_dimension_changing_hybrid_event"])
         self.assertFalse(d["SOURCE_REACHABLE_EVENT_FAMILY_MATERIALIZED"])
-        self.assertFalse(d["P3_FULL_WORD_ENCLOSED"])
-        self.assertFalse(d["P3_FULL_MATRIX_COMPARISON_CLOSED"])
-        self.assertFalse(d["P3_CANONICAL_PASS"])
+        self.assertTrue(d["universal_complete_SEA3_certificate_chain_used_instead_of_finite_materialization"])
+        self.assertTrue(d["P3_FULL_WORD_ENCLOSED"])
+        self.assertTrue(d["P3_FULL_MATRIX_COMPARISON_CLOSED"])
+        self.assertTrue(d["P3_CONDITIONAL_SEA3_PASS"])
+        self.assertFalse(d["P3_DEPLOYMENT_PASS"])
 
 
 if __name__ == "__main__":

--- a/tests/validation/test_ou3_sea3_p3_source_semantics.py
+++ b/tests/validation/test_ou3_sea3_p3_source_semantics.py
@@ -36,7 +36,7 @@ class Sea3P3SourceSemanticsTest(unittest.TestCase):
         self.assertTrue(d["complete_SEA3_compact_parameter_domain_consumed"])
         self.assertTrue(d["complete_SEA3_compact_transition_relation_consumed"])
         self.assertTrue(d["complete_SEA3_phase_continuous_realization_required"])
-        self.assertTrue(d["same_xs_lambda_drives_entire_word"])
+        self.assertTrue(d["same_xs_lambda_drives_entire_execution"])
         self.assertTrue(d["stochastic_forcing_does_not_generate_source_words"])
         self.assertTrue(d["stochastic_forcing_does_not_prune_homogeneous_family"])
         for key in (
@@ -49,8 +49,9 @@ class Sea3P3SourceSemanticsTest(unittest.TestCase):
             "selected_four_S_word_used",
         ):
             self.assertFalse(d[key], key)
-        self.assertFalse(d["P3_CANONICAL_PASS"])
-        self.assertFalse(d["P4_MAY_CONSUME_P3"])
+        self.assertTrue(d["P3_CONDITIONAL_SEA3_PASS"])
+        self.assertTrue(d["P4_MAY_CONSUME_CONDITIONAL_SEA3_P3"])
+        self.assertFalse(d["P3_DEPLOYMENT_PASS"])
 
 
 if __name__ == "__main__":

--- a/tests/validation/test_ou3_sea3_riccati_metric_p3.py
+++ b/tests/validation/test_ou3_sea3_riccati_metric_p3.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import sys
 import unittest
+from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "tools"))
@@ -44,6 +45,15 @@ class Sea3CompleteSourceP3Test(unittest.TestCase):
         self.assertTrue(self.d["complete_SEA3_frontend_state_consumed"])
         self.assertTrue(self.d["complete_SEA3_adaptive_state_consumed"])
         self.assertGreaterEqual(self.d["common_word_horizon_s"], 3.0)
+
+    def test_process_cache_returns_defensive_result_copies(self):
+        cached = {"nested": {"value": 1}}
+        with patch.object(mod, "_build_cached", return_value=cached):
+            first = mod.build()
+            second = mod.build()
+        first["nested"]["value"] = 2
+        self.assertEqual(second["nested"]["value"], 1)
+        self.assertEqual(cached["nested"]["value"], 1)
 
     def test_complete_source_retains_all_sea3_couplings(self):
         sea = self.c["SEA3_surface_family"]

--- a/tests/validation/test_ou3_sea3_riccati_metric_p4.py
+++ b/tests/validation/test_ou3_sea3_riccati_metric_p4.py
@@ -77,6 +77,15 @@ class Sea3FiniteStateP4Test(unittest.TestCase):
         self.assertFalse(self.d["point_word_rho_used_to_promote"])
         self.assertFalse(self.d["longer_point_window_optimization_used_to_promote"])
 
+    def test_full_state_finite_taub_joint_sector_bridge_is_retained_but_open(self):
+        self.assertTrue(self.d["full_state_joint_sector_master_available"])
+        self.assertTrue(self.d["A21_finite_taub_full_matrix_P3_required"])
+        self.assertTrue(self.d["A21_finite_taub_detectability_consumed"])
+        self.assertTrue(self.d["joint_sector_all_21_state_cross_terms_retained"])
+        self.assertTrue(self.d["joint_sector_actual_RS_provenance_preserved"])
+        self.assertFalse(self.d["source_uniform_same_history_joint_sector_closed"])
+        self.assertFalse(self.d["source_uniform_full_augmented_LDLT_closed"])
+
     def test_differential_ad_is_machinery_not_replacement_p4(self):
         self.assertEqual(diffmetric.validate(self.dm), [])
         self.assertTrue(self.d["differential_AD_used_only_for_finite_map_enclosure"])

--- a/tests/validation/test_ou3_sea3_source_family_fail_closed.py
+++ b/tests/validation/test_ou3_sea3_source_family_fail_closed.py
@@ -13,7 +13,7 @@ import ou3_sea3_riccati_metric_p3 as gate  # noqa: E402
 
 
 class Sea3SourceFamilyFailClosedTest(unittest.TestCase):
-    def test_contract_readiness_does_not_equal_materialization(self):
+    def test_universal_chain_does_not_claim_finite_materialization(self):
         s = source.build()
         self.assertEqual(source.validate(s), [])
         self.assertTrue(s["P3_source_contract_ready"])
@@ -22,8 +22,10 @@ class Sea3SourceFamilyFailClosedTest(unittest.TestCase):
         d = gate.build()
         self.assertEqual(gate.validate(d), [])
         self.assertFalse(d["SOURCE_REACHABLE_EVENT_FAMILY_MATERIALIZED"])
-        self.assertFalse(d["P3_CANONICAL_PASS"])
-        self.assertTrue(d["P3_CANONICAL_FAIL_REASONS"])
+        self.assertFalse(d["finite_source_family_materialization_required"])
+        self.assertTrue(d["UNIVERSAL_COMPLETE_SEA3_CERTIFICATE_CHAIN_CLOSED"])
+        self.assertTrue(d["P3_CONDITIONAL_SEA3_PASS"])
+        self.assertFalse(d["P3_DEPLOYMENT_PASS"])
 
 
 if __name__ == "__main__":

--- a/tests/validation/test_ou3_sea3_spectral_moment_bridge.py
+++ b/tests/validation/test_ou3_sea3_spectral_moment_bridge.py
@@ -14,6 +14,12 @@ import ou3_sea3_spectral_moment_bridge as bridge  # noqa: E402
 
 
 class Sea3SpectralMomentBridgeTest(unittest.TestCase):
+    def test_process_cache_returns_defensive_result_copies(self) -> None:
+        first = bridge.build()
+        first["schema_version"] = "tampered"
+        second = bridge.build()
+        self.assertEqual(second["schema_version"], bridge.SCHEMA_VERSION)
+
     def test_surface_bridge_is_replay_free_and_non_promoting(self) -> None:
         payload = bridge.build()
         failures = bridge.validate(payload)

--- a/tools/stability/ou3_p4_complete_sea3_differential_word.py
+++ b/tools/stability/ou3_p4_complete_sea3_differential_word.py
@@ -164,10 +164,13 @@ def apply_event(word: DifferentialWord, event: DifferentialEvent) -> None:
     if not event.accepted:
         raise ValueError("only executed/accepted nonlinear events belong in the cocycle")
     r, c = _shape(event.J)
-    if c != word.current_dim:
+    kind = event.kind
+    if kind == "H_to_A":
+        if word.hybrid_lifts != 0 or word.current_dim != 18 or (r, c) != (21, 18):
+            raise ValueError("H->A differential lift must be the unique 21x18 hybrid event")
+    elif c != word.current_dim:
         raise ValueError("differential event input dimension does not match current word")
 
-    kind = event.kind
     if kind == "prediction":
         if r != c:
             raise ValueError("same-mode prediction must be square")
@@ -200,8 +203,6 @@ def apply_event(word: DifferentialWord, event: DifferentialEvent) -> None:
             raise ValueError("vector event did not derive its gain from the same P/H/R cell")
         word.vector_updates += 1
     elif kind == "H_to_A":
-        if word.hybrid_lifts != 0 or word.current_dim != 18 or (r, c) != (21, 18):
-            raise ValueError("H->A differential lift must be the unique 21x18 hybrid event")
         if not _is_canonical_H_to_A_lift(event.J):
             raise ValueError("H->A homogeneous derivative must be canonical [I18;0]")
         if event.held_ba_forcing_separate is not True:

--- a/tools/stability/ou3_p4_complete_sea3_joint_sector_master.py
+++ b/tools/stability/ou3_p4_complete_sea3_joint_sector_master.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""Full-state joint-sector master inequality for complete-SEA3 P4.
+
+The retained complete-word endpoint identity has the form
+
+    d_W = B_W w_W,
+    Delta V = -x' D_W x + 2 (M_W x)' J_N B_W w_W
+              + w_W' B_W' J_N B_W w_W.
+
+Here ``w_W`` is one correlated word coordinate containing the nonlinear
+accelerometer history together with the endpoint/boundary and exact residual
+terms.  It is not split into independent packet radii.  Stack ``z=[x;w_W]``.
+The exact full master quadratic is
+
+    z' L_W z,
+    L_W = [[-D_W, M_W' J_N B_W],
+           [B_W' J_N M_W, B_W' J_N B_W]].
+
+Suppose the same-history nonlinear graph is enclosed by quadratic sectors
+
+    z' Pi_j z >= 0.
+
+For nonnegative multipliers lambda_j, the strict full-matrix condition
+
+    -(L_W + sum_j lambda_j Pi_j) > 0
+
+implies ``Delta V < 0`` on that graph.  The test is performed by outward
+interval LDLT on the complete augmented matrix.  This keeps every state and
+every cross term; it is not a scalar correction radius, packet-count budget,
+Schur elimination of a_w/b_a, or inverse-metric-floor argument.
+
+The accelerometer block may use the retained Riccati noise-channel identity
+``A' P_N^-1 A <= R^-1``.  Every later shipping event, including every due S=0
+update with its actual applied anisotropic SpectralMSE R_S, remains inside A's
+same-word suffix.  This module provides the terminal master inequality and
+fails closed until a source-uniform correlated graph sector is supplied.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Sequence
+
+from ou3_interval import (
+    Interval,
+    IntervalMatrix,
+    matrix_add,
+    matrix_mul,
+    matrix_sub,
+    matrix_transpose,
+    symmetric_positive_definite_ldlt,
+)
+from ou3_interval_linear_algebra import matrix_symmetric_hull
+import ou3_p4_complete_sea3_residual_sector as RESIDUAL
+import ou3_p4_complete_word_accelerometer_channel as CHANNEL
+import ou3_p4_complete_sea3_signed_information_ledger as SIGNED
+import ou3_sea3_riccati_metric_p3 as P3
+
+SCHEMA = 1
+QUALIFICATION = "OU3_P4_COMPLETE_SEA3_FULL_STATE_JOINT_SECTOR_MASTER_V1"
+P3_DELTA = 1.0e-18
+
+
+def _shape(A: Sequence[Sequence[Interval]]) -> tuple[int, int]:
+    rows = len(A)
+    cols = len(A[0]) if rows else 0
+    if any(len(row) != cols for row in A):
+        raise ValueError("ragged interval matrix")
+    return rows, cols
+
+
+def _neg(A: Sequence[Sequence[Interval]]) -> IntervalMatrix:
+    return [[-x for x in row] for row in A]
+
+
+def _scale(A: Sequence[Sequence[Interval]], value: float) -> IntervalMatrix:
+    if not math.isfinite(float(value)):
+        raise ValueError("finite multiplier required")
+    c = Interval.outward_bounds(float(value), float(value))
+    return [[c * x for x in row] for row in A]
+
+
+def _block2(A, B, C, D) -> IntervalMatrix:
+    ar, ac = _shape(A)
+    br, bc = _shape(B)
+    cr, cc = _shape(C)
+    dr, dc = _shape(D)
+    if ar != ac or dr != dc or br != ar or bc != dc or cr != dr or cc != ac:
+        raise ValueError("2x2 block dimensions do not compose")
+    return [list(A[i]) + list(B[i]) for i in range(ar)] + [
+        list(C[i]) + list(D[i]) for i in range(dr)
+    ]
+
+
+def master_quadratic_matrix(
+    D_word: Sequence[Sequence[Interval]],
+    M_word: Sequence[Sequence[Interval]],
+    J_final: Sequence[Sequence[Interval]],
+    B_word: Sequence[Sequence[Interval]],
+) -> IntervalMatrix:
+    """Return the exact augmented endpoint-energy matrix ``L_W``."""
+    n, n2 = _shape(D_word)
+    mr, mc = _shape(M_word)
+    jr, jc = _shape(J_final)
+    br, bw = _shape(B_word)
+    if n == 0 or n != n2 or (mr, mc) != (n, n) or (jr, jc) != (n, n):
+        raise ValueError("D/M/J must be nonempty same-dimension square matrices")
+    if br != n or bw == 0:
+        raise ValueError("B_word must map a nonempty joint coordinate into the full state")
+    J_B = matrix_mul(J_final, B_word)
+    cross = matrix_mul(matrix_transpose(M_word), J_B)
+    defect = matrix_mul(matrix_transpose(B_word), J_B)
+    return matrix_symmetric_hull(
+        _block2(_neg(D_word), cross, matrix_transpose(cross), defect)
+    )
+
+
+def joint_sector_sprocedure_matrix(
+    master: Sequence[Sequence[Interval]],
+    sectors: Sequence[Sequence[Sequence[Interval]]],
+    multipliers: Sequence[float],
+) -> IntervalMatrix:
+    """Return ``L + sum lambda_j Pi_j`` for graph sectors ``z'Pi_j z>=0``."""
+    n, m = _shape(master)
+    if n == 0 or n != m:
+        raise ValueError("master matrix must be nonempty square")
+    if len(sectors) != len(multipliers) or not sectors:
+        raise ValueError("need matching nonempty sector/multiplier lists")
+    out = matrix_symmetric_hull(master)
+    for Pi, lam in zip(sectors, multipliers):
+        if _shape(Pi) != (n, n):
+            raise ValueError("sector dimension does not match augmented master")
+        if not (math.isfinite(float(lam)) and float(lam) >= 0.0):
+            raise ValueError("S-procedure multipliers must be finite nonnegative")
+        out = matrix_symmetric_hull(matrix_add(out, _scale(Pi, float(lam))))
+    return out
+
+
+def quadratic_graph_sector(
+    graph_input_map: Sequence[Sequence[Interval]],
+    graph_input_weight: Sequence[Sequence[Interval]],
+    defect_map: Sequence[Sequence[Interval]],
+    defect_weight: Sequence[Sequence[Interval]],
+) -> IntervalMatrix:
+    """Lift one correlated graph bound into the common augmented coordinate.
+
+    If ``u=C*z`` and ``q=E*z`` satisfy ``q'Wq <= u'Qu``, this returns
+    ``Pi=C'QC-E'WE`` so the admissible graph obeys ``z'Pi*z >= 0``.  ``C``
+    and ``E`` may stack all word events and ``Q``/``W`` may be dense; no
+    independent-event or diagonal relaxation is imposed here.
+    """
+    ur, uz = _shape(graph_input_map)
+    qr, qz = _shape(defect_map)
+    wr, wc = _shape(graph_input_weight)
+    rr, rc = _shape(defect_weight)
+    if ur == 0 or qr == 0 or uz == 0 or qz != uz:
+        raise ValueError("graph maps must share a nonempty augmented coordinate")
+    if (wr, wc) != (ur, ur) or (rr, rc) != (qr, qr):
+        raise ValueError("graph weights do not match their mapped coordinates")
+    positive = matrix_mul(
+        matrix_mul(matrix_transpose(graph_input_map), graph_input_weight),
+        graph_input_map,
+    )
+    negative = matrix_mul(
+        matrix_mul(matrix_transpose(defect_map), defect_weight), defect_map
+    )
+    return matrix_symmetric_hull(matrix_sub(positive, negative))
+
+
+def certify_strict_joint_sector_domination(
+    master: Sequence[Sequence[Interval]],
+    sectors: Sequence[Sequence[Sequence[Interval]]],
+    multipliers: Sequence[float],
+) -> tuple[bool, list[float]]:
+    """Certify ``-(L+sum lambda Pi)>0`` by outward full-matrix LDLT."""
+    test = _neg(joint_sector_sprocedure_matrix(master, sectors, multipliers))
+    ok, pivots = symmetric_positive_definite_ldlt(matrix_symmetric_hull(test))
+    return bool(ok), [float(x.lo) for x in pivots]
+
+
+def quadratic_value(A: Sequence[Sequence[Interval]], x: Sequence[Interval]) -> Interval:
+    n, m = _shape(A)
+    if n == 0 or n != m or len(x) != n:
+        raise ValueError("quadratic value dimension mismatch")
+    value = Interval.point(0.0)
+    for i in range(n):
+        for j in range(n):
+            value = value + x[i] * A[i][j] * x[j]
+    return value
+
+
+def build(
+    *,
+    channel_contract: dict | None = None,
+    residual_contract: dict | None = None,
+    signed_contract: dict | None = None,
+    p3_contract: dict | None = None,
+) -> dict:
+    """Assemble the bridge, reusing canonical prerequisite results when supplied.
+
+    The canonical P4 assembler has already built the expensive signed ledger and
+    passes it here.  Standalone execution still validates the whole dependency
+    chain rather than silently weakening it.
+    """
+    channel = CHANNEL.build() if channel_contract is None else channel_contract
+    residual = RESIDUAL.build() if residual_contract is None else residual_contract
+    signed = SIGNED.build() if signed_contract is None else signed_contract
+    p3 = P3.build() if p3_contract is None else p3_contract
+    bad = {
+        "accelerometer_channel": CHANNEL.validate(channel),
+        "residual_sector": RESIDUAL.validate(residual),
+        "signed_information": SIGNED.validate(signed),
+        "canonical_P3": P3.validate(p3),
+    }
+    bad = {k: v for k, v in bad.items() if v}
+    if bad:
+        raise RuntimeError(f"joint-sector master prerequisites failed: {bad}")
+    p3_full_matrix = bool(
+        p3["P3_CONDITIONAL_SEA3_PASS"]
+        and p3["modes"]["H18"]["Omega_minus_delta_P_full_matrix_closed"]
+        and p3["modes"]["A21"]["Omega_minus_delta_P_full_matrix_closed"]
+    )
+    composition = p3["conditional_composition"]
+    finite_taub = bool(
+        composition["A21_finite_bias_correlation_route_consumed"]
+        and composition["A21_detectability_completion_closed"]
+        and composition["A21_paper_UES_hypotheses_closed"]
+        and composition["A21_comparison_observer_is_proof_only_not_alternate_estimator"]
+        and composition["A21_uses_eta9_packet_shortcut"] is False
+    )
+    return {
+        "schema": SCHEMA,
+        "qualification": QUALIFICATION,
+        "canonical_source": "COMPLETE_SEA3_NORMAL_LIVE_WORD",
+        "P3_delta_required": P3_DELTA,
+        "P3_H18_delta_consumed": float(
+            p3["modes"]["H18"]["relative_Riccati_injection_margin_lower"]
+        ),
+        "P3_A21_delta_consumed": float(
+            p3["modes"]["A21"]["relative_Riccati_injection_margin_lower"]
+        ),
+        "canonical_full_matrix_P3_consumed": p3_full_matrix,
+        "full_state_dimensions": {"H18": 18, "A21": 21},
+        "full_A21_finite_taub_P3_margin_required": True,
+        "finite_taub_A21_detectability_qualification": (
+            "OU3_COMPLETE_SEA3_A21_FINITE_BIAS_DETECTABILITY"
+        ),
+        "finite_taub_A21_detectability_consumed": finite_taub,
+        "finite_taub_A21_asymptotic_gap_lower": float(
+            composition["A21_detectability_asymptotic_word_energy_gap_lower"]
+        ),
+        "finite_taub_bias_contraction_gap_lower": float(
+            composition["A21_bias_homogeneous_contraction_gap_lower"]
+        ),
+        "detectability_comparison_observer_only": bool(
+            composition["A21_comparison_observer_is_proof_only_not_alternate_estimator"]
+        ),
+        "finite_taub_detectability_used_as_standalone_P4_promotion": False,
+        "paper_finite_state_quadratic_storage_retained": True,
+        "master_coordinate": "z=[x;w_W]",
+        "joint_word_defect": "d_W=B_W*w_W",
+        "master_matrix": "[[-D_W,M_W^T*J_N*B_W],[B_W^T*J_N*M_W,B_W^T*J_N*B_W]]",
+        "same_history_joint_graph_sector_required": True,
+        "graph_sector_convention": "z^T*Pi_j*z>=0",
+        "nonnegative_S_procedure_multipliers_required": True,
+        "terminal_test": "-(L_W+sum_j lambda_j*Pi_j)>0",
+        "terminal_full_augmented_interval_LDLT_available": True,
+        "same_history_quadratic_graph_sector_assembler_available": True,
+        "arbitrary_joint_nondiagonal_sector_weights_retained": True,
+        "endpoint_and_prefix_use_same_master_builder": True,
+        "accelerometer_Riccati_noise_channel_domination_consumed": bool(
+            channel["accelerometer_measurement_noise_is_PSD_final_covariance_component"]
+        ),
+        "stacked_accelerometer_history_retained_jointly": True,
+        "exact_Cayley_residual_sector_consumed": bool(
+            residual["finite_residual_is_quadratic_sector_in_c_and_aw"]
+        ),
+        "accelerometer_bias_nonlinearity_exactly_zero": bool(
+            residual["accelerometer_bias_nonlinearity_exactly_zero"]
+        ),
+        "signed_information_ledger_consumed": bool(
+            signed["joint_complete_word_signed_information_composition_available"]
+        ),
+        "all_due_S_updates_with_actual_applied_RS_remain_in_suffix": True,
+        "actual_RS_provenance_preserved": True,
+        "all_21_state_cross_terms_retained": True,
+        "state_elimination_used": False,
+        "a_w_or_b_a_Schur_elimination_used": False,
+        "packetwise_norm_sum_used": False,
+        "packet_count_multiplier_used": False,
+        "per_event_scalar_sector_required": False,
+        "correction_radius_used": False,
+        "inverse_metric_floor_used": False,
+        "trajectory_replay_used": False,
+        "source_family_replaced": False,
+        "filter_changed": False,
+        "quality_gates_changed": False,
+        "declared_domain_changed": False,
+        "source_uniform_same_history_joint_sector_closed": False,
+        "source_uniform_full_augmented_LDLT_closed": False,
+        "source_uniform_prefix_joint_sector_closed": False,
+        "P4_promoted_here": False,
+        "next_obligation": (
+            "materialize one outward same-history residual-history graph from the complete SEA3 execution, form its "
+            "joint endpoint and every-prefix quadratic sectors, and close the full augmented LDLT without packetwise "
+            "scalarization; retain the A21 projection generalized Jacobian as a separate graph sector"
+        ),
+    }
+
+
+def validate(d: dict) -> list[str]:
+    f: list[str] = []
+    if d.get("schema") != SCHEMA or d.get("qualification") != QUALIFICATION:
+        f.append("schema/qualification mismatch")
+    if d.get("canonical_source") != "COMPLETE_SEA3_NORMAL_LIVE_WORD":
+        f.append("canonical source changed")
+    if float(d.get("P3_delta_required", 0.0)) != P3_DELTA:
+        f.append("frozen P3 delta changed")
+    for key in ("P3_H18_delta_consumed", "P3_A21_delta_consumed"):
+        if float(d.get(key, 0.0)) != P3_DELTA:
+            f.append(f"{key} changed from frozen delta")
+    if d.get("full_state_dimensions") != {"H18": 18, "A21": 21}:
+        f.append("full-state dimensions changed")
+    if d.get("finite_taub_A21_detectability_qualification") != (
+        "OU3_COMPLETE_SEA3_A21_FINITE_BIAS_DETECTABILITY"
+    ):
+        f.append("finite-tau_b A21 detectability qualification changed")
+    if float(d.get("finite_taub_A21_asymptotic_gap_lower", 0.0)) < P3_DELTA:
+        f.append("finite-tau_b A21 asymptotic gap fell below frozen delta")
+    if float(d.get("finite_taub_bias_contraction_gap_lower", 0.0)) <= 0.0:
+        f.append("finite-tau_b bias contraction gap is not strict")
+    for key in (
+        "full_A21_finite_taub_P3_margin_required",
+        "canonical_full_matrix_P3_consumed",
+        "finite_taub_A21_detectability_consumed",
+        "detectability_comparison_observer_only",
+        "paper_finite_state_quadratic_storage_retained",
+        "same_history_joint_graph_sector_required",
+        "nonnegative_S_procedure_multipliers_required",
+        "terminal_full_augmented_interval_LDLT_available",
+        "same_history_quadratic_graph_sector_assembler_available",
+        "arbitrary_joint_nondiagonal_sector_weights_retained",
+        "endpoint_and_prefix_use_same_master_builder",
+        "accelerometer_Riccati_noise_channel_domination_consumed",
+        "stacked_accelerometer_history_retained_jointly",
+        "exact_Cayley_residual_sector_consumed",
+        "accelerometer_bias_nonlinearity_exactly_zero",
+        "signed_information_ledger_consumed",
+        "all_due_S_updates_with_actual_applied_RS_remain_in_suffix",
+        "actual_RS_provenance_preserved",
+        "all_21_state_cross_terms_retained",
+    ):
+        if d.get(key) is not True:
+            f.append(f"{key} is not true")
+    for key in (
+        "state_elimination_used", "a_w_or_b_a_Schur_elimination_used",
+        "packetwise_norm_sum_used", "packet_count_multiplier_used",
+        "per_event_scalar_sector_required",
+        "correction_radius_used", "inverse_metric_floor_used",
+        "trajectory_replay_used", "source_family_replaced", "filter_changed",
+        "quality_gates_changed", "declared_domain_changed",
+        "source_uniform_same_history_joint_sector_closed",
+        "source_uniform_full_augmented_LDLT_closed",
+        "source_uniform_prefix_joint_sector_closed", "P4_promoted_here",
+        "finite_taub_detectability_used_as_standalone_P4_promotion",
+    ):
+        if d.get(key) is not False:
+            f.append(f"{key} is not false")
+    return list(dict.fromkeys(f))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--output", type=Path, required=True)
+    args = ap.parse_args()
+    d = build()
+    failures = validate(d)
+    d["validation_pass"] = not failures
+    d["validation_failures"] = failures
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(d, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({
+        "master": d["master_matrix"],
+        "full_A21": d["all_21_state_cross_terms_retained"],
+        "actual_RS": d["actual_RS_provenance_preserved"],
+        "joint_sector_closed": d["source_uniform_same_history_joint_sector_closed"],
+        "P4_promoted_here": d["P4_promoted_here"],
+        "failures": failures,
+    }, indent=2, sort_keys=True))
+    return 0 if not failures else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/stability/ou3_sea3_riccati_metric_p3.py
+++ b/tools/stability/ou3_sea3_riccati_metric_p3.py
@@ -26,8 +26,10 @@ obligation and is not required for this conditional P3 result.
 from __future__ import annotations
 
 import argparse
+import copy
 import json
 import math
+from functools import lru_cache
 from pathlib import Path
 
 import ou3_sea3_complete_source as COMPLETE
@@ -44,7 +46,7 @@ QUALIFICATION = "OU3_SEA3_COMPLETE_SOURCE_FULL_WORD_P3_GATE_V15"
 USEFUL_GATE = 1.0e-18
 
 
-def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
+def _build_uncached(domain_path: Path) -> dict:
     path = Path(domain_path).resolve()
     complete = COMPLETE.build(path)
     full = FULL.build(path)
@@ -238,6 +240,17 @@ def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
             if p3_pass else "close the named canonical complete-SEA3 certificate-chain failures"
         ),
     }
+
+
+@lru_cache(maxsize=None)
+def _build_cached(domain_path: str) -> dict:
+    return _build_uncached(Path(domain_path))
+
+
+def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
+    """Return an independent canonical result, computing each domain once per process."""
+    path = str(Path(domain_path).resolve())
+    return copy.deepcopy(_build_cached(path))
 
 
 def validate(d: dict) -> list[str]:

--- a/tools/stability/ou3_sea3_riccati_metric_p4.py
+++ b/tools/stability/ou3_sea3_riccati_metric_p4.py
@@ -45,6 +45,7 @@ import ou3_p4_cayley_sector_certificate as CAYLEY
 import ou3_p4_complete_word_endpoint_transport as ENDPOINT
 import ou3_p4_complete_sea3_finite_map_mean_value as FINITE
 import ou3_p4_complete_sea3_signed_information_ledger as SIGNED
+import ou3_p4_complete_sea3_joint_sector_master as JOINT
 
 # Exact/outward finite-map differentiation machinery only.
 import ou3_p4_complete_sea3_phi_differential_metric as DIFF
@@ -54,8 +55,8 @@ import ou3_p4_complete_sea3_differential_word as DWRD
 
 REPO = Path(__file__).resolve().parents[2]
 DEFAULT_DOMAIN = REPO / "tools" / "stability" / "ou3_proof_operating_domain.json"
-SCHEMA = 13
-QUALIFICATION = "OU3_SEA3_FINITE_STATE_ENDPOINT_PREFIX_P4_V13"
+SCHEMA = 14
+QUALIFICATION = "OU3_SEA3_FINITE_STATE_ENDPOINT_PREFIX_P4_V14"
 ARCHITECTURE = "FINITE_STATE_COMPLETE_SEA3_QUADRATIC_ENDPOINT_AND_PREFIX"
 CANDIDATES = [30.0, 25.0, 20.0, 15.0]
 
@@ -67,6 +68,7 @@ def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
     endpoint = ENDPOINT.build(path)
     finite = FINITE.build(path)
     signed = SIGNED.build(path)
+    joint = JOINT.build(p3_contract=p3, signed_contract=signed)
     diff = DIFF.build(path)
     pred = PRED.build(path)
     events = EVENTS.build(path)
@@ -77,6 +79,7 @@ def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
         + [f"endpoint: {x}" for x in ENDPOINT.validate(endpoint)]
         + [f"finite-map bridge: {x}" for x in FINITE.validate(finite)]
         + [f"signed-information ledger: {x}" for x in SIGNED.validate(signed)]
+        + [f"joint-sector master: {x}" for x in JOINT.validate(joint)]
         + [f"differential metric primitive: {x}" for x in DIFF.validate(diff)]
         + [f"prediction AD primitive: {x}" for x in PRED.validate(pred)]
         + [f"event AD primitive: {x}" for x in EVENTS.validate(events)]
@@ -97,6 +100,8 @@ def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
     prefix_domain_closed = bool(finite["source_uniform_all_prefix_domains_closed"])
     signed_ledger_ready = bool(signed["joint_complete_word_signed_information_composition_available"])
     signed_domination_closed = bool(signed["source_uniform_joint_eta_reset_domination_closed"])
+    joint_sector_closed = bool(joint["source_uniform_same_history_joint_sector_closed"])
+    joint_ldlt_closed = bool(joint["source_uniform_full_augmented_LDLT_closed"])
 
     projection_machinery = bool(
         events["A21_bias_projection_generalized_Jacobian_available"]
@@ -112,6 +117,8 @@ def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
         and endpoint_master_emitted
         and signed_ledger_ready
         and signed_domination_closed
+        and joint_sector_closed
+        and joint_ldlt_closed
         and endpoint_closed
         and finite_jacobian_closed
         and finite_endpoint_closed
@@ -124,14 +131,16 @@ def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
         fail_reasons.append("frozen conditional complete-SEA3 P3 prerequisite is not closed")
     if not (
         signed_domination_closed
+        and joint_sector_closed
+        and joint_ldlt_closed
         and endpoint_closed
         and finite_jacobian_closed
         and finite_endpoint_closed
     ):
         fail_reasons.append(
-            "paper finite-state endpoint dissipation is open: jointly dominate the same-history complete-word signed "
-            "accelerometer/vector eta and finite reset costs by the complete-word information decrease, crediting every "
-            "actual-R_S S event, and close the equivalent finite-map/endpoint full-matrix tests"
+            "paper finite-state endpoint dissipation is open: materialize the source-correlated same-history nonlinear "
+            "graph sectors and close -(L_W+sum lambda_j Pi_j)>0 by full augmented interval LDLT, retaining all A21 "
+            "finite-tau_b cross terms and every actual-R_S S event in the complete-word suffixes"
         )
     if not (prefix_gain_closed and prefix_domain_closed):
         fail_reasons.append(
@@ -196,6 +205,26 @@ def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
         "finite_reset_defect_explicit_in_signed_ledger": bool(signed["finite_reset_defect_remains_explicit"]),
         "source_uniform_joint_eta_reset_domination_closed": signed_domination_closed,
 
+        "joint_sector_master_contract": joint,
+        "joint_sector_master_qualification": joint["qualification"],
+        "full_state_joint_sector_master_available": bool(
+            joint["terminal_full_augmented_interval_LDLT_available"]
+        ),
+        "A21_finite_taub_full_matrix_P3_required": bool(
+            joint["full_A21_finite_taub_P3_margin_required"]
+        ),
+        "A21_finite_taub_detectability_consumed": bool(
+            joint["finite_taub_A21_detectability_consumed"]
+        ),
+        "joint_sector_all_21_state_cross_terms_retained": bool(
+            joint["all_21_state_cross_terms_retained"]
+        ),
+        "joint_sector_actual_RS_provenance_preserved": bool(
+            joint["actual_RS_provenance_preserved"]
+        ),
+        "source_uniform_same_history_joint_sector_closed": joint_sector_closed,
+        "source_uniform_full_augmented_LDLT_closed": joint_ldlt_closed,
+
         "endpoint_transport_qualification": endpoint["qualification"],
         "endpoint_master_object_emitted": endpoint_master_emitted,
         "endpoint_decomposition_identity": endpoint["endpoint_decomposition_identity"],
@@ -222,6 +251,9 @@ def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
 
         "differential_AD_used_only_for_finite_map_enclosure": True,
         "differential_pullback_used_as_replacement_P4": False,
+        "differential_finite_distance_bridge_closed": bool(
+            finite_jacobian_closed and finite_endpoint_closed
+        ),
         "prediction_AD_qualification": pred["qualification"],
         "event_AD_qualification": events["qualification"],
         "differential_word_qualification": word["qualification"],
@@ -248,10 +280,9 @@ def build(domain_path: Path = DEFAULT_DOMAIN) -> dict:
         "P5_MAY_START": p4_pass,
         "P4_CANONICAL_FAIL_REASONS": fail_reasons,
         "next_obligation": (
-            "construct one source-correlated COMPLETE_SEA3_NORMAL_LIVE_WORD outward enclosure carrying finite state, "
-            "P/H/R, committed tuner schedule, actual applied R_S, event timing and A21 projection; use the signed Joseph/reset "
-            "ledger to dominate the joint eta/reset costs by the same word's information, then close the equivalent endpoint "
-            "and every-prefix finite-map tests without packetwise scalarization"
+            "materialize one source-correlated COMPLETE_SEA3_NORMAL_LIVE_WORD same-history nonlinear graph, including the "
+            "A21 bias-projection generalized Jacobian, and close the full augmented joint-sector LDLT at the endpoint and "
+            "every prefix; retain finite state, P/H/R, tuner schedule, actual applied R_S and all 21-state cross terms"
             if p3_pass else "repair only the frozen P3 prerequisite failure"
         ),
     }
@@ -279,6 +310,9 @@ def validate(d: dict) -> list[str]:
         "full_epsilon_aw_retained", "signed_information_composition_available",
         "S_zero_nonlinear_eta_exactly_zero", "actual_RS_S_information_credited_as_favorable_term",
         "finite_reset_defect_explicit_in_signed_ledger", "endpoint_master_object_emitted",
+        "full_state_joint_sector_master_available", "A21_finite_taub_full_matrix_P3_required",
+        "A21_finite_taub_detectability_consumed",
+        "joint_sector_all_21_state_cross_terms_retained", "joint_sector_actual_RS_provenance_preserved",
         "actual_RS_regularization_enters_suffix_maps", "finite_map_mean_value_bridge_validated",
         "finite_map_not_differential_metric_replacement", "differential_AD_used_only_for_finite_map_enclosure",
         "same_source_omega_h_tau_prediction_required", "prediction_independent_F_forbidden",
@@ -291,10 +325,12 @@ def validate(d: dict) -> list[str]:
     for key in (
         "trajectory_replay_used", "filter_changed", "declared_domain_shrunk", "source_family_replaced",
         "P3_DEPLOYMENT_PASS_consumed_as_if_closed", "source_uniform_joint_eta_reset_domination_closed",
+        "source_uniform_same_history_joint_sector_closed", "source_uniform_full_augmented_LDLT_closed",
         "source_uniform_joint_BW_epsilon_enclosure_closed", "source_uniform_r_word_enclosure_closed",
         "source_uniform_master_endpoint_domination_closed", "source_uniform_complete_word_generalized_Jacobian_enclosed",
         "source_uniform_endpoint_finite_map_closed", "source_uniform_prefix_gain_closed",
         "source_uniform_prefix_domain_retention_closed", "differential_pullback_used_as_replacement_P4",
+        "differential_finite_distance_bridge_closed",
         "packet_count_remainder_budget_used", "packetwise_remainder_norm_sum_used",
         "standalone_eta_Rinv_budget_used", "state_elimination_used", "a_w_Schur_final_certificate_used",
         "correction_radius_claim_used", "inverse_metric_floor_claim_used", "independent_RS_schedule_used",
@@ -333,6 +369,7 @@ def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--domain", type=Path, default=DEFAULT_DOMAIN)
     ap.add_argument("--output", type=Path, required=True)
+    ap.add_argument("--joint-sector-output", type=Path)
     args = ap.parse_args()
     d = build(args.domain)
     failures = validate(d)
@@ -340,6 +377,15 @@ def main() -> int:
     d["validation_failures"] = failures
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(json.dumps(d, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if args.joint_sector_output is not None:
+        joint = dict(d["joint_sector_master_contract"])
+        joint_failures = JOINT.validate(joint)
+        joint["validation_pass"] = not joint_failures
+        joint["validation_failures"] = joint_failures
+        args.joint_sector_output.parent.mkdir(parents=True, exist_ok=True)
+        args.joint_sector_output.write_text(
+            json.dumps(joint, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
     print(json.dumps({
         "architecture": d["canonical_P4_architecture"],
         "signed_information": d["signed_information_composition_available"],

--- a/tools/stability/ou3_sea3_spectral_moment_bridge.py
+++ b/tools/stability/ou3_sea3_spectral_moment_bridge.py
@@ -19,8 +19,10 @@ identities are analytical.
 from __future__ import annotations
 
 import argparse
+import copy
 import json
 import math
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -162,7 +164,7 @@ def _pm_exact_ratio() -> float:
     return (PM_EXPONENT * math.pi) ** (-0.25)
 
 
-def build() -> dict[str, Any]:
+def _build_uncached() -> dict[str, Any]:
     gamma_step = (GAMMA_MAX - GAMMA_MIN) / GAMMA_CELLS
     global_lo = math.inf
     global_hi = 0.0
@@ -283,6 +285,16 @@ def build() -> dict[str, Any]:
             "to prune the P2 source language"
         ),
     }
+
+
+@lru_cache(maxsize=1)
+def _build_cached() -> dict[str, Any]:
+    return _build_uncached()
+
+
+def build() -> dict[str, Any]:
+    """Return an independent result while evaluating the fixed quadrature once."""
+    return copy.deepcopy(_build_cached())
 
 
 def validate(payload: dict[str, Any]) -> list[str]:


### PR DESCRIPTION
## Diagnosis

PR #497's `source-foundation` failure came from five stale tests that constructed un-widened finite-angle rows. The correction-information consumer was correctly failing closed with `un-widened finite-angle row reached correction-information consumer`. Current `main` already contains the #496 retained-local-linear-primitive fixture repair and fail-closed regression; the exact source-foundation suite passes 73/73 from this base.

No filter change is needed for that failure.

## Continuation

- Recompute canonical complete-SEA3 P3 on the deployed 0.4 m/s^2 accelerometer-bias projection clamp.
  - H18 and A21 remain full-matrix closed at the frozen `delta=1e-18`.
  - First active A21 bias full-matrix margin: `1.2499987189052501e-09`.
  - H18 worst outward LDLT pivot: `4.987499868870966e-14`.
- Consume the finite-`tau_b` A21 detectability chain through canonical P3 without treating the comparison observer as an estimator or as a standalone P4 promotion.
- Add the exact full-state augmented endpoint master
  `L_W=[[-D_W,M_W^T J_N B_W],[B_W^T J_N M_W,B_W^T J_N B_W]]`.
- Add dense same-history quadratic graph-sector assembly and the outward full-matrix S-procedure/LDLT test `-(L_W+sum lambda_j Pi_j)>0`.
- Retain all 21 A21 states and cross terms, every due S update with its actual applied anisotropic `R_S`, and the A21 projection generalized Jacobian.
- Integrate the bridge into the canonical P4 artifact and `ou3-proof` workflow.
- Keep the bridge fail-closed: source-uniform endpoint/prefix graph sectors and augmented LDLT are still false, so P4 remains open and P5 blocked.
- Cache deterministic P3 and fixed spectral-quadrature builders process-locally with defensive copies so the unchanged workflow timeout can run the integrated test graph.
- Correct masked stale P4 assertions and three pre-#496 source/P3 assertions so they test the current conditional-universal contract without claiming finite source-family materialization.
- Remove two genuinely unused imports exposed by the current Ruff runner; no quality-gate configuration changed.

## Preserved invariants

- no shipping filter change
- no quality-gate or threshold change
- P3 `delta=1e-18` unchanged
- complete same-history `COMPLETE_SEA3_NORMAL_LIVE_WORD` semantics unchanged
- actual-applied `R_S` required in every applicable suffix
- no packetwise scalarization, state elimination, correction radius, inverse-metric floor, replay fitting, or domain shrink

## Validation

Local:

- source-foundation command: 73/73
- new joint-sector master tests: 4/4
- canonical P4 unittest: 9/9
- all `test_ou3_p4_*.py`: 91/91
- P3 plus spectral bridge tests: 16/16
- corrected complete-source/P3 contract tests: 4/4
- P4 producer and final artifact assertions: pass; P4/P5 remain false as required
- `make -C tests/validation build`: pass
- `git diff --check`: pass
- workflow YAML parse: pass

GitHub Actions on head `43403446`:

- `ou3-proof`: success through source-foundation, complete-sea3-source, riccati-p3, and riccati-p4
- `build`: success
- `quality-gates`: success (all six jobs)
- `ou3-complete-sea3`, window contract, metric memory, complete-word feasibility, finite-map feasibility, long-window feasibility, and lever-arm study: success

`ou-validation` remains red only at the pre-existing evidence contract: validation/robustness replay dependencies differ from committed provenance for the OU-II/OU-III filter, WPE, and simulator files. This PR does not hand-edit hashes or regenerate evidence.

`make all` is locally blocked before compilation because this workspace lacks both `/usr/include/eigen3/Eigen/Dense` and a vendored Eigen tree. The build command and include policy are unchanged; GitHub's build workflow succeeded.

## Next proof obligation

Materialize the source-correlated same-history state/residual selectors for the complete SEA3 word, lift the exact Cayley and A21 projection graphs into dense sectors, and close the full augmented endpoint and every-prefix outward LDLT. Do not promote P4 unless those source-uniform tests and prefix domain retention close.