### PR TITLE
ALT: attach actual finite-increment shipping words and isolate memory-closure obligation

### DIFF
--- a/.github/workflows/ou3-alt-contraction.yml
+++ b/.github/workflows/ou3-alt-contraction.yml
@@ -6,12 +6,14 @@ on:
       - "tools/stability/ou3_alt_contraction/**"
       - "tests/ou3_alt_contraction/**"
       - "docs/ou3-alt-contraction.md"
+      - "docs/ou3-alt-contraction-handover.md"
       - ".github/workflows/ou3-alt-contraction.yml"
   pull_request:
     paths:
       - "tools/stability/ou3_alt_contraction/**"
       - "tests/ou3_alt_contraction/**"
       - "docs/ou3-alt-contraction.md"
+      - "docs/ou3-alt-contraction-handover.md"
       - ".github/workflows/ou3-alt-contraction.yml"
   workflow_dispatch:
 
@@ -44,9 +46,27 @@ jobs:
       - name: Install host diagnostic dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libeigen3-dev python3-numpy python3-scipy python3-mpmath
+          sudo apt-get install -y libeigen3-dev clang python3-numpy python3-scipy python3-mpmath
       - name: Test independent inverse-free and joint-bias algebra
         run: python3 -m unittest discover -s tests/ou3_alt_contraction -v
+      - name: Attach actual finite-increment words and check observation transparency
+        env:
+          CXX: clang++
+        run: |
+          python3 tools/stability/ou3_alt_contraction/shipping_word.py \
+            --work /tmp/ou3-alt-finite-word \
+            --output /tmp/ou3-alt-finite-word.json \
+            --verify-uninstrumented
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: ou3-alt-finite-word-${{ github.run_id }}
+          path: |
+            /tmp/ou3-alt-finite-word.json
+            /tmp/ou3-alt-finite-word/manifest.json
+            /tmp/ou3-alt-finite-word/producer.json
+          if-no-files-found: warn
+          retention-days: 14
       - name: Fetch existing coupled source and build unchanged shipping observer
         run: |
           make ensure-sim-data

--- a/docs/ou3-alt-contraction-handover.md
+++ b/docs/ou3-alt-contraction-handover.md
@@ -2,86 +2,146 @@
 
 ## Where to resume
 
-This is the canonical handover for the independent whole-word joint24 hybrid dissipativity proof introduced by PR #517. After PR #517 is merged, start the next ALT continuation as a NEW PR from the latest `main`. Read, in order:
+Continue ALT in a NEW PR from latest main. Read, in order: `AGENTS.md`, this
+file, `docs/ou3-alt-contraction.md`, the ALT section of
+`docs/ou3-proof-research-state.md`, then `docs/ou3-brmm-main-handover.md`.
 
-1. `AGENTS.md`
-2. `docs/ou3-alt-contraction-handover.md` (this file)
-3. `docs/ou3-alt-contraction.md`
-4. the ALT section of `docs/ou3-proof-research-state.md`
-5. `docs/ou3-brmm-main-handover.md` for the shared physical/runtime contracts
+The existing P2/P3/P4/P5 proof is an independently continuable route. Do not
+rewrite it, make it depend on ALT, or consume its PASS labels as an ALT master
+certificate. Shared source/runtime facts require their actual hypotheses and
+same-history ancestry. The shipping implementation and shared proof machinery
+are unchanged by the ALT attachment experiment.
 
-The existing P2/P3/P4/P5 proof is a separate, independently continuable route. Do not delete, rewrite, bypass, or silently make it depend on ALT. Likewise, ALT must not consume old PASS labels as proof of its own master inequality. Shared source/runtime facts may be reused only with their actual hypotheses and same-history ancestry.
+## Immutable contracts and target
 
-## Immutable shared constraints
+Keep corrected COMPLETE-BRMM, including `||a_wave|| <= 8.8 m/s^2`,
+`D_S <= 1100 m*s`, one-time Live S origin, zero lever arm, actual anisotropic
+R_S, same-signal WPE -> sigma -> tau -> T_S -> R_S, staged tuner/scheduler,
+Joseph/reset/projection, BIAS0/BIAS1/BIAS2, H18 and A21. P3 stays `1e-18`.
+No replay fitting, finite-seed qualification, wordwise S reset, covariance
+consistency as hard entry, operating-domain shrinkage, or filter retuning.
 
-Preserve the unchanged shipping implementation and corrected COMPLETE-BRMM physics from main: padded `||a_wave|| <= 8.8 m/s^2`, `D_S <= 1100 m*s`, one-time Live S origin, zero/disabled lever arm in current proof scope, actual anisotropic `R_S`, same-signal WPE -> sigma -> tau -> T_S -> R_S relation, staged tuner/scheduler state, actual Joseph/reset/projection path, BIAS0/BIAS1/BIAS2 ancestry, H18 and A21, and deployment finite precision as a theorem obligation. P3 remains frozen at `1e-18`. No replay fitting, finite-seed qualification, wordwise S re-zeroing, covariance consistency as hard entry membership, or filter changes for proof convenience.
+Use true-minus-estimate joint24
 
-## ALT theorem target
+`z=(e_theta,e_bg,e_v,e_p,e_S,e_aw,e_ba,beta_true)`.
 
-Use the full true-minus-estimate augmented state
+The target is coercive joint storage with motion/bias cross terms and justified
+supply, not strict homogeneous contraction of persistent bias coordinates:
 
-`z = (e_theta,e_bg,e_v,e_p,e_S,e_aw,e_ba,beta_true) in R^24`.
+`m||z||^2 <= V(z,xi) <= Mbar||z||^2`,
 
-Do NOT demand strict homogeneous contraction of every coordinate. H18 held bias and BIAS2 constant physical bias provide neutral/persistent directions. The selected target is coercive joint storage with a justified supply:
+`V_next <= rho V + w^T Gamma w + c^T Beta c`, `0<rho<1`.
 
-`m||z||^2 <= V(z,xi) <= Mbar||z||^2`
+Only independently bounded physical/bias/reference quantities belong in c.
+Unknown motion or covariance-memory errors cannot be relabeled as bounded
+inputs. A finite but enormous ultimate bound is not a useful Live basin.
 
-`V(z_next,xi_next) <= rho V(z,xi) + w^T Gamma w + c^T Beta c`, with `0 < rho < 1`.
+## Executable attachment
 
-Only independently bounded physical/bias/reference quantities may enter `c`; unknown motion errors may not be relabeled as bounded inputs. Keep motion/bias cross terms in storage. The ultimate bound must be quantitatively useful, not merely finite.
+`core.py` retains the inverse-free/IQC algebra, joint bias prediction and
+projection sector. `shipping_graph.py` now derives conditional N/S/residual
+relations from the same pre-state for accepted accelerometer, magnetometer,
+and S updates. It does not infer H from P^-1 N. H18 masks gain bias columns/rows
+while retaining bias uncertainty and cross terms in S. Actual R_S is read,
+not replaced by a scalar nominal value.
 
-## Implemented proof primitives
+`shipping_word.py` and `tests/ou3_alt_contraction/shipping_word.cpp` execute the
+full default Fusion runtime with a continuous analytic physical source and
+separate bias examples. Actual startup supplies baseline H18, H18->A21 and A21
+roots. Host fork preserves all private runtime memory at each root. Tilt,
+held-bias, and covariance-only finite perturbations yield 27 paired 600-step
+words, with nine baseline words. The injected roots are NOT proved reachable.
+The analytic examples satisfy checked kinematic/bias parameter bounds, NOT
+full COMPLETE-BRMM/PE or hard-entry admission.
 
-`tools/stability/ou3_alt_contraction/core.py` contains non-promoting algebra for:
+Temporary headers add observation hooks only; repository runtime files are
+not edited. The optional uninstrumented control requires bit-identical
+sample-boundary records for the same compiler/executions. Capture includes
+actual P/N/S/K/residual, gain masks, mean update, Joseph, quaternion/covariance
+reset, projection, attempts/returns, prediction/floor and bias-mode events.
+Private frontend evolution is executed, not frozen. Emitted frontend summaries
+are not a complete analytic recurrence or source-uniform reachable cover.
+The default continuous magnetometer hard-iron correction and learned magnetic
+reference are retained in the physical-input binding.
 
-- inverse-free measurement graph `S q = r`, correction `N q`, where `N` is the ACTUAL shipping numerator after masks;
-- exact finite endogenous innovation increments
-  `S1*dq + dS*q0 = dr`, `dcorrection = N1*dq + dN*q0`;
-- joint24 bias prediction retaining `(phi_true-phi_hat)*beta` inside the state map and the SAME physical driver in bias error and true bias;
-- a radial projection IQC retaining the same true bias on both sides;
-- sign-correct descriptor/IQC dissipativity assembly;
-- exact structural regressions showing why strict full-state homogeneous contraction and unqualified H18 information-form replacement are invalid shortcuts;
-- an exact rational two-state masked-update analogue showing that joint storage plus bounded neutral supply can close despite a neutral coordinate. This analogue is not a shipping certificate.
+The shipping implementation solves each gain row before multiplying by r.
+For its LDLT Lower view, write
 
-`tests/ou3_alt_contraction/test_core.py` has 15 algebra/anti-shortcut tests. The independent `ou3-alt-contraction` workflow passed on PR #517.
+`S_i^L K_i^T = N_i^T + E_i`,
 
-## Executed diagnostic evidence
+`S_1^L delta_K^T + delta_S^L K_0^T = delta_N^T + delta_E`,
 
-The unchanged shipping observer produced 29 retained H18 and 359 retained A21 approximately three-second same-mode words. Worst stored-map ratios were approximately:
+`delta(Kr) = K_0 delta_r + delta_K r_1`.
 
-- H18: `0.999513639919454`, margin about `4.8636e-4`
-- A21: `0.995985717839491`, margin about `4.0143e-3`
+E is a measured solve defect, not a uniform roundoff enclosure. Raw S is kept
+separately for the literal upper-triangle Joseph update. The driver
+`w_b=beta_next-phi_true beta` is used once in both truth and bias-error graphs;
+`(phi_true-phi_hat)beta` is retained. Conditional identities are useful
+attachment primitives, not a complete source-uniform word.
 
-The selected-direction signed ledgers also contracted. Treat these only as falsification/exploratory evidence. The observer reconstructs H from covariance/PCt, freezes endogenous gain dependence, accumulates a binary32 homogeneous product, and H18's 18-state ratio fixes held-bias error at zero. Re-evaluating that stored matrix at 80/120 digits does NOT produce the missing actual nonlinear joint24 word or a source-uniform certificate. No metric was fitted to replay.
+Run on a Linux host with Eigen, NumPy, SciPy, mpmath and a C++20 compiler:
 
-## Current blockers
+```sh
+python -m unittest discover -s tests/ou3_alt_contraction -v
+CXX=clang++ python tools/stability/ou3_alt_contraction/shipping_word.py \
+  --work /tmp/ou3-alt-finite-word \
+  --output /tmp/ou3-alt-finite-word.json --verify-uninstrumented
+```
 
