### PR TITLE
OU-III ALT: isolate Live source attachment and rank-3 increment ports

### DIFF
--- a/.github/workflows/ou3-alt-contraction.yml
+++ b/.github/workflows/ou3-alt-contraction.yml
@@ -6,12 +6,14 @@ on:
       - "tools/stability/ou3_alt_contraction/**"
       - "tests/ou3_alt_contraction/**"
       - "docs/ou3-alt-contraction.md"
+      - "docs/ou3-proof-research-state.md"
       - ".github/workflows/ou3-alt-contraction.yml"
   pull_request:
     paths:
       - "tools/stability/ou3_alt_contraction/**"
       - "tests/ou3_alt_contraction/**"
       - "docs/ou3-alt-contraction.md"
+      - "docs/ou3-proof-research-state.md"
       - ".github/workflows/ou3-alt-contraction.yml"
   workflow_dispatch:
 
@@ -47,6 +49,10 @@ jobs:
           sudo apt-get install -y libeigen3-dev python3-numpy python3-scipy python3-mpmath
       - name: Test independent inverse-free and joint-bias algebra
         run: python3 -m unittest discover -s tests/ou3_alt_contraction -v
+      - name: Audit source-uniform finite-increment attachment without promotion
+        run: |
+          python3 tools/stability/ou3_alt_contraction/source_uniform_attachment.py \
+            --output /tmp/ou3-alt-source-attachment.json
       - name: Fetch existing coupled source and build unchanged shipping observer
         run: |
           make ensure-sim-data
@@ -112,6 +118,7 @@ jobs:
         with:
           name: ou3-alt-experiment-${{ github.run_id }}
           path: |
+            /tmp/ou3-alt-source-attachment.json
             /tmp/ou3-alt-maps.bin
             /tmp/ou3-alt-cov.bin
             /tmp/ou3-alt-baseline.json

--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -288,3 +288,42 @@ Selected next experiment: bind the already implemented exact finite solve
 increment graph to the analytic same-history shipping source, then run the
 full-word high-precision feasibility experiment before any interval refinement.
 All ALT and existing final theorem gates remain false/unpromoted.
+
+### ALT continuation experiment — source attachment and rank-three product ports
+
+The next falsifiable attachment experiment was executed without changing the
+shipping filter or the original P2/P3/P4/P5 route. The event-local
+estimator-owned JOINT/kernel relation executes for both H18 and A21: H/A cells
+bind, literal event orders agree, and the authoritative next frontend is the
+JOINT image. However, invoking the inherited theorem-facing source-selector
+builder pulls in the separate Mahony startup invariant and currently stops at
+`continuous_all_live_PI_invariant_closed` / `initial seed angle not closed`.
+Classification: proof-architecture coupling, not an ALT Live theorem failure.
+It invalidates reuse of that theorem-facing wrapper as the ALT Live attachment;
+it does not invalidate the inverse-free finite-increment algebra, the joint24
+bounded-supply target, or the independently continuable original proof.
+
+The attachment gap is now sharper. The available relation is
+single-execution/differential: it does not supply paired admissible estimator,
+covariance, frontend/tuner and guard states with same-history `r0/r1`, `N0/N1`,
+`S0/S1`, and `q0/q1`. Therefore `deltaN` and `deltaS` are not yet tied to one
+paired COMPLETE-BRMM continuation and
+`ALT_ACTUAL_SOURCE_UNIFORM_FINITE_INCREMENT_WORD_ATTACHED=false`.
+
+Rank-three structure is retained only as an exact representation optimization.
+The new thin kernels use `Psi+ = Psi-K(H Psi)`, the actual-numerator Joseph
+polynomial, and the rank-at-most-six storage correction without discarding any
+state or cross term. The endogenous increment master can carry
+`u_S=deltaS*q0` and `u_N=deltaN*q0`; for joint24 this reduces the local lifted
+coordinate count from 87 to 33. This is exact only when hard same-history
+product graphs enforce both identities. The ports may not be treated as
+independent bounded disturbances.
+
+Critic: the strongest reason to abandon the inherited wrapper is that it makes
+a Live-word feasibility experiment depend on an unrelated, still-open startup
+theorem. The selected alternative is a Live-only paired JOINT+kernel transition,
+not more refinement of that wrapper. Current limiter and next falsifiable
+experiment: take two estimator states over one admitted COMPLETE-BRMM source
+continuation, emit paired literal H18/A21 event cells, bind both inverse-free
+solves, and enforce hard `u_S/u_N` same-history product graphs. Startup remains
+a separate later theorem. All ALT and original P4/P5 gates remain fail-closed.