-1. **Primary ALT blocker — actual source-uniform joint24 word attachment.** The exact finite solve-increment algebra exists, but `dN`, `dS`, residual, covariance, frontend/tuner, guards, true-bias recurrence, source forcing and all event branches are not yet bound together as one same-history source-uniform word.
-2. **Fresh-Live hard entry is not closed.** The shared aggregate bias-supply builder currently stops with `qualified fresh-entry source failed` and reports hard-coordinate membership / source-uniform other-coordinate / fresh-Live-cover failures. Do not bypass it. The individual BIAS0/BIAS1/BIAS2 definition validators pass, but that is not startup/hardware admission.
-3. **Uniform storage is not solved.** No common, parameter-dependent, or piecewise joint24 storage has yet been certified for the actual family. Search common joint storage with bounded neutral supply first; only then move down the hierarchy.
-4. **Nonlinear/hybrid closure is open.** Hard finite-horizon IQCs or equivalent exact graph constraints for finite-angle attitude/reset/chord/floor/clamps/acceptance branches, compatible H18/A21 and H18->A21 edges, and literal every-prefix chart/domain retention remain open.
-5. **Startup is separate and open.** The actual Mahony/proxy/learning path must be proved to land in the ALT Live basin in finite time for both measured-period takeover and prior-frequency timeout under the padded physical family.
-6. **Finite precision is open.** Real-arithmetic solve identities do not enclose LDLT, Eigen, reset, projection, covariance-floor, and other deployment roundoff defects.
-7. The existing proof's PE/vector-domain consistency problem remains separate; ALT should not inherit it unless a shared lemma is actually required.
+Use `--eigen PATH` when Eigen is elsewhere. The independent ALT workflow
+retains the report, compiler/source fingerprints and manifest; full traces
+are reproducible in the work directory. This experiment needs no downloaded
+wave dataset. The older frozen-map diagnostic remains a separate baseline.
 
-## Next falsifiable sequence
+## Result and precise blocker
 
-1. Build an **actual source-uniform finite-increment joint24 shipping word**. Preserve nonzero nominal residual, endogenous `N/S`, true bias, physical source, frontend/tuner and guard ancestry. Instrument or derive missing actual finite increments rather than inferring them from the old frozen observer.
-2. Before rigorous interval/outward work, run a high-precision complete-word feasibility diagnostic of THAT graph. It must report worst H18/A21 directions, bias/source supply ports, operation-by-operation margin consumption, hybrid edges, and distance to `rho=1`. If rho is above 1, abandon that formulation rather than refining unrelated bounds.
-3. Search the common joint-storage + bounded-neutral-supply master first. If it fails twice by the same mechanism, obey the AGENTS two-strike rule: record failure analysis, compare at least three qualitatively different alternatives, and perform an architecture review before more refinement.
-4. If a full master is feasible, make it rigorous over the analytic source family: source cover, metric coercivity/compatibility, hard nonlinear graph constraints, every-prefix reachability, first-exit/domain retention, and finite precision.
-5. Determine the largest physics-compatible ALT Live basin and its quantitative ultimate bound.
-6. Separately prove actual Mahony/proxy finite-time capture and H18->A21 landing into that basin.
-7. Only after all obligations close may ALT claim an end-to-end theorem. Do not promote existing P4/P5 merely because ALT closes; reconcile theorem/gate policy explicitly in a later PR.
+All three bias definition validators and the conditional operand regressions
+are exercised. The covariance-only probes start with delta-z24=0 and end with
+nonzero state differences on the same physical history. Thus an incremental
+master cannot allow arbitrary covariance-memory differences while measuring
+only delta-z24 and giving no memory supply. A nonzero nominal residual makes
+the omitted endogenous gain term material even when delta-r initially vanishes.
 
-## Fail-closed status at PR #517 handover
+This is a dependency/representation obstruction to that relaxed graph, NOT a
+physical counterexample: the perturbed covariance roots are not admitted by a
+source-uniform reachability theorem. It was anticipated by the warning that xi
+must not be frozen. Do not repeat this probe with smaller intervals as a new
+proof attempt. A source-dependent metric alone cannot make V(delta-z=0)
+positive for an omitted memory difference.
 
-`ALT_LIVE_PASS=false`
+No source-uniform rho, maximizing generalized direction, per-operation storage
+margin, useful ultimate bound, or basin has been obtained. They remain null,
+not manufactured from mixed-unit Euclidean norms. The 80/120-digit checks are
+of recorded finite row-solve identities, NOT high-precision nonlinear word
+re-execution. The old frozen-map ratios likewise do not supply that master.
 
-`ALT_STARTUP_PASS=false`
+## Next falsifiable experiment
 
-`ALT_END_TO_END_PASS=false`
+1. Keep the new actual operand bindings and choose a closed master before any
+   interval refinement. Compare three distinct routes: memory-augmented
+   incremental storage; same-trajectory error-to-truth dissipativity; or a
+   source-reachable pair invariant tying covariance/frontend increments to
+   state and physical inputs. The current priority is a same-trajectory
+   error-to-truth graph, which does not compare arbitrary covariance histories.
+   Keep common joint24 storage plus bounded neutral supply as the first metric
+   search; do not silently jump to independently fitted wordwise metrics.
+2. Derive that graph's physical reference defect, especially S=0 forcing,
+   actual covariance evolution, nonlinear attitude and frontend/guard ancestry.
+   Truth is not an estimator solution. Neither physical forcing nor an omitted
+   memory coordinate may be charged to an unproved bounded error port.
+3. Once the complete master is closed, run its high-precision H18/A21/edge
+   feasibility test with maximizing directions, supply coefficients, signed
+   operation margins and distance to rho=1. Current finite probes do not meet
+   this requirement. Obey the two-strike rule before refining a failed method.
+4. Only if feasible: outward source-uniform verification, common/compatible
+   coercivity, every-prefix chart retention, finite precision, useful basin and
+   ultimate bound. Separately close actual Mahony/proxy capture for measured
+   period takeover and prior timeout, plus H18->A21 landing.
 
-Existing `P4_PASS=false` / `P5_MAY_START=false` remain untouched by this route.
+Fresh-Live aggregate hard membership remains open; individual bias definitions
+do not close it. The existing PE/vector consistency blocker stays on the other
+route unless a shared lemma is actually required.
 
-The purpose of merging PR #517 is to preserve a tested second proof architecture and its falsifiable continuation path on main, not to claim the stability theorem is finished.
+`ALT_LIVE_PASS=false`, `ALT_STARTUP_PASS=false`, `ALT_END_TO_END_PASS=false`.
+Existing `P4_PASS=false` / `P5_MAY_START=false` remain untouched. Green ALT CI
+means the experiment and its regressions ran, not that stability is proved.

--- a/docs/ou3-alt-contraction.md
+++ b/docs/ou3-alt-contraction.md
@@ -1,6 +1,6 @@
 # Parallel OU-III whole-word dissipativity proof
 
-> **Continuation:** after PR #517, start a NEW PR from latest `main` and read
+> **Continuation:** start a NEW PR from latest `main` and read
 > [`ou3-alt-contraction-handover.md`](ou3-alt-contraction-handover.md) first.
 > The existing P2/P3/P4/P5 route remains independently continuable through
 > [`ou3-brmm-main-handover.md`](ou3-brmm-main-handover.md).