--- a/tests/ou3_alt_contraction/test_core.py
+++ b/tests/ou3_alt_contraction/test_core.py
@@ -1,5 +1,4 @@
 """Host algebra and anti-shortcut tests; none is a universal stability gate."""
-import importlib.util
 from pathlib import Path
 import sys
 import unittest

--- a/tests/ou3_alt_contraction/test_rank3.py
+++ b/tests/ou3_alt_contraction/test_rank3.py
@@ -67,8 +67,10 @@ class Rank3Tests(unittest.TestCase):
             N1 @ q1 - N0 @ q0,
             atol=1e-12,
         )
+        old_vec_lift_size = m + n*m + m*m + m
+        self.assertEqual(old_vec_lift_size, 87)
         self.assertEqual(chi.size, 33)
-        self.assertLess(chi.size, 105)
+        self.assertLess(chi.size, old_vec_lift_size)
 
 
 if __name__ == '__main__':

--- a/tests/ou3_alt_contraction/test_rank3.py
+++ b/tests/ou3_alt_contraction/test_rank3.py
@@ -1,0 +1,75 @@
+import unittest
+import numpy as np
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+from tools.stability.ou3_alt_contraction import rank3
+
+
+class Rank3Tests(unittest.TestCase):
+    def test_state_apply_matches_dense(self):
+        rng = np.random.default_rng(17)
+        for n in (18, 21, 24):
+            Psi = rng.normal(size=(n, n))
+            K = rng.normal(size=(n, 3))
+            H = rng.normal(size=(3, n))
+            np.testing.assert_allclose(
+                rank3.state_apply(Psi, K, H),
+                (np.eye(n) - K @ H) @ Psi,
+                rtol=2e-13, atol=2e-13,
+            )
+
+    def test_joseph_matches_dense(self):
+        rng = np.random.default_rng(23)
+        n = 24
+        X = rng.normal(size=(n, n))
+        P = X @ X.T + np.eye(n)
+        H = rng.normal(size=(3, n))
+        R = np.diag([.7, .9, 1.1])
+        PCt = P @ H.T
+        S = H @ PCt + R
+        K = np.linalg.solve(S, PCt.T).T
+        A = np.eye(n) - K @ H
+        np.testing.assert_allclose(
+            rank3.joseph(P, K, S, PCt),
+            A @ P @ A.T + K @ R @ K.T,
+            rtol=2e-12, atol=2e-12,
+        )
+
+    def test_storage_delta_rank_at_most_six(self):
+        rng = np.random.default_rng(29)
+        n = 24
+        X = rng.normal(size=(n, n))
+        M = X @ X.T + np.eye(n)
+        K = rng.normal(size=(n, 3))
+        H = rng.normal(size=(3, n))
+        A = np.eye(n) - K @ H
+        d = rank3.storage_delta(M, K, H)
+        np.testing.assert_allclose(d, A.T @ M @ A - M, rtol=2e-12, atol=2e-12)
+        self.assertLessEqual(np.linalg.matrix_rank(d, tol=1e-9), 6)
+
+    def test_product_ports_match_exact_finite_increment(self):
+        rng = np.random.default_rng(41)
+        n, m = 24, 3
+        B0, B1 = rng.normal(size=(m, m)), rng.normal(size=(m, m))
+        S0, S1 = B0 @ B0.T + np.eye(m), B1 @ B1.T + np.eye(m)
+        N0, N1 = rng.normal(size=(n, m)), rng.normal(size=(n, m))
+        r0, r1 = rng.normal(size=m), rng.normal(size=m)
+        q0, q1 = np.linalg.solve(S0, r0), np.linalg.solve(S1, r1)
+        dS, dN = S1 - S0, N1 - N0
+        chi = np.r_[r1 - r0, q1 - q0, dS @ q0, dN @ q0]
+        lift = rank3.increment_product_ports(N1, S1)
+        np.testing.assert_allclose(lift.equality @ chi, 0, atol=1e-12)
+        np.testing.assert_allclose(
+            lift.correction_difference @ chi,
+            N1 @ q1 - N0 @ q0,
+            atol=1e-12,
+        )
+        self.assertEqual(chi.size, 33)
+        self.assertLess(chi.size, 105)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/ou3_alt_contraction/test_source_uniform_attachment.py
+++ b/tests/ou3_alt_contraction/test_source_uniform_attachment.py
@@ -18,8 +18,8 @@ class SourceUniformAttachmentTests(unittest.TestCase):
         self.assertFalse(d['ALT_ACTUAL_SOURCE_UNIFORM_FINITE_INCREMENT_WORD_ATTACHED'])
         self.assertFalse(d['ALT_LIVE_PASS'])
         self.assertFalse(d['rank3_structure_safe_to_use']['full_state_reduction_permitted'])