@@ -19,12 +19,13 @@ contracts are consumed read-only. The [research ledger](ou3-proof-research-state
 contains separate ALT failure analysis. Neither route's tests substitute for
 the other route's certificates.
 
-**Current result:** exact inverse-free algebra, shared-bias lifts, a projection
-IQC, structural anti-shortcut regressions, and a captured frozen-map diagnostic
-are executable. A source-uniform shipping joint24 master has NOT been solved.
+**Current result:** inverse-free algebra and conditional shipping operand
+bindings are executable. Actual finite paired words now retain endogenous
+gain/covariance changes, shared true-bias drivers, frontend evolution and natural
+H18->A21 release. A source-uniform joint24 master has NOT been solved.
 `ALT_LIVE_PASS`, `ALT_STARTUP_PASS`, and `ALT_END_TO_END_PASS` are false.
-Existing P4/P5 are not promoted. A green exploratory workflow means successful
-execution of the experiments, not proof completion.
+Existing P4/P5 are not promoted. Green exploratory CI means execution, not
+proof completion.
 
 ## 1. The right state and target
 
@@ -233,76 +234,89 @@ padded physical family. A timeout proves a scheduler event occurs, not that
 its state lies in the certified basin. Covariance consistency is not a hard
 error bound. Do not import fresh-Live membership as an assumed success.
 
-## 6. Executable evidence and current blockers
+## 6. Actual finite-increment attachment experiment
 
-Run from the repository root:
+Run the algebra tests and the Linux host experiment:
 
 ```sh
 python -m unittest discover -s tests/ou3_alt_contraction -v
-python tools/stability/ou3_alt_contraction/diagnose.py --output /tmp/ou3-alt.json
+CXX=clang++ python tools/stability/ou3_alt_contraction/shipping_word.py \
+  --work /tmp/ou3-alt-finite-word \
+  --output /tmp/ou3-alt-finite-word.json --verify-uninstrumented
 ```
 
-With paired traces from the unchanged observer:
+`--eigen PATH` selects a nondefault Eigen installation. The experiment requires
+no downloaded wave dataset. Temporary headers expose actual operation operands
+without editing deployed files; an uninstrumented build checks sample-boundary
+bit identity for these executions. The full default Fusion startup/frontend is
+run on continuous analytic physical motion with separate BIAS0/BIAS1/BIAS2
+examples. Fork preserves all private state at actual H18, H18->A21 and A21 roots.
+Nine baseline words and three perturbations per word give 27 finite paired
+600-step experiments. Injected roots are NOT a hard entry set or a reachable
+source-uniform pair cover. Kinematic/bias parameter checks are not full BRMM/PE
+or hardware admission.
 
-```sh
-python tools/stability/ou3_alt_contraction/diagnose.py \
-  --maps /tmp/ou3-alt-maps.bin --cov /tmp/ou3-alt-cov.bin \
-  --output /tmp/ou3-alt-diagnostic.json
+`shipping_graph.py` binds accepted accelerometer, magnetometer and S operations
+through their actual pre-state, deriving H from the measurement model rather
+than P^-1 N. It retains H18 numerator masks, full bias uncertainty in S, learned
+magnetic reference, continuous hard-iron correction, anisotropic R_S and the
+same true-bias driver. Predicted bias, mean injection, Joseph, reset covariance
+and projection are checked against their recorded successors. Observed defects
+are reported rather than hidden as exact deployment identities. Attempts and
+returns preserve rejection evidence instead of dropping unmatched events.
+
+### Actual inverse-free row-solve graph
+
+Shipping computes K by solving each numerator row, then forms K*r. With the
+symmetric matrix `S^L` read by Eigen's LDLT Lower view and measured defect E,
+
+```
+S_i^L K_i^T = N_i^T + E_i,
+S_1^L delta_K^T + delta_S^L K_0^T = delta_N^T + delta_E,
+delta(Kr) = K_0 delta_r + delta_K r_1.
 ```
 
-The workflow `ou3-alt-contraction` creates those traces and retains source
-fingerprints, diagnostic JSON and signed operation ledgers. Captured words
-are only falsification/exploratory evidence: no replay fitting or promotion.
-The high-precision option re-evaluates the STORED binary32 word product at
-80 and 120 digits; it does not reconstruct high-precision nonlinear events.
+These finite identities retain the nonzero nominal residual and endogenous
+terms without reconstructing an inverse. Raw S remains separate for the actual
+upper-triangle Joseph write/mirror. In real exact symmetric arithmetic these
+relations are compatible with the innovation-q formulation in section 2;
+measured row-solve/correction defects are additional ports, not a theorem-level
+roundoff bound. The report's 80/120-digit checks verify these recorded finite
+identities only. They are NOT a high-precision nonlinear complete-word run.
 
-Current algebra tests check masked/unmasked solve graphs, finite endogenous
-increments, shared bias recurrence, retained joint cross terms, IQC sign and
-fail-closed status. An exact rational two-state masked-update analogue has
+### The current dependency obstruction
 
-```
-A = [[2/3,-1/3],[0,1]], M = [[1,1/4],[1/4,1]], rho=9/10,
-A^T M A-rho M-diag(0,1)
-  = [[-41/90,-101/360],[-101/360,-43/45]] < 0.
-```
+Covariance-only probes have zero initial joint24 state increment yet nonzero
+final state increments on the same physical history. Therefore an incremental
+master measuring only delta-z24 cannot allow arbitrary initial covariance
+variation without a retained memory relation or supply. A metric depending on
+xi still vanishes when delta-z24=0; it does not repair a discarded memory
+coordinate. This is an obstruction to that relaxed graph, not a physical
+COMPLETE-BRMM counterexample: source reachability of the injected roots remains
+unproved. It does not invalidate same-trajectory error-to-truth dissipativity.
+The [research ledger](ou3-proof-research-state.md) records the critic and three
+qualitatively different alternatives.
 
-Its determinant is 1027/2880>0 and first diagonal negative, while det(M)=15/16.
-This proves bounded-supply joint storage resolves the neutral-direction
-obstruction in that analogue, NOT in the shipping filter.
+No source-uniform rho, maximizing generalized direction, signed storage margin,
+ultimate bound or basin is claimed. Those report fields remain null rather than
+using mixed-unit Euclidean ratios. Before a metric search, close either an
+augmented-memory incremental graph, a reachable pair invariant, or the selected
+same-trajectory error-to-truth graph. Search common joint storage with justified
+neutral supply first. Preserve the physical reference-map defect, actual source
+continuation and every-prefix nonlinear obligations.
 
-The captured baseline has 29 H18 and 359 A21 retained same-mode words; worst
-stored-map ratios are approximately 0.999513639919454 and 0.995985717839491.
-H18 uses its existing 18-state homogeneous map with held error zero; A21 keeps
-all 21 estimated-error states. The observer reconstructs H from P^-1 N and
-freezes gain dependence. Neither result is full actual joint24 feasibility,
-a source-uniform metric, a chart-retention proof or a hybrid-edge certificate.
-The H18 margin of about 0.00048636 is the tighter observed frozen-map margin,
-not an available budget for an unbound nonlinear master.
+The independent ALT workflow retains report/manifest/compiler fingerprints.
+The earlier `diagnose.py` captured frozen-map baseline remains available as a
+separate falsification tool: its stored-map ratios approximately 0.99951364
+(H18, held-bias error fixed to zero) and 0.99598572 (A21) are not the full ALT
+master or an available nonlinear margin. No replay is used for metric fitting.
 
-All three individual bias definition validators pass. The shared aggregate
-supply builder currently fails fresh-entry hard-coordinate membership; ALT
-reports that failure, leaves its source unchanged and does not claim entry.
-The existing PE/vector domain consistency issue remains separately open.
-
-### Next falsifiable work, in order
-
-1. Attach a **source-uniform actual** finite-increment joint24 word, retaining
-   N/S endogenous increments, true bias, frontend/tuner and guard ancestry.
-   Reuse old validated source facts read-only, not old PASS labels.
-2. Before rigorous enclosure, run a high-precision complete-word feasibility
-   diagnostic of THAT graph. Report worst H/A directions, bias/source ports,
-   every operation's margin consumption and hybrid edges. Current captured
-   frozen-map ratios do not meet this requirement.
-3. Search the common-storage/bounded-supply formulation first. If it fails,
-   record the exact limiting direction and compare genuinely different metric
-   or source-graph choices before refining. Use the repository two-strike rule.
-4. Only after a feasible full master exists: outward-check its source cover,
-   compatible endpoints, all prefix reachability, physical working tube,
-   projection/bias bounds and finite precision. Then prove startup landing.
-
-No rigorous full-word margin, uniform ultimate bound, certified basin radius,
-finite capture time or H18->A21 landing is presently supplied by ALT. The
-original proof can continue independently while these obligations are pursued.
+All three individual bias definition validators pass for the current examples;
+the aggregate hard-entry builder still fails fresh-Live membership. No startup
+capture, source-uniform storage, all-prefix basin retention, hybrid landing or
+deployment finite-precision theorem is supplied by these experiments. Continue
+through [the ALT handover](ou3-alt-contraction-handover.md), while the original
+P2/P3/P4/P5 route remains independently continuable.
 
 ## Reference
 

--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -255,36 +255,68 @@ and validator separately, preserve their exact shared-error/truth recurrence
 in the new lift, and report aggregate entry admission as false. No change to
 the shared builder or admission gate is authorized by this experiment.
 
-Local `make all` is infrastructure-blocked at `tests/ahrs/ahrs-qmekf-sim.cpp`
-because `Eigen/Dense` is absent from `/usr/include/eigen3`. This is not a
-mathematical failure. The independent CI installs Eigen before the unchanged
-shipping observer is built.
+The default local `make all` include path is infrastructure-blocked at
+`tests/ahrs/ahrs-qmekf-sim.cpp`: `fatal error: Eigen/Dense: No such file or directory`.
+This is not a mathematical failure. The actual finite-word experiment accepts
+`--eigen` for a nondefault installation; independent CI installs Eigen.
 
-### Current ALT evidence and next experiment
+### Current ALT attachment experiment and failure analysis
 
-The separate BIAS0/BIAS1/BIAS2 definition validators all pass; this does not
-close aggregate hard-entry or hardware admission. Fifteen ALT algebra tests
-pass, including exact finite gain/innovation increments and a rational
-masked-update analogue with joint cross storage and bounded neutral supply.
-The analogue is not a shipping certificate.
+The executable `tools/stability/ou3_alt_contraction/shipping_word.py` drives
+unchanged default Fusion startup/frontend with an analytic harmonic physical
+source and separate BIAS0/BIAS1/BIAS2 examples. At each actual H18, H18->A21,
+and A21 root it preserves all private runtime memory and runs literal
+600-step finite perturbations. No metric is fitted. These examples are not a
+source cover, hard entry qualification, or high-precision nonlinear word.
 
-The captured observer contains 29 H18 and 359 A21 retained three-second words.
-Re-evaluation of its stored products at 80/120 digits gives worst ratios
-0.9995136399194538514 and 0.9959857178394911698. The existing H18 ratio fixes
-held-bias error at zero, while A21 retains all 21 estimated-error coordinates.
-No metric is fitted to this replay. The limiting observed frozen-map margin
-is H18's approximately 0.00048636.
+**Current failed shortcut (dependency/representation, class C):** an
+incremental graph on delta-z24 alone is not closed when covariance memory is
+allowed to vary independently. In all nine covariance-only probes delta-z0=0
+but delta-zN is nonzero with the same physical history and matching recorded
+event path. Nonzero nominal residual multiplies the endogenous gain increment.
+The injected covariance roots have NOT been proved source reachable, so this
+is a witness against that relaxed graph, not a COMPLETE-BRMM counterexample
+or a failure of the nonincremental error-to-truth theorem.
 
-A new attachment limitation is explicit: the observer reconstructs H=P^-1 N
-and accumulates a binary32 homogeneous map, not the complete endogenous
-nonlinear joint24 finite-increment map. Treating it as the latter would be a
-proof/implementation correspondence error. Its strict ratios do not justify
-outward certification of the unsupplied ALT master. The strongest critic is
-that high precision cannot restore omitted physics or gain dependence.
-Alternatives: instrument actual finite increments; derive an analytic graph
-of actual N/S/residual/tuner operations; or prove a fixed-trajectory nonlinear
-storage identity that legitimately avoids incremental gain derivatives.
-Selected next experiment: bind the already implemented exact finite solve
-increment graph to the analytic same-history shipping source, then run the
-full-word high-precision feasibility experiment before any interval refinement.
-All ALT and existing final theorem gates remain false/unpromoted.
+**Invalidated:** dropping covariance/frontend increments merely because xi
+is called a source parameter; a frozen-gain incremental observer as the actual
+word. **Not invalidated:** fixed-trajectory joint storage with physical supply,
+a memory-augmented incremental theorem, or a correctly constrained same-history
+pair graph. Limiter: missing reachable joint memory relation, not interval
+precision or a measured rho. No contraction ratio is claimed for this graph.
+
+**Independent critic:** the handover already warned against freezing xi;
+a covariance-only injected probe does not resolve its reachable relation.
+Do not spend a refinement on proving this known dependency with tighter norms.
+Three distinct alternatives are: (1) augment incremental storage with Riccati
+and frontend memory; (2) use a same-trajectory error-to-truth dissipation graph
+that legitimately avoids comparing arbitrary covariance histories; (3) derive
+a reachable pair invariant that constrains memory differences jointly with
+state and physical inputs. Continue the current attachment question by deriving
+and checking actual state-to-N/S/residual relations and retained common-driver
+ports. Before a later metric search, select among these alternatives using an
+actual closed master. Do not treat a trace as that master.
+
+**Attachment implementation check:** temperature centering depends on
+`T - T_ref = 0`, not on the temperature coefficient itself being zero. The
+initial diagnostic rejected the nonzero default coefficient at the reference
+temperature; that diagnostic precondition is corrected without touching runtime.
+This is an instrumentation defect, not a bias-model or filter failure.
+
+**Retained execution evidence:** 33 algebra/binding tests pass. Conditional
+state-to-N/S/residual, Joseph/reset/projection and shared bias-driver checks run
+on 27 paired words plus nine baselines. The default continuous hard-iron
+correction explains why raw magnetic input is not the actual innovation input;
+its same-history value and the learned reference are explicitly captured.
+No independent coefficient rectangles, frozen gain, replay-fit metric or
+wordwise S origin is used. Measured numerical defects are not uniform bounds.
+
+**Next falsifiable experiment:** form a closed same-trajectory error-to-truth
+master with actual covariance/frontend/source recurrence and physical reference
+forcing, rather than a relaxed comparison with freely varying covariance.
+Search common joint24 storage plus bounded neutral supply first. If that graph
+cannot close its dependencies, compare the retained augmented-memory and
+reachable-pair alternatives before any interval work. Only a closed master may
+produce the requested high-precision H/A/edge ratios, generalized directions,
+per-operation margins and useful supply bound.
+All ALT gates and existing P4/P5 remain false/unpromoted.

--- a/tests/ou3_alt_contraction/shipping_word.cpp
+++ b/tests/ou3_alt_contraction/shipping_word.cpp
@@ -1,0 +1,219 @@
+// Host-only literal paired-word experiment. Runtime sources are not edited.
+// fork() preserves EVERY private field at the same reachable baseline root;
+// injected error/covariance probes are explicitly not claimed reachable roots.
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <Eigen/Dense>
+#include <Eigen/Geometry>
+#include <Eigen/Eigenvalues>
+
+namespace alt {
+template<class F> void point(unsigned kind, const F& f);
+template<class V> void set_hard_iron(const V& v);
+template<class F,class V,class N,class S,class M> void solve(unsigned kind,const F& f,
+    const V& r,const N& n,const S& s,const N& k,const S& noise,const M& measured);
+template<class F> struct ExitGuard {
+    unsigned kind; const F& filter;
+    ExitGuard(unsigned k,const F& f):kind(k),filter(f){}
+    ~ExitGuard(){point(kind,filter);}
+};
+}
+#define private public
+#include "kalman_ou_iii/SeaStateFusionFilter_OU_III.h"
+#undef private
+
+const float g_std=9.80665f;
+using Fusion=SeaStateFusion_OU_III<TrackerType::KALMANF>;
+using V3=Eigen::Vector3f;
+constexpr float DT=1.0f/200.0f;
+constexpr double PI=3.1415926535897932384626433832795029;
+constexpr double W=0.7853981633974483096156608458198757;
+namespace alt {
+std::ofstream trace;
+unsigned sample_index=0;
+std::array<float,27> source{};
+std::array<float,14> frontend{};
+std::array<float,3> hard_iron{};
+template<class V> void set_hard_iron(const V& v) {
+    for(int i=0;i<3;++i)hard_iron[i]=v[i];
+}
+
+void write_u(unsigned x) { const std::uint32_t y=x;trace.write(reinterpret_cast<const char*>(&y),4); }
+void write_f(float x) {trace.write(reinterpret_cast<const char*>(&x),4);}
+template<class M> void matrix(const M& m) {
+    for(int i=0;i<m.rows();++i)for(int j=0;j<m.cols();++j)write_f(float(m(i,j)));
+}
+template<class F,class V,class N,class S,class M> void solve(unsigned kind,const F& f,
+    const V& r,const N& n,const S& s,const N& k,const S& noise,const M& measured) {
+    if(!trace.is_open())return;
+    write_u(kind);write_u(sample_index);write_u(f.acc_bias_updates_enabled()?1:0);
+    write_f(f.qref.w());write_f(f.qref.x());write_f(f.qref.y());write_f(f.qref.z());
+    matrix(f.xext);matrix(f.Pext);matrix(n);matrix(s);matrix(k);matrix(r);matrix(noise);
+    for(float v:source)write_f(v);
+    for(float v:frontend)write_f(v);
+    matrix(measured);matrix(f.v2ref);
+    write_f(f.gravity_magnitude_);write_f(f.get_acc_bias_time_constant());
+    write_f(f.acc_bias_limit_);write_f(f.use_imu_lever_arm_?1.0f:0.0f);
+    write_f(f.wind_heel_rad_);write_f(f.k_a_.norm());
+    for(float v:hard_iron)write_f(v);
+}
+template<class F> void point(unsigned kind,const F& f) {
+    if(!trace.is_open())return;
+    Eigen::Matrix<float,21,3> n=Eigen::Matrix<float,21,3>::Zero();
+    Eigen::Matrix3f s=Eigen::Matrix3f::Zero();V3 r=V3::Zero();
+    solve(kind,f,r,n,s,n,s,r);
+}
+void front(Fusion& f) {
+    auto& r=f.raw();
+    set_hard_iron(f.mag_hard_iron_body_uT_);
+    frontend={r.getFreqHz(),r.getWavePeriodSec(),r.getTauTarget(),r.getSigmaTarget(),
+        r.getRSTarget(),r.getTauApplied(),r.getSigmaApplied(),r.getRSApplied(),
+        r.getPseudoUpdatePeriodSec(),r.getAccelVariance(),r.getAccelVertical(),
+        float(r.online_tune_apply_pending_),float(r.getStartupStage()),float(r.time_)};
+}
+}
+
+struct Physical {
+    V3 p,v,a,beta,gyro,acc,mag;
+    Eigen::Quaternionf q;
+    std::array<float,3> angles{};
+};
+Physical physical(unsigned k,int family) {
+    const double t=double(k)*double(DT),s=std::sin(W*t),c=std::cos(W*t);
+    Physical z;
+    z.p=V3(float(.3*std::sin(W*t+.4)),float(.2*c),float(s));
+    z.v=V3(float(.3*W*std::cos(W*t+.4)),float(-.2*W*s),float(W*c));
+    z.a=-float(W*W)*z.p;
+    const double roll=.12*std::sin(W*t+.2), pitch=.09*std::sin(1.25*W*t+.7),
+                 yaw=.08*std::sin(.75*W*t+.6);
+    const double rd=.12*W*std::cos(W*t+.2),pd=.09*1.25*W*std::cos(1.25*W*t+.7),
+                 yd=.08*.75*W*std::cos(.75*W*t+.6);
+    z.q=Eigen::AngleAxisf(float(yaw),V3::UnitZ())*
+        Eigen::AngleAxisf(float(pitch),V3::UnitY())*
+        Eigen::AngleAxisf(float(roll),V3::UnitX());
+    z.gyro=V3(float(rd-yd*std::sin(pitch)),
+              float(pd*std::cos(roll)+yd*std::sin(roll)*std::cos(pitch)),
+              float(-pd*std::sin(roll)+yd*std::cos(roll)*std::cos(pitch)));
+    if(family==0) z.beta=V3(.025f,-.020f,.015f)+
+        float(.005*std::exp(-t/900))*V3(1,-.8f,.6f)+
+        float(.002*std::sin(2*PI*t/900))*V3(1,.5f,-.5f);
+    else if(family==1) z.beta=float(std::exp(-t/1200))*V3(.05f,-.04f,.03f)+
+        float(.01*std::sin(2*PI*t/600))*V3(1,-.8f,.6f);
+    else z.beta=V3(.04f,-.03f,.02f)+float(.005*std::sin(2*PI*t/900))*V3(1,-.8f,.6f);
+    z.acc=z.q.conjugate()*(z.a-V3(0,0,g_std))+z.beta;
+    z.mag=z.q.conjugate()*V3(22,0,43);
+    z.angles={float(roll),float(pitch),float(yaw)};
+    return z;
+}
+V3 primitive(unsigned k,unsigned origin) {
+    const double t=double(k)*double(DT),u=double(origin)*double(DT);
+    return V3(float(.3*(std::cos(W*u+.4)-std::cos(W*t+.4))/W),
+              float(.2*(std::sin(W*t)-std::sin(W*u))/W),
+              float((std::cos(W*u)-std::cos(W*t))/W));
+}
+void advance(Fusion& f,unsigned k,int family,unsigned origin) {
+    Physical z=physical(k,family);alt::sample_index=k;
+    V3 ss=primitive(k,origin);
+    for(int i=0;i<3;++i) {
+        alt::source[i]=z.p[i];alt::source[3+i]=z.v[i];alt::source[6+i]=z.a[i];
+        alt::source[9+i]=ss[i];alt::source[12+i]=z.gyro[i];alt::source[15+i]=z.acc[i];
+        alt::source[18+i]=z.beta[i];alt::source[21+i]=z.mag[i];alt::source[24+i]=z.angles[i];
+    }
+    alt::front(f);
+    f.update(DT,z.gyro,z.acc,35.0f);
+    if(k%8==0)f.updateMag(z.mag);
+    alt::front(f);alt::point(40,f.raw().mekf());
+}
+void begin(Fusion& f) { Fusion::Config cfg;f.begin(cfg); }
+
+struct Boundary {unsigned live=0,active=0;};
+Boundary locate(int family) {
+    Fusion f;begin(f);Boundary b;
+    for(unsigned k=1;k<=120000;++k) {
+        advance(f,k,family,b.live);
+        if(!b.live&&f.isLive())b.live=k;
+        if(b.live&&f.raw().mekf().acc_bias_updates_enabled()) {b.active=k;break;}
+    }
+    if(!b.live||!b.active||b.active<=b.live+900)
+        throw std::runtime_error("analytic probe did not expose a sufficiently long actual H18 and A21 prelude");
+    return b;
+}
+void perturb(Fusion& f,const std::string& name) {
+    auto& k=f.raw().mekf();
+    if(name=="tilt") {
+        k.qref=Eigen::Quaternionf(Eigen::AngleAxisf(1.0f/512.0f,V3::UnitX()))*k.qref;
+        k.qref.normalize();
+    } else if(name=="held_bias") k.xext.template segment<3>(18)+=V3(1.0f/64.0f,0,0);
+    else if(name=="covariance") {
+        Eigen::Matrix<float,21,1> v=Eigen::Matrix<float,21,1>::Zero();
+        v[0]=1;v[15]=.25f;
+        k.Pext.noalias()+=(1.0f/65536.0f)*(v*v.transpose());
+    } else if(name!="base") throw std::runtime_error("unknown probe");
+}
+void word(Fusion& root,unsigned start,unsigned origin,int family,
+          const std::filesystem::path& out,const std::string& stem,const std::string& direction) {
+    std::cout.flush();std::cerr.flush();
+    const pid_t child=fork();
+    if(child<0)throw std::runtime_error("fork failed");
+    if(child==0) {
+        try {
+            perturb(root,direction);
+            alt::trace.open(out/(stem+"-"+direction+".bin"),std::ios::binary);
+            if(!alt::trace)throw std::runtime_error("trace open failed");
+            alt::point(40,root.raw().mekf());
+            for(unsigned k=start+1;k<=start+600;++k)advance(root,k,family,origin);
+            if(!alt::trace)throw std::runtime_error("trace write failed");
+            alt::trace.close();
+            _exit(0);
+        }catch(const std::exception& e){std::cerr<<e.what()<<'\n';_exit(2);}
+    }
+    int status=0;
+    if(waitpid(child,&status,0)!=child||!WIFEXITED(status)||WEXITSTATUS(status)!=0)
+        throw std::runtime_error("word child failed");
+}
+int main(int argc,char**argv) {
+    try {
+        static_assert(sizeof(float)==4 && std::numeric_limits<float>::is_iec559);
+        if(argc!=2)throw std::runtime_error("usage: shipping-word OUTPUT_DIRECTORY");
+        const std::filesystem::path out=argv[1];std::filesystem::create_directories(out);
+        std::ofstream manifest(out/"manifest.json");
+        manifest<<"{\"runtime\":\"binary32 unchanged default fusion via temporary read-only hooks\","
+            "\"word_steps\":600,\"dt\":"<<std::setprecision(17)<<double(DT)<<",\"words\":[";
+        bool first=true;
+        for(int family=0;family<3;++family) {
+            Boundary b=locate(family);
+            std::cerr<<"BIAS"<<family<<" Live sample="<<b.live<<" A21 sample="<<b.active<<'\n';
+            const std::array<unsigned,3> starts={b.live+200,b.active-300,b.active+600};
+            const std::array<std::string,3> names={"H18","H18_to_A21","A21"};
+            Fusion root;begin(root);unsigned cursor=0;
+            for(unsigned i=0;i<3;++i) {
+                while(cursor<starts[i]) {++cursor;advance(root,cursor,family,b.live);}
+                const std::string stem="BIAS"+std::to_string(family)+"-"+names[i];
+                for(const std::string direction:{"base","tilt","held_bias","covariance"})
+                    word(root,cursor,b.live,family,out,stem,direction);
+                if(!first)manifest<<',';first=false;
+                manifest<<"{\"name\":\""<<stem<<"\",\"start_sample\":"<<cursor
+                    <<",\"live_origin_sample\":"<<b.live<<",\"release_sample\":"<<b.active<<'}';
+                std::cerr<<stem<<" complete\n";
+            }
+        }
+        manifest<<"]}\n";
+        if(!manifest)throw std::runtime_error("manifest write failed");
+        return 0;
+    }catch(const std::exception&e){std::cerr<<e.what()<<'\n';return 1;}
+}

--- a/tests/ou3_alt_contraction/test_shipping_word.py
+++ b/tests/ou3_alt_contraction/test_shipping_word.py
@@ -1,0 +1,191 @@
+"""Analytic operand binding and anti-shortcut regressions, not stability gates."""
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+import numpy as np
+
+ROOT=Path(__file__).resolve().parents[2]
+sys.path.insert(0,str(ROOT))
+from tools.stability.ou3_alt_contraction.shipping_graph import (
+    measurement_graph, quaternion_matrix, same_driver_bias_graph, binding_defects,
+)
+from tools.stability.ou3_alt_contraction.shipping_word import (
+    DTYPE, HEADER, analyze_pair, gain_pair_identity, high_precision_pair,
+    instrument_header, instrument_fusion, read_trace, source_contract, bias_contracts, FUSION, verify_transparency, reference_error, state_difference,
+)
+
+
+def record(active=False,kind=10):
+    row=np.zeros(1,dtype=DTYPE)[0]
+    row['kind']=kind;row['active']=active;row['q']=[1,0,0,0]
+    row['P']=np.eye(21,dtype=np.float32).ravel()
+    row['R']=np.eye(3,dtype=np.float32).ravel()
+    row['parameters']=[9.80665,5000,.4,0,0,.0034641]
+    row['measured']=[.1,.2,-9.7];row['mag_reference']=[22,0,43]
+    row['source'][15:18]=row['measured']
+    graph=measurement_graph(kind,row['P'],row['q'],row['x'],row['measured'],
+                            row['R'],active,row['mag_reference'],row['parameters'][0])
+    for name in ('N','S','r'):row[name]=graph[name].ravel()
+    row['K']=np.linalg.solve(graph['S'],graph['N'].T).T.ravel()
+    return row
+
+
+class ShippingAttachmentTests(unittest.TestCase):
+    def test_H18_keeps_bias_uncertainty_but_masks_actual_gain(self):
+        a=record(False);b=record(True)
+        np.testing.assert_array_equal(a['S'],b['S'])
+        self.assertGreater(np.linalg.norm(b['N'].reshape(21,3)[18:]),0)
+        np.testing.assert_array_equal(a['N'].reshape(21,3)[18:],0)
+        h=measurement_graph(10,a['P'],a['q'],a['x'],a['measured'],a['R'],False,
+                            a['mag_reference'],a['parameters'][0])
+        self.assertFalse(np.array_equal(h['H_residual'],h['H_gain']))
+
+    def test_dense_same_P_H_R_relation_with_nonzero_cross_blocks(self):
+        rng=np.random.default_rng(76)
+        b=rng.normal(size=(21,21));p=b@b.T+np.eye(21)
+        q=np.array([.98,.1,.04,-.15]);q/=np.linalg.norm(q)
+        for active in (False,True):
+            h=measurement_graph(10,p,q,np.linspace(.01,.21,21),[1,2,-9],np.eye(3),active,[22,0,43],9.80665)
+            np.testing.assert_allclose(h['S'],h['H_residual']@p@h['H_residual'].T+np.eye(3),atol=1e-10)
+            expected=p@h['H_gain'].T
+            if not active:expected[18:]=0
+            np.testing.assert_allclose(h['N'],expected)
+
+    def test_mag_and_S_graphs_use_actual_reference_and_anisotropic_R(self):
+        p=np.diag(np.arange(1.,22.));noise=np.diag([.2,.3,.7])
+        for kind in (11,12):
+            g=measurement_graph(kind,p,[1,0,0,0],np.arange(21.),[1,2,3],noise,True,[20,1,40],9.8)
+            np.testing.assert_allclose(g['S'],g['H_residual']@p@g['H_residual'].T+noise)
+        g=measurement_graph(12,p,[1,0,0,0],np.arange(21.),[1,2,3],noise,False,[20,1,40],9.8)
+        np.testing.assert_array_equal(g['r'],[-12,-13,-14])
+
+    def test_nonzero_nominal_residual_exposes_covariance_memory(self):
+        a=record();b=a.copy()
+        p=b['P'].reshape(21,21);p[0,0]+=np.float32(.01)
+        g=measurement_graph(10,p,b['q'],b['x'],b['measured'],b['R'],False,b['mag_reference'],b['parameters'][0])
+        for name in ('N','S','r'):b[name]=g[name].ravel()
+        b['K']=np.linalg.solve(g['S'],g['N'].T).T.ravel()
+        s=gain_pair_identity(a,b)
+        self.assertEqual(s['frozen_correction_norm'],0.)
+        self.assertGreater(s['endogenous_correction_norm'],1e-9)
+        self.assertLess(s['equality_max_abs'],1e-12)
+        self.assertLess(s['correction_identity_max_abs'],1e-14)
+        for digits in (80,120):
+            h=high_precision_pair(a,b,digits)
+            self.assertLess(float(h['row_graph_residual']),1e-60)
+            self.assertIn('NOT high-precision nonlinear',h['scope'])
+
+    def test_lower_triangle_solve_does_not_replace_raw_Joseph_S(self):
+        a=record();b=a.copy();b['S'][1]+=np.float32(.25)
+        s=gain_pair_identity(a,b)
+        self.assertEqual(s['dS_norm'],0.)
+        self.assertGreater(s['raw_S_asymmetry_max_abs'],0.)
+        self.assertLess(s['equality_max_abs'],1e-12)
+
+    def test_binding_uses_pre_state_not_reconstructed_H(self):
+        a=record();d=binding_defects(a)
+        self.assertLess(max(d[k+'_scaled_defect'] for k in ('N','S','r')),1e-5)
+        a['N'][0]+=.5
+        self.assertGreater(binding_defects(a)['N_absolute_defect'],.49)
+
+    def test_nonzero_thermal_coefficient_is_allowed_at_reference_temperature(self):
+        a=record();a['parameters'][5]=.0034641018
+        self.assertLess(binding_defects(a)['r_absolute_defect'],1e-5)
+
+    def test_out_of_scope_lever_branch_is_not_silently_accepted(self):
+        a=record();a['parameters'][3]=1
+        with self.assertRaises(ValueError):binding_defects(a)
+
+    def test_joint_bias_prediction_retains_same_driver_and_mismatch(self):
+        b0=np.array([.04,-.02,.03]);b1=b0+np.array([.001,0,-.001])
+        bh0=np.array([.01,-.01,.02])
+        for pt in (.99,1.):
+            for ph in (.98,1.):
+                w,defect=same_driver_bias_graph(b0,b1,bh0,ph*bh0,pt,ph)
+                np.testing.assert_allclose(defect,0,atol=1e-17)
+                np.testing.assert_allclose(pt*b0+w,b1)
+
+    def test_quaternion_polynomial_does_not_normalize_away_roundoff(self):
+        q=np.array([.99,.02,.03,.04])
+        self.assertGreater(np.max(np.abs(quaternion_matrix(q)-quaternion_matrix(q/np.linalg.norm(q)))),1e-6)
+
+    def test_mismatched_hybrid_words_are_not_zipped_or_truncated(self):
+        a=np.array([record()],dtype=DTYPE);b=np.array([record(kind=11)],dtype=DTYPE)
+        r=analyze_pair(a,b)
+        self.assertFalse(r['event_paths_equal'])
+        self.assertIn('MISMATCH',r['classification'])
+
+    def test_hooks_are_temporary_and_fail_closed_on_anchor_changes(self):
+        original=(ROOT/HEADER).read_text();patched=instrument_header(original)
+        self.assertEqual((ROOT/HEADER).read_text(),original)
+        self.assertIn('alt::solve(10',patched)
+        self.assertIn('alt::ExitGuard alt_guard(120',patched)
+        self.assertIn('alt::point(70',patched)
+        with self.assertRaises(ValueError):
+            instrument_header(original.replace('xext.noalias() += K * r;','xext += K * r;'))
+        with self.assertRaises(ValueError):
+            instrument_header(original.replace('tempC_ref = T(35.0)','tempC_ref = T(25.0)'))
+
+    def test_all_three_bias_definitions_are_invoked_separately(self):
+        r=bias_contracts()
+        self.assertEqual(set(r),{'BIAS0','BIAS1','BIAS2'})
+        for v in r.values():
+            self.assertTrue(v['definition_validator_pass'])
+            self.assertTrue(v['analytic_example_parameter_membership'])
+            self.assertFalse(v['fresh_Live_admission'])
+
+    def test_actual_continuous_hard_iron_is_kept_in_input_binding(self):
+        a=record(kind=11);a['hard_iron']=[.02,-.01,.03]
+        a['source'][21:24]=a['measured']+a['hard_iron']
+        self.assertLess(binding_defects(a)['physical_input_max_abs_defect'],1e-6)
+        a['hard_iron']=0
+        self.assertGreater(binding_defects(a)['physical_input_max_abs_defect'],.029)
+        original=(ROOT/FUSION).read_text()
+        self.assertIn('alt::set_hard_iron',instrument_fusion(original))
+        self.assertEqual(original,(ROOT/FUSION).read_text())
+
+    def test_transparency_comparison_detects_one_bit_of_state_change(self):
+        import json
+        with tempfile.TemporaryDirectory() as d:
+            left,right=Path(d)/'left',Path(d)/'right'
+            left.mkdir();right.mkdir()
+            manifest={'words':[{'name':'sample'}]}
+            for folder in (left,right):
+                (folder/'manifest.json').write_text(json.dumps(manifest))
+                for direction in ('base','tilt','held_bias','covariance'):
+                    a=np.array([record()],dtype=DTYPE);a['kind']=40
+                    a.tofile(folder/('sample-'+direction+'.bin'))
+            self.assertTrue(verify_transparency(left,right)['all_sample_records_bit_identical'])
+            a['x'][0,3]=1e-9;a.tofile(right/'sample-base.bin')
+            with self.assertRaises(ValueError):verify_transparency(left,right)
+
+    def test_reference_error_keeps_physical_truth_and_one_S_origin(self):
+        a=record();a['kind']=40
+        a['source'][:12]=np.arange(12,dtype=np.float32)
+        a['source'][18:21]=[.03,-.02,.01]
+        e=reference_error(a)
+        np.testing.assert_array_equal(e[6:9],[3,4,5])
+        np.testing.assert_array_equal(e[9:12],[0,1,2])
+        np.testing.assert_array_equal(e[12:15],[9,10,11])
+        np.testing.assert_array_equal(e[18:21],e[21:24])
+        b=a.copy();b['x'][18]+=.01
+        self.assertAlmostEqual(state_difference(a,b)[18],-.01,places=8)
+        np.testing.assert_array_equal(state_difference(a,b)[21:24],0)
+        b['kind']=50
+        with self.assertRaises(ValueError):reference_error(b)
+
+    def test_truncated_trace_fails_closed(self):
+        with tempfile.TemporaryDirectory() as d:
+            p=Path(d)/'broken.bin';p.write_bytes(b'bad')
+            with self.assertRaises(ValueError):read_trace(p)
+
+    def test_analytic_source_is_not_promoted_to_COMPLETE_BRMM(self):
+        c=source_contract()
+        self.assertTrue(c['kinematic_envelope_sufficient'])
+        self.assertFalse(c['BRMM_full_admission'])
+        self.assertFalse(c['PE_admission'])
+        self.assertTrue(c['probes_are_not_source_cover'])
+
+
+if __name__=='__main__':unittest.main()

--- a/tools/stability/ou3_alt_contraction/shipping_graph.py
+++ b/tools/stability/ou3_alt_contraction/shipping_graph.py
@@ -1,0 +1,154 @@
+"""Conditional shipping graph, not a reachable source cover or stability gate.
+
+Operands are functions of the SAME pre-operation state. H is derived from the
+measurement model, never from P^-1 N. Float execution defects remain explicit;
+these real-arithmetic identities alone do not enclose deployment roundoff.
+"""
+from __future__ import annotations
+import math
+import numpy as np
+
+
+def skew(v):
+    x,y,z=np.asarray(v,dtype=float)
+    return np.array([[0.,-z,y],[z,0.,-x],[-y,x,0.]])
+
+
+def quaternion_matrix(q):
+    """Eigen's quaternion-to-matrix polynomial, without silently normalizing q."""
+    w,x,y,z=np.asarray(q,dtype=float)
+    return np.array([[1-2*(y*y+z*z),2*(x*y-z*w),2*(x*z+y*w)],
+                     [2*(x*y+z*w),1-2*(x*x+z*z),2*(y*z-x*w)],
+                     [2*(x*z-y*w),2*(y*z+x*w),1-2*(x*x+y*y)]])
+
+
+def measurement_graph(kind,P,q,x,measured,noise,active,mag_reference,gravity):
+    """Real-arithmetic N/S/r for zero lever arm and temperature-centered bias.
+
+    This is a conditional identity for all operands in that branch, not a
+    selection of independent N/S boxes. Shipping builds S from the displayed
+    upper cross blocks and their transposes; retaining that evaluation matters
+    when the recorded binary32 P has a small asymmetry. H_residual is full even
+    when H18 masks the gain's bias columns and rows.
+    """
+    P=np.asarray(P,dtype=float).reshape(21,21)
+    x=np.asarray(x,dtype=float).reshape(21)
+    noise=np.asarray(noise,dtype=float).reshape(3,3)
+    measured=np.asarray(measured,dtype=float).reshape(3)
+    rot=quaternion_matrix(q)
+    H=np.zeros((3,21))
+    if kind==10:
+        cog=rot@(x[15:18]-np.array([0.,0.,gravity]))
+        J=-skew(cog); A=rot
+        H[:,:3]=J;H[:,15:18]=A;H[:,18:21]=np.eye(3)
+        r=measured-cog-x[18:21]
+        S=(noise+J@P[:3,:3]@J.T+J@P[:3,15:18]@A.T
+           +A@P[:3,15:18].T@J.T+A@P[15:18,15:18]@A.T
+           +J@P[:3,18:21]+P[:3,18:21].T@J.T
+           +A@P[15:18,18:21]+P[15:18,18:21].T@A.T+P[18:21,18:21])
+    elif kind==11:
+        predicted=rot@np.asarray(mag_reference,dtype=float)
+        H[:,:3]=-skew(predicted)
+        r=measured-predicted
+        S=noise+H[:,:3]@P[:3,:3]@H[:,:3].T
+    elif kind==12:
+        H[:,12:15]=np.eye(3);r=-x[12:15]
+        S=P[12:15,12:15]+noise
+    else:
+        raise ValueError('not a supported measurement event')
+    Hg=H.copy()
+    if kind==10 and not active:Hg[:,18:21]=0
+    N=P@Hg.T
+    if not active:N[18:21]=0
+    return {'N':N,'S':S,'r':r,'H_residual':H,'H_gain':Hg}
+
+
+def binding_defects(row):
+    params=row['parameters'].astype(float)
+    if params[3]!=0:
+        raise ValueError('lever extension has no analytic binding here')
+    graph=measurement_graph(int(row['kind']),row['P'],row['q'],row['x'],
+        row['measured'],row['R'],bool(row['active']),row['mag_reference'],params[0])
+    result={}
+    for name in ('N','S','r'):
+        actual=row[name].astype(float).reshape(graph[name].shape)
+        result[name+'_absolute_defect']=float(np.max(np.abs(actual-graph[name])))
+        result[name+'_scaled_defect']=result[name+'_absolute_defect']/max(1.,float(np.max(np.abs(actual))))
+    # Current probe has zero de-heel. Do not assume that if the default changes.
+    if params[4]!=0:raise ValueError('nonzero de-heel needs a physical input binding')
+    kind=int(row['kind'])
+    raw=(row['source'][15:18].astype(float) if kind==10
+         else row['source'][21:24].astype(float)-row['hard_iron'].astype(float))
+    result['physical_input_max_abs_defect']=(float(np.max(np.abs(row['measured']-raw))) if kind!=12 else 0.)
+    result['held_bias_N_max_abs']=float(np.max(np.abs(row['N'].reshape(21,3)[18:21]))) if not row['active'] else 0.
+    return result
+
+
+def same_driver_bias_graph(beta_before,beta_after,bhat_before,bhat_after,phi_true,phi_hat):
+    """One w, not two independent driver slots; mismatch stays in the joint map."""
+    beta0,beta1,bh0,bh1=map(lambda v:np.asarray(v,dtype=float),
+                           (beta_before,beta_after,bhat_before,bhat_after))
+    w=beta1-phi_true*beta0
+    e0,e1=beta0-bh0,beta1-bh1
+    expected=phi_hat*e0+(phi_true-phi_hat)*beta0+w
+    return w,e1-expected
+
+
+def binding_report(rows,family,dt):
+    """Observed residuals and event census. No maximum is a universal bound."""
+    maxima={};bias_max=0.;driver_max=0.;bias_count=0;solve_count=0
+    mean_max=joseph_max=reset_max=projection_max=0.
+    last_sample=None;pre_prediction=None;last_solve=None;last_joseph=None;pre_projection=None
+    for row in rows:
+        kind=int(row['kind'])
+        if kind in (10,11,12):
+            for name,value in binding_defects(row).items():maxima[name]=max(maxima.get(name,0.),value)
+            last_solve=row;solve_count+=1
+        elif kind in (50,51,52):
+            if last_solve is None or int(last_solve['kind'])!=kind-40:raise ValueError('mean event ancestry mismatch')
+            before=last_solve['x'].astype(float)
+            expected=before+last_solve['K'].reshape(21,3).astype(float)@last_solve['r'].astype(float)
+            mean_max=max(mean_max,float(np.max(np.abs(row['x']-expected))))
+        elif kind in (60,61,62):
+            if last_solve is None or int(last_solve['kind'])!=kind-50:raise ValueError('Joseph event ancestry mismatch')
+            p=last_solve['P'].reshape(21,21).astype(float)
+            n=last_solve['N'].reshape(21,3).astype(float);k=last_solve['K'].reshape(21,3).astype(float)
+            s=last_solve['S'].reshape(3,3).astype(float)
+            raw=p-k@n.T-n@k.T+k@s@k.T
+            # Literal upper-triangle write and mirror, not an independent symmetric S.
+            expected=np.triu(raw)+np.triu(raw,1).T
+            joseph_max=max(joseph_max,float(np.max(np.abs(row['P'].reshape(21,21)-expected))))
+            last_joseph=row
+        elif kind==70:
+            if last_joseph is None:raise ValueError('reset without Joseph ancestor')
+            g=np.eye(21);g[:3,:3]+=.5*skew(last_joseph['x'][:3])
+            expected=g@last_joseph['P'].reshape(21,21).astype(float)@g.T
+            reset_max=max(reset_max,float(np.max(np.abs(row['P'].reshape(21,21)-expected))))
+            pre_projection=row
+        elif kind==80:
+            if pre_projection is None:raise ValueError('projection without reset ancestor')
+            b=pre_projection['x'][18:21].astype(float);limit=float(row['parameters'][2])
+            expected=b*min(1.,limit/np.linalg.norm(b)) if limit>0 and np.linalg.norm(b)>0 else b
+            projection_max=max(projection_max,float(np.max(np.abs(row['x'][18:21]-expected))))
+        elif kind==40:last_sample=row
+        elif kind==1:pre_prediction=row
+        elif kind==2:
+            if pre_prediction is None or last_sample is None:raise ValueError('prediction source ancestry missing')
+            if int(row['sample'])!=int(last_sample['sample'])+1:raise ValueError('nonconsecutive physical source')
+            phi_true=1. if family==2 else math.exp(-dt/(900. if family==0 else 1200.))
+            phi_hat=(math.exp(-dt/float(row['parameters'][1])) if pre_prediction['active'] else 1.)
+            w,defect=same_driver_bias_graph(last_sample['source'][18:21],row['source'][18:21],
+                pre_prediction['x'][18:21],row['x'][18:21],phi_true,phi_hat)
+            bias_max=max(bias_max,float(np.max(np.abs(defect))))
+            driver_max=max(driver_max,float(np.max(np.abs(w))));bias_count+=1
+    # Diagnostic tolerances catch broken attachment, not theorem thresholds.
+    defects_ok=(all(maxima.get(k+'_scaled_defect',math.inf)<2e-5 for k in ('N','S','r'))
+                and maxima.get('physical_input_max_abs_defect',math.inf)<1e-5)
+    return {'qualification':'OBSERVED_OPERAND_BINDING_DEFECTS_NOT_UNIFORM_ENCLOSURE',
+        'solves':solve_count,'measurement_graph':maxima,
+        'mean_update_max_abs_defect':mean_max,'Joseph_max_abs_defect':joseph_max,
+        'reset_covariance_max_abs_defect':reset_max,'projection_max_abs_defect':projection_max,
+        'same_driver_bias_predictions':bias_count,'same_driver_bias_graph_max_abs_defect':bias_max,
+        'observed_bias_driver_component_max_abs':driver_max,
+        'measurement_binding_regression_pass':defects_ok,
+        'source_uniform_attachment_certified':False,'roundoff_bounds_certified':False}

--- a/tools/stability/ou3_alt_contraction/shipping_word.py
+++ b/tools/stability/ou3_alt_contraction/shipping_word.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""Actual paired shipping-word attachment experiment; never a proof gate.
+
+Temporary read-only hooks expose actual P/N/S/K/residuals; no deployed source
+is edited. A continuous analytic source drives the full private startup and
+frontend. Selected finite perturbations are falsification probes, not a cover
+of COMPLETE-BRMM, a hard entry set, or a metric training set.
+"""
+from __future__ import annotations
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0,str(ROOT))
+sys.path.insert(0,str(ROOT/"tools/stability"))
+from tools.stability.ou3_alt_contraction.shipping_graph import binding_report
+HEADER = Path('src/kalman_ou_iii/Kalman3D_Wave_OU_III.h')
+FUSION = Path('src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h')
+# Binary payload, always row-major; Eigen's in-memory order is not serialized.
+FIELDS = [('q', 4), ('x', 21), ('P', 441), ('N', 63), ('S', 9),
+          ('K', 63), ('r', 3), ('R', 9), ('source', 27), ('frontend', 14),
+          ('measured',3), ('mag_reference',3), ('parameters',6), ('hard_iron',3)]
+DTYPE = np.dtype([('kind','<u4'),('sample','<u4'),('active','<u4')] +
+                 [(name,'<f4',(size,)) for name,size in FIELDS])
+KIND = {1:'prediction_entry',2:'prediction_exit',3:'floor_exit',
+        10:'accelerometer',11:'magnetometer',12:'S_zero',
+        20:'accelerometer_exit',21:'magnetometer_exit',22:'S_zero_exit',
+        30:'bias_mode_entry',31:'bias_mode_exit',40:'sample_exit',
+        50:'accelerometer_mean',51:'magnetometer_mean',52:'S_zero_mean',
+        60:'accelerometer_Joseph',61:'magnetometer_Joseph',62:'S_zero_Joseph',
+        70:'quaternion_covariance_reset',80:'bias_projection',
+        110:'accelerometer_attempt',111:'magnetometer_attempt',112:'S_zero_attempt',
+        120:'accelerometer_return',121:'magnetometer_return',122:'S_zero_return'}
+
+
+def once(text, old, new):
+    if text.count(old) != 1:
+        raise ValueError(f'shipping hook anchor changed: expected once: {old!r}')
+    return text.replace(old, new, 1)
+
+
+def instrument_header(text):
+    """Insert pure observation calls at verified lexical anchors, fail closed."""
+    if 'static constexpr T tempC_ref = T(35.0);' not in text:
+        raise ValueError('probe temperature no longer equals shipping reference')
+    # Method-scoped replacement keeps unrelated pseudo-measurements untouched.
+    for method, kind, noise, measured in [
+            ('measurement_update_acc_only',10,'Racc','f_meas'),
+            ('measurement_update_mag_only',11,'Rmag','mag_meas'),
+            ('applyIntegralZeroPseudoMeas',12,'R_S','Vector3::Zero()')]:
+        marker = f'::'+method+'('
+        start = text.index(marker)
+        stop = text.find('\ntemplate<', start+len(marker))
+        if stop == -1: stop = len(text)
+        body = text[start:stop]
+        brace = body.index('{')
+        body = (body[:brace+1] + f'\n    alt::point({kind+100}, *this);\n'
+                + f'    alt::ExitGuard alt_guard({kind+110}, *this);\n' + body[brace+1:])
+        anchor = 'xext.noalias() += K * r;'
+        body = once(body, anchor,
+            f'alt::solve({kind}, *this, r, PCt, S_mat, K, {noise}, {measured});\n    '
+            +anchor+f'\n    alt::point({kind+40}, *this);')
+        anchor = 'joseph_update3_(K, S_mat, PCt);'
+        body = once(body, anchor, anchor+f'\n    alt::point({kind+50}, *this);')
+        anchor = 'applyQuaternionCorrectionFromErrorState();'
+        body = once(body, anchor, anchor+f'\n    alt::point({kind+10}, *this);')
+        text = text[:start]+body+text[stop:]
+    anchor = '    apply_pending_aw_covariance_inflation_();\n    symmetrize_Pext_();   // Symmetry hygiene'
+    text = once(text, anchor,
+        '    alt::point(2, *this);\n'+anchor+'\n    alt::point(3, *this);')
+    start = text.index('::time_update(')
+    brace = text.index('{', start)
+    text = text[:brace+1]+'\n    alt::point(1, *this);'+text[brace+1:]
+    anchor = '    void set_acc_bias_updates_enabled(bool en) {\n'
+    text = once(text, anchor, anchor+'        alt::point(30, *this);\n')
+    anchor = '        acc_bias_updates_enabled_ = en;\n'
+    text = once(text, anchor, anchor+'        alt::point(31, *this);\n')
+    anchor = '    project_acc_bias_();\n}'
+    text = once(text, anchor, '    alt::point(70, *this);\n' + anchor[:-2]
+                + '\n    alt::point(80, *this);\n}')
+    return text
+
+
+def instrument_fusion(text):
+    anchor='            impl_.updateMag(mag_body_ned - mag_hard_iron_body_uT_);'
+    return once(text,anchor,'            alt::set_hard_iron(mag_hard_iron_body_uT_);\n'+anchor)
+
+
+def gain_pair_identity(a, b):
+    """Actual row-solve graph with explicit defects; no inverse and no r0=0.
+
+    Eigen LDLT's default Lower view solves the symmetric matrix reconstructed
+    from S's lower triangle. The raw (possibly asymmetric) S remains separate
+    for shipping Joseph. E_i = Ssolve_i K_i^T - N_i^T is a measured numerical
+    defect, not a rigorous all-input error bound.
+    """
+    def unpack(r):
+        raw = r['S'].reshape(3,3).astype(float)
+        s = np.tril(raw)+np.tril(raw,-1).T
+        return s, r['N'].reshape(21,3).astype(float), r['K'].reshape(21,3).astype(float), r['r'].astype(float)
+    s0,n0,k0,r0 = unpack(a); s1,n1,k1,r1 = unpack(b)
+    ds,dn,dk,dr = s1-s0,n1-n0,k1-k0,r1-r0
+    e0,e1 = s0@k0.T-n0.T, s1@k1.T-n1.T
+    equality = s1@dk.T+ds@k0.T-dn.T-(e1-e0)
+    full = k1@r1-k0@r0
+    frozen = k0@dr
+    gain_term = dk@r1  # exact alternate decomposition full=K0*dr+dK*r1
+    return dict(equality_max_abs=float(np.max(np.abs(equality))),
+                correction_identity_max_abs=float(np.max(np.abs(full-frozen-gain_term))),
+                nominal_residual_norm=float(np.linalg.norm(r0)),
+                dN_norm=float(np.linalg.norm(dn)), dS_norm=float(np.linalg.norm(ds)),
+                endogenous_correction_norm=float(np.linalg.norm(gain_term)),
+                frozen_correction_norm=float(np.linalg.norm(frozen)),
+                total_correction_norm=float(np.linalg.norm(full)),
+                row_solve_defect_max_abs=float(max(np.max(np.abs(e0)),np.max(np.abs(e1)))),
+                raw_S_asymmetry_max_abs=float(max(np.max(np.abs(a['S'].reshape(3,3)-a['S'].reshape(3,3).T)),np.max(np.abs(b['S'].reshape(3,3)-b['S'].reshape(3,3).T)))))
+
+
+def high_precision_pair(a,b,dps):
+    """Recompute the *finite row-solve identity*, not an omitted nonlinear word."""
+    import mpmath as mp
+    with mp.workdps(dps):
+        def mat(values,rows,cols):
+            vals=[mp.mpf(float(v)) for v in values]
+            return mp.matrix([[vals[i*cols+j] for j in range(cols)] for i in range(rows)])
+        def unpack(r):
+            s=mat(r['S'],3,3)
+            for i in range(3):
+                for j in range(i+1,3):s[i,j]=s[j,i]
+            return s,mat(r['N'],21,3),mat(r['K'],21,3),mat(r['r'],3,1)
+        s0,n0,k0,r0=unpack(a);s1,n1,k1,r1=unpack(b)
+        e0=s0*k0.T-n0.T;e1=s1*k1.T-n1.T
+        eq=s1*(k1-k0).T+(s1-s0)*k0.T-(n1-n0).T-(e1-e0)
+        gap=k1*r1-k0*r0-k0*(r1-r0)-(k1-k0)*r1
+        return {'digits':dps,'row_graph_residual':str(max(abs(v) for v in eq)),
+                'correction_graph_residual':str(max(abs(v) for v in gap)),
+                'scope':'finite recorded row-solve graph, NOT high-precision nonlinear re-execution'}
+
+
+def read_trace(path):
+    if path.stat().st_size % DTYPE.itemsize:
+        raise ValueError(f'truncated trace {path}')
+    rows=np.fromfile(path,dtype=DTYPE)
+    if not len(rows): raise ValueError(f'empty trace {path}')
+    if not np.isin(rows['kind'],list(KIND)).all():raise ValueError('unknown trace event')
+    for field,_ in FIELDS:
+        if not np.isfinite(rows[field]).all():
+            raise ValueError(f'nonfinite {field} in {path.name}')
+    return rows
+
+
+def reference_error(row):
+    """Diagnostic true-minus-estimate joint24 at a sample boundary.
+
+    The reference orientation uses the recorded physical Euler angles and the
+    principal SO(3) log. Their evaluation/roundoff and chart domain are not
+    certified. Temporary uninjected error-state slots are not endpoint states.
+    """
+    from scipy.spatial.transform import Rotation
+    if int(row['kind'])!=40:raise ValueError('reference error requires a sample boundary')
+    source=row['source'].astype(float);x=row['x'].astype(float)
+    q=row['q'].astype(float)
+    estimate=Rotation.from_quat(np.r_[q[1:],q[0]])
+    truth=Rotation.from_euler('xyz',source[24:27]).inv()
+    theta=(truth*estimate.inv()).as_rotvec()
+    return np.r_[theta,-x[3:6],source[3:6]-x[6:9],source[:3]-x[9:12],
+                 source[9:12]-x[12:15],source[6:9]-x[15:18],
+                 source[18:21]-x[18:21],source[18:21]]
+
+
+def state_difference(a,b):
+    return reference_error(b)-reference_error(a)
+
+
+def analyze_pair(base,other):
+    # Mismatched guard paths are an explicit attachment failure, never zipped
+    # away or repaired by dropping the extra event.
+    same=np.array_equal(base[['kind','sample','active']],other[['kind','sample','active']])
+    result={'event_paths_equal':same,'records_baseline':len(base),'records_perturbed':len(other)}
+    if not same:
+        result['classification']='HYBRID_PAIR_PATH_MISMATCH_REQUIRES_BRANCH_GRAPH'
+        return result
+    solve=np.flatnonzero(np.isin(base['kind'],[10,11,12]))
+    if not len(solve): raise ValueError('word has no actual measurement solves')
+    stats=[gain_pair_identity(base[i],other[i]) for i in solve]
+    worst=int(np.argmax([s['endogenous_correction_norm'] for s in stats])); idx=int(solve[worst])
+    start,end=state_difference(base[0],other[0]),state_difference(base[-1],other[-1])
+    result.update(qualification='ACTUAL_FINITE_PAIRED_WORD_ATTACHMENT_DIAGNOSTIC',
+        solve_count=len(solve), counts={KIND[k]:int(np.count_nonzero(base['kind']==k)) for k in KIND},
+        initial_joint24_increment=start.tolist(), final_joint24_increment=end.tolist(),
+        initial_covariance_increment_norm=float(np.linalg.norm(base[0]['P'].astype(float)-other[0]['P'].astype(float))),
+        max_frontend_increment=float(np.max(np.abs(base['frontend'].astype(float)-other['frontend'].astype(float)))),
+        max_mag_reference_increment=float(np.max(np.abs(base['mag_reference'].astype(float)-other['mag_reference'].astype(float)))),
+        max_hard_iron_increment=float(np.max(np.abs(base['hard_iron'].astype(float)-other['hard_iron'].astype(float)))),
+        largest_endogenous_term={**stats[worst],'sample':int(base[idx]['sample']),'event':KIND[int(base[idx]['kind'])]},
+        maximum_row_identity_residual=max(s['equality_max_abs'] for s in stats),
+        maximum_correction_identity_residual=max(s['correction_identity_max_abs'] for s in stats),
+        maximum_measured_row_solve_defect=max(s['row_solve_defect_max_abs'] for s in stats),
+        checks_80_120=[high_precision_pair(base[idx],other[idx],d) for d in (80,120)],
+        source_uniform_cover=False, hard_entry_qualified=False, common_metric_searched=False,
+        rho=None, contraction_margin=None, maximum_generalized_direction=None,
+        prefix_chart_retention_certified=False, finite_precision_enclosure=False)
+    # A raw Euclidean quantity with mixed units is deliberately not called rho.
+    return result
+
+
+def source_contract():
+    """Sufficient analytic kinematic bounds, not the complete theorem's PE cover."""
+    import math
+    w=math.pi/4
+    p=math.sqrt(0.3**2+0.2**2+1.0**2)
+    return {'type':'continuous harmonic kinematic subfamily; analytic bounds, no sampled maxima',
+        'position_norm_upper_m':p,'velocity_norm_upper_mps':w*p,
+        'acceleration_norm_upper_mps2':w*w*p,'centered_primitive_any_u_t_upper_ms':2*p/w,
+        'body_rate_norm_upper_radps':w*(.12+1.25*.09+.75*.08),
+        'translation_frequency_hz':.125,
+        'S_origin':'first actual Live sample, retained across all word boundaries',
+        'sensor_equation':'acc=R_bw^T*(a-g*ez)+beta; gyro=exact Euler body rate; mag=R_bw^T*B',
+        'lever_arm':0,'temperature_C':35,
+        'BRMM_full_admission':False,'PE_admission':False,
+        'kinematic_envelope_sufficient':p<=8.1 and w*p<=5.5 and w*w*p<=8.8 and 2*p/w<=1100,
+        'probes_are_not_source_cover':True}
+
+
+def bias_contracts():
+    """Read-only definitions plus analytic membership of the chosen examples."""
+    import importlib, math
+    result={}
+    for i in range(3):
+        module=importlib.import_module(f'tools.stability.ou3_p4_bias{i}_family')
+        definition=module.build();failures=module.validate(definition)
+        if failures:raise ValueError(f'BIAS{i} definition failed: {failures}')
+        if i==0:
+            ok=(definition['gauss_markov_component_abs_upper_mps2']>=.005
+                and definition['gauss_markov_tau_true_s'][0]<=900<=definition['gauss_markov_tau_true_s'][1]
+                and definition['turn_on_offset_component_abs_upper_mps2']>=.025
+                and definition['non_gauss_markov_component_abs_upper_mps2']>=.002
+                and definition['non_gauss_markov_rate_abs_upper_mps3']>=.002*2*math.pi/900)
+            channels='GM=.005*exp(-t/900), offset<=.025, nonGM sine .002/900s; thermal=strain=0'
+        elif i==1:
+            ok=(definition['root_component_abs_upper_mps2']>=.05
+                and definition['tau_true_s'][0]<=1200<=definition['tau_true_s'][1]
+                and definition['sinusoid_component_amplitude_abs_upper_mps2']>=.01
+                and definition['sinusoid_period_s'][0]<=600<=definition['sinusoid_period_s'][1])
+            channels='root<=.05, tau=1200s, sine .01/600s, deterministic mismatch=0'
+        else:
+            ok=(definition['true_bias_component_abs_upper_mps2']>=.045
+                and definition['variation_rate_abs_upper_mps3']>=.005*2*math.pi/900)
+            channels='phi_true=1; offset<=.04 plus .005/900s sine; magnitude<=.045'
+        if not ok:raise ValueError(f'BIAS{i} analytic example no longer fits definition')
+        result[f'BIAS{i}']={'definition_validator_pass':True,'analytic_example_parameter_membership':ok,
+            'channels':channels,'declared_driver_component_upper':definition['driver_increment_component_abs_upper_mps2'],
+            'hardware_admission':False,'fresh_Live_admission':False,'binary32_source_roundoff_enclosed':False}
+    return result
+
+
+def run(output,work,eigen,verify_uninstrumented=False):
+    work.mkdir(parents=True,exist_ok=True)
+    overlay=work/'include'; dst=overlay/'kalman_ou_iii'; dst.mkdir(parents=True,exist_ok=True)
+    (dst/HEADER.name).write_text(instrument_header((ROOT/HEADER).read_text()))
+    (dst/FUSION.name).write_text(instrument_fusion((ROOT/FUSION).read_text()))
+    binary=work/'shipping-word'
+    command=[os.environ.get('CXX','g++'),'-O1','-DEIGEN_UNROLLING_LIMIT=0','-std=c++20','-DEIGEN_NON_ARDUINO',
+        '-I'+str(overlay),'-I'+str(ROOT/'src'),'-isystem',str(eigen),
+        str(ROOT/'tests/ou3_alt_contraction/shipping_word.cpp'),'-o',str(binary)]
+    fingerprints={str(p):hashlib.sha256((ROOT/p).read_bytes()).hexdigest()
+        for p in (HEADER,FUSION,Path('src/kalman_ou_common/KalmanOUCoreMath.h'),
+                  Path('tests/ou3_alt_contraction/shipping_word.cpp'))}
+    producer={'source_sha256':fingerprints,'compiler_command':command,
+              'compiler_version':subprocess.check_output([command[0],'--version'],text=True).splitlines()[0],
+              'temporary_Kalman_sha256':hashlib.sha256((dst/HEADER.name).read_bytes()).hexdigest(),
+              'temporary_Fusion_sha256':hashlib.sha256((dst/FUSION.name).read_bytes()).hexdigest()}
+    (work/'producer.json').write_text(json.dumps(producer,indent=2)+'\n')
+    subprocess.run(command,check=True)
+    subprocess.run([str(binary),str(work)],check=True)
+    if verify_uninstrumented:
+        plain=work/'uninstrumented';plain.mkdir(exist_ok=True)
+        plain_command=[v for v in command if v!='-I'+str(overlay)]
+        plain_command[-1]=str(plain/'shipping-word')
+        subprocess.run(plain_command,check=True)
+        subprocess.run([plain_command[-1],str(plain)],check=True)
+        producer['transparency']=verify_transparency(work,plain)
+        (work/'producer.json').write_text(json.dumps(producer,indent=2)+'\n')
+    return analyze(output,work,command)
+
+
+def verify_transparency(hooked,plain):
+    manifest=json.loads((hooked/'manifest.json').read_text())
+    if manifest!=json.loads((plain/'manifest.json').read_text()):
+        raise ValueError('observation hooks changed actual runtime boundaries')
+    samples=0
+    for word in manifest['words']:
+        for direction in ('base','tilt','held_bias','covariance'):
+            name=word['name']+'-'+direction+'.bin'
+            a=read_trace(hooked/name);b=read_trace(plain/name)
+            a=a[a['kind']==40];b=b[b['kind']==40]
+            if a.tobytes()!=b.tobytes():raise ValueError('hooks changed sample state: '+name)
+            samples+=len(a)
+    return {'sample_records_compared':samples,'all_sample_records_bit_identical':True,
+            'scope':'these executions and this compiler, NOT an all-input instrumentation theorem'}
+
+
+def analyze(output,work,command=None):
+    manifest=json.loads((work/'manifest.json').read_text())
+    report={'schema':1,'qualification':'ACTUAL_SHIPPING_FINITE_INCREMENT_ATTACHMENT_EXPERIMENT',
+        'ALT_LIVE_PASS':False,'ALT_STARTUP_PASS':False,'ALT_END_TO_END_PASS':False,
+        'P4_promoted':False,'P5_promoted':False,'source':source_contract(),
+        'source_sha256':{str(p):hashlib.sha256((ROOT/p).read_bytes()).hexdigest() for p in (HEADER,FUSION)},
+        'execution':manifest,'pairs':{},'operand_bindings':{},'reference_words':{},'compiler_command':command,
+        'analysis_sha256':{str(p):hashlib.sha256((ROOT/p).read_bytes()).hexdigest() for p in
+            (Path('tools/stability/ou3_alt_contraction/shipping_word.py'),
+             Path('tools/stability/ou3_alt_contraction/shipping_graph.py'))},
+        'producer':json.loads((work/'producer.json').read_text()) if (work/'producer.json').exists() else None,
+        'bias_definitions':bias_contracts(),
+        'unclosed':['source-uniform joint24 word and reachable covariance/frontend pair relation',
+                    'coercive compatible storage with justified bias/source/roundoff supply',
+                    'full nonlinear high-precision complete-word feasibility and every-prefix charts',
+                    'fresh-Live hard membership, all hybrid guards and deployment roundoff enclosure']}
+    for word in manifest['words']:
+        stem=word['name'];base=read_trace(work/(stem+'-base.bin'))
+        family=int(stem[4])
+        report['reference_words'][stem]={'initial_joint24_error':reference_error(base[0]).tolist(),
+            'final_joint24_error':reference_error(base[-1]).tolist(),
+            'qualification':'diagnostic physical reference chart, no hard membership or coercivity claim'}
+        report['operand_bindings'][stem+'/base']=binding_report(base,family,manifest['dt'])
+        for direction in ('tilt','held_bias','covariance'):
+            other=read_trace(work/(stem+'-'+direction+'.bin'))
+            report['pairs'][stem+'/'+direction]=analyze_pair(base,other)
+            report['operand_bindings'][stem+'/'+direction]=binding_report(other,family,manifest['dt'])
+    if not all(v['measurement_binding_regression_pass'] for v in report['operand_bindings'].values()):
+        report['execution_failure']='measurement operand binding regression failed'
+    output.parent.mkdir(parents=True,exist_ok=True)
+    output.write_text(json.dumps(report,indent=2,sort_keys=True)+'\n')
+    print(json.dumps({'output':str(output),'pairs':len(report['pairs']),
+                      'ALT_LIVE_PASS':False,'source_uniform_cover':False}))
+    if 'execution_failure' in report:raise RuntimeError(report['execution_failure'])
+    return report
+
+
+if __name__=='__main__':
+    ap=argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--output',type=Path,required=True)
+    ap.add_argument('--work',type=Path,required=True)
+    ap.add_argument('--verify-uninstrumented',action='store_true',
+        help='also compile without hooks and demand bit-identical sample-boundary traces')
+    ap.add_argument('--eigen',type=Path,default=Path('/usr/include/eigen3'))
+    a=ap.parse_args()
+    run(a.output.resolve(),a.work.resolve(),a.eigen.resolve(),a.verify_uninstrumented)


### PR DESCRIPTION
## Research question
Continue the independent ALT route from latest main (`347783e469271f8b6ce27e1f9d1296f97dc75bfe`, merged #517): bind finite increments to actual shipping operands before attempting a source-uniform joint24 master. The existing P2/P3/P4/P5 route remains independently continuable and unchanged.

## Executed experiment
- Temporary read-only observation hooks expose the actual masked gain numerator, raw innovation matrix, row-wise LDLT gain solve, nonzero residual, Joseph, reset, projection, source, and frontend/conditioning state. Production source files are not modified.
- Derive conditional measurement identities from the same pre-operation P/q/x/R and actual conditioned sensor input, rather than reconstructing H from P^-1 N. Keep raw S for Joseph separate from LDLT's lower-triangle solve matrix.
- Drive the actual private startup/frontend with continuous analytic physical/bias examples. Invoke and validate BIAS0, BIAS1, and BIAS2 definitions separately. Preserve the first actual Live S origin and the natural H18→A21 release.
- Execute nine baseline words and 27 finite perturbation comparisons across H18, H18→A21, and A21. Preserve full private runtime memory at each root; do not claim the injected roots are source-uniformly reachable.
- Check instrumentation against an independently compiled uninstrumented control: all 21,636 sample-boundary records are bit-identical in these executions.

## Result and limitation
All 27 paired event paths agree and all 36 operand-binding regressions pass. The covariance-only probes have zero initial joint24 state increment but a nonzero endpoint state increment. This falsifies a relaxed incremental graph that allows independent covariance-memory changes while storing only the 24 state/truth increments. It does **not** establish a physical COMPLETE-BRMM counterexample: the perturbed covariance roots have not been qualified as reachable.

The source-uniform reachable memory relation, compatible storage/supply inequality, full nonlinear high-precision complete-word feasibility, every-prefix charts, hard entry/startup admission, and deployment roundoff enclosure remain open. The 80/120-digit checks concern recorded finite row-solve identities only. `rho`, contraction margin, and maximizing generalized direction remain unset rather than being manufactured from these probes.

`ALT_LIVE_PASS=false`, `ALT_STARTUP_PASS=false`, `ALT_END_TO_END_PASS=false`. No P4/P5 promotion, filter changes, source-envelope changes, threshold changes, or replay-fitted metrics.

## Validation
- 33 ALT unit tests pass (15 existing plus 18 attachment/anti-shortcut regressions).
- 36 actual word executions plus matching uninstrumented controls complete locally with explicit Eigen include path and clang++.
- All 36 measurement binding checks pass; 21,600 shared-driver bias prediction steps are checked.
- `git diff --check` passes.
- `make all` was attempted and fails at the unchanged AHRS build: `src/ahrs/KalmanQMEKF.h:30:10: fatal error: Eigen/Dense: No such file or directory` because the default `/usr/include/eigen3` is absent. The targeted experiment uses the available Eigen copy explicitly; this is not a full-build PASS.

The independent ALT workflow now runs the finite-word experiment and transparency control and retains its report and producer manifest. Existing proof workflows are untouched.