-        self.assertEqual(d['rank3_structure_safe_to_use']['thin_master_port_dimension_A21'], 33)
-        self.assertEqual(d['rank3_structure_safe_to_use']['old_vec_increment_dimension_A21'], 105)
+        self.assertEqual(d['rank3_structure_safe_to_use']['thin_master_port_dimension_joint24'], 33)
+        self.assertEqual(d['rank3_structure_safe_to_use']['old_vec_increment_dimension_joint24'], 87)
         missing = [k for k, v in d['paired_finite_increment_requirements'].items() if not v]
         self.assertIn('deltaN_and_deltaS_bound_to_same_paired_history', missing)
         self.assertIn('paired_guard_outcomes_or_hard_guard_graph', missing)

--- a/tests/ou3_alt_contraction/test_source_uniform_attachment.py
+++ b/tests/ou3_alt_contraction/test_source_uniform_attachment.py
@@ -1,0 +1,30 @@
+"""ALT source-uniform attachment audit remains deliberately fail-closed."""
+from pathlib import Path
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path[:0] = [str(ROOT), str(ROOT / 'tools/stability')]
+from tools.stability.ou3_alt_contraction import source_uniform_attachment as audit
+
+
+class SourceUniformAttachmentTests(unittest.TestCase):
+    def test_event_relation_executes_without_promoting_pair(self):
+        d = audit.build()
+        self.assertEqual(audit.validate(d), [])
+        self.assertTrue(d['event_local_attachment_executes_without_startup_theorem'])
+        self.assertTrue(d['inherited_theorem_builder']['startup_coupled'])
+        self.assertFalse(d['paired_finite_increment_relation_closed'])
+        self.assertFalse(d['ALT_ACTUAL_SOURCE_UNIFORM_FINITE_INCREMENT_WORD_ATTACHED'])
+        self.assertFalse(d['ALT_LIVE_PASS'])
+        self.assertFalse(d['rank3_structure_safe_to_use']['full_state_reduction_permitted'])
+        self.assertEqual(d['rank3_structure_safe_to_use']['thin_master_port_dimension_A21'], 33)
+        self.assertEqual(d['rank3_structure_safe_to_use']['old_vec_increment_dimension_A21'], 105)
+        missing = [k for k, v in d['paired_finite_increment_requirements'].items() if not v]
+        self.assertIn('deltaN_and_deltaS_bound_to_same_paired_history', missing)
+        self.assertIn('paired_guard_outcomes_or_hard_guard_graph', missing)
+        self.assertIn('thin_product_ports_uN_uS_have_hard_same_history_product_graphs', missing)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/stability/ou3_alt_contraction/rank3.py
+++ b/tools/stability/ou3_alt_contraction/rank3.py
@@ -1,0 +1,86 @@
+"""Exact thin-factor primitives for ALT's three-component measurements.
+
+These are arithmetic/representation optimizations only. They preserve the full
+H18/A21/joint24 state and all cross terms; they do not freeze endogenous gains.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import numpy as np
+
+
+def _matrix(x, name, shape=None):
+    a = np.array(x, dtype=float, copy=True)
+    if a.ndim != 2 or not np.isfinite(a).all():
+        raise ValueError(f"{name} must be finite matrix")
+    if shape is not None and a.shape != shape:
+        raise ValueError(f"{name}: expected {shape}, got {a.shape}")
+    return a
+
+
+def _symmetric(x, name, size=None):
+    a = _matrix(x, name)
+    if a.shape[0] != a.shape[1] or (size is not None and a.shape != (size, size)):
+        raise ValueError(f"{name} must be square")
+    if not np.allclose(a, a.T, rtol=0, atol=1e-12):
+        raise ValueError(f"{name} must be symmetric")
+    return (a + a.T) / 2
+
+
+def state_apply(Psi, K, H):
+    """Exact (I-KH)Psi as Psi-K(H Psi), retaining the full state."""
+    Psi = _matrix(Psi, "Psi")
+    n, _ = Psi.shape
+    K = _matrix(K, "K", (n, 3))
+    H = _matrix(H, "H", (3, n))
+    return Psi - K @ (H @ Psi)
+
+
+def joseph(P, K, S, PCt):
+    """Actual-numerator Joseph polynomial with n x 3 thin factors."""
+    P = _symmetric(P, "P")
+    n = P.shape[0]
+    K = _matrix(K, "K", (n, 3))
+    PCt = _matrix(PCt, "PCt", (n, 3))
+    S = _symmetric(S, "S", 3)
+    out = P - K @ PCt.T - PCt @ K.T + K @ S @ K.T
+    return (out + out.T) / 2
+
+
+def storage_delta(M, K, H):
+    """Exact (I-KH)'M(I-KH)-M; each event has rank at most six."""
+    M = _symmetric(M, "M")
+    n = M.shape[0]
+    K = _matrix(K, "K", (n, 3))
+    H = _matrix(H, "H", (3, n))
+    MK = M @ K
+    core = K.T @ MK
+    out = -H.T @ MK.T - MK @ H + H.T @ core @ H
+    return (out + out.T) / 2
+
+
+@dataclass(frozen=True)
+class ProductPortLift:
+    equality: np.ndarray
+    correction_difference: np.ndarray
+
+
+def increment_product_ports(N1, S1):
+    """Thin exact descriptor conditional on hard product graphs.
+
+    chi=(dr,dq,uS,uN), uS=dS*q0, uN=dN*q0. Then
+      S1*dq+uS-dr=0,
+      dcorrection=N1*dq+uN.
+    uS/uN are NOT free disturbances; the source-uniform master must enforce
+    their same-history product identities.
+    """
+    N1 = _matrix(N1, "N1")
+    n, m = N1.shape
+    S1 = _symmetric(S1, "S1", m)
+    np.linalg.cholesky(S1)
+    k = 3 * m + n
+    Dr = np.hstack((np.eye(m), np.zeros((m, k - m))))
+    Dq = np.hstack((np.zeros((m, m)), np.eye(m), np.zeros((m, m + n))))
+    Us = np.hstack((np.zeros((m, 2 * m)), np.eye(m), np.zeros((m, n))))
+    Un = np.hstack((np.zeros((n, 3 * m)), np.eye(n)))
+    return ProductPortLift(-Dr + S1 @ Dq + Us, N1 @ Dq + Un)

--- a/tools/stability/ou3_alt_contraction/source_uniform_attachment.py
+++ b/tools/stability/ou3_alt_contraction/source_uniform_attachment.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Falsifiable ALT attachment audit for the actual source-uniform shipping word.
+
+This consumes existing COMPLETE-BRMM/JOINT event machinery read-only. It asks
+which ingredients required by the ALT finite-increment joint24 word are present,
+and refuses to promote a differential or single-execution cell into a paired
+finite-increment relation.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path[:0] = [str(ROOT / "tools/stability"), str(ROOT)]
+
+import ou3_p4_source_uniform_estimator_event_attachment as ATTACH
+import ou3_brmm_complete_source as COMPLETE
+
+QUALIFICATION = "ALT_SOURCE_UNIFORM_FINITE_INCREMENT_ATTACHMENT_AUDIT_V1"
+
+
+def build() -> dict:
+    source = COMPLETE.build()
+    sf = COMPLETE.validate(source)
+    if sf:
+        raise RuntimeError(f"COMPLETE-BRMM source invalid: {sf}")
+
+    # Execute the event-local relation without importing the old route's startup
+    # theorem. This proves the mechanics needed by ALT are callable.
+    smoke = ATTACH._smoke()
+    event_local_closed = bool(
+        smoke["joint_successors_retained"] > 0
+        and smoke["all_H_cells_bound"]
+        and smoke["all_A_cells_bound"]
+        and smoke["all_event_orders_equal"]
+        and smoke["authoritative_next_frontend_is_joint"]
+    )
+
+    # Deliberately try the inherited theorem-facing builder. On current main it
+    # reaches into the separate Mahony startup invariant. ALT Live-word
+    # attachment must not silently acquire that prerequisite.
+    inherited = {"builder_completed": False, "startup_coupled": False, "error": None}
+    try:
+        d = ATTACH.build()
+    except RuntimeError as exc:
+        msg = str(exc)
+        inherited.update(
+            error=msg,
+            startup_coupled=(
+                "continuous Mahony invariant invalid" in msg
+                or "continuous_all_live_PI_invariant_closed" in msg
+                or "initial seed angle not closed" in msg
+            ),
+        )
+    else:
+        inherited.update(
+            builder_completed=True,
+            relation_closed=bool(
+                d.get("source_uniform_estimator_owned_event_attachment_relation_closed")
+            ),
+        )
+
+    paired_fields = {
+        "paired_admissible_predecessor_states": False,
+        "paired_covariance_states_P0_P1": False,
+        "paired_frontend_tuner_states": False,
+        "paired_guard_outcomes_or_hard_guard_graph": False,
+        "paired_measurement_residuals_r0_r1": False,
+        "paired_gain_numerators_N0_N1": False,
+        "paired_innovations_S0_S1": False,
+        "nominal_solve_variable_q0_bound_to_S0_q0_eq_r0": False,
+        "deltaN_and_deltaS_bound_to_same_paired_history": False,
+        "thin_product_ports_uN_uS_have_hard_same_history_product_graphs": False,
+    }
+
+    return {
+        "qualification": QUALIFICATION,
+        "canonical_source": "COMPLETE_BRMM_NORMAL_LIVE_WORD",
+        "event_local_attachment_executes_without_startup_theorem": event_local_closed,
+        "event_local_smoke": smoke,
+        "inherited_theorem_builder": inherited,
+        "ALT_must_not_inherit_startup_for_Live_word_attachment": True,
+        "available_actual_shipping_relations": {
+            "same_history_estimator_owned_event_cells_executable": event_local_closed,
+            "correlated_P_H_R_same_cell": True,
+            "actual_applied_anisotropic_R_S": True,
+            "frontend_tuner_scheduler_ancestry": True,
+            "H18_and_A21_literal_event_order": True,
+            "A21_same_history_true_bias_coordinate": True,
+            "physical_wave_payload_in_literal_event_cells": True,
+        },
+        "paired_finite_increment_requirements": paired_fields,
+        "paired_finite_increment_relation_closed": False,
+        "rank3_structure_safe_to_use": {
+            "measurement_dimension": 3,
+            "inverse_free_form": "S*q=r, correction=N*q",
+            "thin_increment_ports": "u_S=delta_S*q0; u_N=delta_N*q0",
+            "thin_master_port_dimension_A21": 33,
+            "old_vec_increment_dimension_A21": 105,
+            "storage_measurement_delta_rank_upper": 6,
+            "full_state_reduction_permitted": False,
+            "A21_motion_bias_cross_terms_retained": True,
+        },
+        "ALT_ACTUAL_SOURCE_UNIFORM_FINITE_INCREMENT_WORD_ATTACHED": False,
+        "ALT_LIVE_PASS": False,
+        "P4_promoted": False,
+        "classification": (
+            "proof-method/representation attachment failure plus unwanted startup coupling"
+        ),
+        "limiter": (
+            "event-local same-history H/A attachment executes, but the theorem-facing "
+            "inherited builder is startup-coupled and ALT still lacks a paired coefficient "
+            "graph tying r0/r1, N0/N1, S0/S1, q0/q1 and thin products u_N/u_S to one "
+            "paired COMPLETE-BRMM history"
+        ),
+        "does_not_invalidate": [
+            "inverse-free finite-increment algebra",
+            "joint24 bounded-neutral-supply target",
+            "rank-three thin-factor arithmetic",
+            "independent old P2/P3/P4/P5 route",
+        ],
+        "next_falsifiable_experiment": (
+            "construct a Live-only paired JOINT+kernel transition that takes two estimator "
+            "states over one admitted COMPLETE-BRMM source continuation, emits paired literal "
+            "event cells, and enforces u_S=delta_S*q0 and u_N=delta_N*q0 as hard same-history "
+            "product graphs; keep startup separate"
+        ),
+    }
+
+
+def validate(d: dict) -> list[str]:
+    f = []
+    if d.get("qualification") != QUALIFICATION:
+        f.append("qualification mismatch")
+    if d.get("event_local_attachment_executes_without_startup_theorem") is not True:
+        f.append("event-local Live attachment did not execute")
+    inherited = d.get("inherited_theorem_builder", {})
+    if inherited.get("builder_completed") is False and inherited.get("startup_coupled") is not True:
+        f.append("inherited builder failed for an unclassified reason")
+    if d.get("paired_finite_increment_relation_closed") is not False:
+        f.append("paired finite-increment relation must remain fail-closed")
+    if d.get("ALT_ACTUAL_SOURCE_UNIFORM_FINITE_INCREMENT_WORD_ATTACHED") is not False:
+        f.append("ALT actual word promoted without paired relation")
+    if d.get("ALT_LIVE_PASS") is not False or d.get("P4_promoted") is not False:
+        f.append("proof gate promoted")
+    r = d.get("rank3_structure_safe_to_use", {})
+    if r.get("measurement_dimension") != 3 or r.get("full_state_reduction_permitted") is not False:
+        f.append("rank-three structure mischaracterized")
+    if not int(r.get("thin_master_port_dimension_A21", 999)) < int(
+        r.get("old_vec_increment_dimension_A21", 0)
+    ):
+        f.append("thin product-port representation did not reduce lifted dimension")
+    return f
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--output", type=Path, required=True)
+    a = ap.parse_args()
+    d = build()
+    f = validate(d)
+    d["validation_pass"] = not f
+    d["validation_failures"] = f
+    a.output.parent.mkdir(parents=True, exist_ok=True)
+    a.output.write_text(json.dumps(d, indent=2, sort_keys=True) + "\n")
+    print(
+        json.dumps(
+            {
+                "event_local": d["event_local_attachment_executes_without_startup_theorem"],
+                "startup_coupled": d["inherited_theorem_builder"].get("startup_coupled"),
+                "paired": d["paired_finite_increment_relation_closed"],
+                "limiter": d["limiter"],
+                "failures": f,
+            },
+            indent=2,
+        )
+    )
+    return 0 if not f else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/stability/ou3_alt_contraction/source_uniform_attachment.py
+++ b/tools/stability/ou3_alt_contraction/source_uniform_attachment.py
@@ -98,8 +98,8 @@ def build() -> dict:
             "measurement_dimension": 3,
             "inverse_free_form": "S*q=r, correction=N*q",
             "thin_increment_ports": "u_S=delta_S*q0; u_N=delta_N*q0",
-            "thin_master_port_dimension_A21": 33,
-            "old_vec_increment_dimension_A21": 105,
+            "thin_master_port_dimension_joint24": 33,
+            "old_vec_increment_dimension_joint24": 87,
             "storage_measurement_delta_rank_upper": 6,
             "full_state_reduction_permitted": False,
             "A21_motion_bias_cross_terms_retained": True,
@@ -149,8 +149,8 @@ def validate(d: dict) -> list[str]:
     r = d.get("rank3_structure_safe_to_use", {})
     if r.get("measurement_dimension") != 3 or r.get("full_state_reduction_permitted") is not False:
         f.append("rank-three structure mischaracterized")
-    if not int(r.get("thin_master_port_dimension_A21", 999)) < int(
-        r.get("old_vec_increment_dimension_A21", 0)
+    if not int(r.get("thin_master_port_dimension_joint24", 999)) < int(
+        r.get("old_vec_increment_dimension_joint24", 0)
     ):
         f.append("thin product-port representation did not reduce lifted dimension")
     return f


### PR DESCRIPTION
## Research question

Execute the next ALT falsifiable experiment from the #517 handover: determine whether the existing COMPLETE-BRMM estimator-owned event relation can supply the actual source-uniform finite-increment joint24 word without importing unrelated startup obligations, and exploit the 3-component measurement structure without reducing the full state.

## Result

- Preserves the existing P2/P3/P4/P5 route unchanged and independently continuable.
- Executes the reusable event-local H18/A21 JOINT/kernel attachment successfully: H/A cells bind, literal event orders agree, and the authoritative next frontend remains the JOINT image.
- Finds a concrete architecture failure in the inherited theorem-facing wrapper: it reaches into the separate Mahony startup invariant and currently stops on `continuous_all_live_PI_invariant_closed` / `initial seed angle not closed`. ALT Live-word feasibility therefore must not consume that wrapper as-is.
- Sharpens the primary remaining attachment gap: the existing relation is single-execution/differential and does not provide paired same-history `r0/r1`, `N0/N1`, `S0/S1`, `q0/q1`, covariance/frontend/tuner states, and guard outcomes. The actual source-uniform finite-increment word remains fail-closed.
- Adds exact rank-3 thin-factor kernels for `Psi-K(H Psi)`, the actual-numerator Joseph polynomial, and the rank-at-most-six storage correction. These preserve full joint24 and all motion/bias cross terms.
- Adds exact finite-increment product ports `u_S=deltaS*q0` and `u_N=deltaN*q0`. For joint24 the local measurement increment lift falls from 87 scalar coordinates to 33, conditional on hard same-history product graphs; the ports are not treated as independent disturbances.
- Records failure analysis, critic pass, limiter, and next experiment in the research ledger.

## Next falsifiable experiment

Construct a Live-only paired JOINT+kernel transition over one admitted COMPLETE-BRMM continuation, emit paired literal H18/A21 event cells, bind both inverse-free solves, and enforce hard same-history `u_S/u_N` product graphs. Keep startup separate.

## Validation

- Local ALT unit suite passed in the recovered source workspace.
- `make all` was attempted and remains infrastructure-blocked exactly at `tests/ahrs/ahrs-qmekf-sim.cpp`: `fatal error: Eigen/Dense: No such file or directory` under `/usr/include/eigen3`. The ALT CI installs `libeigen3-dev` before running.
- The exploratory workflow now emits the attachment audit JSON as an artifact.

No proof gate is promoted: `ALT_LIVE_PASS=false`, `ALT_STARTUP_PASS=false`, `ALT_END_TO_END_PASS=false`; existing `P4_PASS=false` / `P5_MAY_START=false` are untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validated rank-three calculation support for ALT measurements, including covariance updates, storage metrics, and product-port mappings.
  * Added an automated source-uniform attachment audit that produces a structured report and remains fail-closed when required paired-history conditions are unavailable.

* **Documentation**
  * Documented the current ALT continuation findings, limitations, and next experimental requirements.

* **Tests**
  * Added coverage for rank-three calculations and source-uniform attachment validation.

* **Chores**
  * Extended automated workflow coverage to run the attachment audit for relevant documentation changes and upload its report.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->