### PR TITLE
OU-III ALT: consolidated physical whole-word proof route

### DIFF
--- a/docs/ou3-alt-finite-measurement-proof.md
+++ b/docs/ou3-alt-finite-measurement-proof.md
@@ -1,0 +1,246 @@
+# ALT finite physical measurement identity
+
+## Scope and role in the master inequality
+
+The state is `z=(c,e_bg,e_v,e_p,e_S,e_aw,e_ba,beta)`, with
+`c=2 tan(theta/2) u` and `E=R_true R_hat^T`. These are **finite** errors,
+not perturbations. This note proves the accepted, finite, real-arithmetic,
+zero-lever measurement map used in a fixed-trajectory dissipation argument.
+The actual estimator supplies covariance, geometry, tuning, gain masks and
+measurement conditioning at every event. Their dependence on the trajectory
+is retained; there is no comparison with a second, frozen-gain estimator.
+
+The controlling expression is `V(z_N)-rho V(z_0)-physical/bias supply` over the
+complete literal word. A product of pointwise Jacobians is not an identity
+for `z_N`. In particular the physical S event does not fix zero error when
+`S_phys != 0`. Before evaluating that expression, the word must either compose
+finite maps with all reference offsets, or have a proved anchored mean-value
+representation on the entire required domain. The construction below gives
+finite measurement descriptors directly, without a Taylor remainder or an
+unproved radial-segment bridge. It is a necessary map-construction step, not a
+local contraction certificate or permission to refine an infeasible metric.
+
+The code is `tools/stability/ou3_alt_contraction/finite_measurement_graph.py`.
+Its rational interface evaluates the identities exactly. Universal coefficient
+checks expand all monomials, rather than treating a finite collection of
+sampled states as proof. It intentionally returns no source-coverage or
+stability PASS.
+
+## 1. Exact residual secant
+
+Write `C=[c]x`, `D=4+c^T c`, and
+
+```
+U = 4 I + 2 C + c c^T,
+T = U/D,
+E = I + (4 C + 2 C^2)/D.
+```
+
+Using `C^2=c c^T-(c^T c)I` and `c^T C=0` gives
+
+```
+(I-C/2) U = D I,       E-I = T C.
+```
+
+Consequently, for every vector f, **exactly**
+
+```
+(E-I)f = -T [f]x c.
+```
+
+For an accelerometer event, let `f_hat=R_hat(a_hat-g)` and let `nu_acc` be the
+actual conditioned sensor/model residual relative to `R_true(a_true-g)+beta`.
+Temperature-centering differences belong in that actual model residual unless
+the physical beta definition already includes them. Then
+
+```
+r_acc = -T [f_hat]x c + E R_hat e_aw + e_ba + nu_acc.
+```
+
+The coefficient of e_ba is I in BOTH H18 and A21: holding the estimate does not
+remove a physical bias error from the measurement. For magnetometer data,
+
+```
+r_mag = -T [m_hat]x c + nu_mag,
+nu_mag = measured_conditioned_m - E m_hat.
+```
+
+Thus a learned-reference error or hard-iron/de-heel discrepancy is not silently
+set to zero. Its bound and source ancestry remain required in the full theorem.
+For every due S event,
+
+```
+r_S = e_S - S_phys.
+```
+
+All three cases have the exact form `r=Hbar(z,xi)z+nu`. Hbar is a **secant
+factor**, not the derivative used to compute the gain. The physical S value
+retains its single Live-origin primitive; nu is not permission to create an
+independent bounded S input. All source relations stay in the master.
+
+## 2. The actual masked gain and held covariance
+
+Use the full physical 21-state covariance even in held mode. In symmetric real
+arithmetic and the accepted unrepaired positive-innovation branch, let H be the
+shipping linearization, H_g its column-masked version and D_h the row mask:
+
+```
+Sigma = H P H^T + R,
+N = D_h P H_g^T,
+Sigma q = r,             delta = N q.
+```
+
+In A21 both masks are identity. In H18 the BA columns of H_g and BA rows of N
+are zero, but H used for Sigma still contains BA. This is exactly the distinction
+in `measurement_update_acc_only`; it is not an unmasked information-form
+replacement. The raw Joseph covariance polynomial remains
+
+```
+P_after = P - K N^T - N K^T + K Sigma K^T.
+```
+
+**Held covariance reduction.** Conditional on the existing held invariant
+`P=diag_block(P18,B0)` with zero BA cross blocks, the accelerometer operands are
+
+```
+Sigma_H = H18 P18 H18^T + R_acc + B0,
+N_H = [P18 H18^T; 0].
+```
+
+For arbitrary P18, this follows by block multiplication, not by fitting a
+trajectory. Substitution into the actual Joseph polynomial leaves BA cross
+blocks zero and B0 unchanged; the motion covariance is exactly the reduced
+18-state covariance update with **effective noise R_acc+B0**. Magnetometer and
+S residual Jacobians have no BA column and need no such addition. Prediction
+and reset preserve the block invariant when their held BA blocks are identity,
+BA process covariance is zero, and their other blocks do not mix BA. The
+queued a_w covariance addition has no BA rows or columns.
+
+This is a covariance computation reduction, NOT an 18-state error/storage
+reduction. The finite residual still contains e_ba and the storage still has
+24 coordinates and all cross terms. A kernel using bare R_acc in the reduced
+H18 gain needs this bridge and corrected covariance ancestry before its word
+can stand for shipping. Merely fixing the final gain does not fix earlier P.
+
+The existing release-floor lemma uses the same B0 at enable, so
+`max(B0_ii,B0_ii)=B0_ii` exactly. Its interval implementation must enclose the
+real seed product and apply max by endpoint selection; an additional numerical
+widening of max is not a mathematical change of the covariance fixed point.
+
+## 3. Exact finite quaternion injection
+
+At a normal measurement boundary the nominal local attitude-error slots are
+zero (initialization and every successful injection clear them; prediction
+propagates the reference quaternion rather than assigning those slots).
+Let `d=delta[0:3]`. Shipping constructs the normalization of `(w,k d)`, with
+`u=d^T d` and the following real-arithmetic branches:
+
+```
+||d|| < 1/100:
+  w = 1-u/8+u^2/384,
+  k = 1/2-u/48+u^2/3840;
+otherwise:
+  w = cos(||d||/2),
+  k = sin(||d||/2)/||d||.
+```
+
+These are the two branches of `quat_from_delta_theta`. They remain hard graph
+relations. Neither the small polynomial nor its derivative replaces the other
+branch. The point `||d||=1/100` belongs to the axis-angle branch.
+
+The estimator injects on the left, so the physical relative attitude satisfies
+`E_after=E Q(d)^T`. Multiplying homogeneous quaternions `(2,c)` and `(w,-k d)`
+gives
+
+```
+W = 2w + k c^T d,
+V = w c - 2k d - k c cross d,
+c_after = 2V/W.
+```
+
+For every c,d,w,k with nonzero W, normalization cancels and subtraction yields
+
+```
+W(c_after-c) + k U d = 0,
+c_after = c - L(c,d) d,
+L(c,d) = k U/W.
+```
+
+This is a polynomial identity after clearing the denominator, valid for all
+values of its eight scalar indeterminates, and therefore for both deployed
+quaternion branches. No small-angle replacement `c_after=c-d` is used. W=0 is
+not accepted by the finite chart evaluator. A uniform separation from that
+pole is still an every-prefix/chart-retention obligation, not a supplied fact.
+
+## 4. Projection and the full finite descriptor
+
+Lift N into a thin 24-by-3 factor B: its attitude rows are `L N_theta`, its
+remaining estimated-error rows are the corresponding rows of N, and its beta
+rows are zero. The pre-projection error is exactly `z_pre=z-Bq`.
+
+Set `b_pre=beta-e_ba_pre`. The radial projection has the exact graph
+
+```
+alpha=1                    when ||b_pre|| <= R_b,
+0<alpha<1,
+alpha^2 ||b_pre||^2=R_b^2   when ||b_pre|| > R_b.
+```
+
+Then `e_ba_after=alpha e_ba_pre+(1-alpha)beta`. Let P_alpha be identity except
+for precisely those BA/error-truth blocks. The full mean map is
+
+```
+z_after = P_alpha (z-Bq),
+Sigma q = Hbar z + nu,
+d = N_theta q.
+```
+
+The same projection runs after injection in held mode. Taking alpha=1 there
+requires the actual held estimate already be inside the projection ball; it
+must not be assumed from a covariance-consistency claim.
+
+The implementation uses `chi=(z24,q3,nu3,h)` with h=1. Its descriptor equalities
+include both `N_theta q=d h` and `z[0:3]=c h`, so the finite-correction parameters
+cannot be detached from the state and innovation variables. Quaternion and
+projection branch graphs, P/H/R ancestry, conditioned-sensor relations and the
+physical source constraints remain additional hard constraints. Matrices
+computed at one point alone do not certify that family.
+
+## 5. Exact storage contribution using thin factors
+
+For any symmetric common 24-by-24 M, put `M_alpha=P_alpha^T M P_alpha`.
+Expanding the finite map, with no omitted cross terms, gives
+
+```
+V_after-V_before =
+  z^T(M_alpha-M)z
+  -2 z^T M_alpha B q
+  +q^T (B^T M_alpha B) q.
+```
+
+M_alpha is computed by the three affected bias columns and rows, not a dense
+24-state congruence. The measurement work uses `M_alpha B` (24-by-3) and
+`B^T M_alpha B` (3-by-3). This is exact thin-factor arithmetic on full storage;
+it does not freeze any gain, delete true bias, or assert low rank of the whole
+word. A later derivative of this graph must still retain derivatives of B and
+all its endogenous coefficient factors; rank three of its value correction does
+not bound the rank of that derivative. The contribution can be summed inside
+the one physical word with its hard constraints before deciding the sign. There is no claim that individual
+measurements must be contractive.
+
+## Remaining bridge and non-promotion
+
+These identities close the finite accepted-measurement algebra. They do not
+close continuous physical attitude-versus-sampled-gyro prediction forcing,
+all covariance/frontend successors and repairs, the asynchronous branch family,
+or a complete finite endpoint/prefix certificate. The current
+`physical_word.compose_endpoint_lineage` produces Jacobian products; those
+must not be submitted as the finite map in a storage search. The executable
+finite-master guard rejects that representation before the coarse endpoint
+or metric calculation starts.
+
+Binary32 row-wise LDLT solves, raw innovation asymmetry, scalar accumulation,
+normalization, projection and covariance updates need their actual numerical
+residual relations. The real formulas above do not bound them. BIAS family
+admission, a useful ultimate bound, startup capture and all final ALT gates
+remain separate. Original P2/P3/P4/P5 machinery is unchanged.

--- a/docs/ou3-alt-main-handover.md
+++ b/docs/ou3-alt-main-handover.md
@@ -1,0 +1,66 @@
+# OU-III ALT post-merge handover
+
+Resume from latest `main` after PR #522. Read, in order:
+
+1. `AGENTS.md`
+2. `docs/ou3-alt-proof-plan.md`
+3. `docs/ou3-alt-finite-measurement-proof.md`
+4. `docs/ou3-alt-contraction.md`
+5. the ALT section of `docs/ou3-proof-research-state.md`
+6. `docs/ou3-brmm-main-handover.md`
+
+The original P2/P3/P4/P5 proof remains an independently continuable route. ALT must not rewrite it, consume its PASS labels as ALT proof, or import its PE/vector mismatch unless ALT genuinely needs that lemma.
+
+## What is genuinely proved on ALT
+
+- Exact finite accepted-measurement algebra on joint24, including finite Cayley reset, exact secant residuals, physical `r_S=e_S-S_phys`, actual H18/A21 gain masking, radial bias projection, and thin rank-3 storage contribution without state reduction.
+- Exact H18 held-covariance invariant and conditional H18->A21 covariance map: BA cross blocks stay zero, the hidden BA marginal stays at the configured seed variance, and the enable-floor is a fixed point on that invariant.
+- Separate analytic BIAS0/1/2 contracts with one persistent physical history/root token and one shared driver entering both `e_ba` and `beta`.
+- Exact finite prediction algebra for attitude, translation, and physical accelerometer bias. Translation uses the existing correlated q15 `(a0,a1,J0,J1,J2)` forcing relation.
+- The deployed quaternion predictor is source-uniformly inside the polynomial branch on the declared regional Live domain: the worst shadow increment is about `0.00311 rad < 0.01 rad`.
+- Regional Live/source lineage machinery is separated from startup capture. Startup remains a separate theorem.
+- Anti-dead-end guards are executable: replay, unreachable perturbations, Jacobian cocycles, incomplete source tokens, and premature common-metric/rho searches are blocked from promotion.
+
+## What is NOT proved
+
+- The complete finite 600-step physical word is still OPEN. `physical_word.py` currently composes pointwise Jacobians/source responses and is explicitly not a finite endpoint identity.
+- The exact finite measurement and prediction descriptors have not yet been composed through all literal covariance/frontend successors, due-S events, asynchronous magnetometer events, H18/A21 branches, and the H18->A21 splice into one source-uniform finite word.
+- No common joint24 storage, source-uniform rho, useful ultimate bound, every-prefix chart-retention certificate, deployment finite-precision enclosure, startup capture, or end-to-end theorem exists yet.
+- `ALT_LIVE_PASS=false`, `ALT_STARTUP_PASS=false`, `ALT_END_TO_END_PASS=false`.
+- Original P4/P5 remain unpromoted by ALT.
+
+## Next theorem obligation — do this first
+
+Build a **finite physical word composer**, replacing the remaining derivative/Jacobian word representation. It must compose the exact finite prediction and measurement descriptors along the already-admitted same-history source relation while retaining:
+
+1. one BRMM generator and one Live S origin over the full word;
+2. the correlated q15 forcing relation, never independent per-step boxes;
+3. one BIAS-family root/history token and the same driver in truth/error recurrences;
+4. actual covariance/frontend/tuner successors and actual anisotropic `R_S`;
+5. H18 held covariance with BA uncertainty retained in innovation, then the exact H18->A21 covariance splice when the literal release guard fires;
+6. every configured due-S and accelerometer event and all admitted asynchronous magnetometer branches;
+7. finite Cayley reset/projection branch graphs and chart denominators;
+8. physical reference forcing, especially `S_phys` and continuous-physical-vs-sampled-gyro attitude forcing.
+
+Only when the finite-word guard closes may the first common coercive joint24 storage search run. Search one common `M` first. Parameter-dependent or piecewise storage is allowed only after a genuine falsified common-M attempt on the complete finite master. Rank-3 structure is an exact arithmetic optimization only.
+
+## Dead-end guards to preserve
+
+Do not:
+
+- use replay or finite seeds as theorem evidence;
+- perturb unreachable covariance/frontend roots and call that physical admission;
+- freeze `K`, `P`, frontend, tuner, or guard state;
+- replace the finite map by products of Jacobians;
+- Cartesianize correlated source variables or bias history;
+- reset `S` per word or re-anchor physical displacement;
+- marginalize A21 to motion-only storage;
+- import the old PE/vector mismatch unless ALT actually requires that lemma;
+- shrink the declared source/error domain or lower the frozen P3 delta;
+- run common-metric/rho/high-precision refinement before the complete finite physical word exists.
+
+## Handover validation state
+
+PR #522 was mergeable at handover preparation. Its head immediately before adding this file was `8c5f460c170ae92dbebac87ea42dda117046f026`; this handover commit advances that head. CI for the preceding head had started but was still pending/queued, so merging must not be interpreted as an all-CI-green claim. Earlier focused finite-map tests passed; broader-suite/environment limitations are documented in PR #522. The shipping filter itself is unchanged by ALT proof tooling.
+
+For the next conversation, start a new PR from latest `main` and continue only the finite-word obligation above. Do not resurrect superseded PRs #519/#520/#521 or their replay/finite-perturbation diagnostics as theorem evidence.

--- a/docs/ou3-alt-proof-plan.md
+++ b/docs/ou3-alt-proof-plan.md
@@ -139,20 +139,37 @@ If (1) has no concrete answer, do not run it.  If (2) is diagnostic-only, run it
 only when it can falsify the *current complete theorem candidate*; never open a
 proof PR whose main deliverable is such a diagnostic.
 
+### G13 — A derivative cocycle is not a finite physical master
+
+The six Phase-1 assembly flags are necessary bookkeeping, not an equality for
+finite errors. Before a common-M, rho, high-precision or endpoint-refinement
+attempt, `proof_plan.assert_finite_storage_master` must validate the declared
+representation. A Jacobian product, a source token, or a collection of TRUE
+metadata fields cannot replace an exact finite graph or a proved anchored
+mean-value representation. Nonzero physical S and other reference offsets must
+remain present, as must all coefficient product and branch graphs.
+
+The common-metric entry point and its candidate helper invoke this guard before
+building a covariance outer or loading fresh-entry scales. They reject the
+current `physical_word` Jacobian cocycle. Substituting a thinner gain enclosure
+or a different metric does not discharge this missing identity.
+
 ## Current physical-map obligation
 
-The immediate ALT work is Phase 1, not storage search.  Shared main already has
-rigorous same-history translational forcing and its joint 15D physical source
-sector.  ALT must consume those facts and complete the missing physical
-reference terms:
+The accepted, finite, real-arithmetic accelerometer, magnetometer and S graphs
+are proved in [the finite measurement note](ou3-alt-finite-measurement-proof.md).
+They include the exact Cayley injection, both quaternion branches, same-beta
+radial projection and a thin-factor full joint24 storage identity. In held mode,
+BA uncertainty remains in the innovation: the reduced accelerometer covariance
+uses R_acc+B0, not bare R_acc. This is not an error-state reduction.
 
-- preserve the exact prediction forcing generated from the same committed tau;
-- use `r_S=e_S-S_phys` at every due S event with the same centered primitive;
-- preserve the BIAS0/1/2 true-bias/error recurrence and H18 held-bias residual;
-- bind all of the above to the estimator-owned source cells and literal event
-  order, including accepted/rejected branches.
-
-Only after this complete finite physical word is materialized may Phase 3 begin.
+The complete finite word remains OPEN. Connect these graphs to the actual
+covariance/frontend successors, preserve physical continuous-rotation versus
+sampled-gyro prediction forcing, and cover every configured accepted/rejected
+and asynchronous branch with the same source/primitive/bias ancestry. Either
+compose finite descriptors directly or prove the complete anchored mean-value
+bridge. Do not present pointwise Jacobian products as the finite endpoint map.
+Only a closed finite master may enter the first common joint24 storage search.
 
 ## Promotion state
 

--- a/docs/ou3-alt-proof-plan.md
+++ b/docs/ou3-alt-proof-plan.md
@@ -1,0 +1,166 @@
+# OU-III ALT proof execution plan — theorem work only
+
+This plan is normative for the parallel ALT route.  It exists to prevent
+research time being spent on attractive diagnostics that cannot discharge the
+shipping stability theorem.  The original P2/P3/P4/P5 route remains separate
+and independently continuable.
+
+## Target theorem chain
+
+ALT work proceeds only through this dependency chain:
+
+1. **Physical finite error map.**  Materialize the true-minus-estimate shipping
+   map on the corrected COMPLETE-BRMM source, including model mismatch,
+   physical-reference forcing, BIAS0/1/2 ancestry, actual covariance/frontend
+   coefficients and every shipping branch.
+2. **Literal source-uniform Live word.**  Compose every prediction, floor,
+   due/rejected S update, accelerometer, magnetometer, reset, projection,
+   clamp/acceptance branch and H18/A21 mode edge on one same-history source.
+3. **Common joint24 storage feasibility.**  Only after (2), search one common
+   coercive joint24 metric with bounded neutral/source supply.  Use rank-three
+   arithmetic as an exact implementation optimization, never as a state
+   reduction.
+4. **Rigorous source-uniform certificate.**  Outward-check the common storage,
+   all source sectors, endpoint and every-prefix inequalities, metric
+   compatibility, first-exit/chart retention and finite precision.
+5. **Live basin and hybrid continuation.**  Certify H18, A21, H18->A21 and
+   every allowed subsequent edge indefinitely.
+6. **Startup capture.**  Separately prove Mahony/proxy/learning reaches the
+   certified Live basin for both measured-period takeover and prior-frequency
+   timeout.  Only then compose an end-to-end theorem.
+
+No later phase may be started because an earlier one “looks numerically good.”
+
+## Mandatory anti-dead-end guards
+
+Every ALT task, commit and PR must name the theorem obligation it changes from
+OPEN toward CLOSED.  If it cannot do that, it is not ALT proof work.
+
+### G1 — Physical admissibility
+
+Proof evidence must quantify the corrected COMPLETE-BRMM family and one of the
+admitted BIAS0/BIAS1/BIAS2 histories.  Replay, finite seeds, synthetic
+unreachable state/covariance perturbations and captured trajectories may only
+falsify an algebraic implementation; they can never qualify a theorem set,
+metric, source bound or basin.
+
+### G2 — Same-history ancestry
+
+Physical source, true bias, estimator state, covariance, frontend/tuner,
+scheduler/guards, geometry, actual R_S and every event coefficient must descend
+from one source lineage.  Independent P/H/R/K, f/sigma/tau/T_S/R_S, source
+moment or guard boxes are forbidden unless a proved outer-relation theorem
+explicitly permits the relaxation.
+
+### G3 — No homogeneous-truth shortcut
+
+A filter model is not a physical truth model.  Prediction must retain the exact
+same-history defect.  For translation this includes
+
+`u=[J0-phi_va a0, J1-phi_pa a0, J2-phi_Sa a0, a1-alpha a0]`.
+
+The existing joint 15D `(a0,a1,J0,J1,J2)` sector is the required source object;
+its moments may not be Cartesianized.  A homogeneous error prediction is
+allowed only where a source identity proves its defect is zero.
+
+### G4 — Physical S=0 residual
+
+For `e_S=S_phys-S_hat`, the shipping pseudo-measurement residual is
+
+`r_S = -S_hat = e_S - S_phys`,
+
+not `e_S`.  `S_phys` must retain the one-time Live origin and physical primitive
+ancestry.  Wordwise re-zeroing, the legacy 300 m*s error ball, or silently
+setting `S_phys=0` is forbidden.
+
+### G5 — Bias is one physical history
+
+The true bias and bias-error recurrences share one driver/root.  Equivalently,
+for an estimator factor `phi_hat`,
+
+`e_ba+ = phi_hat e_ba + beta+ - phi_hat beta`.
+
+H18 hold is `phi_hat=1`.  H18 accelerometer residuals retain the held
+`e_ba`; A21 retains the projection and true-bias cross information.  Two
+independent bias drivers or fresh per-sample truth slots are forbidden.
+
+### G6 — Complete word before storage
+
+No rho search, common metric optimization, parameter-dependent metric search,
+or high-precision contraction calculation is allowed until the literal
+physical word graph contains every shipping event/branch and its source
+forcing.  High precision cannot repair a missing term.
+
+### G7 — Common storage first
+
+Once the master is complete, search a single common joint24 storage with
+bounded neutral/source supply first.  Metrics may not be fitted to replay.
+If two source-uniform attempts fail by the same limiting mechanism, stop and
+perform the AGENTS architecture review: record the failure, compare at least
+three qualitatively different alternatives, and only then consider
+source-dependent or piecewise storage.
+
+### G8 — Rank-three means arithmetic, not theorem reduction
+
+Use `Psi-K(H Psi)`, thin Joseph factors, 3D innovation variables and rank-at-most
+six storage corrections where exactly equivalent.  Never drop state
+coordinates, covariance/source dependencies, motion-bias cross terms,
+`delta N*q`, `delta S*q`, or finite reset/projection coupling merely because a
+measurement has dimension three.
+
+### G9 — Hybrid and prefix closure
+
+Endpoint decay alone cannot promote ALT.  Every literal prefix must remain in
+its nonlinear/chart domain, every accepted/rejected branch must be covered,
+and H18/A21 plus H18->A21 storage/guard compatibility must close.  No hidden
+metric restart, bias root restart or S-origin restart is permitted.
+
+### G10 — Finite precision is a promotion prerequisite
+
+Real-arithmetic identities are intermediate lemmas only.  ALT_LIVE_PASS cannot
+become true until actual binary32 Eigen/LDLT, Joseph, reset, projection, floor
+and relevant frontend numerical defects have an outward additive enclosure.
+
+### G11 — Startup remains downstream of a real Live basin
+
+Live-word proof work must not import Mahony startup or the old route's PE/vector
+mismatch.  Startup is addressed only after a quantitative ALT Live basin exists,
+and must cover both measured-period takeover and prior-frequency timeout.
+
+### G12 — Stop rule
+
+Before executing a computation, answer both questions:
+
+1. Which theorem obligation can this make strictly stronger or close?
+2. Is every input an admitted analytic/source-uniform object, or is the result
+   only diagnostic?
+
+If (1) has no concrete answer, do not run it.  If (2) is diagnostic-only, run it
+only when it can falsify the *current complete theorem candidate*; never open a
+proof PR whose main deliverable is such a diagnostic.
+
+## Current physical-map obligation
+
+The immediate ALT work is Phase 1, not storage search.  Shared main already has
+rigorous same-history translational forcing and its joint 15D physical source
+sector.  ALT must consume those facts and complete the missing physical
+reference terms:
+
+- preserve the exact prediction forcing generated from the same committed tau;
+- use `r_S=e_S-S_phys` at every due S event with the same centered primitive;
+- preserve the BIAS0/1/2 true-bias/error recurrence and H18 held-bias residual;
+- bind all of the above to the estimator-owned source cells and literal event
+  order, including accepted/rejected branches.
+
+Only after this complete finite physical word is materialized may Phase 3 begin.
+
+## Promotion state
+
+`ALT_LIVE_PASS=false`
+
+`ALT_STARTUP_PASS=false`
+
+`ALT_END_TO_END_PASS=false`
+
+Existing `P4_PASS` / `P5_MAY_START` are not controlled by ALT and remain
+untouched by this plan.

--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -206,124 +206,93 @@ witness is outside corrected COMPLETE-BRMM and may not be recycled as A or B.
 
 ## Parallel ALT contraction/dissipativity track
 
-The independent track is specified in `docs/ou3-alt-contraction.md`. The
-existing architecture, its next sequence above, and all P2/P3/P4/P5 gates remain
-unchanged. ALT does not promote those gates. The current ALT research question
-is whether an inverse-free whole-word joint24 dissipation formulation is a
-viable alternative, not whether isolated algebra tests establish stability.
+Continue only PR #522 (`proof/ou3-alt-physical-master`) while it is open. The
+original P2/P3/P4/P5 route and the sequence above remain independently
+continuable. ALT does not promote their gates or consume them as a replacement
+for its own complete-word certificate. The normative ALT execution plan is
+`docs/ou3-alt-proof-plan.md`.
 
-### Current hypothesis and exact architecture failures
+### Current hypothesis and exact positive result
 
-Keep a coercive joint24 storage, but charge non-decaying held-error/true-bias
-coordinates through bounded, same-history supply ports. Seek strict decay of
-the motion performance with finite ultimate bounds, not contraction of the
-physical source itself.
+Use a same-trajectory finite physical joint24 descriptor and common coercive
+storage with bounded neutral/source supply. Strict homogeneous decay of held
+bias and BIAS2 constant truth is not the target: a persistent coordinate cannot
+contract in a uniformly coercive metric. Do not discard motion/bias cross terms.
 
-The stricter common-metric target fails structurally: a held coordinate or
-BIAS2 constant truth supplies an identity block. If `A v = v != 0`, then
-`v^T(A^T M A - rho M)v = (1-rho)v^T M v > 0` for every SPD common M and
-`rho < 1`. This invalidates strict homogeneous contraction of the entire
-augmented state; it does not invalidate motion ISS or the existing proof.
-Limiter: an exact neutral direction, not interval width. The independent
-critic's strongest objection is that merely renaming P4 as contraction cannot
-remove that direction. Alternatives are (1) bounded-bias supply with full
-joint storage, (2) a quotient/incremental metric at fixed physical source,
-and (3) finite-duration held-mode storage followed by active-mode performance
-storage. The first is selected without dropping bias cross-information.
+The accepted real-arithmetic measurement graph now has an exact finite form,
+not a linearized reset. With C=[c]x, U=4I+2C+cc', the deployed quaternion
+parameters w,k and correction d give
 
-A second shortcut fails at the shipping H18 gain mask: the actual `PCt` is not
-unconditionally the full residual Jacobian's `P H^T`. The unqualified full-state
-information-addition identity is therefore not an allowed rewrite. Retain
-`S q = r`, `delta_e = -N q`, with actual `N=PCt`, and the implemented Joseph
-polynomial. An effective H18 information model requires its own invariant
-bridge. This is a proof-method mismatch, not a filter defect.
+`W=2w+k*c'd`, `W*(c_after-c)+k*U*d=0`.
 
-### Shared-contract execution failure
+The coefficient identity holds for all c,d,w,k, so it covers both quaternion
+branches subject to their actual hard graphs and a nonzero Cayley denominator.
+Together with exact residual secants and the same-beta radial projection it
+gives `z_after=P_alpha*(z-B*q)`, `Sigma*q=Hbar*z+nu` with a 24x3 B. The exact
+storage contribution retains every joint cross term and uses a 3x3 core. See
+`docs/ou3-alt-finite-measurement-proof.md` for the derivation, hypotheses and
+source/numerical limitations. This is finite-map algebra, not a contraction or
+source-cover PASS.
 
-`ou3_p4_bias_family_joint_iss_supply.build()` currently stops in
-`ou3_p4_hard_entry_set.build()` with:
+H18 covariance must retain the latent BA marginal. On the held zero-cross-block
+invariant, the reduced accelerometer innovation is
+`H18*P18*H18'+R_acc+B0`. A kernel using bare R_acc has not implemented that
+shipping relation; changing only its last gain would leave its earlier P
+ancestry wrong. The finite graph requires the full 21-state operands and keeps
+held e_ba in the residual. The 24-state storage is not marginalized.
 
-`qualified fresh-entry source failed: ['all_hard_entry_coordinates_inside_full_scale not true', 'source_uniform_reachable_other_entry_coordinates_closed not true', 'fresh_live_entry_cover_closed not true', 'one or more coordinate memberships failed']`.
+### Limiter and failure classification
 
-Classification: entry/working-domain qualification failure. This invalidates
-using the aggregate supply builder as already-qualified ALT entry evidence.
-It does not invalidate the separately defined BIAS0/BIAS1/BIAS2 recurrences.
-Limiter: fresh-Live hard membership, not covariance consistency. Critic:
-consuming the aggregate as a successful theorem would import an unproved
-startup assumption. Next falsifiable experiment: invoke each family definition
-and validator separately, preserve their exact shared-error/truth recurrence
-in the new lift, and report aggregate entry admission as false. No change to
-the shared builder or admission gate is authorized by this experiment.
+**C — finite-map/derivative representation gap.** The current endpoint object
+is made from pointwise Jacobian and source-derivative products. Without a finite
+identity or an anchored mean-value theorem, those products do not give the
+physical endpoint error; F(0) is nonzero at a physical S event. Thus the earlier
+Phase-1 assembly labels are not a closed finite-state master. This invalidates
+using that object directly in a finite-state common-storage inequality. It
+does not prove filter instability or invalidate the separate original route.
+The common-metric entry point and candidate helper now reject it before any
+coarse endpoint calculation or scale-based candidate is constructed.
 
-Local `make all` is infrastructure-blocked at `tests/ahrs/ahrs-qmekf-sim.cpp`
-because `Eigen/Dense` is absent from `/usr/include/eigen3`. This is not a
-mathematical failure. The independent CI installs Eigen before the unchanged
-shipping observer is built.
+The controlling missing quantity is the complete **finite** same-history error
+map and its physical reference forcing, not an interval pivot or a near-one
+rho. No source-uniform rho or failed common-metric impossibility is claimed.
+No interval refinement is authorized merely by naming the endpoint family.
 
-### Current ALT evidence and next experiment
+**Implementation defects in retained ALT prerequisites.** The BIAS2 adapter
+re-widened an already-certified phi endpoint 1 to greater than 1, then rejected
+its own result. It now consumes the certified endpoints directly; the
+nonrelaxing limit is unchanged. Quadratic bias supply coefficients enclose the
+exact real squares instead of using a rounded point product. The H18 enable
+fixed-point check unnecessarily widened max after endpoint selection; max now
+preserves its represented fixed point, while the seed square is outward.
+These fixes do not change source assumptions or deployment arithmetic.
 
-The separate BIAS0/BIAS1/BIAS2 definition validators all pass; this does not
-close aggregate hard-entry or hardware admission. Fifteen ALT algebra tests
-pass, including exact finite gain/innovation increments and a rational
-masked-update analogue with joint cross storage and bounded neutral supply.
-The analogue is not a shipping certificate.
+### Critic and alternatives
 
-The captured observer contains 29 H18 and 359 A21 retained three-second words.
-Re-evaluation of its stored products at 80/120 digits gives worst ratios
-0.9995136399194538514 and 0.9959857178394911698. The existing H18 ratio fixes
-held-bias error at zero, while A21 retains all 21 estimated-error coordinates.
-No metric is fitted to this replay. The limiting observed frozen-map margin
-is H18's approximately 0.00048636.
+The strongest objection to the old candidate is mathematical: high precision,
+a common metric or a thinner gain bound cannot turn an unanchored derivative
+product into a finite error map. The alternatives are (1) exact finite
+measurement/prediction descriptors, (2) a fully anchored radial mean-value
+construction with its reference defect and domain proof, or (3) incremental
+storage augmented by covariance/frontend memory plus a separate physical-truth
+bridge. The first is selected for the measurement part because its exact
+rational identity eliminates the finite-reset approximation rather than merely
+shrinking a bound. The second and third remain alternatives, not simultaneous
+new proof tracks. No replay, unreachable-root probe, metric fitting or
+independent source boxes are accepted as universal evidence.
 
-A new attachment limitation is explicit: the observer reconstructs H=P^-1 N
-and accumulates a binary32 homogeneous map, not the complete endogenous
-nonlinear joint24 finite-increment map. Treating it as the latter would be a
-proof/implementation correspondence error. Its strict ratios do not justify
-outward certification of the unsupplied ALT master. The strongest critic is
-that high precision cannot restore omitted physics or gain dependence.
-Alternatives: instrument actual finite increments; derive an analytic graph
-of actual N/S/residual/tuner operations; or prove a fixed-trajectory nonlinear
-storage identity that legitimately avoids incremental gain derivatives.
-Selected next experiment: bind the already implemented exact finite solve
-increment graph to the analytic same-history shipping source, then run the
-full-word high-precision feasibility experiment before any interval refinement.
-All ALT and existing final theorem gates remain false/unpromoted.
+### Next falsifiable theorem work
 
-### ALT continuation experiment — source attachment and rank-three product ports
+Compose the finite measurement descriptors with physical prediction forcing and
+actual held/active covariance/frontend lineage. Retain physical angular
+integration/model defects rather than modeling truth as a second estimator.
+Enforce every configured branch, one bias root/driver, and one Live primitive
+origin. Then form the first common-joint24 master on that actual finite
+relation. Before a numerical attempt can run, the finite-representation guard
+must have genuine supplying lemmas, not edited flags.
 
-The next falsifiable attachment experiment was executed without changing the
-shipping filter or the original P2/P3/P4/P5 route. The event-local
-estimator-owned JOINT/kernel relation executes for both H18 and A21: H/A cells
-bind, literal event orders agree, and the authoritative next frontend is the
-JOINT image. However, invoking the inherited theorem-facing source-selector
-builder pulls in the separate Mahony startup invariant and currently stops at
-`continuous_all_live_PI_invariant_closed` / `initial seed angle not closed`.
-Classification: proof-architecture coupling, not an ALT Live theorem failure.
-It invalidates reuse of that theorem-facing wrapper as the ALT Live attachment;
-it does not invalidate the inverse-free finite-increment algebra, the joint24
-bounded-supply target, or the independently continuable original proof.
-
-The attachment gap is now sharper. The available relation is
-single-execution/differential: it does not supply paired admissible estimator,
-covariance, frontend/tuner and guard states with same-history `r0/r1`, `N0/N1`,
-`S0/S1`, and `q0/q1`. Therefore `deltaN` and `deltaS` are not yet tied to one
-paired COMPLETE-BRMM continuation and
-`ALT_ACTUAL_SOURCE_UNIFORM_FINITE_INCREMENT_WORD_ATTACHED=false`.
-
-Rank-three structure is retained only as an exact representation optimization.
-The new thin kernels use `Psi+ = Psi-K(H Psi)`, the actual-numerator Joseph
-polynomial, and the rank-at-most-six storage correction without discarding any
-state or cross term. The endogenous increment master can carry
-`u_S=deltaS*q0` and `u_N=deltaN*q0`; for joint24 this reduces the local lifted
-coordinate count from 87 to 33. This is exact only when hard same-history
-product graphs enforce both identities. The ports may not be treated as
-independent bounded disturbances.
-
-Critic: the strongest reason to abandon the inherited wrapper is that it makes
-a Live-word feasibility experiment depend on an unrelated, still-open startup
-theorem. The selected alternative is a Live-only paired JOINT+kernel transition,
-not more refinement of that wrapper. Current limiter and next falsifiable
-experiment: take two estimator states over one admitted COMPLETE-BRMM source
-continuation, emit paired literal H18/A21 event cells, bind both inverse-free
-solves, and enforce hard `u_S/u_N` same-history product graphs. Startup remains
-a separate later theorem. All ALT and original P4/P5 gates remain fail-closed.
+A useful source-uniform storage bound, every-prefix chart retention, actual
+H18->A21 landing, deployment roundoff and Mahony/proxy capture remain OPEN.
+Individual BIAS definitions do not imply aggregate fresh-Live hard admission.
+The old PE/vector issue remains separate unless ALT uses that lemma. All ALT
+final gates and original P4/P5 remain false/unpromoted.

--- a/tests/ou3_alt_contraction/test_asynchronous_event_star.py
+++ b/tests/ou3_alt_contraction/test_asynchronous_event_star.py
@@ -1,0 +1,22 @@
+import unittest
+from tools.stability.ou3_alt_contraction import asynchronous_event_star as A
+
+
+class AsynchronousEventStarTest(unittest.TestCase):
+    def test_finite_nonexpansive_star_needs_no_count_cap(self):
+        self.assertEqual(A.finite_star_rho(1.0,0),1.0)
+        self.assertEqual(A.finite_star_rho(1.0,1000000),1.0)
+        self.assertLess(A.finite_star_rho(0.9,10),1.0)
+
+    def test_shipping_kernel_requires_star_not_zero_one_shortcut(self):
+        d=A.build();self.assertEqual(A.validate(d),[])
+        self.assertTrue(d['typed_kernel_executes_every_async_event'])
+        self.assertFalse(d['magnetometer_event_count_upper_bound_assumed'])
+        self.assertFalse(d['zero_or_one_mag_per_IMU_is_universal_cover'])
+        self.assertTrue(d['finite_star_composition_theorem_closed'])
+        self.assertFalse(d['single_source_uniform_magnetometer_nonexpansive_certificate_closed'])
+        self.assertFalse(d['arbitrary_finite_async_magnetometer_sequence_closed'])
+        self.assertFalse(d['ALT_LIVE_PASS'])
+
+
+if __name__=='__main__':unittest.main()

--- a/tests/ou3_alt_contraction/test_bias_families.py
+++ b/tests/ou3_alt_contraction/test_bias_families.py
@@ -1,4 +1,5 @@
 import unittest
+from fractions import Fraction as F
 from tools.stability.ou3_alt_contraction import bias_families as B
 
 class BiasFamilyContractTests(unittest.TestCase):
@@ -11,6 +12,17 @@ class BiasFamilyContractTests(unittest.TestCase):
             Q=B.driver_ball_iqc(c);self.assertEqual((len(Q),len(Q[0])),(4,4));self.assertGreater(Q[0][0].lo,0)
             T=B.true_bias_ball_iqc(c);self.assertGreater(T[0][0].lo,0)
         self.assertTrue(next(c for c in cs if c.name=='BIAS2').phi_true.contains(1.0))
+    def test_BIAS2_nonrelaxing_endpoint_is_exact_not_widened_above_one(self):
+        c=next(c for c in B.contracts() if c.name=='BIAS2')
+        self.assertEqual(c.phi_true.hi,1.0)
+        self.assertTrue(c.non_relaxing_limit_admitted)
+        self.assertEqual(c.phi_true.lo,B.BIAS2.build()['phi_true_interval'][0])
+    def test_quadratic_supply_coefficients_enclose_exact_squares(self):
+        for c in B.contracts():
+            for Q,bound in ((B.driver_ball_iqc(c),c.driver_norm_bound),(B.true_bias_ball_iqc(c),c.true_bias_norm_bound)):
+                exact=F.from_float(bound)**2
+                self.assertLessEqual(F.from_float(Q[0][0].lo),exact)
+                self.assertGreaterEqual(F.from_float(Q[0][0].hi),exact)
     def test_build_does_not_import_broken_fresh_live_aggregate(self):
         d=B.build();self.assertEqual(B.validate(d),[]);self.assertTrue(d['three_families_invoked_separately']);self.assertTrue(d['one_persistent_parameter_token_per_family']);self.assertFalse(d['aggregate_fresh_Live_entry_builder_consumed']);self.assertFalse(d['all_bias_families_attached_to_complete_word']);self.assertFalse(d['ALT_LIVE_PASS'])
 

--- a/tests/ou3_alt_contraction/test_bias_families.py
+++ b/tests/ou3_alt_contraction/test_bias_families.py
@@ -1,0 +1,17 @@
+import unittest
+from tools.stability.ou3_alt_contraction import bias_families as B
+
+class BiasFamilyContractTests(unittest.TestCase):
+    def test_all_three_source_families_are_separate_and_analytic(self):
+        cs=B.contracts();self.assertEqual(tuple(c.name for c in cs),('BIAS0','BIAS1','BIAS2'))
+        self.assertEqual(len({c.parameter_token for c in cs}),3)
+        for c in cs:
+            self.assertTrue(c.one_history_required);self.assertGreater(c.driver_norm_bound,0);self.assertGreater(c.true_bias_norm_bound,0)
+            self.assertLessEqual(c.phi_true.lo,c.phi_true.hi);self.assertLessEqual(c.phi_true.hi,1)
+            Q=B.driver_ball_iqc(c);self.assertEqual((len(Q),len(Q[0])),(4,4));self.assertGreater(Q[0][0].lo,0)
+            T=B.true_bias_ball_iqc(c);self.assertGreater(T[0][0].lo,0)
+        self.assertTrue(next(c for c in cs if c.name=='BIAS2').phi_true.contains(1.0))
+    def test_build_does_not_import_broken_fresh_live_aggregate(self):
+        d=B.build();self.assertEqual(B.validate(d),[]);self.assertTrue(d['three_families_invoked_separately']);self.assertTrue(d['one_persistent_parameter_token_per_family']);self.assertFalse(d['aggregate_fresh_Live_entry_builder_consumed']);self.assertFalse(d['all_bias_families_attached_to_complete_word']);self.assertFalse(d['ALT_LIVE_PASS'])
+
+if __name__=='__main__':unittest.main()

--- a/tests/ou3_alt_contraction/test_coarse_endpoint_outer_attempt.py
+++ b/tests/ou3_alt_contraction/test_coarse_endpoint_outer_attempt.py
@@ -1,0 +1,28 @@
+import unittest
+from ou3_interval import matrix_point,matrix_mul
+from tools.stability.ou3_alt_contraction import coarse_endpoint_outer_attempt as E
+
+
+class CoarseEndpointOuterAttemptTest(unittest.TestCase):
+    def test_interval_power_contains_literal_two_branch_products(self):
+        # Small exact regression: hull({A,B})^3 contains every explicit product.
+        A=matrix_point([[0.5,0.0],[0.0,1.0]]);B=matrix_point([[0.8,0.0],[0.0,1.0]])
+        from tools.stability.ou3_alt_contraction.endpoint_family_induction import hull_matrices,matrix_encloses
+        H=hull_matrices([A,B]);P=E.interval_matrix_power(H,3)
+        for X in (A,B):
+            for Y in (A,B):
+                for Z in (A,B):
+                    self.assertTrue(matrix_encloses(P,matrix_mul(Z,matrix_mul(Y,X))))
+
+    def test_first_600_step_universal_outer_attempt(self):
+        d=E.build();self.assertEqual(E.validate(d),[])
+        print('ALT_COARSE_600_ENDPOINT',E.summary(d))
+        self.assertTrue(d['binary_interval_power_encloses_all_length_600_IMU_core_products'])
+        self.assertTrue(d['async_magnetometer_excluded_and_star_obligation_retained'])
+        # Finiteness is diagnostic of representation quality, never theorem truth.
+        self.assertFalse(d['async_magnetometer_nonexpansive_same_M_closed'])
+        self.assertFalse(d['common_storage_closed'])
+        self.assertFalse(d['ALT_LIVE_PASS'])
+
+
+if __name__=='__main__':unittest.main()

--- a/tests/ou3_alt_contraction/test_coarse_imu_core_outer.py
+++ b/tests/ou3_alt_contraction/test_coarse_imu_core_outer.py
@@ -1,0 +1,17 @@
+import unittest
+from tools.stability.ou3_alt_contraction import coarse_imu_core_outer as C
+
+
+class CoarseImuCoreOuterTest(unittest.TestCase):
+    def test_mag_is_not_hidden_in_finite_sample_family(self):
+        d=C.build();self.assertEqual(C.validate(d),[])
+        print('ALT_COARSE_IMU_CORE',C.summary(d))
+        self.assertTrue(d['async_magnetometer_excluded_from_finite_IMU_core_family'])
+        self.assertFalse(d['async_magnetometer_count_upper_bound_assumed'])
+        self.assertTrue(d['async_magnetometer_star_theorem_consumed'])
+        self.assertFalse(d['async_magnetometer_nonexpansive_same_M_closed'])
+        self.assertFalse(d['complete_async_sample_family_closed'])
+        self.assertFalse(d['ALT_LIVE_PASS'])
+
+
+if __name__=='__main__':unittest.main()

--- a/tests/ou3_alt_contraction/test_coarse_universal_local_outer.py
+++ b/tests/ou3_alt_contraction/test_coarse_universal_local_outer.py
@@ -1,0 +1,26 @@
+import unittest
+from ou3_interval import Interval
+from tools.stability.ou3_alt_contraction import coarse_universal_local_outer as C
+
+
+class CoarseUniversalLocalOuterTest(unittest.TestCase):
+    def test_psd_diagonal_ceiling_implies_cross_entry_outer_box(self):
+        P=C.psd_covariance_box_from_diagonal_upper([4.0,9.0])
+        self.assertLessEqual(P[0][1].lo,-6.0)
+        self.assertGreaterEqual(P[0][1].hi,6.0)
+        self.assertLessEqual(P[0][0].lo,0.0)
+        self.assertGreaterEqual(P[0][0].hi,4.0)
+
+    def test_first_complete_source_local_outer_attempt(self):
+        d=C.build(); self.assertEqual(C.validate(d),[])
+        # Finiteness is deliberately not asserted.  A failure here identifies
+        # the certified projection that must be split; it is not replaced by a
+        # trace or source shrink.  Emit the exact failure ledger into CI.
+        print('ALT_COARSE_LOCAL_OUTER',C.summary(d))
+        self.assertEqual(d['physical_centered_S_bound_m_s'],1100.0)
+        self.assertFalse(d['outer_projection_product_is_history_generator'])
+        self.assertFalse(d['replay_or_finite_source_sample_used'])
+        self.assertFalse(d['ALT_LIVE_PASS'])
+
+
+if __name__=='__main__':unittest.main()

--- a/tests/ou3_alt_contraction/test_common_storage_master.py
+++ b/tests/ou3_alt_contraction/test_common_storage_master.py
@@ -1,0 +1,57 @@
+import unittest
+import numpy as np
+
+from tools.stability.ou3_alt_contraction import common_storage_master as C
+
+
+class CommonStorageMasterTest(unittest.TestCase):
+    def test_joint24_selector_is_exactly_bias_reference_coordinates(self):
+        S=C.joint24_neutral_selector(); Z=C.joint24_motion_injection()
+        self.assertEqual(S.shape,(6,24)); self.assertEqual(Z.shape,(24,18))
+        np.testing.assert_array_equal(S@Z,np.zeros((6,18)))
+        np.testing.assert_array_equal(S[:,18:24],np.eye(6))
+        np.testing.assert_array_equal(Z[:18,:],np.eye(18))
+        np.testing.assert_array_equal(Z[18:24,:],np.zeros((6,18)))
+
+    def test_neutral_coordinate_is_closed_by_finite_supply(self):
+        # x1 contracts; x2 is exactly held.  Strict homogeneous contraction is
+        # impossible for rho<1, but a bounded x2 supply closes the full SPD
+        # storage inequality exactly as required for H18.
+        A=np.diag([0.5,1.0]); M=np.eye(2); rho=0.9
+        R=C.unsupplied_storage_form(A,M,rho,(1,))
+        self.assertLess(float(np.linalg.eigvalsh(R)[-1]),0.0)
+        d=C.coordinate_supply_completion(A,M,rho,(1,),margin=1e-12)
+        self.assertTrue(d['feasible']); self.assertGreater(d['beta_scalar'],0.0)
+        self.assertLess(d['completed_lambda_max'],0.0)
+
+    def test_unsupplied_neutral_direction_cannot_be_hidden_by_supply(self):
+        # x1 is neutral but only x2 is admitted as supply.  Finsler restriction
+        # correctly fails; no Beta on x2 can manufacture contraction of x1.
+        A=np.eye(2); M=np.eye(2); rho=0.9
+        d=C.coordinate_supply_completion(A,M,rho,(1,),margin=1e-12)
+        self.assertFalse(d['feasible'])
+        self.assertGreater(d['projected_lambda_max'],0.0)
+
+    def test_cross_coupling_uses_schur_completion_not_diagonal_handwave(self):
+        A=np.array([[0.5,0.7],[0.0,1.0]])
+        M=np.array([[2.0,0.3],[0.3,1.0]])
+        d=C.coordinate_supply_completion(A,M,0.95,(1,),margin=1e-10)
+        self.assertTrue(d['feasible'])
+        self.assertLess(d['completed_lambda_max'],0.0)
+
+    def test_bounded_additive_supply_multiplier(self):
+        self.assertAlmostEqual(C.bounded_additive_supply_multiplier(0.5,0.75),3.0)
+        self.assertEqual(C.bounded_additive_supply_multiplier(0.0,0.5),1.0)
+        with self.assertRaises(ValueError): C.bounded_additive_supply_multiplier(0.9,0.8)
+
+    def test_phase1_bound_reduction_remains_fail_closed(self):
+        d=C.build(); f=C.validate(d)
+        self.assertEqual(f,[])
+        self.assertTrue(d['phase1_storage_search_allowed_consumed'])
+        self.assertFalse(d['common_M_source_uniform_search_closed'])
+        self.assertFalse(d['source_uniform_outward_projected_LDLT_closed'])
+        self.assertFalse(d['ALT_LIVE_PASS'])
+
+
+if __name__=='__main__':
+    unittest.main()

--- a/tests/ou3_alt_contraction/test_endpoint_family_induction.py
+++ b/tests/ou3_alt_contraction/test_endpoint_family_induction.py
@@ -1,0 +1,57 @@
+import unittest
+from ou3_interval import Interval, matrix_point
+from tools.stability.ou3_alt_contraction import endpoint_family_induction as E
+
+
+class EndpointFamilyInductionTest(unittest.TestCase):
+    def test_hull_contains_every_explicit_branch_product(self):
+        A1=matrix_point([[0.5,0.0],[0.0,1.0]])
+        A2=matrix_point([[0.6,0.0],[0.0,1.0]])
+        B1=matrix_point([[0.8,0.0],[0.0,1.0]])
+        B2=matrix_point([[0.9,0.0],[0.0,1.0]])
+        s0=[E.PartitionSuccessor('p',('root',),E.QualifiedLocalFamily('s0',(A1,A2),True))]
+        s1=[E.PartitionSuccessor('q',('p',),E.QualifiedLocalFamily('s1',(B1,B2),True))]
+        d=E.prove_endpoint_outer_induction(2,[s0,s1])
+        outer=d['endpoint_partitions']['q']
+        for B in (B1,B2):
+            for A in (A1,A2):
+                from ou3_interval import matrix_mul
+                self.assertTrue(E.matrix_encloses(outer,matrix_mul(B,A)))
+        self.assertTrue(d['outer_union_inclusion_by_induction'])
+        self.assertFalse(d['outer_hull_is_realizable_source_history'])
+
+    def test_partitions_prevent_unnecessary_cross_hull(self):
+        A=matrix_point([[0.5,0.0],[0.0,1.0]])
+        B=matrix_point([[0.9,0.0],[0.0,1.0]])
+        step=[
+          E.PartitionSuccessor('H',('root',),E.QualifiedLocalFamily('H',(A,),True)),
+          E.PartitionSuccessor('A',('root',),E.QualifiedLocalFamily('A',(B,),True)),
+        ]
+        d=E.prove_endpoint_outer_induction(2,[step])
+        self.assertEqual(set(d['endpoint_partitions']),{'H','A'})
+        self.assertEqual(d['endpoint_partitions']['H'][0][0].lo,0.5)
+        self.assertEqual(d['endpoint_partitions']['A'][0][0].lo,0.9)
+
+    def test_unqualified_or_replay_family_fails_closed(self):
+        A=matrix_point([[1.0]])
+        with self.assertRaises(ValueError):
+            E.advance_partitions(E.initial_partition(1),[
+                E.PartitionSuccessor('x',('root',),E.QualifiedLocalFamily('bad',(A,),False))])
+        with self.assertRaises(ValueError):
+            E.advance_partitions(E.initial_partition(1),[
+                E.PartitionSuccessor('x',('root',),E.QualifiedLocalFamily('bad',(A,),True,True))])
+
+    def test_missing_parent_fails_closed(self):
+        A=matrix_point([[1.0]])
+        with self.assertRaises(ValueError):
+            E.advance_partitions(E.initial_partition(1),[
+                E.PartitionSuccessor('x',('not-root',),E.QualifiedLocalFamily('x',(A,),True))])
+
+    def test_module_status_requires_actual_600_step_binding(self):
+        d=E.build(); self.assertEqual(E.validate(d),[])
+        self.assertTrue(d['endpoint_outer_inclusion_induction_materialized'])
+        self.assertFalse(d['actual_600_step_source_family_bound'])
+        self.assertFalse(d['ALT_LIVE_PASS'])
+
+
+if __name__=='__main__': unittest.main()

--- a/tests/ou3_alt_contraction/test_exact_endpoint_relation.py
+++ b/tests/ou3_alt_contraction/test_exact_endpoint_relation.py
@@ -1,0 +1,20 @@
+import unittest
+from tools.stability.ou3_alt_contraction import exact_endpoint_relation as E
+
+
+class ExactEndpointRelationTest(unittest.TestCase):
+    def test_exact_relation_is_universal_not_enumerated(self):
+        d=E.build(); self.assertEqual(E.validate(d),[])
+        self.assertTrue(d['exact_universal_endpoint_map_relation_defined'])
+        self.assertTrue(d['all_branch_successors_retained'])
+        self.assertTrue(d['all_bias_lineages_retained'])
+        self.assertEqual(d['endpoint_map_set_symbol'],'W_ALT_joint24(O^601_BRMM)')
+        self.assertFalse(d['finite_source_enumeration_used'])
+        self.assertFalse(d['trajectory_replay_used'])
+        self.assertFalse(d['independent_sample_boxes_used'])
+        self.assertFalse(d['numeric_interval_endpoint_representation_closed'])
+        self.assertFalse(d['common_M_source_uniform_projected_LDLT_closed'])
+        self.assertFalse(d['ALT_LIVE_PASS'])
+
+
+if __name__=='__main__': unittest.main()

--- a/tests/ou3_alt_contraction/test_finite_measurement_graph.py
+++ b/tests/ou3_alt_contraction/test_finite_measurement_graph.py
@@ -1,0 +1,200 @@
+"""Universal coefficient proofs and exact graph regressions, never source admission."""
+from collections import defaultdict
+from fractions import Fraction as F
+from pathlib import Path
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+from tools.stability.ou3_alt_contraction import finite_measurement_graph as G
+
+
+class Poly:
+    """Tiny exact polynomial ring for all-variable, non-sampled identity checks."""
+    N = 8
+
+    def __init__(self, value=0):
+        if isinstance(value, Poly):
+            self.terms = value.terms.copy()
+        elif isinstance(value, dict):
+            self.terms = {m: F(c) for m, c in value.items() if c}
+        else:
+            self.terms = {(0,)*self.N: F(value)} if value else {}
+
+    @classmethod
+    def var(cls, i):
+        e = [0]*cls.N
+        e[i] = 1
+        return cls({tuple(e): F(1)})
+
+    def __add__(self, other):
+        terms = defaultdict(F, self.terms)
+        for m, c in Poly(other).terms.items():
+            terms[m] += c
+        return Poly(dict(terms))
+
+    __radd__ = __add__
+
+    def __neg__(self):
+        return Poly({m: -c for m, c in self.terms.items()})
+
+    def __sub__(self, other):
+        return self+-Poly(other)
+
+    def __rsub__(self, other):
+        return Poly(other)+-self
+
+    def __mul__(self, other):
+        out = defaultdict(F)
+        for m, c in self.terms.items():
+            for n, d in Poly(other).terms.items():
+                out[tuple(a+b for a, b in zip(m, n))] += c*d
+        return Poly(dict(out))
+
+    __rmul__ = __mul__
+
+    def __eq__(self, other):
+        return self.terms == Poly(other).terms
+
+
+def solve3(S, r):
+    a = [row[:]+[x] for row, x in zip(S, r)]
+    for j in range(3):
+        pivot = next(i for i in range(j, 3) if a[i][j])
+        a[j], a[pivot] = a[pivot], a[j]
+        v = a[j][j]
+        a[j] = [x/v for x in a[j]]
+        for i in range(3):
+            if i != j:
+                v = a[i][j]
+                a[i] = [x-v*y for x, y in zip(a[i], a[j])]
+    return [row[3] for row in a]
+
+
+def dense_covariance():
+    u = [F((i % 4)-2, 20) for i in range(21)]
+    return G.plus(G.eye(21), [[x*y for y in u] for x in u])
+
+
+class FiniteMeasurementTests(unittest.TestCase):
+    def test_cayley_secant_identity_all_polynomial_coefficients(self):
+        c = [Poly.var(i) for i in range(3)]
+        U, D, En = G.cayley_polynomials(c)
+        C = G.skew(c)
+        self.assertEqual(G.mm(G.plus(G.scaled(G.eye(3), 2), C, -1), U), G.scaled(G.eye(3), 2*D))
+        self.assertEqual(G.mm(U, C), G.plus(En, G.scaled(G.eye(3), D), -1))
+        # E is a rotation on the real Cayley chart, not a linear approximation.
+        self.assertEqual(G.mm(G.transpose(En), En), G.scaled(G.eye(3), D*D))
+
+    def test_finite_reset_identity_all_eight_indeterminates(self):
+        c, d = [Poly.var(i) for i in range(3)], [Poly.var(i) for i in range(3, 6)]
+        w, k = Poly.var(6), Poly.var(7)
+        W, twice_V, Lnum = G.right_reset_polynomials(c, d, w, k)
+        gap = [twice_V[i]-W*c[i]+G.mv(Lnum, d)[i] for i in range(3)]
+        self.assertEqual(gap, [Poly(0)]*3)
+        # Includes BOTH quaternion branches because w,k were not specialized.
+
+    def test_H18_full_latent_bias_covariance_enters_S_not_N(self):
+        P = G.eye(21)
+        latent = F(1, 62500)  # (0.004)^2 in exact real arithmetic.
+        for i in range(18, 21):
+            P[i][i] = latent
+        H, _ = G.residual_factors('accelerometer', [0]*3, f_hat=[0, 0, -10], R_hat=G.eye(3))
+        N, S = G.measurement_operands(P, G.eye(3), H, active_bias=False)
+        H18 = [row[:18] for row in H]
+        missing = G.plus(G.mm(G.mm(H18, G.eye(18)), G.transpose(H18)), G.eye(3))
+        self.assertEqual(G.plus(S, missing, -1), G.scaled(G.eye(3), latent))
+        self.assertEqual(N[18:21], G.zeros(3, 3))
+        self.assertEqual(G.measurement_operands(P, G.eye(3), H, active_bias=True)[1], S)
+
+    def test_masks_keep_all_nonzero_cross_covariance_terms(self):
+        P = dense_covariance()
+        H, _ = G.residual_factors('accelerometer', [0]*3, f_hat=[1, 2, -9], R_hat=G.eye(3))
+        N, S = G.measurement_operands(P, G.eye(3), H, active_bias=False)
+        expected = G.mm(P, G.transpose([row[:18]+[F(0)]*3 for row in H]))
+        expected[18:21] = G.zeros(3, 3)
+        self.assertEqual(N, expected)
+        self.assertEqual(S, G.plus(G.mm(G.mm(H, P), G.transpose(H)), G.eye(3)))
+
+    def test_descriptor_is_exact_at_finite_errors_all_three_measurements(self):
+        z = [F((i % 3)-1, 10000) for i in range(24)]
+        for active in (False, True):
+            for kind in ('accelerometer', 'magnetometer', 'S_zero'):
+                kw = dict(f_hat=[1, 2, -9], R_hat=G.eye(3), m_hat=[22, 0, 43])
+                H, Hb = G.residual_factors(kind, z[:3], **kw)
+                N, S = G.measurement_operands(dense_covariance(), G.eye(3), H, active_bias=active)
+                # Source-coordinate values exercise algebra, not BRMM admission.
+                nu = [F(1, 10000), F(-1, 12000), F(1, 15000)]
+                r = [x+y for x, y in zip(G.mv(Hb, z), nu)]
+                q = solve3(S, r)
+                d = G.mv(N, q)
+                w, k = G.small_quaternion_parameters(d[:3])
+                g = G.descriptor(z[:3], d[:3], w, k, N, S, Hb, alpha=1)
+                chi = z+q+nu+[F(1)]
+                self.assertEqual(G.mv(g.equality, chi), [F(0)]*9)
+                W, twice_V, _ = G.right_reset_polynomials(z[:3], d[:3], w, k)
+                direct = [x/W for x in twice_V]+[z[i]-d[i] for i in range(3, 21)]+z[21:24]
+                self.assertEqual(G.mv(g.after, chi), direct)
+                self.assertEqual(G.mv(g.before, chi), z)
+                # Exact graph is generally NOT obtained by applying its Jacobian.
+                self.assertNotEqual(direct[:3], [z[i]-d[i] for i in range(3)])
+
+    def test_wrong_c_or_theta_correction_cannot_satisfy_descriptor(self):
+        H, Hb = G.residual_factors('S_zero', [0]*3)
+        N, S = G.measurement_operands(dense_covariance(), G.eye(3), H, active_bias=True)
+        g = G.descriptor([F(1, 10), 0, 0], [F(1, 20), 0, 0], 1, F(1, 2), N, S, Hb, alpha=1)
+        self.assertNotEqual(G.mv(g.equality, [F(0)]*30+[F(1)]), [F(0)]*9)
+
+    def test_physical_S_forcing_is_nonzero_at_zero_error(self):
+        z = [F(0)]*24
+        H, Hb = G.residual_factors('S_zero', z[:3])
+        N, S = G.measurement_operands(dense_covariance(), G.eye(3), H, active_bias=True)
+        physical_S = [F(1, 10000), 0, 0]
+        nu = [-s for s in physical_S]
+        q = solve3(S, nu)
+        d = G.mv(N, q)
+        w, k = G.small_quaternion_parameters(d[:3])
+        g = G.descriptor(z[:3], d[:3], w, k, N, S, Hb, alpha=1)
+        self.assertNotEqual(G.mv(g.after, z+q+nu+[F(1)]), z)
+        self.assertEqual(G.mv(g.equality, z+q+nu+[F(1)]), [F(0)]*9)
+
+    def test_projection_graph_and_same_beta_cross_terms(self):
+        e, beta = [F(-4, 5), 0, 0], [F(0)]*3
+        self.assertTrue(G.projection_graph_holds(e, beta, F(1, 2), F(2, 5)))
+        self.assertFalse(G.projection_graph_holds(e, beta, F(1, 3), F(2, 5)))
+        P = G.projection_matrix(F(1, 2))
+        z = [F(0)]*18+e+beta
+        self.assertEqual(G.mv(P, z)[18:21], [F(-2, 5), 0, 0])
+        self.assertEqual(P[18][21], F(1, 2))
+        self.assertTrue(G.projection_graph_holds([0]*3, [0]*3, 1, F(2, 5)))
+
+    def test_rank3_full_storage_ledger_matches_dense_exactly(self):
+        u = [F((i % 7)-3, 30) for i in range(24)]
+        M = G.plus(G.eye(24), [[x*y for y in u] for x in u])
+        B = [[F(((i+j) % 5)-2, 30) for j in range(3)] for i in range(24)]
+        z, q = u, [F(1, 5), F(-1, 6), F(1, 7)]
+        for a in (F(1), F(2, 3)):
+            P = G.projection_matrix(a)
+            self.assertEqual(G.projected_metric(M, a), G.mm(G.mm(G.transpose(P), M), P))
+            out = G.mv(P, [x-y for x, y in zip(z, G.mv(B, q))])
+            direct = G.dot(out, G.mv(M, out))-G.dot(z, G.mv(M, z))
+            self.assertEqual(G.finite_storage_change(M, z, q, B, alpha=a), direct)
+
+    def test_invalid_data_and_chart_poles_fail_closed(self):
+        with self.assertRaises(TypeError):
+            G.rational(.1)
+        with self.assertRaises(ValueError):
+            G.small_quaternion_parameters([F(1, 100), 0, 0])
+        with self.assertRaises(ValueError):
+            G.projection_matrix(0)
+        H, Hb = G.residual_factors('S_zero', [0]*3)
+        N, S = G.measurement_operands(G.eye(21), G.eye(3), H, active_bias=True)
+        with self.assertRaises(ValueError):
+            G.descriptor([0]*3, [1, 0, 0], 0, 1, N, S, Hb, alpha=1)
+        with self.assertRaises(ValueError):
+            G.measurement_operands(G.eye(18), G.eye(3), H, active_bias=False)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/ou3_alt_contraction/test_finite_prediction_deployed_step.py
+++ b/tests/ou3_alt_contraction/test_finite_prediction_deployed_step.py
@@ -1,0 +1,34 @@
+import unittest
+from fractions import Fraction as F
+from tools.stability.ou3_alt_contraction import finite_prediction_deployed_step as D
+from tools.stability.ou3_alt_contraction import finite_prediction_graph as G
+
+
+class FinitePredictionDeployedStepTests(unittest.TestCase):
+    def test_zero_increment_step_is_identity_quaternion(self):
+        self.assertEqual(D.step_quaternion_polynomial([0,0,0]),[F(1),F(0),F(0),F(0)])
+
+    def test_threshold_is_strict(self):
+        with self.assertRaises(ValueError):D.step_quaternion_polynomial([F(1,100),0,0])
+
+    def test_same_omega_bg_h_drive_shadow_and_nominal(self):
+        z=[F(0)]*24;z[:3]=[F(1,4),F(-1,7),F(1,9)];z[3:6]=[F(1,100),F(-1,120),F(1,140)]
+        omega=[F(3,10),F(-1,5),F(1,4)];h=F(1,200)
+        coeff=G.translation_axis_coefficients(0,0,0,1,h)
+        d=D.prediction('H',z,omega_hat=omega,h=h,q15=[F(0)]*15,coeff=coeff,w_bias=[0,0,0],phi_true=1)
+        dn=[-x*h for x in omega];ds=[(-omega[i]+z[3+i])*h for i in range(3)]
+        expected=G.relative_attitude_prediction(z[:3],D.step_quaternion_polynomial(ds),D.step_quaternion_polynomial(dn))
+        self.assertEqual(d.state_after[:3],expected)
+
+    def test_readiness_closes_branch_binding_but_not_source_word(self):
+        d=D.readiness()
+        self.assertTrue(d['finite_prediction_graph_consumed'])
+        self.assertTrue(d['source_uniform_polynomial_quaternion_branch_consumed'])
+        self.assertTrue(d['same_omega_bg_h_generate_nominal_and_shadow_steps'])
+        self.assertFalse(d['free_step_quaternion_coefficients_used'])
+        self.assertFalse(d['q15_same_history_source_relation_attached_to_finite_word'])
+        self.assertFalse(d['complete_word_finite_identity'])
+        self.assertFalse(d['ALT_LIVE_PASS'])
+
+
+if __name__=='__main__': unittest.main()

--- a/tests/ou3_alt_contraction/test_finite_prediction_graph.py
+++ b/tests/ou3_alt_contraction/test_finite_prediction_graph.py
@@ -1,0 +1,87 @@
+import unittest
+from fractions import Fraction as F
+from tools.stability.ou3_alt_contraction import finite_prediction_graph as G
+
+
+class FinitePredictionGraphTests(unittest.TestCase):
+    def test_identity_steps_preserve_finite_cayley_error(self):
+        c=[F(3,10),F(-1,5),F(1,7)]
+        self.assertEqual(G.relative_attitude_prediction(c,[1,0,0,0],[1,0,0,0]),c)
+
+    def test_projective_step_quaternion_scaling_cancels(self):
+        c=[F(1,3),F(-2,7),F(1,5)]
+        qs=[F(9,10),F(1,10),F(-1,20),F(1,30)]
+        qn=[F(19,20),F(-1,12),F(1,15),F(1,18)]
+        a=G.relative_attitude_prediction(c,qs,qn)
+        b=G.relative_attitude_prediction(c,[3*x for x in qs],[5*x for x in qn])
+        self.assertEqual(a,b)
+
+    def test_output_cayley_reconstructs_same_projective_quaternion(self):
+        c=[F(2,9),F(-1,8),F(1,11)]
+        qs=[F(7,8),F(1,7),F(-1,13),F(1,17)]
+        qn=[F(11,12),F(-1,9),F(1,14),F(1,19)]
+        qp=G.quat_mul(G.quat_mul(qs,[F(2),*c]),G.quat_conj(qn))
+        cp=G.relative_attitude_prediction(c,qs,qn)
+        # (2,c_plus) is exactly a scalar multiple of q_plus.
+        for i in range(3):
+            self.assertEqual(qp[0]*cp[i],2*qp[1+i])
+
+    def test_translation_is_exact_true_minus_estimate_recurrence(self):
+        h=F(1,200); pva=F(1,250); ppa=F(1,100000); pSa=F(1,50000000); alpha=F(99,100)
+        coeff=G.translation_axis_coefficients(pva,ppa,pSa,alpha,h)
+        e=[F(i-5,20) for i in range(12)]
+        q=[F(i-7,30) for i in range(15)]
+        out=G.translation_prediction(e,q,coeff)
+        for a in range(3):
+            ev,ep,eS,ea=e[a],e[3+a],e[6+a],e[9+a]
+            a0,a1,J0,J1,J2=q[a],q[3+a],q[6+a],q[9+a],q[12+a]
+            self.assertEqual(out[a],ev+pva*ea+J0-pva*a0)
+            self.assertEqual(out[3+a],ep+h*ev+ppa*ea+J1-ppa*a0)
+            self.assertEqual(out[6+a],eS+h*ep+h*h*ev/2+pSa*ea+J2-pSa*a0)
+            self.assertEqual(out[9+a],alpha*ea+a1-alpha*a0)
+
+    def test_bias_driver_is_shared_not_duplicated(self):
+        e=[F(1,5),F(-1,7),F(1,9)]; beta=[F(1,11),F(1,13),F(-1,15)]; w=[F(1,100),F(-1,120),F(1,140)]
+        ph=F(9,10);pt=F(19,20)
+        ep,bp=G.bias_prediction(e,beta,w,ph,pt)
+        for i in range(3):
+            self.assertEqual(ep[i]-ph*e[i]-(pt-ph)*beta[i],w[i])
+            self.assertEqual(bp[i]-pt*beta[i],w[i])
+
+    def test_H_mode_holds_estimated_bias_but_not_physical_truth(self):
+        z=[F(0)]*24
+        z[18:21]=[F(1,5),F(-1,6),F(1,7)]
+        z[21:24]=[F(1,8),F(1,9),F(-1,10)]
+        w=[F(1,100),F(-1,110),F(1,120)]
+        pt=F(49,50)
+        q15=[F(0)]*15
+        coeff=G.translation_axis_coefficients(0,0,0,1,F(1,200))
+        d=G.prediction('H',z,q_shadow=[1,0,0,0],q_nominal=[1,0,0,0],q15=q15,coeff=coeff,w_bias=w,phi_true=pt)
+        for i in range(3):
+            self.assertEqual(d.state_after[18+i],z[18+i]+(pt-1)*z[21+i]+w[i])
+            self.assertEqual(d.state_after[21+i],pt*z[21+i]+w[i])
+
+    def test_A_mode_uses_configured_estimator_factor(self):
+        z=[F(0)]*24;z[18]=F(2,5);z[21]=F(1,4)
+        coeff=G.translation_axis_coefficients(0,0,0,1,F(1,200))
+        d=G.prediction('A',z,q_shadow=[1,0,0,0],q_nominal=[1,0,0,0],q15=[F(0)]*15,coeff=coeff,w_bias=[F(1,100),0,0],phi_true=F(19,20),phi_hat=F(9,10))
+        self.assertEqual(d.state_after[18],F(9,10)*F(2,5)+F(1,20)*F(1,4)+F(1,100))
+
+    def test_cayley_pole_and_missing_A_factor_fail_closed(self):
+        with self.assertRaises(ValueError):
+            G.relative_attitude_prediction([0,0,0],[0,1,0,0],[1,0,0,0])
+        coeff=G.translation_axis_coefficients(0,0,0,1,F(1,200))
+        with self.assertRaises(TypeError):
+            G.prediction('A',[F(0)]*24,q_shadow=[1,0,0,0],q_nominal=[1,0,0,0],q15=[F(0)]*15,coeff=coeff,w_bias=[0,0,0],phi_true=1)
+
+    def test_readiness_closes_only_algebra(self):
+        d=G.readiness()
+        self.assertTrue(d['finite_attitude_prediction_identity'])
+        self.assertTrue(d['finite_translation_q15_forcing_identity'])
+        self.assertTrue(d['finite_shared_bias_driver_identity'])
+        self.assertFalse(d['source_uniform_step_quaternion_graph_attached'])
+        self.assertFalse(d['complete_word_finite_identity'])
+        self.assertFalse(d['ALT_LIVE_PASS'])
+
+
+if __name__=='__main__': unittest.main()

--- a/tests/ou3_alt_contraction/test_finite_prediction_source_attachment.py
+++ b/tests/ou3_alt_contraction/test_finite_prediction_source_attachment.py
@@ -1,0 +1,37 @@
+import unittest
+from ou3_interval import Interval
+from tools.stability.ou3_alt_contraction import finite_prediction_source_attachment as A
+from tools.stability.ou3_alt_contraction import bias_families as B
+
+
+class FinitePredictionSourceAttachmentTests(unittest.TestCase):
+    def test_all_mode_family_rows_attach_correlated_sources(self):
+        d=A.build();self.assertEqual(A.validate(d),[])
+        self.assertEqual(len(d['rows']),6)
+        self.assertTrue(d['all_H_A_BIAS_families_have_one_step_finite_source_attachment'])
+        self.assertTrue(d['no_independent_q15_or_bias_boxes'])
+        self.assertFalse(d['complete_word_finite_identity'])
+        self.assertFalse(d['ALT_LIVE_PASS'])
+        for r in d['rows']:
+            self.assertEqual(r['q15_coordinate_order'],A.Q15_ORDER)
+            self.assertEqual(r['q15_dimension'],15)
+            self.assertTrue(r['q15_same_history_relation_attached_to_finite_prediction'])
+            self.assertTrue(r['same_physical_bias_driver_used_by_error_and_truth'])
+            self.assertTrue(r['bias_parameter_root_token_attached_to_finite_prediction'])
+            self.assertFalse(r['multi_transition_BRMM_primitive_chain_closed_here'])
+            self.assertFalse(r['covariance_frontend_successor_attached'])
+
+    def test_explicit_family_token_is_preserved(self):
+        c=B.contracts()[1]
+        r=A.attach(mode='A',tau=Interval.point(1.7),h=Interval.point(.005),bias_contract=c)
+        self.assertEqual(r['bias_family'],'BIAS1')
+        self.assertEqual(r['bias_parameter_token'],c.parameter_token)
+        self.assertEqual(r['bias_phi_true_interval'],c.phi_true)
+
+    def test_invalid_mode_or_detached_bias_contract_fails(self):
+        c=B.contracts()[0]
+        with self.assertRaises(ValueError):A.attach(mode='X',tau=Interval.point(1),h=Interval.point(.005),bias_contract=c)
+        with self.assertRaises(TypeError):A.attach(mode='H',tau=Interval.point(1),h=Interval.point(.005),bias_contract=object())
+
+
+if __name__=='__main__': unittest.main()

--- a/tests/ou3_alt_contraction/test_first_common_metric_attempt.py
+++ b/tests/ou3_alt_contraction/test_first_common_metric_attempt.py
@@ -1,0 +1,18 @@
+import unittest
+from tools.stability.ou3_alt_contraction import first_common_metric_attempt as M
+
+
+class FirstCommonMetricAttemptTest(unittest.TestCase):
+    def test_first_common_metric_attempt_is_fail_closed_and_universal(self):
+        d=M.build();self.assertEqual(M.validate(d),[])
+        print('ALT_FIRST_COMMON_METRIC',M.summary(d))
+        self.assertTrue(d['same_M_used_for_all_H_A_BIAS_families'])
+        self.assertFalse(d['trajectory_or_replay_fit_used_for_M'])
+        self.assertFalse(d['per_mode_metric_used'])
+        self.assertFalse(d['per_bias_family_metric_used'])
+        self.assertFalse(d['async_magnetometer_nonexpansive_same_M_closed'])
+        self.assertFalse(d['common_joint24_storage_complete'])
+        self.assertFalse(d['ALT_LIVE_PASS'])
+
+
+if __name__=='__main__':unittest.main()

--- a/tests/ou3_alt_contraction/test_first_common_metric_attempt.py
+++ b/tests/ou3_alt_contraction/test_first_common_metric_attempt.py
@@ -1,18 +1,20 @@
+"""The actual entry point must not start a coarse search on a Jacobian word."""
 import unittest
+from unittest.mock import patch
 from tools.stability.ou3_alt_contraction import first_common_metric_attempt as M
 
 
 class FirstCommonMetricAttemptTest(unittest.TestCase):
-    def test_first_common_metric_attempt_is_fail_closed_and_universal(self):
-        d=M.build();self.assertEqual(M.validate(d),[])
-        print('ALT_FIRST_COMMON_METRIC',M.summary(d))
-        self.assertTrue(d['same_M_used_for_all_H_A_BIAS_families'])
-        self.assertFalse(d['trajectory_or_replay_fit_used_for_M'])
-        self.assertFalse(d['per_mode_metric_used'])
-        self.assertFalse(d['per_bias_family_metric_used'])
-        self.assertFalse(d['async_magnetometer_nonexpansive_same_M_closed'])
-        self.assertFalse(d['common_joint24_storage_complete'])
-        self.assertFalse(d['ALT_LIVE_PASS'])
+    def test_candidate_helper_cannot_bypass_the_finite_master_guard(self):
+        with self.assertRaisesRegex(RuntimeError, 'finite-state storage blocked'):
+            M.normalized_diagonal_metric()
+
+    def test_first_common_metric_attempt_requires_a_finite_master(self):
+        with patch.object(M, 'normalized_diagonal_metric') as candidate:
+            with self.assertRaisesRegex(RuntimeError, 'finite-state storage blocked'):
+                M.build()
+            candidate.assert_not_called()
 
 
-if __name__=='__main__':unittest.main()
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/ou3_alt_contraction/test_h18_a21_edge.py
+++ b/tests/ou3_alt_contraction/test_h18_a21_edge.py
@@ -1,0 +1,34 @@
+import unittest
+from ou3_interval import Interval
+from tools.stability.ou3_alt_contraction import h18_a21_edge as E
+
+I=Interval.point
+
+def P18():
+    P=[[I(0) for _ in range(18)] for _ in range(18)]
+    for i in range(18):P[i][i]=I(1+i/10)
+    return P
+
+class H18A21EdgeTests(unittest.TestCase):
+    def test_held_covariance_lift_is_enable_floor_fixed_point(self):
+        p=E.held_covariance_from_H18(P18())
+        self.assertEqual((len(p),len(p[0])),(21,21))
+        self.assertTrue(E.covariance_fixed_point(P18()))
+        for i in range(3):
+            self.assertTrue(p[18+i][18+i].contains(E.DEFAULT_SIGMA_BACC0**2))
+            for j in range(18):
+                self.assertEqual((p[18+i][j].lo,p[18+i][j].hi),(0,0))
+                self.assertEqual((p[j][18+i].lo,p[j][18+i].hi),(0,0))
+    def test_joint24_mean_edge_is_identity(self):
+        A=E.joint24_mean_edge();self.assertEqual((len(A),len(A[0])),(24,24))
+        for i in range(24):
+            for j in range(24):self.assertTrue(A[i][j].contains(1 if i==j else 0))
+    def test_literal_guard_requires_every_shipping_condition_and_no_hold(self):
+        kw=dict(startup_live=True,accel_bias_locked=True,mag_updates_applied=250,mag_updates_to_unlock=250,first_mag_finite=True,elapsed_since_first_mag_s=1.0001,external_hold=False)
+        self.assertTrue(E.release_guard(**kw)['learning_enabled_after_edge'])
+        for key,value in [('startup_live',False),('accel_bias_locked',False),('mag_updates_applied',249),('first_mag_finite',False),('elapsed_since_first_mag_s',1.0),('external_hold',True)]:
+            q=dict(kw);q[key]=value;self.assertFalse(E.release_guard(**q)['learning_enabled_after_edge'])
+    def test_source_parity_and_conditional_edge_close_but_reachability_does_not(self):
+        d=E.build();self.assertEqual(E.validate(d),[]);self.assertTrue(d['conditional_H18_A21_state_and_covariance_edge_closed']);self.assertTrue(d['release_guard_literal_relation_closed']);self.assertFalse(d['release_guard_source_uniform_reachability_closed']);self.assertFalse(d['H18_A21_complete_word_edge_attached']);self.assertFalse(d['storage_search_allowed'])
+
+if __name__=='__main__':unittest.main()

--- a/tests/ou3_alt_contraction/test_h18_a21_edge.py
+++ b/tests/ou3_alt_contraction/test_h18_a21_edge.py
@@ -1,4 +1,5 @@
 import unittest
+from fractions import Fraction as F
 from ou3_interval import Interval
 from tools.stability.ou3_alt_contraction import h18_a21_edge as E
 
@@ -19,6 +20,25 @@ class H18A21EdgeTests(unittest.TestCase):
             for j in range(18):
                 self.assertEqual((p[18+i][j].lo,p[18+i][j].hi),(0,0))
                 self.assertEqual((p[j][18+i].lo,p[j][18+i].hi),(0,0))
+    def test_seed_variance_encloses_exact_real_product(self):
+        s=E.DEFAULT_SIGMA_BACC0
+        exact=F.from_float(s)**2
+        v=E.held_covariance_from_H18(P18())[18][18]
+        self.assertLessEqual(F.from_float(v.lo),exact)
+        self.assertGreaterEqual(F.from_float(v.hi),exact)
+    def test_enable_floor_handles_values_below_crossing_and_above(self):
+        seed=E.held_covariance_from_H18(P18())[18][18]
+        p=E.held_covariance_from_H18(P18())
+        p[18][18]=Interval(0,seed.lo/2)
+        p[19][19]=Interval(0,seed.hi*2)
+        p[20][20]=Interval(seed.hi*3,seed.hi*4)
+        q=E.enable_covariance_floor(p)
+        self.assertEqual(q[18][18],seed)
+        self.assertEqual(q[19][19],Interval(seed.lo,seed.hi*2))
+        self.assertEqual(q[20][20],p[20][20])
+    def test_negative_seed_rejected_at_both_entry_points(self):
+        with self.assertRaises(ValueError):E.held_covariance_from_H18(P18(),-.1)
+        with self.assertRaises(ValueError):E.enable_covariance_floor(E.held_covariance_from_H18(P18()),-.1)
     def test_joint24_mean_edge_is_identity(self):
         A=E.joint24_mean_edge();self.assertEqual((len(A),len(A[0])),(24,24))
         for i in range(24):

--- a/tests/ou3_alt_contraction/test_hybrid_word.py
+++ b/tests/ou3_alt_contraction/test_hybrid_word.py
@@ -1,0 +1,12 @@
+import unittest
+from tools.stability.ou3_alt_contraction import hybrid_word as H
+
+class HybridWordTests(unittest.TestCase):
+    def test_configured_hybrid_factorization_closes_without_claiming_release_progress(self):
+        d=H.build();self.assertEqual(H.validate(d),[])
+        self.assertTrue(d['H18_same_mode_word_closed']);self.assertTrue(d['A21_same_mode_word_closed'])
+        self.assertTrue(d['both_configured_guard_outcomes_covered']);self.assertTrue(d['H18_A21_edge_attached']);self.assertTrue(d['hybrid_H18_A21_word_closed'])
+        self.assertTrue(d['actual_A21_release_covariance_comes_from_H18_held_covariance']);self.assertFalse(d['parallel_hypothetical_A21_covariance_used_at_release'])
+        self.assertFalse(d['release_guard_eventual_reachability_closed_here']);self.assertFalse(d['startup_capture_consumed']);self.assertFalse(d['storage_search_allowed_here'])
+
+if __name__=='__main__':unittest.main()

--- a/tests/ou3_alt_contraction/test_inverse_free_endpoint_and_metric_attempt.py
+++ b/tests/ou3_alt_contraction/test_inverse_free_endpoint_and_metric_attempt.py
@@ -1,0 +1,22 @@
+import unittest
+from tools.stability.ou3_alt_contraction import inverse_free_endpoint_outer_attempt as E
+from tools.stability.ou3_alt_contraction import inverse_free_common_metric_attempt as M
+
+class InverseFreeEndpointAndMetricAttemptTest(unittest.TestCase):
+    def test_corrected_600_step_endpoint_attempt(self):
+        d=E.build();self.assertEqual(E.validate(d),[])
+        print('ALT_INVERSE_FREE_ENDPOINT',E.summary(d))
+        self.assertTrue(d['inverse_free_local_family_consumed'])
+        self.assertFalse(d['endpoint_Pbar_route_consumed'])
+        self.assertFalse(d['common_storage_closed'])
+        self.assertFalse(d['ALT_LIVE_PASS'])
+    def test_corrected_first_common_metric_attempt(self):
+        d=M.build();self.assertEqual(M.validate(d),[])
+        print('ALT_INVERSE_FREE_COMMON_METRIC',M.summary(d))
+        self.assertTrue(d['corrected_inverse_free_endpoint_outer_consumed'])
+        self.assertFalse(d['superseded_endpoint_Pbar_local_route_consumed'])
+        self.assertTrue(d['same_M_all_modes_bias_families'])
+        self.assertFalse(d['async_magnetometer_nonexpansive_same_M_closed'])
+        self.assertFalse(d['ALT_LIVE_PASS'])
+
+if __name__=='__main__':unittest.main()

--- a/tests/ou3_alt_contraction/test_inverse_free_endpoint_and_metric_attempt.py
+++ b/tests/ou3_alt_contraction/test_inverse_free_endpoint_and_metric_attempt.py
@@ -1,9 +1,9 @@
 import unittest
-from tools.stability.ou3_alt_contraction import inverse_free_endpoint_outer_attempt as E
 from tools.stability.ou3_alt_contraction import inverse_free_common_metric_attempt as M
 
 class InverseFreeEndpointAndMetricAttemptTest(unittest.TestCase):
     def test_corrected_600_step_endpoint_attempt(self):
+        from tools.stability.ou3_alt_contraction import inverse_free_endpoint_outer_attempt as E
         d=E.build();self.assertEqual(E.validate(d),[])
         print('ALT_INVERSE_FREE_ENDPOINT',E.summary(d))
         self.assertTrue(d['inverse_free_local_family_consumed'])
@@ -11,12 +11,7 @@ class InverseFreeEndpointAndMetricAttemptTest(unittest.TestCase):
         self.assertFalse(d['common_storage_closed'])
         self.assertFalse(d['ALT_LIVE_PASS'])
     def test_corrected_first_common_metric_attempt(self):
-        d=M.build();self.assertEqual(M.validate(d),[])
-        print('ALT_INVERSE_FREE_COMMON_METRIC',M.summary(d))
-        self.assertTrue(d['corrected_inverse_free_endpoint_outer_consumed'])
-        self.assertFalse(d['superseded_endpoint_Pbar_local_route_consumed'])
-        self.assertTrue(d['same_M_all_modes_bias_families'])
-        self.assertFalse(d['async_magnetometer_nonexpansive_same_M_closed'])
-        self.assertFalse(d['ALT_LIVE_PASS'])
+        with self.assertRaisesRegex(RuntimeError,'finite-state storage blocked'):
+            M.build()
 
 if __name__=='__main__':unittest.main()

--- a/tests/ou3_alt_contraction/test_inverse_free_gain_outer.py
+++ b/tests/ou3_alt_contraction/test_inverse_free_gain_outer.py
@@ -1,0 +1,17 @@
+import unittest
+from ou3_interval import matrix_point
+from tools.stability.ou3_alt_contraction import inverse_free_gain_outer as G
+
+class InverseFreeGainOuterTest(unittest.TestCase):
+    def test_gershgorin_R_lower(self):
+        R=matrix_point([[2.0,0.1],[0.1,3.0]])
+        self.assertGreater(G.gershgorin_spd_lower(R),1.8)
+    def test_source_uniform_gain_bounds_are_finite_without_inverse(self):
+        d=G.build();self.assertEqual(G.validate(d),[])
+        print('ALT_INVERSE_FREE_GAIN',{m:{k:r['K_norm_upper'] for k,r in rows.items()} for m,rows in d['reports'].items()})
+        self.assertTrue(d['all_event_gain_outers_finite'])
+        self.assertFalse(d['innovation_inverse_computed'])
+        self.assertFalse(d['endpoint_Pbar_used_for_local_gain'])
+        self.assertFalse(d['independent_covariance_box_used'])
+
+if __name__=='__main__':unittest.main()

--- a/tests/ou3_alt_contraction/test_inverse_free_universal_local_outer.py
+++ b/tests/ou3_alt_contraction/test_inverse_free_universal_local_outer.py
@@ -1,0 +1,15 @@
+import unittest
+from tools.stability.ou3_alt_contraction import inverse_free_universal_local_outer as L
+
+class InverseFreeUniversalLocalOuterTest(unittest.TestCase):
+    def test_corrected_local_family_does_not_use_endpoint_covariance(self):
+        d=L.build();self.assertEqual(L.validate(d),[])
+        print('ALT_INVERSE_FREE_LOCAL_OUTER',L.summary(d))
+        self.assertTrue(d['inverse_free_gain_outer_consumed'])
+        self.assertFalse(d['endpoint_Pbar_used_for_local_gain'])
+        self.assertFalse(d['independent_covariance_box_used'])
+        self.assertFalse(d['magnetometer_count_assumption_used'])
+        self.assertEqual(d['physical_D_S_bound_m_s'],1100.0)
+        self.assertFalse(d['ALT_LIVE_PASS'])
+
+if __name__=='__main__':unittest.main()

--- a/tests/ou3_alt_contraction/test_joint24_events.py
+++ b/tests/ou3_alt_contraction/test_joint24_events.py
@@ -1,0 +1,32 @@
+import sys,unittest
+from pathlib import Path
+ROOT=Path(__file__).resolve().parents[2];sys.path[:0]=[str(ROOT),str(ROOT/'tools/stability')]
+from ou3_interval import Interval
+import ou3_brmm_complete_window_execution_kernel as K
+import ou3_p4_complete_brmm_source_cover_contract as C
+import ou3_p4_complete_brmm_differential_events as E
+from tools.stability.ou3_alt_contraction import joint24_events as J
+I=Interval.point
+def eye(n):return [[I(1 if i==j else 0) for j in range(n)] for i in range(n)]
+def prim(S=(1,0,0)):
+ z=(I(0),)*3;return K.WavePrimitivePayload('g','p0','p1','live',z,z,tuple(map(I,S)),z,z,z)
+def cell(mode,kind):
+ n=18 if mode=='H' else 21
+ kw=dict(R=eye(3),radial_scale=I(1),estimator_source_token='est',estimator_predecessor_token='root',estimator_generated_coefficients=True,wave_primitive=prim())
+ if kind=='S_zero':kw['R_provenance']=E.ACTUAL_RS_PROVENANCE
+ if kind=='accelerometer':kw.update(f_hat=[I(0),I(0),I(-9.8)],R_hat=eye(3))
+ if mode=='A':kw.update(true_bias=[I(.1),I(0),I(0)],bias_projection_limit=.4)
+ return C.SourceCoverCell('est:e0','est',mode,0,0,kind,[I(0) for _ in range(n)],eye(n),I(.005),I(1.5),I(.4),I(.1),**kw)
+class Joint24Tests(unittest.TestCase):
+ def test_H18_accel_has_held_bias_columns(self):
+  d=J.h18_accelerometer_event(cell('H','accelerometer'));M=d['J_joint24'];self.assertEqual((len(M),len(M[0])),(24,24));self.assertTrue(d['same_history_held_bias_retained']);self.assertTrue(any(not (M[i][18+j].lo==0 and M[i][18+j].hi==0) for i in range(18) for j in range(3)))
+ def test_H18_prediction_shares_one_physical_driver(self):
+  A,B=J.h18_prediction_lift(eye(18),I(.99))
+  for i in range(3):self.assertTrue(B[18+i][i].contains(1) and B[21+i][i].contains(1))
+  self.assertTrue(any(not (A[18+i][21+i].lo==0 and A[18+i][21+i].hi==0) for i in range(3)))
+ def test_physical_S_columns_exist_in_H18_and_A21(self):
+  for mode in ('H','A'):
+   d=J.s_zero_event_joint24(cell(mode,'S_zero'));self.assertEqual((len(d['J_joint24']),len(d['J_joint24'][0])),(24,24));self.assertEqual((len(d['J_S_phys']),len(d['J_S_phys'][0])),(24,3));self.assertTrue(any(not (x.lo==0 and x.hi==0) for r in d['J_S_phys'] for x in r))
+ def test_contract_still_blocks_storage(self):
+  d=J.build();self.assertEqual(J.validate(d),[]);self.assertFalse(d['storage_search_allowed']);self.assertFalse(d['ALT_LIVE_PASS'])
+if __name__=='__main__':unittest.main()

--- a/tests/ou3_alt_contraction/test_live_frontend_predecessor.py
+++ b/tests/ou3_alt_contraction/test_live_frontend_predecessor.py
@@ -1,0 +1,15 @@
+import unittest
+from tools.stability.ou3_alt_contraction import live_frontend_predecessor as F
+
+class LiveFrontendPredecessorTests(unittest.TestCase):
+    def test_live_predecessor_closes_without_startup_capture(self):
+        d=F.build();self.assertEqual(F.validate(d),[])
+        self.assertTrue(d['regional_normal_live_frontend_predecessor_set_closed'])
+        self.assertTrue(d['regional_Live_entry_membership_is_theorem_premise'])
+        self.assertTrue(d['regional_Mahony_invariant_consumed'])
+        self.assertFalse(d['startup_capture_consumed'])
+        self.assertFalse(d['startup_entry_closed_here'])
+        self.assertTrue(all(d['strict_invariance_checks'].values()))
+        self.assertFalse(d['ALT_LIVE_PASS'])
+
+if __name__=='__main__':unittest.main()

--- a/tests/ou3_alt_contraction/test_live_mahony_regional.py
+++ b/tests/ou3_alt_contraction/test_live_mahony_regional.py
@@ -1,0 +1,16 @@
+import unittest
+from tools.stability.ou3_alt_contraction import live_mahony_regional as M
+
+class LiveMahonyRegionalTests(unittest.TestCase):
+    def test_regional_invariance_closes_without_claiming_startup_entry(self):
+        d=M.build();self.assertEqual(M.validate(d),[])
+        self.assertTrue(d['regional_continuous_invariance_closed'])
+        self.assertTrue(d['regional_source_order_binary32_discrete_invariance_closed'])
+        self.assertGreater(d['binary32_robust_boundary_margin_lower'],0)
+        self.assertGreater(d['discrete_V_margin_lower'],0)
+        self.assertGreater(d['one_step_chart_round_margin_rad'],0)
+        self.assertFalse(d['startup_entry_into_regional_set_closed_here'])
+        self.assertFalse(d['startup_initial_seed_membership_required_for_Live_invariance'])
+        self.assertFalse(d['ALT_LIVE_PASS'])
+
+if __name__=='__main__':unittest.main()

--- a/tests/ou3_alt_contraction/test_live_source_relation.py
+++ b/tests/ou3_alt_contraction/test_live_source_relation.py
@@ -1,0 +1,22 @@
+import unittest
+from tools.stability.ou3_alt_contraction import live_source_relation as R
+
+class LiveSourceRelationTests(unittest.TestCase):
+    def test_regional_universal_relation_closes_without_startup(self):
+        d=R.build();self.assertEqual(R.validate(d),[])
+        self.assertEqual(d['physical_outer_relation'],'O^601_BRMM')
+        self.assertEqual(d['sample_count'],601)
+        self.assertTrue(d['COMPLETE_BRMM_left_inclusion_consumed'])
+        self.assertTrue(d['regional_frontend_predecessor_invariant_consumed'])
+        self.assertTrue(d['same_history_joint_frontend_transition_operator_bound'])
+        self.assertTrue(d['trusted_Riccati_event_attachment_operator_bound'])
+        self.assertTrue(d['all_branch_successors_retained_by_operator'])
+        self.assertTrue(d['regional_universal_Normal_Live_source_relation_closed'])
+        self.assertFalse(d['startup_capture_consumed'])
+        self.assertFalse(d['startup_entry_membership_closed_here'])
+        self.assertFalse(d['replay_or_seeded_realization_used'])
+        self.assertFalse(d['complete_600_step_physical_joint24_cocycle_closed_here'])
+        self.assertFalse(d['storage_search_allowed'])
+        self.assertFalse(d['ALT_LIVE_PASS'])
+
+if __name__=='__main__':unittest.main()

--- a/tests/ou3_alt_contraction/test_local_covariance_norm_envelope.py
+++ b/tests/ou3_alt_contraction/test_local_covariance_norm_envelope.py
@@ -1,0 +1,21 @@
+import unittest
+from ou3_interval import matrix_point
+from tools.stability.ou3_alt_contraction import local_covariance_norm_envelope as C
+
+
+class LocalCovarianceNormEnvelopeTest(unittest.TestCase):
+    def test_interval_norm_upper_contains_point_spectral_norm(self):
+        A=matrix_point([[3.0,0.0],[4.0,0.0]])
+        # exact spectral norm is 5; sqrt(||A||1 ||A||inf)=sqrt(7*4)>5.
+        self.assertGreaterEqual(C.interval_matrix_norm2_upper(A),5.0)
+
+    def test_event_local_covariance_bound_does_not_use_endpoint_Pbar(self):
+        d=C.build();self.assertEqual(C.validate(d),[])
+        print('ALT_LOCAL_COVARIANCE_NORM',d['reports'])
+        self.assertTrue(d['event_local_covariance_norm_envelope_closed'])
+        self.assertTrue(d['aw_floor_bound_independent_of_current_P'])
+        self.assertFalse(d['endpoint_referenced_Pbar_used_as_local_bound'])
+        self.assertFalse(d['trajectory_replay_used'])
+
+
+if __name__=='__main__':unittest.main()

--- a/tests/ou3_alt_contraction/test_local_covariance_norm_envelope.py
+++ b/tests/ou3_alt_contraction/test_local_covariance_norm_envelope.py
@@ -9,13 +9,21 @@ class LocalCovarianceNormEnvelopeTest(unittest.TestCase):
         # exact spectral norm is 5; sqrt(||A||1 ||A||inf)=sqrt(7*4)>5.
         self.assertGreaterEqual(C.interval_matrix_norm2_upper(A),5.0)
 
-    def test_event_local_covariance_bound_does_not_use_endpoint_Pbar(self):
+    def test_event_local_covariance_bound_uses_endpoint_Pbar_only_at_word_boundaries(self):
         d=C.build();self.assertEqual(C.validate(d),[])
         print('ALT_LOCAL_COVARIANCE_NORM',d['reports'])
         self.assertTrue(d['event_local_covariance_norm_envelope_closed'])
         self.assertTrue(d['aw_floor_bound_independent_of_current_P'])
-        self.assertFalse(d['endpoint_referenced_Pbar_used_as_local_bound'])
+        self.assertTrue(d['endpoint_Pbar_used_only_at_certified_sliding_word_endpoints'])
+        self.assertFalse(d['endpoint_Pbar_substituted_directly_for_preJoseph_covariance'])
+        self.assertTrue(d['H_to_A_release_covariance_ancestry_retained'])
+        self.assertTrue(d['A_release_after_H_endpoint_regime_guaranteed'])
         self.assertFalse(d['trajectory_replay_used'])
+
+        H=d['reports']['H']; A=d['reports']['A']
+        self.assertGreaterEqual(H['early_word_every_event_upper'], H['live_seed_norm_upper'])
+        self.assertGreaterEqual(A['early_active_word_every_event_upper'], A['release_seed_from_H_endpoint_plus_fixed_ba_upper'])
+        self.assertGreaterEqual(A['release_seed_from_H_endpoint_plus_fixed_ba_upper'], H['sliding_endpoint_Pbar_norm_upper'])
 
 
 if __name__=='__main__':unittest.main()

--- a/tests/ou3_alt_contraction/test_phase1_closure.py
+++ b/tests/ou3_alt_contraction/test_phase1_closure.py
@@ -1,0 +1,18 @@
+import unittest
+from tools.stability.ou3_alt_contraction import phase1_closure as P
+
+class Phase1ClosureTests(unittest.TestCase):
+    def test_phase1_closes_master_graph_but_not_stability(self):
+        d=P.build();self.assertEqual(P.validate(d),[])
+        self.assertTrue(all(d['phase1_status'].values()))
+        self.assertTrue(d['storage_search_allowed'])
+        self.assertTrue(d['common_joint24_storage_must_be_searched_first'])
+        self.assertFalse(d['parameter_dependent_storage_search_allowed_initially'])
+        self.assertFalse(d['release_guard_eventual_reachability_closed'])
+        self.assertFalse(d['startup_capture_closed'])
+        self.assertFalse(d['every_prefix_chart_retention_closed'])
+        self.assertFalse(d['deployment_finite_precision_closed'])
+        self.assertFalse(d['ALT_LIVE_PASS'])
+        self.assertFalse(d['ALT_END_TO_END_PASS'])
+
+if __name__=='__main__':unittest.main()

--- a/tests/ou3_alt_contraction/test_physical_events.py
+++ b/tests/ou3_alt_contraction/test_physical_events.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+import unittest
+ROOT=Path(__file__).resolve().parents[2];sys.path[:0]=[str(ROOT),str(ROOT/'tools/stability')]
+from ou3_interval import Interval
+import ou3_brmm_complete_window_execution_kernel as K
+import ou3_p4_complete_brmm_source_cover_contract as C
+import ou3_p4_complete_brmm_differential_events as E
+from tools.stability.ou3_alt_contraction import physical_events as P
+
+def I(x):return Interval.point(float(x))
+def eye(n):return [[I(1 if i==j else 0) for j in range(n)] for i in range(n)]
+def primitive(s=(0,0,0)):
+    v=tuple(I(x) for x in (0,0,0));p=v;S=tuple(I(x) for x in s)
+    return K.WavePrimitivePayload('generator','p0','p1','live0',v,p,S,p,p,p)
+def cell(mode='H',s=(0,0,0)):
+    n=18 if mode=='H' else 21
+    return C.SourceCoverCell('est:e0','est','H' if mode=='H' else 'A',0,0,'S_zero',[I(0) for _ in range(n)],eye(n),I(.005),I(1.5),I(.4),I(.1),R=eye(3),R_provenance=E.ACTUAL_RS_PROVENANCE,true_bias=[I(0),I(0),I(0)] if mode=='A' else None,bias_projection_limit=.4 if mode=='A' else None,radial_scale=I(1),estimator_source_token='est',estimator_predecessor_token='root',estimator_generated_coefficients=True,wave_primitive=primitive(s))
+
+class PhysicalEventTests(unittest.TestCase):
+    def test_nonzero_physical_S_changes_actual_finite_event(self):
+        zero=cell('H',(0,0,0));nonzero=cell('H',(2,-1,.5))
+        old=E.source_joseph_event(**C.joseph_event_kwargs(nonzero));new=P.s_zero_event(nonzero)
+        self.assertTrue(any(not (x.lo==0 and x.hi==0) for x in new['residual']))
+        self.assertNotEqual([(x.lo,x.hi) for x in old['state_out']],[(x.lo,x.hi) for x in new['state_out']])
+        parity=P.s_zero_event(zero);baseline=E.source_joseph_event(**C.joseph_event_kwargs(zero))['state_out']
+        self.assertLess(max(max(abs(x.lo-y.lo),abs(x.hi-y.hi)) for x,y in zip(baseline,parity['state_out'])),1e-320)
+    def test_A21_projection_is_composed(self):
+        d=P.s_zero_event(cell('A',(1,0,0)));self.assertEqual(len(d['state_out']),21);self.assertEqual(len(d['J_state']),21);self.assertTrue(d['same_history_physical_reference_attached'])
+    def test_missing_or_detached_physical_ancestry_fails(self):
+        c=cell();object.__setattr__(c,'wave_primitive',None)
+        with self.assertRaises(ValueError):P.s_zero_event(c)
+        c=cell();object.__setattr__(c,'R_provenance','fake')
+        with self.assertRaises(ValueError):P.s_zero_event(c)
+    def test_contract_remains_fail_closed(self):
+        d=P.build();self.assertEqual(P.validate(d),[]);self.assertFalse(d['complete_physical_word_closed']);self.assertFalse(d['ALT_LIVE_PASS'])
+if __name__=='__main__':unittest.main()

--- a/tests/ou3_alt_contraction/test_physical_lineage.py
+++ b/tests/ou3_alt_contraction/test_physical_lineage.py
@@ -1,0 +1,105 @@
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT=Path(__file__).resolve().parents[2]
+sys.path[:0]=[str(ROOT),str(ROOT/'tools/stability')]
+from ou3_interval import Interval
+import ou3_brmm_complete_window_execution_kernel as KERNEL
+import ou3_p4_complete_brmm_source_cover_contract as COVER
+import ou3_p4_complete_brmm_differential_events as EVENTS
+from tools.stability.ou3_alt_contraction import physical_lineage as L
+
+I=Interval.point
+
+def eye(n):
+    return [[I(1 if i==j else 0) for j in range(n)] for i in range(n)]
+
+def primitive(S=(2.0,-1.0,.5)):
+    z=(I(0),I(0),I(0))
+    return KERNEL.WavePrimitivePayload(
+        'generator-1','phi-in-7','phi-out-8','live-origin-3',
+        z,z,tuple(I(x) for x in S),z,z,z)
+
+def cell(mode,kind,ordinal,*,S=(2.0,-1.0,.5)):
+    n=18 if mode=='H' else 21
+    kw=dict(
+        source_token=f'est:e{ordinal}', predecessor_token='est', mode=mode,
+        sample_index=7,event_ordinal=ordinal,kind=kind,state=[I(0) for _ in range(n)],
+        P=eye(n),dt_s=I(.005),tau_applied_s=I(1.7),sigma_aw_mps2=I(.4),
+        pseudo_elapsed_s=I(.1),radial_scale=I(1),estimator_source_token='est',
+        estimator_predecessor_token='root',estimator_generated_coefficients=True,
+        wave_primitive=primitive(S))
+    if kind=='S_zero':
+        kw.update(R=eye(3),R_provenance=EVENTS.ACTUAL_RS_PROVENANCE)
+    if kind=='accelerometer':
+        kw.update(R=eye(3),f_hat=[I(0),I(0),I(-9.80665)],R_hat=eye(3))
+    if kind=='magnetometer':
+        kw.update(R=eye(3),m_body=[I(20),I(0),I(40)])
+    if mode=='A':
+        kw.update(true_bias=[I(.03),I(-.02),I(.01)],bias_projection_limit=.4)
+    return COVER.SourceCoverCell(**kw)
+
+def lineage(mode,cells):
+    sample=SimpleNamespace(omega_body_corrected=(I(.01),I(-.02),I(.005)))
+    selector=SimpleNamespace(sample_coordinates=sample)
+    return SimpleNamespace(mode=mode,cells=tuple(cells),selector=selector)
+
+class PhysicalLineageTests(unittest.TestCase):
+    def test_H18_q15_and_physical_S_are_one_literal_cocycle(self):
+        p=cell('H','prediction',0)
+        s=cell('H','S_zero',1)
+        lin=lineage('H',[p,s])
+        d=L.compose_attached_sample(
+            lin,phi_true=I(.99999),
+            held_bias_error=[Interval(-.85,.85) for _ in range(3)],
+            true_bias=[Interval(-.45,.45) for _ in range(3)])
+        self.assertEqual(d['literal_event_kinds'],('prediction','S_zero'))
+        self.assertTrue(d['all_literal_cells_consumed'])
+        self.assertEqual(d['q15_prediction_blocks'],1)
+        self.assertEqual(d['physical_S_blocks'],1)
+        self.assertEqual(d['bias_driver_blocks'],1)
+        self.assertTrue(d['same_history_source_ancestry_retained'])
+        q=next(b for b in d['source_blocks'] if b.kind=='BRMM_q15_prediction')
+        self.assertEqual(len(q.sectors),3)
+        self.assertTrue(q.homogeneous_scale_fixed_one)
+        self.assertIn('generator-1',q.token)
+        self.assertIn('live-origin-3',q.token)
+        # S=0 follows prediction, so its Joseph map must suffix-propagate the
+        # earlier q15 forcing; the physical S response is appended afterwards.
+        raw=L._q15_injection('H',I(1.7),I(.005))
+        self.assertNotEqual(q.response,tuple(tuple(x for x in r) for r in raw))
+
+    def test_A21_prediction_uses_one_bias_driver_for_error_and_truth(self):
+        p=cell('A','prediction',0)
+        d=L.compose_attached_sample(lineage('A',[p]),phi_true=I(.9999),tau_ba=I(1800))
+        b=next(x for x in d['source_blocks'] if x.kind=='shared_bias_driver')
+        B=b.response
+        for i in range(3):
+            self.assertTrue(B[18+i][i].contains(1.0))
+            self.assertTrue(B[21+i][i].contains(1.0))
+        self.assertEqual(d['q15_prediction_blocks'],1)
+
+    def test_accelerometer_and_magnetometer_suffix_propagate_existing_sources(self):
+        cells=[cell('H','prediction',0),cell('H','accelerometer',1),cell('H','magnetometer',2)]
+        d=L.compose_attached_sample(
+            lineage('H',cells),phi_true=I(.9999),
+            held_bias_error=[Interval(-.85,.85) for _ in range(3)],
+            true_bias=[Interval(-.45,.45) for _ in range(3)])
+        self.assertEqual(d['literal_event_kinds'],('prediction','accelerometer','magnetometer'))
+        self.assertEqual(d['q15_prediction_blocks'],1)
+        self.assertEqual(len(d['J_joint24']),24)
+        self.assertEqual(len(d['J_joint24'][0]),24)
+
+    def test_contract_is_real_progress_but_still_blocks_storage(self):
+        d=L.build()
+        self.assertEqual(L.validate(d),[])
+        self.assertTrue(d['source_uniform_attached_sample_cocycle_available'])
+        self.assertTrue(d['joint_q15_quadratic_sector_attached_to_same_block'])
+        self.assertFalse(d['multi_sample_COMPLETE_BRMM_word_composed'])
+        self.assertFalse(d['storage_search_allowed'])
+        self.assertFalse(d['ALT_LIVE_PASS'])
+
+if __name__=='__main__':
+    unittest.main()

--- a/tests/ou3_alt_contraction/test_physical_lineage.py
+++ b/tests/ou3_alt_contraction/test_physical_lineage.py
@@ -9,97 +9,54 @@ from ou3_interval import Interval
 import ou3_brmm_complete_window_execution_kernel as KERNEL
 import ou3_p4_complete_brmm_source_cover_contract as COVER
 import ou3_p4_complete_brmm_differential_events as EVENTS
+from tools.stability.ou3_alt_contraction import bias_families as BIAS
 from tools.stability.ou3_alt_contraction import physical_lineage as L
 
 I=Interval.point
 
-def eye(n):
-    return [[I(1 if i==j else 0) for j in range(n)] for i in range(n)]
-
+def eye(n): return [[I(1 if i==j else 0) for j in range(n)] for i in range(n)]
 def primitive(S=(2.0,-1.0,.5)):
     z=(I(0),I(0),I(0))
-    return KERNEL.WavePrimitivePayload(
-        'generator-1','phi-in-7','phi-out-8','live-origin-3',
-        z,z,tuple(I(x) for x in S),z,z,z)
-
+    return KERNEL.WavePrimitivePayload('generator-1','phi-in-7','phi-out-8','live-origin-3',z,z,tuple(I(x) for x in S),z,z,z)
 def cell(mode,kind,ordinal,*,S=(2.0,-1.0,.5)):
     n=18 if mode=='H' else 21
-    kw=dict(
-        source_token=f'est:e{ordinal}', predecessor_token='est', mode=mode,
-        sample_index=7,event_ordinal=ordinal,kind=kind,state=[I(0) for _ in range(n)],
-        P=eye(n),dt_s=I(.005),tau_applied_s=I(1.7),sigma_aw_mps2=I(.4),
-        pseudo_elapsed_s=I(.1),radial_scale=I(1),estimator_source_token='est',
-        estimator_predecessor_token='root',estimator_generated_coefficients=True,
-        wave_primitive=primitive(S))
-    if kind=='S_zero':
-        kw.update(R=eye(3),R_provenance=EVENTS.ACTUAL_RS_PROVENANCE)
-    if kind=='accelerometer':
-        kw.update(R=eye(3),f_hat=[I(0),I(0),I(-9.80665)],R_hat=eye(3))
-    if kind=='magnetometer':
-        kw.update(R=eye(3),m_body=[I(20),I(0),I(40)])
-    if mode=='A':
-        kw.update(true_bias=[I(.03),I(-.02),I(.01)],bias_projection_limit=.4)
+    kw=dict(source_token=f'est:e{ordinal}',predecessor_token='est',mode=mode,sample_index=7,event_ordinal=ordinal,kind=kind,state=[I(0) for _ in range(n)],P=eye(n),dt_s=I(.005),tau_applied_s=I(1.7),sigma_aw_mps2=I(.4),pseudo_elapsed_s=I(.1),radial_scale=I(1),estimator_source_token='est',estimator_predecessor_token='root',estimator_generated_coefficients=True,wave_primitive=primitive(S))
+    if kind=='S_zero': kw.update(R=eye(3),R_provenance=EVENTS.ACTUAL_RS_PROVENANCE)
+    if kind=='accelerometer': kw.update(R=eye(3),f_hat=[I(0),I(0),I(-9.80665)],R_hat=eye(3))
+    if kind=='magnetometer': kw.update(R=eye(3),m_body=[I(20),I(0),I(40)])
+    if mode=='A': kw.update(true_bias=[I(.03),I(-.02),I(.01)],bias_projection_limit=.4)
     return COVER.SourceCoverCell(**kw)
-
 def lineage(mode,cells):
-    sample=SimpleNamespace(omega_body_corrected=(I(.01),I(-.02),I(.005)))
-    selector=SimpleNamespace(sample_coordinates=sample)
-    return SimpleNamespace(mode=mode,cells=tuple(cells),selector=selector)
+    return SimpleNamespace(mode=mode,cells=tuple(cells),selector=SimpleNamespace(sample_coordinates=SimpleNamespace(omega_body_corrected=(I(.01),I(-.02),I(.005)))))
+def family(name): return next(c for c in BIAS.contracts() if c.name==name)
 
 class PhysicalLineageTests(unittest.TestCase):
-    def test_H18_q15_and_physical_S_are_one_literal_cocycle(self):
-        p=cell('H','prediction',0)
-        s=cell('H','S_zero',1)
-        lin=lineage('H',[p,s])
-        d=L.compose_attached_sample(
-            lin,phi_true=I(.99999),
-            held_bias_error=[Interval(-.85,.85) for _ in range(3)],
-            true_bias=[Interval(-.45,.45) for _ in range(3)])
-        self.assertEqual(d['literal_event_kinds'],('prediction','S_zero'))
-        self.assertTrue(d['all_literal_cells_consumed'])
-        self.assertEqual(d['q15_prediction_blocks'],1)
-        self.assertEqual(d['physical_S_blocks'],1)
-        self.assertEqual(d['bias_driver_blocks'],1)
-        self.assertTrue(d['same_history_source_ancestry_retained'])
-        q=next(b for b in d['source_blocks'] if b.kind=='BRMM_q15_prediction')
-        self.assertEqual(len(q.sectors),3)
-        self.assertTrue(q.homogeneous_scale_fixed_one)
-        self.assertIn('generator-1',q.token)
-        self.assertIn('live-origin-3',q.token)
-        # S=0 follows prediction, so its Joseph map must suffix-propagate the
-        # earlier q15 forcing; the physical S response is appended afterwards.
-        raw=L._q15_injection('H',I(1.7),I(.005))
-        self.assertNotEqual(q.response,tuple(tuple(x for x in r) for r in raw))
+    def test_H18_q15_physical_S_and_BIAS0_are_one_literal_cocycle(self):
+        lin=lineage('H',[cell('H','prediction',0),cell('H','S_zero',1)])
+        d=L.compose_attached_sample(lin,bias_contract=family('BIAS0'),held_bias_error=[Interval(-.85,.85) for _ in range(3)],true_bias=[Interval(-.45,.45) for _ in range(3)])
+        self.assertEqual(d['literal_event_kinds'],('prediction','S_zero'));self.assertTrue(d['all_literal_cells_consumed'])
+        self.assertEqual((d['q15_prediction_blocks'],d['physical_S_blocks'],d['bias_driver_blocks']),(1,1,1))
+        self.assertTrue(d['same_history_source_ancestry_retained']);self.assertTrue(d['same_bias_parameter_token_on_all_predictions']);self.assertTrue(d['bias_driver_ball_sector_attached_on_all_predictions'])
+        q=next(b for b in d['source_blocks'] if b.kind=='BRMM_q15_prediction');self.assertEqual(len(q.sectors),3);self.assertTrue(q.homogeneous_scale_fixed_one);self.assertIn('generator-1',q.token);self.assertIn('live-origin-3',q.token)
+        raw=L._q15_injection('H',I(1.7),I(.005));self.assertNotEqual(q.response,tuple(tuple(x for x in r) for r in raw))
+        b=next(x for x in d['source_blocks'] if x.kind=='shared_bias_driver');self.assertEqual(len(b.response[0]),4);self.assertEqual(b.family_parameter_token,family('BIAS0').parameter_token)
 
-    def test_A21_prediction_uses_one_bias_driver_for_error_and_truth(self):
+    def test_each_BIAS_family_uses_same_driver_for_error_and_truth(self):
         p=cell('A','prediction',0)
-        d=L.compose_attached_sample(lineage('A',[p]),phi_true=I(.9999),tau_ba=I(1800))
-        b=next(x for x in d['source_blocks'] if x.kind=='shared_bias_driver')
-        B=b.response
-        for i in range(3):
-            self.assertTrue(B[18+i][i].contains(1.0))
-            self.assertTrue(B[21+i][i].contains(1.0))
-        self.assertEqual(d['q15_prediction_blocks'],1)
+        for contract in BIAS.contracts():
+            d=L.compose_attached_sample(lineage('A',[p]),bias_contract=contract,tau_ba=I(1800))
+            b=next(x for x in d['source_blocks'] if x.kind=='shared_bias_driver');B=b.response
+            for i in range(3):
+                self.assertTrue(B[18+i][1+i].contains(1.0));self.assertTrue(B[21+i][1+i].contains(1.0))
+            self.assertEqual(b.family_parameter_token,contract.parameter_token);self.assertTrue(any(n=='bias_driver_ball' for n,_ in b.sectors))
+        self.assertTrue(family('BIAS2').phi_true.contains(1.0))
 
     def test_accelerometer_and_magnetometer_suffix_propagate_existing_sources(self):
         cells=[cell('H','prediction',0),cell('H','accelerometer',1),cell('H','magnetometer',2)]
-        d=L.compose_attached_sample(
-            lineage('H',cells),phi_true=I(.9999),
-            held_bias_error=[Interval(-.85,.85) for _ in range(3)],
-            true_bias=[Interval(-.45,.45) for _ in range(3)])
-        self.assertEqual(d['literal_event_kinds'],('prediction','accelerometer','magnetometer'))
-        self.assertEqual(d['q15_prediction_blocks'],1)
-        self.assertEqual(len(d['J_joint24']),24)
-        self.assertEqual(len(d['J_joint24'][0]),24)
+        d=L.compose_attached_sample(lineage('H',cells),bias_contract=family('BIAS1'),held_bias_error=[Interval(-.85,.85) for _ in range(3)],true_bias=[Interval(-.45,.45) for _ in range(3)])
+        self.assertEqual(d['literal_event_kinds'],('prediction','accelerometer','magnetometer'));self.assertEqual(d['q15_prediction_blocks'],1);self.assertEqual((len(d['J_joint24']),len(d['J_joint24'][0])),(24,24))
 
     def test_contract_is_real_progress_but_still_blocks_storage(self):
-        d=L.build()
-        self.assertEqual(L.validate(d),[])
-        self.assertTrue(d['source_uniform_attached_sample_cocycle_available'])
-        self.assertTrue(d['joint_q15_quadratic_sector_attached_to_same_block'])
-        self.assertFalse(d['multi_sample_COMPLETE_BRMM_word_composed'])
-        self.assertFalse(d['storage_search_allowed'])
-        self.assertFalse(d['ALT_LIVE_PASS'])
+        d=L.build();self.assertEqual(L.validate(d),[]);self.assertTrue(d['source_uniform_attached_sample_cocycle_available']);self.assertTrue(d['joint_q15_quadratic_sector_attached_to_same_block']);self.assertTrue(d['explicit_BIAS0_BIAS1_BIAS2_contract_required_by_cocycle']);self.assertFalse(d['multi_sample_COMPLETE_BRMM_word_composed']);self.assertFalse(d['storage_search_allowed']);self.assertFalse(d['ALT_LIVE_PASS'])
 
-if __name__=='__main__':
-    unittest.main()
+if __name__=='__main__': unittest.main()

--- a/tests/ou3_alt_contraction/test_physical_numeric_bounds.py
+++ b/tests/ou3_alt_contraction/test_physical_numeric_bounds.py
@@ -1,0 +1,15 @@
+import unittest
+from tools.stability.ou3_alt_contraction import physical_numeric_bounds as P
+
+
+class PhysicalNumericBoundsTest(unittest.TestCase):
+    def test_repaired_physics_supplies_alt_centered_S_bound(self):
+        d=P.build(); self.assertEqual(P.validate(d),[])
+        self.assertTrue(d['numeric_complete_family_physical_envelope_closed'])
+        self.assertEqual(d['centered_S_norm_upper_m_s'],1100.0)
+        self.assertFalse(d['legacy_300m_s_used_as_physical_bound'])
+        self.assertFalse(d['D_S_comes_from_P4_working_radius'])
+        self.assertTrue(d['usable_by_ALT_finite_event_outer_enclosure'])
+
+
+if __name__=='__main__': unittest.main()

--- a/tests/ou3_alt_contraction/test_physical_reference.py
+++ b/tests/ou3_alt_contraction/test_physical_reference.py
@@ -1,0 +1,37 @@
+"""Theorem algebra regressions for ALT physical-reference forcing."""
+import sys,unittest
+from pathlib import Path
+ROOT=Path(__file__).resolve().parents[2]
+sys.path[:0]=[str(ROOT),str(ROOT/'tools/stability')]
+from ou3_interval import Interval
+import ou3_brmm_complete_window_execution_kernel as K
+from tools.stability.ou3_alt_contraction import physical_reference as P
+I=Interval.point
+
+def primitive(S=(7,-2,1)):
+    z=(I(0),I(0),I(0));return K.WavePrimitivePayload('generator','qin','qout','one-live-origin',z,z,tuple(map(I,S)),z,z,z)
+
+class PhysicalReferenceTests(unittest.TestCase):
+    def test_s_zero_is_error_minus_same_physical_S(self):
+        r=P.s_zero_residual((I(8),I(-1),I(4)),primitive())
+        self.assertTrue(all(x.contains(v) for x,v in zip(r,[1,1,3])))
+        M=P.s_zero_residual_operator();q=[I(8),I(-1),I(4),I(7),I(-2),I(1)]
+        mr=P._matvec(M,q);self.assertTrue(all(mr[i].contains([1,1,3][i]) for i in range(3)))
+    def test_bias_error_uses_one_truth_history(self):
+        e=(I(.1),I(-.2),I(.3));b0=(I(.04),I(-.03),I(.02));b1=(I(.041),I(-.029),I(.018));ph=I(.99)
+        direct=P.bias_error_prediction(e,b0,b1,ph);M=P.bias_prediction_operator(ph);lift=P._matvec(M,[*e,*b0,*b1])
+        self.assertTrue(all(direct[i].contains_interval(lift[i]) or lift[i].contains_interval(direct[i]) for i in range(3)))
+    def test_H18_held_bias_is_not_dropped(self):
+        r=P.h18_accelerometer_residual((I(1),I(2),I(3)),(I(.1),I(-.2),I(.3)))
+        self.assertTrue(all(x.contains(v) for x,v in zip(r,[1.1,1.8,3.3])))
+    def test_shared_physical_forcing_and_sector_are_consumed(self):
+        d=P.build();self.assertEqual(P.validate(d),[])
+        self.assertTrue(d['shared_exact_BRMM_vs_OU_prediction_forcing_consumed'])
+        self.assertTrue(d['shared_joint_15D_acceleration_witness_sector_consumed'])
+        self.assertTrue(d['shared_one_time_S_origin_prefix_invariant_consumed'])
+        self.assertFalse(d['complete_word_master_closed']);self.assertFalse(d['ALT_LIVE_PASS'])
+    def test_detached_or_missing_primitive_is_rejected(self):
+        with self.assertRaises(TypeError):P.validate_primitive_reference(None)
+        w=primitive();object.__setattr__(w,'live_origin_id','')
+        with self.assertRaises(ValueError):P.validate_primitive_reference(w)
+if __name__=='__main__':unittest.main()

--- a/tests/ou3_alt_contraction/test_physical_word.py
+++ b/tests/ou3_alt_contraction/test_physical_word.py
@@ -1,0 +1,39 @@
+import unittest
+from types import SimpleNamespace
+
+from ou3_interval import Interval
+import ou3_brmm_complete_window_execution_kernel as KERNEL
+import ou3_p4_complete_brmm_source_cover_contract as COVER
+import ou3_p4_complete_brmm_differential_events as EVENTS
+from tools.stability.ou3_alt_contraction import bias_families as BIAS
+from tools.stability.ou3_alt_contraction import physical_word as W
+
+I=Interval.point
+
+def eye(n):return [[I(1 if i==j else 0) for j in range(n)] for i in range(n)]
+def prim(k):
+    z=(I(0),I(0),I(0))
+    return KERNEL.WavePrimitivePayload('g',f'p{k}',f'p{k+1}','live',z,z,z,z,z,z)
+def line(k,parent,child,mode='H'):
+    n=18 if mode=='H' else 21;p=prim(k)
+    common=dict(source_token=child+':e0',predecessor_token=child,mode=mode,sample_index=k,event_ordinal=0,kind='prediction',state=[I(0) for _ in range(n)],P=eye(n),dt_s=I(.005),tau_applied_s=I(1.5),sigma_aw_mps2=I(.4),pseudo_elapsed_s=I(.1),radial_scale=I(1),estimator_source_token=child,estimator_predecessor_token=parent,estimator_generated_coefficients=True,wave_primitive=p)
+    if mode=='A':common.update(true_bias=[I(0),I(0),I(0)],bias_projection_limit=.4)
+    c=COVER.SourceCoverCell(**common)
+    s=SimpleNamespace(prefix_length=k+1,parent_source_cell_id=parent,source_cell_id=child,sample_coordinates=SimpleNamespace(omega_body_corrected=(I(0),I(0),I(0))))
+    return SimpleNamespace(mode=mode,cells=(c,),selector=s)
+def family(name='BIAS0'):return next(c for c in BIAS.contracts() if c.name==name)
+
+class PhysicalWordTests(unittest.TestCase):
+    def test_two_prefix_cocycle_preserves_source_and_bias_ancestry(self):
+        d=W.compose_endpoint_lineage([line(0,'root','c1'),line(1,'c1','c2')],bias_contract=family())
+        self.assertEqual(d['transitions_composed'],2);self.assertTrue(d['selector_ancestry_continuous']);self.assertTrue(d['primitive_transition_continuity']);self.assertTrue(d['one_generator_over_word']);self.assertTrue(d['one_Live_S_origin_over_word']);self.assertTrue(d['all_physical_blocks_tied_to_global_relation']);self.assertTrue(d['one_bias_parameter_token_over_word']);self.assertFalse(d['complete_word_length'])
+    def test_broken_primitive_or_selector_continuity_fails_closed(self):
+        a=line(0,'root','c1');b=line(1,'bad','c2')
+        with self.assertRaises(ValueError):W.compose_endpoint_lineage([a,b],bias_contract=family())
+        b=line(1,'c1','c2');object.__setattr__(b.cells[0].wave_primitive,'primitive_in_id','wrong')
+        with self.assertRaises(ValueError):W.compose_endpoint_lineage([a,b],bias_contract=family())
+    def test_universal_single_mode_word_induction_closes_but_hybrid_stays_blocked(self):
+        d=W.induction_theorem();self.assertEqual(W.validate(d),[])
+        self.assertTrue(d['finite_induction_premises_closed']);self.assertTrue(d['H18_complete_word_construction_closed']);self.assertTrue(d['A21_complete_word_construction_closed']);self.assertTrue(d['physical_prediction_forcing_attached']);self.assertTrue(d['physical_S_residual_attached']);self.assertTrue(d['all_bias_families_attached_to_single_mode_word']);self.assertTrue(d['same_history_COMPLETE_BRMM_single_mode_word_closed']);self.assertFalse(d['hybrid_H18_A21_word_closed']);self.assertFalse(d['storage_search_allowed'])
+
+if __name__=='__main__':unittest.main()

--- a/tests/ou3_alt_contraction/test_prediction_quaternion_branch.py
+++ b/tests/ou3_alt_contraction/test_prediction_quaternion_branch.py
@@ -1,0 +1,24 @@
+import unittest
+from tools.stability.ou3_alt_contraction import prediction_quaternion_branch as B
+
+
+class PredictionQuaternionBranchTests(unittest.TestCase):
+    def test_regional_domain_excludes_trig_branch(self):
+        d=B.build();self.assertEqual(B.validate(d),[])
+        self.assertLess(d['nominal_step_angle_norm_upper_rad'],B.THRESHOLD_RAD)
+        self.assertLess(d['shadow_step_angle_norm_upper_rad'],B.THRESHOLD_RAD)
+        self.assertGreater(d['shadow_margin_to_threshold_rad'],0.006)
+        self.assertFalse(d['trigonometric_prediction_branch_reachable_in_regional_domain'])
+        self.assertFalse(d['binary32_polynomial_and_normalization_roundoff_closed'])
+        self.assertFalse(d['ALT_LIVE_PASS'])
+
+    def test_polynomial_parameters_match_branch_origin(self):
+        w,k=B.small_branch_parameters(0.0)
+        self.assertEqual(w,1.0);self.assertEqual(k,0.5)
+
+    def test_threshold_is_strict(self):
+        with self.assertRaises(ValueError):B.small_branch_parameters(B.THRESHOLD_RAD**2)
+        with self.assertRaises(ValueError):B.small_branch_parameters(-1.0)
+
+
+if __name__=='__main__': unittest.main()

--- a/tests/ou3_alt_contraction/test_projected_storage_certificate.py
+++ b/tests/ou3_alt_contraction/test_projected_storage_certificate.py
@@ -1,0 +1,48 @@
+import unittest
+import numpy as np
+
+from ou3_interval import Interval, matrix_point
+from tools.stability.ou3_alt_contraction import projected_storage_certificate as C
+
+
+class ProjectedStorageCertificateTest(unittest.TestCase):
+    def test_point_interval_family_certifies_neutral_supply_example(self):
+        A=matrix_point([[0.5,0.7],[0.0,1.0]])
+        M=np.array([[2.0,0.3],[0.3,1.0]])
+        d=C.certify_projected_interval_family(A,M,0.95,(1,))
+        self.assertTrue(d['metric_spd'])
+        self.assertTrue(d['projected_strict'])
+        self.assertGreater(d['worst_projected_ldlt_pivot_lower'],0.0)
+        self.assertFalse(d['ordinary_eigenvalue_used_for_certificate'])
+
+    def test_interval_family_is_certified_as_family_not_midpoint(self):
+        # A11 in [0.45,0.55] is still uniformly contracting on ker(C).
+        A=[[Interval.outward_bounds(0.45,0.55),Interval.outward_bounds(0.6,0.8)],
+           [Interval.point(0.0),Interval.point(1.0)]]
+        d=C.certify_projected_interval_family(A,np.eye(2),0.9,(1,))
+        self.assertTrue(d['projected_strict'])
+        self.assertTrue(d['interval_family_consumed'])
+
+    def test_unsupplied_neutral_family_fails_outward_ldlt(self):
+        A=matrix_point([[1.0,0.0],[0.0,1.0]])
+        d=C.certify_projected_interval_family(A,np.eye(2),0.9,(1,))
+        self.assertTrue(d['metric_spd'])
+        self.assertFalse(d['projected_strict'])
+
+    def test_non_spd_metric_fails_before_storage_claim(self):
+        A=matrix_point([[0.5,0.0],[0.0,1.0]])
+        d=C.certify_projected_interval_family(A,[[1.0,0.0],[0.0,-1.0]],0.9,(1,))
+        self.assertFalse(d['metric_spd'])
+        self.assertFalse(d['projected_strict'])
+
+    def test_theorem_backend_remains_fail_closed_without_universal_family(self):
+        d=C.build(); f=C.validate(d)
+        self.assertEqual(f,[])
+        self.assertTrue(d['outward_full_matrix_LDLT_terminal_gate'])
+        self.assertFalse(d['source_uniform_endpoint_family_enclosure_closed'])
+        self.assertFalse(d['common_M_source_uniform_projected_LDLT_closed'])
+        self.assertFalse(d['ALT_LIVE_PASS'])
+
+
+if __name__=='__main__':
+    unittest.main()

--- a/tests/ou3_alt_contraction/test_proof_plan.py
+++ b/tests/ou3_alt_contraction/test_proof_plan.py
@@ -1,0 +1,16 @@
+import unittest
+from tools.stability.ou3_alt_contraction import proof_plan as P
+
+class PlanGuardTests(unittest.TestCase):
+    def test_diagnostic_cannot_be_main_proof_task(self):
+        with self.assertRaises(RuntimeError):
+            P.require_theorem_task(obligation='Live word',evidence_kind='unreachable_perturbation',complete_physical_word=False,requested_phase='physical_map')
+    def test_storage_is_hard_blocked_before_complete_word(self):
+        with self.assertRaises(RuntimeError):
+            P.require_theorem_task(obligation='common storage',evidence_kind='analytic_source',complete_physical_word=False,requested_phase='storage_search')
+        with self.assertRaises(RuntimeError):P.assert_storage_search_allowed({})
+    def test_storage_guard_names_every_required_closure(self):
+        s={k:True for k in ('same_history_complete_BRMM_word','physical_prediction_forcing_attached','physical_S_residual_attached','all_bias_families_attached','all_literal_branches_attached','H18_A21_edge_attached')}
+        self.assertTrue(P.storage_search_allowed(s));P.assert_storage_search_allowed(s)
+
+if __name__=='__main__':unittest.main()

--- a/tests/ou3_alt_contraction/test_proof_plan.py
+++ b/tests/ou3_alt_contraction/test_proof_plan.py
@@ -9,6 +9,22 @@ class PlanGuardTests(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             P.require_theorem_task(obligation='common storage',evidence_kind='analytic_source',complete_physical_word=False,requested_phase='storage_search')
         with self.assertRaises(RuntimeError):P.assert_storage_search_allowed({})
+    def test_six_assembly_flags_do_not_qualify_a_finite_master(self):
+        s={k:True for k in ('same_history_complete_BRMM_word','physical_prediction_forcing_attached','physical_S_residual_attached','all_bias_families_attached','all_literal_branches_attached','H18_A21_edge_attached')}
+        with self.assertRaisesRegex(RuntimeError,'finite-state storage blocked'):
+            P.assert_finite_storage_master(s)
+    def test_derivative_word_is_not_a_finite_state_identity(self):
+        from tools.stability.ou3_alt_contraction import physical_word as W
+        with self.assertRaisesRegex(RuntimeError,'not a Jacobian cocycle'):
+            P.assert_finite_storage_master(W.finite_storage_readiness())
+    def test_finite_guard_requires_every_branch_and_reference_graph(self):
+        s=dict(map_representation='finite_physical_descriptor',finite_error_identity_for_every_event=True,
+               physical_reference_forcing_retained=True,all_coefficient_product_graphs_retained=True,
+               all_configured_branches_bound_to_finite_graph=True)
+        P.assert_finite_storage_master(s)  # Process check only, never a proof certificate.
+        for key in tuple(s):
+            q=dict(s);q.pop(key)
+            with self.assertRaises(RuntimeError):P.assert_finite_storage_master(q)
     def test_storage_guard_names_every_required_closure(self):
         s={k:True for k in ('same_history_complete_BRMM_word','physical_prediction_forcing_attached','physical_S_residual_attached','all_bias_families_attached','all_literal_branches_attached','H18_A21_edge_attached')}
         self.assertTrue(P.storage_search_allowed(s));P.assert_storage_search_allowed(s)

--- a/tools/stability/ou3_alt_contraction/asynchronous_event_star.py
+++ b/tools/stability/ou3_alt_contraction/asynchronous_event_star.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Count-free asynchronous-event closure for the ALT Live theorem.
+
+Normal Live deliberately does not assume a magnetometer ODR as a theorem input.
+The typed shipping kernel accepts a finite tuple of asynchronous magnetometer
+events after an IMU sample and executes *all* of them.  Therefore an endpoint
+cover that merely chooses zero/one magnetic update per IMU sample is not
+universal.
+
+The correct count-free composition is a Kleene-star argument.  Let V be the
+same common storage used by the IMU-word certificate.  If every admitted
+accepted magnetometer event satisfies
+
+    V(M_m(x)) <= V(x)
+
+on the required chart/domain, then by finite induction every finite sequence
+M_{m_q} o ... o M_{m_1} is nonexpansive.  Rejected/not-due packets are identity
+and satisfy the same inequality.  Thus arbitrary finite asynchronous insertions
+do not require an event-count upper bound and cannot worsen the strict
+contraction supplied by the IMU word.
+
+This module closes only the logical composition rule.  The source-uniform
+nonexpansive inequality for one physical magnetometer event remains a numerical
+common-storage obligation and must be certified with the same M; no ODR or
+finite packet-count assumption may replace it.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REPO=Path(__file__).resolve().parents[3]
+DOMAIN=REPO/'tools/stability/ou3_proof_operating_domain.json'
+KERNEL=REPO/'tools/stability/ou3_brmm_complete_window_execution_kernel.py'
+QUALIFICATION='OU3_ALT_ASYNC_MAGNETOMETER_KLEENE_STAR_V1'
+
+
+def finite_star_rho(single_event_rho: float, count: int) -> float:
+    """Composition bound for diagnostic/unit algebra; theorem uses rho<=1."""
+    r=float(single_event_rho); q=int(count)
+    if not (0.0 <= r <= 1.0) or q < 0: raise ValueError('require rho in [0,1], finite count >=0')
+    return r**q
+
+
+def build():
+    live=json.loads(DOMAIN.read_text())['normal_live']; text=KERNEL.read_text()
+    typed_tuple='magnetometer_events_after_imu: tuple[MagneticEvent, ...]' in text
+    all_loop='for magnetic_event_index, event in enumerate(sample.magnetometer_events_after_imu):' in text
+    no_odr=bool(live.get('magnetic_reference_handling'))
+    # PE module/domain deliberately supplies recurrence, not a count cap.
+    return {
+      'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD',
+      'typed_kernel_accepts_finite_async_event_tuple':typed_tuple,
+      'typed_kernel_executes_every_async_event':all_loop,
+      'magnetometer_event_count_upper_bound_assumed':False,
+      'magnetometer_ODR_used_as_stability_assumption':False,
+      'zero_or_one_mag_per_IMU_is_universal_cover':False,
+      'rejected_or_not_due_event_map_is_identity':True,
+      'finite_star_induction_rule':'V(M_m x)<=V(x) for every admitted m => V(M_q...M_1 x)<=V(x) for every finite q',
+      'finite_star_composition_theorem_closed':bool(typed_tuple and all_loop and no_odr),
+      'same_common_storage_required_for_mag_and_IMU_word':True,
+      'single_source_uniform_magnetometer_nonexpansive_certificate_closed':False,
+      'arbitrary_finite_async_magnetometer_sequence_closed':False,
+      'ALT_LIVE_PASS':False,
+      'next_obligation':'with the eventual common M, certify each admitted physical magnetometer event nonexpansive source-uniformly; then finite induction closes every asynchronous event tuple without any ODR/count assumption',
+    }
+
+
+def validate(d):
+    f=[]
+    if d.get('qualification')!=QUALIFICATION:f.append('qualification mismatch')
+    for k in ('typed_kernel_accepts_finite_async_event_tuple','typed_kernel_executes_every_async_event','rejected_or_not_due_event_map_is_identity','finite_star_composition_theorem_closed','same_common_storage_required_for_mag_and_IMU_word'):
+        if d.get(k) is not True:f.append(k+' not true')
+    for k in ('magnetometer_event_count_upper_bound_assumed','magnetometer_ODR_used_as_stability_assumption','zero_or_one_mag_per_IMU_is_universal_cover','single_source_uniform_magnetometer_nonexpansive_certificate_closed','arbitrary_finite_async_magnetometer_sequence_closed','ALT_LIVE_PASS'):
+        if d.get(k) is not False:f.append(k+' not false')
+    return f

--- a/tools/stability/ou3_alt_contraction/bias_families.py
+++ b/tools/stability/ou3_alt_contraction/bias_families.py
@@ -58,7 +58,7 @@ def driver_ball_iqc(contract: BiasFamilyContract):
     if not (math.isfinite(W) and W>=0):
         raise ValueError("finite nonnegative driver norm bound required")
     Q=[[I(0) for _ in range(4)] for _ in range(4)]
-    Q[0][0]=I(W*W)
+    Q[0][0]=I(W).square()
     for i in range(3): Q[1+i][1+i]=I(-1)
     return Q
 
@@ -69,7 +69,7 @@ def true_bias_ball_iqc(contract: BiasFamilyContract):
     if not (math.isfinite(B) and B>=0):
         raise ValueError("finite nonnegative true-bias norm bound required")
     Q=[[I(0) for _ in range(4)] for _ in range(4)]
-    Q[0][0]=I(B*B)
+    Q[0][0]=I(B).square()
     for i in range(3): Q[1+i][1+i]=I(-1)
     return Q
 
@@ -88,7 +88,7 @@ def _contract(name, module):
         raise RuntimeError(name+" lost one-history source requirement")
     c=BiasFamilyContract(
         name=name, qualification=str(d['qualification']),
-        phi_true=Interval.outward_bounds(lo,hi),
+        phi_true=Interval(lo,hi),  # Already-certified source endpoints; phi=1 is exact.
         driver_component_bound=float(d['driver_increment_component_abs_upper_mps2']),
         driver_norm_bound=float(d['driver_increment_norm_upper_mps2']),
         true_bias_component_bound=float(d['true_bias_component_abs_upper_mps2']),

--- a/tools/stability/ou3_alt_contraction/bias_families.py
+++ b/tools/stability/ou3_alt_contraction/bias_families.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Theorem-facing BIAS0/1/2 contracts for the ALT joint24 word.
+
+This module consumes the three existing conditional physical source families
+separately.  It never calls the aggregate fresh-Live entry/supply builder.
+For each family it retains one physical bias history over the word,
+
+    beta+ = phi_true beta + w,
+
+with the family-specific hard interval for phi_true and analytic hard bound on
+the SAME three-component driver w.  The same w columns are used by beta and the
+accelerometer-bias error recurrence in ``physical_lineage``.
+
+The homogeneous driver sector is
+
+    ||w||^2 <= W^2 h_s^2,   h_s=1,
+
+and is an analytic theorem constraint, not a replay fit.  The family contract
+also carries the hard true-bias norm bound needed by projection/basin closure.
+A persistent ``parameter_token`` is deliberately part of the contract: the
+multi-sample master must reuse it at every prediction instead of choosing a new
+phi/root at each sample.  This file makes those source contracts available; it
+does not by itself prove that the 600-step master preserved the token.
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+import math
+
+from ou3_interval import Interval
+import ou3_p4_bias0_family as BIAS0
+import ou3_p4_bias1_family as BIAS1
+import ou3_p4_bias2_family as BIAS2
+
+QUALIFICATION = "OU3_ALT_ANALYTIC_BIAS_FAMILY_CONTRACTS_V1"
+
+
+def I(x: float) -> Interval:
+    return Interval.point(float(x))
+
+
+@dataclass(frozen=True)
+class BiasFamilyContract:
+    name: str
+    qualification: str
+    phi_true: Interval
+    driver_component_bound: float
+    driver_norm_bound: float
+    true_bias_component_bound: float
+    true_bias_norm_bound: float
+    parameter_token: str
+    one_history_required: bool
+    non_relaxing_limit_admitted: bool
+
+
+def driver_ball_iqc(contract: BiasFamilyContract):
+    """Q on [h_s,w_x,w_y,w_z] with z^T Q z >= 0."""
+    W=float(contract.driver_norm_bound)
+    if not (math.isfinite(W) and W>=0):
+        raise ValueError("finite nonnegative driver norm bound required")
+    Q=[[I(0) for _ in range(4)] for _ in range(4)]
+    Q[0][0]=I(W*W)
+    for i in range(3): Q[1+i][1+i]=I(-1)
+    return Q
+
+
+def true_bias_ball_iqc(contract: BiasFamilyContract):
+    """Q on [h_s,beta_x,beta_y,beta_z] with ||beta|| <= B."""
+    B=float(contract.true_bias_norm_bound)
+    if not (math.isfinite(B) and B>=0):
+        raise ValueError("finite nonnegative true-bias norm bound required")
+    Q=[[I(0) for _ in range(4)] for _ in range(4)]
+    Q[0][0]=I(B*B)
+    for i in range(3): Q[1+i][1+i]=I(-1)
+    return Q
+
+
+def _contract(name, module):
+    d=module.build(); failures=module.validate(d)
+    if failures:
+        raise RuntimeError(f"{name} source family invalid: {failures!r}")
+    lo,hi=map(float,d['phi_true_interval'])
+    one_history = bool(
+        d.get('one_composite_history_required')
+        or d.get('one_root_one_parameter_history_required')
+        or d.get('one_drift_history_required')
+    )
+    if not one_history:
+        raise RuntimeError(name+" lost one-history source requirement")
+    c=BiasFamilyContract(
+        name=name, qualification=str(d['qualification']),
+        phi_true=Interval.outward_bounds(lo,hi),
+        driver_component_bound=float(d['driver_increment_component_abs_upper_mps2']),
+        driver_norm_bound=float(d['driver_increment_norm_upper_mps2']),
+        true_bias_component_bound=float(d['true_bias_component_abs_upper_mps2']),
+        true_bias_norm_bound=float(d['true_bias_norm_upper_mps2']),
+        parameter_token=f"{name}:one-physical-history:phi-root-and-driver",
+        one_history_required=True,
+        non_relaxing_limit_admitted=bool(d.get('non_relaxing_limit_admitted',False)),
+    )
+    if not (0<c.phi_true.lo<=c.phi_true.hi<=1):
+        raise RuntimeError(name+" invalid phi interval")
+    return c
+
+
+def contracts():
+    return tuple(_contract(name,module) for name,module in (
+        ('BIAS0',BIAS0),('BIAS1',BIAS1),('BIAS2',BIAS2)))
+
+
+def build():
+    cs=contracts()
+    return {
+        'qualification':QUALIFICATION,
+        'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD',
+        'families':tuple(c.name for c in cs),
+        'three_families_invoked_separately':tuple(c.name for c in cs)==('BIAS0','BIAS1','BIAS2'),
+        'one_persistent_parameter_token_per_family':all(c.one_history_required and bool(c.parameter_token) for c in cs),
+        'analytic_driver_ball_IQC_available_for_each_family':all(driver_ball_iqc(c) for c in cs),
+        'analytic_true_bias_ball_IQC_available_for_each_family':all(true_bias_ball_iqc(c) for c in cs),
+        'BIAS2_non_relaxing_limit_retained':next(c for c in cs if c.name=='BIAS2').non_relaxing_limit_admitted,
+        'aggregate_fresh_Live_entry_builder_consumed':False,
+        'replay_or_finite_seed_bound_used':False,
+        'independent_per_sample_beta_slots_used':False,
+        'multi_sample_parameter_token_continuity_closed_here':False,
+        'all_bias_families_attached_to_complete_word':False,
+        'ALT_LIVE_PASS':False,
+        'next_obligation':'use one selected family contract on every prediction of a complete source lineage, preserve its parameter_token and shared w response columns across all samples, and close all three family masters separately',
+    }
+
+
+def validate(d):
+    f=[]
+    if d.get('qualification')!=QUALIFICATION:f.append('qualification mismatch')
+    if tuple(d.get('families',()))!=('BIAS0','BIAS1','BIAS2'):f.append('family set/order changed')
+    for k in ('three_families_invoked_separately','one_persistent_parameter_token_per_family','analytic_driver_ball_IQC_available_for_each_family','analytic_true_bias_ball_IQC_available_for_each_family','BIAS2_non_relaxing_limit_retained'):
+        if d.get(k) is not True:f.append(k+' not true')
+    for k in ('aggregate_fresh_Live_entry_builder_consumed','replay_or_finite_seed_bound_used','independent_per_sample_beta_slots_used','multi_sample_parameter_token_continuity_closed_here','all_bias_families_attached_to_complete_word','ALT_LIVE_PASS'):
+        if d.get(k) is not False:f.append(k+' not false')
+    return f

--- a/tools/stability/ou3_alt_contraction/coarse_endpoint_outer_attempt.py
+++ b/tools/stability/ou3_alt_contraction/coarse_endpoint_outer_attempt.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""First 600-step numerical outer for the ALT Normal-Live IMU core.
+
+For each H/A x BIAS0/1/2 family, ``coarse_imu_core_outer`` supplies two outward
+24x24 per-sample maps: S not-due and S due.  Their entrywise interval hull H is
+an outer set containing either literal map.  Therefore every length-N product
+A_N...A_1 with A_k chosen from those maps belongs to the interval matrix power
+H^N computed with outward interval multiplication.
+
+This intentionally forgets scheduler correlations after proving set inclusion;
+it does NOT assert the hull is a realizable source transition.  Fast binary
+exponentiation is only an exact arithmetic optimization of that outer product
+set.  If dependency blow-up makes H^600 useless/nonfinite, the result says the
+single-hull representation is too coarse and must be partitioned; it does not
+shrink the physical theorem family.
+
+Asynchronous magnetometer events remain excluded and are governed separately by
+``asynchronous_event_star``.
+"""
+from __future__ import annotations
+
+import math
+from ou3_interval import matrix_identity,matrix_mul
+from tools.stability.ou3_alt_contraction import coarse_imu_core_outer as CORE
+from tools.stability.ou3_alt_contraction import endpoint_family_induction as OUTER
+from tools.stability.ou3_alt_contraction import asynchronous_event_star as MAGSTAR
+
+QUALIFICATION='OU3_ALT_COARSE_600_STEP_IMU_ENDPOINT_OUTER_V1'
+TRANSITIONS=600
+
+
+def interval_matrix_power(A,n:int):
+    n=int(n)
+    if n<0:raise ValueError('nonnegative power required')
+    dim=len(A)
+    if dim==0 or any(len(r)!=dim for r in A):raise ValueError('square matrix required')
+    result=matrix_identity(dim);base=A
+    while n:
+        if n&1:result=matrix_mul(base,result)
+        n//=2
+        if n:base=matrix_mul(base,base)
+    return result
+
+def finite_matrix(A):return all(math.isfinite(x.lo) and math.isfinite(x.hi) for row in A for x in row)
+def max_width(A):return max((x.hi-x.lo for row in A for x in row),default=0.0)
+def max_abs(A):return max((max(abs(x.lo),abs(x.hi)) for row in A for x in row),default=0.0)
+
+def build():
+    core=CORE.build();cf=CORE.validate(core);star=MAGSTAR.build();sf=MAGSTAR.validate(star)
+    if cf or sf:raise RuntimeError(f'endpoint outer prerequisites failed core={cf} star={sf}')
+    reports={}
+    for mode,rows in core['reports'].items():
+        reports[mode]={}
+        for family,row in rows.items():
+            r={'imu_core_family_finite':row['imu_core_family_finite'],'endpoint_outer_finite':False,'endpoint_outer':None,'max_entry_width':None,'max_entry_abs':None,'failure':None}
+            if row['imu_core_family_finite']:
+                try:
+                    H=OUTER.hull_matrices(row['imu_core_family']);E=interval_matrix_power(H,TRANSITIONS)
+                    r.update(endpoint_outer=E,endpoint_outer_finite=finite_matrix(E),max_entry_width=max_width(E),max_entry_abs=max_abs(E))
+                    if not r['endpoint_outer_finite']:r['failure']='600-step interval hull power became nonfinite'
+                except Exception as exc:r['failure']=type(exc).__name__+': '+str(exc)
+            else:r['failure']='local IMU-core outer not finite; endpoint power not attempted'
+            reports[mode][family]=r
+    all_finite=all(r['endpoint_outer_finite'] for rows in reports.values() for r in rows.values())
+    return {
+      'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD','word_transitions':TRANSITIONS,
+      'S_due_two_pattern_hull_is_outer_only_not_history_generator':True,
+      'binary_interval_power_encloses_all_length_600_IMU_core_products':True,
+      'scheduler_correlations_relaxed_only_after_local_same_cell_outer':True,
+      'async_magnetometer_excluded_and_star_obligation_retained':True,
+      'reports':reports,'all_600_step_IMU_endpoint_outers_finite':all_finite,
+      'single_hull_600_step_representation_closed':all_finite,
+      'async_magnetometer_nonexpansive_same_M_closed':False,
+      'common_storage_closed':False,'ALT_LIVE_PASS':False,
+      'next_obligation':('use these endpoint outers only as the first common-M candidate family and certify projected storage; separately certify source-uniform magnetometer nonexpansiveness with the same M' if all_finite else 'partition the local source/scheduler/state/covariance outer before multiplication; do not shrink COMPLETE-BRMM')
+    }
+def summary(d):
+    return {m:{f:{k:r[k] for k in ('imu_core_family_finite','endpoint_outer_finite','max_entry_width','max_entry_abs','failure')} for f,r in rows.items()} for m,rows in d['reports'].items()}
+def validate(d):
+    f=[]
+    if d.get('qualification')!=QUALIFICATION or d.get('word_transitions')!=TRANSITIONS:f.append('qualification/window mismatch')
+    for k in ('S_due_two_pattern_hull_is_outer_only_not_history_generator','binary_interval_power_encloses_all_length_600_IMU_core_products','scheduler_correlations_relaxed_only_after_local_same_cell_outer','async_magnetometer_excluded_and_star_obligation_retained'):
+        if d.get(k) is not True:f.append(k+' not true')
+    for k in ('async_magnetometer_nonexpansive_same_M_closed','common_storage_closed','ALT_LIVE_PASS'):
+        if d.get(k) is not False:f.append(k+' not false')
+    return f

--- a/tools/stability/ou3_alt_contraction/coarse_imu_core_outer.py
+++ b/tools/stability/ou3_alt_contraction/coarse_imu_core_outer.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Universal coarse outer for one Normal-Live IMU core, excluding async mag.
+
+The shipping typed kernel has exactly one prediction and one accelerometer
+update per valid Normal-Live IMU sample, and a boolean S_zero_due flag.  Thus
+the homogeneous per-sample IMU core has exactly two literal event patterns:
+
+    prediction -> accelerometer
+    prediction -> S_zero -> accelerometer
+
+Asynchronous magnetometer calls are *not* part of this finite family because
+the theorem does not impose an event-count upper bound.  They are handled by
+``asynchronous_event_star`` and must later be proved nonexpansive in the same
+common storage.
+
+This module reuses ``coarse_universal_local_outer`` only for the certified
+coordinate-projection evaluation of the individual local shipping Jacobians.
+It never consumes that module's old zero/one-magnetometer sample-family field.
+"""
+from __future__ import annotations
+
+from ou3_interval import matrix_identity
+from tools.stability.ou3_alt_contraction import coarse_universal_local_outer as LOCAL
+from tools.stability.ou3_alt_contraction import asynchronous_event_star as MAGSTAR
+
+QUALIFICATION='OU3_ALT_COARSE_UNIVERSAL_IMU_CORE_OUTER_V1'
+
+
+def _compose(*maps):
+    A=matrix_identity(24)
+    from ou3_interval import matrix_mul
+    for J in maps:A=matrix_mul(J,A)
+    return A
+
+
+def build():
+    d=LOCAL.build();df=LOCAL.validate(d);star=MAGSTAR.build();sf=MAGSTAR.validate(star)
+    if df or sf:raise RuntimeError(f'IMU-core prerequisites failed local={df} star={sf}')
+    reports={}
+    for mode,rows in d['reports'].items():
+        reports[mode]={}
+        for family,row in rows.items():
+            finite=bool(row.get('prediction_finite') and row.get('S_zero_finite') and row.get('accelerometer_finite'))
+            fam={'bias_family':family,'failures':[x for x in row['failures'] if not x.startswith('magnetometer:')],
+                 'magnetometer_failures':[x for x in row['failures'] if x.startswith('magnetometer:')],
+                 'imu_core_family_finite':finite,'imu_core_family':[]}
+            if finite:
+                P=row['maps']['prediction'];S=row['maps']['S_zero'];A=row['maps']['accelerometer'];Id=matrix_identity(24)
+                fam['imu_core_family']=[_compose(P,s,A) for s in (Id,S)]
+            reports[mode][family]=fam
+    closed=all(r['imu_core_family_finite'] for rows in reports.values() for r in rows.values())
+    return {
+      'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD',
+      'one_prediction_per_IMU':True,'one_required_accelerometer_per_IMU':True,
+      'S_due_boolean_gives_zero_or_one_S_per_IMU':True,
+      'async_magnetometer_excluded_from_finite_IMU_core_family':True,
+      'async_magnetometer_count_upper_bound_assumed':False,
+      'async_magnetometer_star_theorem_consumed':star['finite_star_composition_theorem_closed'],
+      'reports':reports,'coarse_universal_IMU_core_family_materialized':closed,
+      'async_magnetometer_nonexpansive_same_M_closed':False,
+      'complete_async_sample_family_closed':False,'ALT_LIVE_PASS':False,
+      'next_obligation':('induct the two-pattern IMU-core outer over 600 steps and search common M; with that same M separately certify every source-uniform magnetometer event nonexpansive' if closed else 'split whichever prediction/S/accelerometer certified projection failed; magnetic failures are separate star obligation')
+    }
+
+
+def summary(d):
+    return {mode:{fam:{'failures':r['failures'],'magnetometer_failures':r['magnetometer_failures'],'imu_core_family_finite':r['imu_core_family_finite']} for fam,r in rows.items()} for mode,rows in d['reports'].items()}
+
+def validate(d):
+    f=[]
+    if d.get('qualification')!=QUALIFICATION:f.append('qualification mismatch')
+    for k in ('one_prediction_per_IMU','one_required_accelerometer_per_IMU','S_due_boolean_gives_zero_or_one_S_per_IMU','async_magnetometer_excluded_from_finite_IMU_core_family','async_magnetometer_star_theorem_consumed'):
+        if d.get(k) is not True:f.append(k+' not true')
+    for k in ('async_magnetometer_count_upper_bound_assumed','async_magnetometer_nonexpansive_same_M_closed','complete_async_sample_family_closed','ALT_LIVE_PASS'):
+        if d.get(k) is not False:f.append(k+' not false')
+    return f

--- a/tools/stability/ou3_alt_contraction/coarse_universal_local_outer.py
+++ b/tools/stability/ou3_alt_contraction/coarse_universal_local_outer.py
@@ -17,10 +17,10 @@ physical theorem.
 """
 from __future__ import annotations
 
-import json, math
+import argparse,json,math
 from pathlib import Path
 
-from ou3_interval import Interval, matrix_identity, matrix_mul
+from ou3_interval import Interval,matrix_identity,matrix_mul
 import ou3_brmm_riccati_tube_factored as TUBE
 import ou3_brmm_complete_window_execution_kernel as KERNEL
 import ou3_brmm_tuner_scheduler_step as TUNER
@@ -37,154 +37,112 @@ REPO=Path(__file__).resolve().parents[3]
 DOMAIN=REPO/'tools/stability/ou3_proof_operating_domain.json'
 QUALIFICATION='OU3_ALT_COARSE_UNIVERSAL_LOCAL_MAP_OUTER_V1'
 
-
-def I(x): return Interval.point(float(x))
-def B(r):
-    r=float(r)
-    return Interval.outward_bounds(-r,r)
-def _zero(r,c): return [[I(0) for _ in range(c)] for _ in range(r)]
-def _shape(A): return len(A),len(A[0]) if A else 0
+def I(x):return Interval.point(float(x))
+def B(r):r=float(r);return Interval.outward_bounds(-r,r)
+def _zero(r,c):return [[I(0) for _ in range(c)] for _ in range(r)]
+def _shape(A):return len(A),len(A[0]) if A else 0
 
 def psd_covariance_box_from_diagonal_upper(diag):
-    """Entrywise outer box for PSD P with P_ii <= diag_i.
-
-    PSD gives |P_ij|^2 <= P_ii P_jj <= d_i d_j.  This is a theorem outer
-    projection only; it is never treated as an independently reachable P box.
-    """
+    """Outer box for PSD P with P_ii<=d_i; never a reachable-P generator."""
     d=[float(x) for x in diag]
-    if not d or any(not math.isfinite(x) or x<=0 for x in d): raise ValueError('positive finite covariance diagonal ceiling required')
-    n=len(d); out=[]
+    if not d or any(not math.isfinite(x) or x<=0 for x in d):raise ValueError('positive finite covariance diagonal ceiling required')
+    n=len(d);out=[]
     for i in range(n):
         row=[]
         for j in range(n):
-            if i==j: row.append(Interval.outward_bounds(0.0,d[i]))
+            if i==j:row.append(Interval.outward_bounds(0.0,d[i]))
             else:
-                q=math.sqrt(d[i]*d[j]); q=math.nextafter(q,math.inf)
-                row.append(Interval(-q,q))
+                q=math.nextafter(math.sqrt(d[i]*d[j]),math.inf);row.append(Interval(-q,q))
         out.append(row)
     return out
 
-def error_state_box(mode, radii):
+def error_state_box(mode,radii):
     groups=(('attitude_cayley_norm',3),('gyro_bias_norm_rad_s',3),('velocity_norm_mps',3),('position_norm_m',3),('integral_displacement_norm_m_s',3),('latent_acceleration_norm_mps2',3))
     out=[]
-    for name,n in groups: out.extend([B(radii[name]) for _ in range(n)])
-    if mode=='A': out.extend([B(radii['accelerometer_bias_error_norm_mps2']) for _ in range(3)])
-    if len(out)!=(18 if mode=='H' else 21): raise RuntimeError('state box dimension drift')
+    for name,n in groups:out.extend([B(radii[name]) for _ in range(n)])
+    if mode=='A':out.extend([B(radii['accelerometer_bias_error_norm_mps2']) for _ in range(3)])
+    if len(out)!=(18 if mode=='H' else 21):raise RuntimeError('state box dimension drift')
     return out
 
-def _bias_domains(contract, projection_radius):
+def _bias_domains(contract,projection_radius):
     beta=[B(contract.true_bias_component_bound) for _ in range(3)]
-    # H18 error e_ba = beta-bhat, with ||bhat|| <= projection_radius.
     ecomp=float(contract.true_bias_component_bound)+float(projection_radius)
     return [B(ecomp) for _ in range(3)],beta
 
 def _a_prediction_lift(J21,phi_hat,phi_true):
     A=_zero(24,24)
     for i in range(21):
-        for j in range(21): A[i][j]=J21[i][j]
-    for i in range(3):
-        A[18+i][21+i]=phi_true-phi_hat
-        A[21+i][21+i]=phi_true
+        for j in range(21):A[i][j]=J21[i][j]
+    for i in range(3):A[18+i][21+i]=phi_true-phi_hat;A[21+i][21+i]=phi_true
     return A
 
 def prediction_outer(mode,state,omega,h,tau,tau_ba,contract):
     p=PRED.prediction_event(mode,state,omega,h,tau,tau_ba=tau_ba if mode=='A' else None)
-    if mode=='H': return J24.h18_prediction_lift(p['J_state'],contract.phi_true)[0]
-    return _a_prediction_lift(p['J_state'],p['phi_ba'],contract.phi_true)
+    return J24.h18_prediction_lift(p['J_state'],contract.phi_true)[0] if mode=='H' else _a_prediction_lift(p['J_state'],p['phi_ba'],contract.phi_true)
 
 def _h_joseph_outer(kind,state,P,R,held,beta,*,f=None,Rhat=None,m=None,Sphys=None):
-    extra=list(Sphys or ())
-    total=24+len(extra)
-    u=EVENTS.AD.independent_vector(list(state)+list(held)+list(beta)+extra,n=total,offset=0)
-    z=u[:18]; eba=u[18:21]
-    H=EVENTS._event_H('H',kind,f_hat=f,R_hat=Rhat,m_body=m)
-    K,_=EVENTS.source_joseph_gain(P,H,R)
-    if kind=='accelerometer': y=J24._h18_accel_residual(z,eba,f,Rhat)
-    elif kind=='magnetometer': y=EVENTS.residual_magnetometer(z,m)
-    elif kind=='S_zero': y=[z[EVENTS.OFF_S+i]-u[24+i] for i in range(3)]
-    else: raise ValueError(kind)
-    out=list(EVENTS._apply_physical_correction(z,K,y))+list(u[18:24])
-    return [row[:24] for row in EVENTS.AD.jacobian(out)]
+    extra=list(Sphys or ());total=24+len(extra);u=EVENTS.AD.independent_vector(list(state)+list(held)+list(beta)+extra,n=total,offset=0);z=u[:18];eba=u[18:21]
+    H=EVENTS._event_H('H',kind,f_hat=f,R_hat=Rhat,m_body=m);K,_=EVENTS.source_joseph_gain(P,H,R)
+    if kind=='accelerometer':y=J24._h18_accel_residual(z,eba,f,Rhat)
+    elif kind=='magnetometer':y=EVENTS.residual_magnetometer(z,m)
+    elif kind=='S_zero':y=[z[EVENTS.OFF_S+i]-u[24+i] for i in range(3)]
+    else:raise ValueError(kind)
+    out=list(EVENTS._apply_physical_correction(z,K,y))+list(u[18:24]);return [row[:24] for row in EVENTS.AD.jacobian(out)]
 def _a_joseph_outer(kind,state,P,R,beta,radius,*,f=None,Rhat=None,m=None,Sphys=None):
-    extra=list(Sphys or ()); total=24+len(extra)
-    u=EVENTS.AD.independent_vector(list(state)+list(beta)+extra,n=total,offset=0)
-    z=u[:21]; b=u[21:24]
-    H=EVENTS._event_H('A',kind,f_hat=f,R_hat=Rhat,m_body=m); K,_=EVENTS.source_joseph_gain(P,H,R)
-    if kind=='accelerometer': y=EVENTS.residual_accelerometer(z,f,Rhat)
-    elif kind=='magnetometer': y=EVENTS.residual_magnetometer(z,m)
-    elif kind=='S_zero': y=[z[EVENTS.OFF_S+i]-u[24+i] for i in range(3)]
-    else: raise ValueError(kind)
-    out21=EVENTS._apply_physical_correction(z,K,y)
-    J21,_,_=J24._project_joint(out21,b,total,float(radius))
-    J=[list(row) for row in J21]
-    for i in range(3):
-        row=[I(0) for _ in range(total)]; row[21+i]=I(1); J.append(row)
+    extra=list(Sphys or ());total=24+len(extra);u=EVENTS.AD.independent_vector(list(state)+list(beta)+extra,n=total,offset=0);z=u[:21];b=u[21:24]
+    H=EVENTS._event_H('A',kind,f_hat=f,R_hat=Rhat,m_body=m);K,_=EVENTS.source_joseph_gain(P,H,R)
+    if kind=='accelerometer':y=EVENTS.residual_accelerometer(z,f,Rhat)
+    elif kind=='magnetometer':y=EVENTS.residual_magnetometer(z,m)
+    elif kind=='S_zero':y=[z[EVENTS.OFF_S+i]-u[24+i] for i in range(3)]
+    else:raise ValueError(kind)
+    out21=EVENTS._apply_physical_correction(z,K,y);J21,_,_=J24._project_joint(out21,b,total,float(radius));J=[list(row) for row in J21]
+    for i in range(3):row=[I(0) for _ in range(total)];row[21+i]=I(1);J.append(row)
     return [row[:24] for row in J]
 def _compose(*maps):
     A=matrix_identity(24)
-    for J in maps: A=matrix_mul(J,A)
+    for J in maps:A=matrix_mul(J,A)
     return A
-
-def _finite_matrix(A):
-    return _shape(A)==(24,24) and all(math.isfinite(x.lo) and math.isfinite(x.hi) for row in A for x in row)
+def _finite_matrix(A):return _shape(A)==(24,24) and all(math.isfinite(x.lo) and math.isfinite(x.hi) for row in A for x in row)
 
 def build():
-    exact=EXACT.build(); xf=EXACT.validate(exact)
-    phys=PHYS.build(); pf=PHYS.validate(phys)
-    entry=ENTRY.build(); ef=ENTRY.validate(entry)
-    tube=TUBE.build(); tf=TUBE.validate_covariance_ceiling(tube)
-    if xf or pf or ef or tf: raise RuntimeError(f'coarse outer prerequisites failed exact={xf} phys={pf} entry={ef} tube={tf}')
-    domain=json.loads(DOMAIN.read_text())['normal_live']; kc=KERNEL._process_constants(DOMAIN); tc=TUNER.constants()
-    tau=Interval.outward_bounds(tc.tau_min,tc.tau_max)
-    omega_cap=math.radians(float(phys['body_rate_norm_upper_deg_s'])); omega=[B(omega_cap) for _ in range(3)]
-    fcap=float(phys['specific_force_norm_upper_mps2']); f=[B(fcap) for _ in range(3)]
-    Rhat=[[Interval(-1.0,1.0) for _ in range(3)] for _ in range(3)]
-    mcap=float(domain['magnetic_vector_norm_upper_uT']); m=[B(mcap) for _ in range(3)]
-    Sphys=[B(float(phys['centered_S_norm_upper_m_s'])) for _ in range(3)]
-    active=TUNER.ActiveSchedule(tau,Interval.outward_bounds(max(tc.acc_noise_floor_sigma,1e-6),tc.sigma_max),Interval.outward_bounds(tc.rs_min,tc.rs_max),Interval.outward_bounds(tc.pseudo_min_s,tc.pseudo_max_s))
-    RS=WORD.R_S_zero(TUNER.active_rs_std_xyz(active,tc)); radii=entry['coordinate_radii']; radius=float(domain['active_accelerometer_bias_projection_limit_mps2'])
-    reports={}
+    exact=EXACT.build();xf=EXACT.validate(exact);phys=PHYS.build();pf=PHYS.validate(phys);entry=ENTRY.build();ef=ENTRY.validate(entry);tube=TUBE.build();tf=TUBE.validate_covariance_ceiling(tube)
+    if xf or pf or ef or tf:raise RuntimeError(f'coarse outer prerequisites failed exact={xf} phys={pf} entry={ef} tube={tf}')
+    domain=json.loads(DOMAIN.read_text())['normal_live'];kc=KERNEL._process_constants(DOMAIN);tc=TUNER.constants();tau=Interval.outward_bounds(tc.tau_min,tc.tau_max)
+    omega_cap=math.radians(float(phys['body_rate_norm_upper_deg_s']));omega=[B(omega_cap) for _ in range(3)];fcap=float(phys['specific_force_norm_upper_mps2']);f=[B(fcap) for _ in range(3)];Rhat=[[Interval(-1.0,1.0) for _ in range(3)] for _ in range(3)];mcap=float(domain['magnetic_vector_norm_upper_uT']);m=[B(mcap) for _ in range(3)];Sphys=[B(float(phys['centered_S_norm_upper_m_s'])) for _ in range(3)]
+    active=TUNER.ActiveSchedule(tau,Interval.outward_bounds(max(tc.acc_noise_floor_sigma,1e-6),tc.sigma_max),Interval.outward_bounds(tc.rs_min,tc.rs_max),Interval.outward_bounds(tc.pseudo_min_s,tc.pseudo_max_s));RS=WORD.R_S_zero(TUNER.active_rs_std_xyz(active,tc));radii=entry['coordinate_radii'];radius=float(domain['active_accelerometer_bias_projection_limit_mps2']);reports={}
     for mode in ('H','A'):
-        n=18 if mode=='H' else 21; state=error_state_box(mode,radii); P=psd_covariance_box_from_diagonal_upper(tube['modes'][mode]['Pbar_diagonal_variance_upper'])
-        mode_rows={}
+        state=error_state_box(mode,radii);P=psd_covariance_box_from_diagonal_upper(tube['modes'][mode]['Pbar_diagonal_variance_upper']);mode_rows={}
         for contract in BIAS.contracts():
-            held,beta=_bias_domains(contract,radius)
-            row={'bias_family':contract.name,'maps':{},'failures':[]}
+            held,beta=_bias_domains(contract,radius);row={'bias_family':contract.name,'maps':{},'failures':[]}
             def attempt(name,fn):
                 try:
-                    A=fn(); row['maps'][name]=A; row[name+'_finite']=_finite_matrix(A)
-                    if not row[name+'_finite']: row['failures'].append(name+': nonfinite interval map')
-                except Exception as exc:
-                    row['maps'][name]=None; row[name+'_finite']=False; row['failures'].append(name+': '+type(exc).__name__+': '+str(exc))
+                    A=fn();row['maps'][name]=A;row[name+'_finite']=_finite_matrix(A)
+                    if not row[name+'_finite']:row['failures'].append(name+': nonfinite interval map')
+                except Exception as exc:row['maps'][name]=None;row[name+'_finite']=False;row['failures'].append(name+': '+type(exc).__name__+': '+str(exc))
             attempt('prediction',lambda:prediction_outer(mode,state,omega,kc.h,tau,kc.accel_bias_tau_s,contract))
             if mode=='H':
-                attempt('S_zero',lambda:_h_joseph_outer('S_zero',state,P,RS,held,beta,Sphys=Sphys))
-                attempt('accelerometer',lambda:_h_joseph_outer('accelerometer',state,P,kc.Racc,held,beta,f=f,Rhat=Rhat))
-                attempt('magnetometer',lambda:_h_joseph_outer('magnetometer',state,P,kc.Rmag,held,beta,m=m))
+                attempt('S_zero',lambda:_h_joseph_outer('S_zero',state,P,RS,held,beta,Sphys=Sphys));attempt('accelerometer',lambda:_h_joseph_outer('accelerometer',state,P,kc.Racc,held,beta,f=f,Rhat=Rhat));attempt('magnetometer',lambda:_h_joseph_outer('magnetometer',state,P,kc.Rmag,held,beta,m=m))
             else:
-                attempt('S_zero',lambda:_a_joseph_outer('S_zero',state,P,RS,beta,radius,Sphys=Sphys))
-                attempt('accelerometer',lambda:_a_joseph_outer('accelerometer',state,P,kc.Racc,beta,radius,f=f,Rhat=Rhat))
-                attempt('magnetometer',lambda:_a_joseph_outer('magnetometer',state,P,kc.Rmag,beta,radius,m=m))
+                attempt('S_zero',lambda:_a_joseph_outer('S_zero',state,P,RS,beta,radius,Sphys=Sphys));attempt('accelerometer',lambda:_a_joseph_outer('accelerometer',state,P,kc.Racc,beta,radius,f=f,Rhat=Rhat));attempt('magnetometer',lambda:_a_joseph_outer('magnetometer',state,P,kc.Rmag,beta,radius,m=m))
             if all(row.get(k+'_finite') for k in ('prediction','S_zero','accelerometer','magnetometer')):
-                # Per-sample outer family: S not-due/due x magnetic not-due/accepted.
-                Pm=row['maps']['prediction']; Sm=row['maps']['S_zero']; Am=row['maps']['accelerometer']; Mm=row['maps']['magnetometer']; Id=matrix_identity(24)
-                row['sample_family']=[_compose(Pm,s,Am,mx) for s in (Id,Sm) for mx in (Id,Mm)]
-                row['sample_family_finite']=all(_finite_matrix(x) for x in row['sample_family'])
-            else:
-                row['sample_family']=[]; row['sample_family_finite']=False
+                Pm=row['maps']['prediction'];Sm=row['maps']['S_zero'];Am=row['maps']['accelerometer'];Mm=row['maps']['magnetometer'];Id=matrix_identity(24);row['sample_family']=[_compose(Pm,s,Am,mx) for s in (Id,Sm) for mx in (Id,Mm)];row['sample_family_finite']=all(_finite_matrix(x) for x in row['sample_family'])
+            else:row['sample_family']=[];row['sample_family_finite']=False
             mode_rows[contract.name]=row
         reports[mode]=mode_rows
     all_local=all(r['sample_family_finite'] for modes in reports.values() for r in modes.values())
-    return {
-      'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD','exact_endpoint_relation_consumed':exact['exact_universal_endpoint_map_relation_defined'],
-      'outer_projection_product_is_history_generator':False,'same_cell_formula_evaluated_after_certified_coordinate_projection':True,
-      'PSD_covariance_cross_bounds_derived_from_rigorous_diagonal_ceiling':True,'physical_centered_S_bound_m_s':phys['centered_S_norm_upper_m_s'],
-      'legacy_300m_s_used_for_physical_S':False,'replay_or_finite_source_sample_used':False,
-      'reports':reports,'all_local_event_outer_maps_finite':all_local,
-      'coarse_universal_sample_family_materialized':all_local,'600_step_endpoint_outer_materialized_here':False,
-      'common_storage_certified_here':False,'ALT_LIVE_PASS':False,
-      'next_obligation':('feed the finite per-sample outer families into partitioned 600-step endpoint induction, then try one common M/rho with outward projected LDLT' if all_local else 'split the certified coordinate projection responsible for each failed local interval map; do not shrink the theorem source or replace it by replay')
-    }
-
-def summary(d):
-    return {mode:{fam:{'failures':r['failures'],'sample_family_finite':r['sample_family_finite']} for fam,r in rows.items()} for mode,rows in d['reports'].items()}
+    return {'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD','exact_endpoint_relation_consumed':exact['exact_universal_endpoint_map_relation_defined'],'outer_projection_product_is_history_generator':False,'same_cell_formula_evaluated_after_certified_coordinate_projection':True,'PSD_covariance_cross_bounds_derived_from_rigorous_diagonal_ceiling':True,'physical_centered_S_bound_m_s':phys['centered_S_norm_upper_m_s'],'legacy_300m_s_used_for_physical_S':False,'replay_or_finite_source_sample_used':False,'reports':reports,'all_local_event_outer_maps_finite':all_local,'coarse_universal_sample_family_materialized':all_local,'600_step_endpoint_outer_materialized_here':False,'common_storage_certified_here':False,'ALT_LIVE_PASS':False,'next_obligation':('feed the finite per-sample outer families into partitioned 600-step endpoint induction, then try one common M/rho with outward projected LDLT' if all_local else 'split the certified coordinate projection responsible for each failed local interval map; do not shrink the theorem source or replace it by replay')}
+def summary(d):return {mode:{fam:{'failures':r['failures'],'sample_family_finite':r['sample_family_finite']} for fam,r in rows.items()} for mode,rows in d['reports'].items()}
+def validate(d):
+    f=[]
+    if d.get('qualification')!=QUALIFICATION or d.get('canonical_source')!='COMPLETE_BRMM_NORMAL_LIVE_WORD':f.append('qualification/source mismatch')
+    for k in ('exact_endpoint_relation_consumed','same_cell_formula_evaluated_after_certified_coordinate_projection','PSD_covariance_cross_bounds_derived_from_rigorous_diagonal_ceiling'):
+        if d.get(k) is not True:f.append(k+' not true')
+    for k in ('outer_projection_product_is_history_generator','legacy_300m_s_used_for_physical_S','replay_or_finite_source_sample_used','600_step_endpoint_outer_materialized_here','common_storage_certified_here','ALT_LIVE_PASS'):
+        if d.get(k) is not False:f.append(k+' not false')
+    if float(d.get('physical_centered_S_bound_m_s',0))!=1100.0:f.append('qualified physical S bound changed')
+    # Finiteness is an experiment result, not a validation prerequisite: this
+    # module is allowed to fail closed and report which projection needs split.
+    return f
+def main():
+    ap=argparse.ArgumentParser();ap.add_argument('--output',type=Path,required=True);a=ap.parse_args();d=build();f=validate(d);out={k:v for k,v in d.items() if k!='reports'};out['local_summary']=summary(d);out['validation_pass']=not f;out['validation_failures']=f;a.output.parent.mkdir(parents=True,exist_ok=True);a.output.write_text(json.dumps(out,indent=2,sort_keys=True)+'\n');print(json.dumps({'all_local':d['all_local_event_outer_maps_finite'],'summary':summary(d),'validation_failures':f},indent=2,sort_keys=True));return int(bool(f))
+if __name__=='__main__':raise SystemExit(main())

--- a/tools/stability/ou3_alt_contraction/coarse_universal_local_outer.py
+++ b/tools/stability/ou3_alt_contraction/coarse_universal_local_outer.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""First numerical universal local-map outer attempt for ALT.
+
+This deliberately conservative construction is NOT a source-history generator.
+The exact same-cell relation has already been defined by exact_endpoint_relation.
+Here we project that relation onto separately certified coordinate enclosures and
+evaluate the exact shipping differential formulas over their Cartesian product.
+Because R subset product(proj_i R), the resulting interval Jacobians are valid
+outer enclosures of every actual same-cell Jacobian.  The product may contain
+unrealizable combinations; that only makes the certificate conservative.
+
+The purpose of this module is to obtain the first concrete numerical local map
+family that can be fed to endpoint_family_induction.  If the broad projection
+product causes interval inversion/chart failure or destroys contraction, the
+failure classifies this representation as too coarse and does NOT falsify the
+physical theorem.
+"""
+from __future__ import annotations
+
+import json, math
+from pathlib import Path
+
+from ou3_interval import Interval, matrix_identity, matrix_mul
+import ou3_brmm_riccati_tube_factored as TUBE
+import ou3_brmm_complete_window_execution_kernel as KERNEL
+import ou3_brmm_tuner_scheduler_step as TUNER
+import ou3_brmm_full_normal_live_word as WORD
+import ou3_p4_complete_brmm_differential_prediction as PRED
+import ou3_p4_complete_brmm_differential_events as EVENTS
+import ou3_p4_hard_entry_set as ENTRY
+from tools.stability.ou3_alt_contraction import bias_families as BIAS
+from tools.stability.ou3_alt_contraction import joint24_events as J24
+from tools.stability.ou3_alt_contraction import physical_numeric_bounds as PHYS
+from tools.stability.ou3_alt_contraction import exact_endpoint_relation as EXACT
+
+REPO=Path(__file__).resolve().parents[3]
+DOMAIN=REPO/'tools/stability/ou3_proof_operating_domain.json'
+QUALIFICATION='OU3_ALT_COARSE_UNIVERSAL_LOCAL_MAP_OUTER_V1'
+
+
+def I(x): return Interval.point(float(x))
+def B(r):
+    r=float(r)
+    return Interval.outward_bounds(-r,r)
+def _zero(r,c): return [[I(0) for _ in range(c)] for _ in range(r)]
+def _shape(A): return len(A),len(A[0]) if A else 0
+
+def psd_covariance_box_from_diagonal_upper(diag):
+    """Entrywise outer box for PSD P with P_ii <= diag_i.
+
+    PSD gives |P_ij|^2 <= P_ii P_jj <= d_i d_j.  This is a theorem outer
+    projection only; it is never treated as an independently reachable P box.
+    """
+    d=[float(x) for x in diag]
+    if not d or any(not math.isfinite(x) or x<=0 for x in d): raise ValueError('positive finite covariance diagonal ceiling required')
+    n=len(d); out=[]
+    for i in range(n):
+        row=[]
+        for j in range(n):
+            if i==j: row.append(Interval.outward_bounds(0.0,d[i]))
+            else:
+                q=math.sqrt(d[i]*d[j]); q=math.nextafter(q,math.inf)
+                row.append(Interval(-q,q))
+        out.append(row)
+    return out
+
+def error_state_box(mode, radii):
+    groups=(('attitude_cayley_norm',3),('gyro_bias_norm_rad_s',3),('velocity_norm_mps',3),('position_norm_m',3),('integral_displacement_norm_m_s',3),('latent_acceleration_norm_mps2',3))
+    out=[]
+    for name,n in groups: out.extend([B(radii[name]) for _ in range(n)])
+    if mode=='A': out.extend([B(radii['accelerometer_bias_error_norm_mps2']) for _ in range(3)])
+    if len(out)!=(18 if mode=='H' else 21): raise RuntimeError('state box dimension drift')
+    return out
+
+def _bias_domains(contract, projection_radius):
+    beta=[B(contract.true_bias_component_bound) for _ in range(3)]
+    # H18 error e_ba = beta-bhat, with ||bhat|| <= projection_radius.
+    ecomp=float(contract.true_bias_component_bound)+float(projection_radius)
+    return [B(ecomp) for _ in range(3)],beta
+
+def _a_prediction_lift(J21,phi_hat,phi_true):
+    A=_zero(24,24)
+    for i in range(21):
+        for j in range(21): A[i][j]=J21[i][j]
+    for i in range(3):
+        A[18+i][21+i]=phi_true-phi_hat
+        A[21+i][21+i]=phi_true
+    return A
+
+def prediction_outer(mode,state,omega,h,tau,tau_ba,contract):
+    p=PRED.prediction_event(mode,state,omega,h,tau,tau_ba=tau_ba if mode=='A' else None)
+    if mode=='H': return J24.h18_prediction_lift(p['J_state'],contract.phi_true)[0]
+    return _a_prediction_lift(p['J_state'],p['phi_ba'],contract.phi_true)
+
+def _h_joseph_outer(kind,state,P,R,held,beta,*,f=None,Rhat=None,m=None,Sphys=None):
+    extra=list(Sphys or ())
+    total=24+len(extra)
+    u=EVENTS.AD.independent_vector(list(state)+list(held)+list(beta)+extra,n=total,offset=0)
+    z=u[:18]; eba=u[18:21]
+    H=EVENTS._event_H('H',kind,f_hat=f,R_hat=Rhat,m_body=m)
+    K,_=EVENTS.source_joseph_gain(P,H,R)
+    if kind=='accelerometer': y=J24._h18_accel_residual(z,eba,f,Rhat)
+    elif kind=='magnetometer': y=EVENTS.residual_magnetometer(z,m)
+    elif kind=='S_zero': y=[z[EVENTS.OFF_S+i]-u[24+i] for i in range(3)]
+    else: raise ValueError(kind)
+    out=list(EVENTS._apply_physical_correction(z,K,y))+list(u[18:24])
+    return [row[:24] for row in EVENTS.AD.jacobian(out)]
+def _a_joseph_outer(kind,state,P,R,beta,radius,*,f=None,Rhat=None,m=None,Sphys=None):
+    extra=list(Sphys or ()); total=24+len(extra)
+    u=EVENTS.AD.independent_vector(list(state)+list(beta)+extra,n=total,offset=0)
+    z=u[:21]; b=u[21:24]
+    H=EVENTS._event_H('A',kind,f_hat=f,R_hat=Rhat,m_body=m); K,_=EVENTS.source_joseph_gain(P,H,R)
+    if kind=='accelerometer': y=EVENTS.residual_accelerometer(z,f,Rhat)
+    elif kind=='magnetometer': y=EVENTS.residual_magnetometer(z,m)
+    elif kind=='S_zero': y=[z[EVENTS.OFF_S+i]-u[24+i] for i in range(3)]
+    else: raise ValueError(kind)
+    out21=EVENTS._apply_physical_correction(z,K,y)
+    J21,_,_=J24._project_joint(out21,b,total,float(radius))
+    J=[list(row) for row in J21]
+    for i in range(3):
+        row=[I(0) for _ in range(total)]; row[21+i]=I(1); J.append(row)
+    return [row[:24] for row in J]
+def _compose(*maps):
+    A=matrix_identity(24)
+    for J in maps: A=matrix_mul(J,A)
+    return A
+
+def _finite_matrix(A):
+    return _shape(A)==(24,24) and all(math.isfinite(x.lo) and math.isfinite(x.hi) for row in A for x in row)
+
+def build():
+    exact=EXACT.build(); xf=EXACT.validate(exact)
+    phys=PHYS.build(); pf=PHYS.validate(phys)
+    entry=ENTRY.build(); ef=ENTRY.validate(entry)
+    tube=TUBE.build(); tf=TUBE.validate_covariance_ceiling(tube)
+    if xf or pf or ef or tf: raise RuntimeError(f'coarse outer prerequisites failed exact={xf} phys={pf} entry={ef} tube={tf}')
+    domain=json.loads(DOMAIN.read_text())['normal_live']; kc=KERNEL._process_constants(DOMAIN); tc=TUNER.constants()
+    tau=Interval.outward_bounds(tc.tau_min,tc.tau_max)
+    omega_cap=math.radians(float(phys['body_rate_norm_upper_deg_s'])); omega=[B(omega_cap) for _ in range(3)]
+    fcap=float(phys['specific_force_norm_upper_mps2']); f=[B(fcap) for _ in range(3)]
+    Rhat=[[Interval(-1.0,1.0) for _ in range(3)] for _ in range(3)]
+    mcap=float(domain['magnetic_vector_norm_upper_uT']); m=[B(mcap) for _ in range(3)]
+    Sphys=[B(float(phys['centered_S_norm_upper_m_s'])) for _ in range(3)]
+    active=TUNER.ActiveSchedule(tau,Interval.outward_bounds(max(tc.acc_noise_floor_sigma,1e-6),tc.sigma_max),Interval.outward_bounds(tc.rs_min,tc.rs_max),Interval.outward_bounds(tc.pseudo_min_s,tc.pseudo_max_s))
+    RS=WORD.R_S_zero(TUNER.active_rs_std_xyz(active,tc)); radii=entry['coordinate_radii']; radius=float(domain['active_accelerometer_bias_projection_limit_mps2'])
+    reports={}
+    for mode in ('H','A'):
+        n=18 if mode=='H' else 21; state=error_state_box(mode,radii); P=psd_covariance_box_from_diagonal_upper(tube['modes'][mode]['Pbar_diagonal_variance_upper'])
+        mode_rows={}
+        for contract in BIAS.contracts():
+            held,beta=_bias_domains(contract,radius)
+            row={'bias_family':contract.name,'maps':{},'failures':[]}
+            def attempt(name,fn):
+                try:
+                    A=fn(); row['maps'][name]=A; row[name+'_finite']=_finite_matrix(A)
+                    if not row[name+'_finite']: row['failures'].append(name+': nonfinite interval map')
+                except Exception as exc:
+                    row['maps'][name]=None; row[name+'_finite']=False; row['failures'].append(name+': '+type(exc).__name__+': '+str(exc))
+            attempt('prediction',lambda:prediction_outer(mode,state,omega,kc.h,tau,kc.accel_bias_tau_s,contract))
+            if mode=='H':
+                attempt('S_zero',lambda:_h_joseph_outer('S_zero',state,P,RS,held,beta,Sphys=Sphys))
+                attempt('accelerometer',lambda:_h_joseph_outer('accelerometer',state,P,kc.Racc,held,beta,f=f,Rhat=Rhat))
+                attempt('magnetometer',lambda:_h_joseph_outer('magnetometer',state,P,kc.Rmag,held,beta,m=m))
+            else:
+                attempt('S_zero',lambda:_a_joseph_outer('S_zero',state,P,RS,beta,radius,Sphys=Sphys))
+                attempt('accelerometer',lambda:_a_joseph_outer('accelerometer',state,P,kc.Racc,beta,radius,f=f,Rhat=Rhat))
+                attempt('magnetometer',lambda:_a_joseph_outer('magnetometer',state,P,kc.Rmag,beta,radius,m=m))
+            if all(row.get(k+'_finite') for k in ('prediction','S_zero','accelerometer','magnetometer')):
+                # Per-sample outer family: S not-due/due x magnetic not-due/accepted.
+                Pm=row['maps']['prediction']; Sm=row['maps']['S_zero']; Am=row['maps']['accelerometer']; Mm=row['maps']['magnetometer']; Id=matrix_identity(24)
+                row['sample_family']=[_compose(Pm,s,Am,mx) for s in (Id,Sm) for mx in (Id,Mm)]
+                row['sample_family_finite']=all(_finite_matrix(x) for x in row['sample_family'])
+            else:
+                row['sample_family']=[]; row['sample_family_finite']=False
+            mode_rows[contract.name]=row
+        reports[mode]=mode_rows
+    all_local=all(r['sample_family_finite'] for modes in reports.values() for r in modes.values())
+    return {
+      'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD','exact_endpoint_relation_consumed':exact['exact_universal_endpoint_map_relation_defined'],
+      'outer_projection_product_is_history_generator':False,'same_cell_formula_evaluated_after_certified_coordinate_projection':True,
+      'PSD_covariance_cross_bounds_derived_from_rigorous_diagonal_ceiling':True,'physical_centered_S_bound_m_s':phys['centered_S_norm_upper_m_s'],
+      'legacy_300m_s_used_for_physical_S':False,'replay_or_finite_source_sample_used':False,
+      'reports':reports,'all_local_event_outer_maps_finite':all_local,
+      'coarse_universal_sample_family_materialized':all_local,'600_step_endpoint_outer_materialized_here':False,
+      'common_storage_certified_here':False,'ALT_LIVE_PASS':False,
+      'next_obligation':('feed the finite per-sample outer families into partitioned 600-step endpoint induction, then try one common M/rho with outward projected LDLT' if all_local else 'split the certified coordinate projection responsible for each failed local interval map; do not shrink the theorem source or replace it by replay')
+    }
+
+def summary(d):
+    return {mode:{fam:{'failures':r['failures'],'sample_family_finite':r['sample_family_finite']} for fam,r in rows.items()} for mode,rows in d['reports'].items()}

--- a/tools/stability/ou3_alt_contraction/common_storage_master.py
+++ b/tools/stability/ou3_alt_contraction/common_storage_master.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Exact reduction used by the first ALT common-joint24 storage attempt.
+
+This is theorem machinery, not a replay metric fit.  Phase 1 has already built
+one physical joint24 cocycle over the COMPLETE-BRMM Normal-Live relation.  The
+remaining structural issue is that H18 contains bounded, deliberately held
+accelerometer-bias coordinates and the physical true-bias reference is itself a
+bounded source state.  Requiring strict homogeneous contraction in those six
+coordinates is therefore stronger than the target theorem.
+
+For a word map x+ = A x + d and coercive storage M>0, ALT seeks
+
+    x+' M x+ <= rho x'Mx + (C x)' Beta (C x) + source_supply,
+
+where C selects only independently bounded neutral/reference coordinates.  For
+fixed A,M,rho define Q=A'MA-rho M.  The coordinate Finsler/Schur lemma gives
+
+    exists Beta>=0 : Q-C'Beta C < 0
+       iff
+    Z'QZ < 0,
+
+where columns of Z span ker(C).  For the shipping joint24 state the admitted
+neutral selector is exactly [e_ba(3), beta_true(3)] = coordinates 18:24.  No
+motion state is moved into supply.
+
+The lemma is valuable because it turns the first common-storage search into a
+strict contraction problem on the 18-dimensional unsupplied motion subspace,
+while retaining one *coercive 24-state* storage and finite bounded-bias supply.
+It does not prove that a common M exists over the full source relation; that is
+the next numerical/outward obligation.
+"""
+from __future__ import annotations
+
+import math
+import numpy as np
+
+from tools.stability.ou3_alt_contraction import phase1_closure as PHASE1
+
+QUALIFICATION = "OU3_ALT_COMMON_JOINT24_NEUTRAL_SUPPLY_REDUCTION_V1"
+JOINT_DIM = 24
+MOTION_DIM = 18
+NEUTRAL_DIM = 6
+NEUTRAL_INDICES = tuple(range(18, 24))
+
+
+def _symmetric(a, name: str) -> np.ndarray:
+    a=np.asarray(a,dtype=float)
+    if a.ndim!=2 or a.shape[0]!=a.shape[1] or not np.isfinite(a).all():
+        raise ValueError(name+" must be finite square")
+    if not np.allclose(a,a.T,rtol=0,atol=1e-12):
+        raise ValueError(name+" must be symmetric")
+    return (a+a.T)/2
+
+
+def coordinate_selector(n: int, supplied_indices) -> np.ndarray:
+    idx=tuple(int(i) for i in supplied_indices)
+    if n<=0 or len(set(idx))!=len(idx) or any(i<0 or i>=n for i in idx):
+        raise ValueError("invalid supplied coordinate set")
+    C=np.zeros((len(idx),n))
+    for r,i in enumerate(idx): C[r,i]=1.0
+    return C
+
+
+def kernel_injection(n: int, supplied_indices) -> np.ndarray:
+    supplied=set(int(i) for i in supplied_indices)
+    keep=[i for i in range(n) if i not in supplied]
+    Z=np.zeros((n,len(keep)))
+    for j,i in enumerate(keep): Z[i,j]=1.0
+    return Z
+
+
+def joint24_neutral_selector() -> np.ndarray:
+    return coordinate_selector(JOINT_DIM,NEUTRAL_INDICES)
+
+
+def joint24_motion_injection() -> np.ndarray:
+    return kernel_injection(JOINT_DIM,NEUTRAL_INDICES)
+
+
+def unsupplied_storage_form(A, M, rho: float, supplied_indices=NEUTRAL_INDICES) -> np.ndarray:
+    """Return Z'(A'MA-rho M)Z, the exact Finsler feasibility restriction."""
+    A=np.asarray(A,dtype=float); M=_symmetric(M,"M")
+    n=M.shape[0]
+    if A.shape!=(n,n) or not np.isfinite(A).all(): raise ValueError("A shape/finite mismatch")
+    if not math.isfinite(rho) or not 0.0<rho<1.0: raise ValueError("rho must be in (0,1)")
+    np.linalg.cholesky(M)
+    Z=kernel_injection(n,supplied_indices)
+    Q=A.T@M@A-rho*M
+    R=Z.T@Q@Z
+    return (R+R.T)/2
+
+
+def coordinate_supply_completion(A, M, rho: float, supplied_indices=NEUTRAL_INDICES, margin=1e-10):
+    """Construct a finite scalar Beta=b I when the Finsler restriction is strict.
+
+    This is a point-coefficient candidate constructor.  Rigorous source-uniform
+    promotion still requires outward eigen/LDLT bounds over the universal word
+    family.  The formula is the Schur complement after permuting unsupplied
+    coordinates first:
+
+      Qxx<0,
+      b > lambda_max(Qcc-Qcx Qxx^{-1} Qxc).
+    """
+    if not math.isfinite(margin) or margin<=0: raise ValueError("positive margin required")
+    A=np.asarray(A,dtype=float); M=_symmetric(M,"M"); n=M.shape[0]
+    if A.shape!=(n,n): raise ValueError("A shape mismatch")
+    idx=tuple(int(i) for i in supplied_indices); supplied=set(idx)
+    keep=[i for i in range(n) if i not in supplied]
+    Q=(A.T@M@A-rho*M); Q=(Q+Q.T)/2
+    Qxx=Q[np.ix_(keep,keep)]
+    eig=np.linalg.eigvalsh(Qxx)
+    if eig[-1]>=-margin:
+        return {"feasible":False,"projected_lambda_max":float(eig[-1]),"beta_scalar":None,"completed_lambda_max":None}
+    Qxc=Q[np.ix_(keep,idx)]; Qcc=Q[np.ix_(idx,idx)]
+    # Qxx is strictly negative definite here, hence nonsingular.
+    schur=Qcc-Qxc.T@np.linalg.solve(Qxx,Qxc)
+    lam=float(np.linalg.eigvalsh((schur+schur.T)/2)[-1]) if len(idx) else -math.inf
+    beta=max(0.0,lam)+margin
+    D=np.zeros((n,n))
+    for i in idx: D[i,i]=beta
+    completed=(Q-D+Q.T-D.T)/2
+    lmax=float(np.linalg.eigvalsh(completed)[-1])
+    return {"feasible":bool(lmax<0.0),"projected_lambda_max":float(eig[-1]),"beta_scalar":float(beta),"completed_lambda_max":lmax}
+
+
+def bounded_additive_supply_multiplier(rho0: float, rho: float) -> float:
+    """Young bound for x+=Ax+d once ||A x||_M^2 <= rho0 ||x||_M^2.
+
+    Choosing eta=rho/rho0-1 gives
+      ||Ax+d||_M^2 <= rho ||x||_M^2 + rho/(rho-rho0) ||d||_M^2.
+    Thus physical-source magnitude affects the practical bound, not existence
+    of the homogeneous contraction margin.  rho0=0 has multiplier 1.
+    """
+    if not (math.isfinite(rho0) and math.isfinite(rho)) or rho0<0 or not rho0<rho<1:
+        raise ValueError("require 0 <= rho0 < rho < 1")
+    return 1.0 if rho0==0 else rho/(rho-rho0)
+
+
+def build() -> dict:
+    phase1=PHASE1.build(); failures=PHASE1.validate(phase1)
+    if failures: raise RuntimeError("Phase-1 physical master not closed: "+repr(failures))
+    C=joint24_neutral_selector(); Z=joint24_motion_injection()
+    return {
+        "qualification":QUALIFICATION,
+        "canonical_source":"COMPLETE_BRMM_NORMAL_LIVE_WORD",
+        "phase1_storage_search_allowed_consumed":bool(phase1["storage_search_allowed"]),
+        "joint_dimension":JOINT_DIM,"unsupplied_motion_dimension":MOTION_DIM,"bounded_neutral_dimension":NEUTRAL_DIM,
+        "bounded_neutral_coordinates":"e_ba[3], beta_true[3]",
+        "neutral_indices":list(NEUTRAL_INDICES),
+        "selector_rank":int(np.linalg.matrix_rank(C)),"kernel_dimension":int(Z.shape[1]),
+        "selector_times_kernel_zero":bool(np.array_equal(C@Z,np.zeros((NEUTRAL_DIM,MOTION_DIM)))),
+        "full_joint24_storage_remains_coercive_required":True,
+        "motion_coordinates_moved_to_supply":False,
+        "held_bias_and_true_bias_may_enter_only_bounded_supply":True,
+        "finsler_equivalence":"exists Beta>=0: Q-C.T Beta C<0 iff Z.T Q Z<0",
+        "finite_scalar_supply_completion_formula_available":True,
+        "physical_source_supply_magnitude_needed_for_metric_feasibility":False,
+        "physical_source_supply_magnitude_needed_for_ultimate_bound":True,
+        "common_M_source_uniform_search_closed":False,
+        "source_uniform_outward_projected_LDLT_closed":False,
+        "ALT_LIVE_PASS":False,
+        "next_obligation":"search one common coercive 24x24 M and rho for which Z.T(A_w.T M A_w-rho M)Z<0 for every H18/A21 physical word in the universal relation; then outward-certify that projected family before completing finite neutral/source supplies",
+    }
+
+
+def validate(d: dict) -> list[str]:
+    f=[]
+    if d.get("qualification")!=QUALIFICATION or d.get("canonical_source")!="COMPLETE_BRMM_NORMAL_LIVE_WORD": f.append("qualification/source mismatch")
+    for k in ("phase1_storage_search_allowed_consumed","selector_times_kernel_zero","full_joint24_storage_remains_coercive_required","held_bias_and_true_bias_may_enter_only_bounded_supply","finite_scalar_supply_completion_formula_available","physical_source_supply_magnitude_needed_for_ultimate_bound"):
+        if d.get(k) is not True: f.append(k+" not true")
+    for k in ("motion_coordinates_moved_to_supply","physical_source_supply_magnitude_needed_for_metric_feasibility","common_M_source_uniform_search_closed","source_uniform_outward_projected_LDLT_closed","ALT_LIVE_PASS"):
+        if d.get(k) is not False: f.append(k+" not false")
+    if d.get("joint_dimension")!=24 or d.get("unsupplied_motion_dimension")!=18 or d.get("bounded_neutral_dimension")!=6: f.append("dimension mismatch")
+    if d.get("neutral_indices")!=list(NEUTRAL_INDICES) or d.get("selector_rank")!=6 or d.get("kernel_dimension")!=18: f.append("selector/kernel mismatch")
+    return list(dict.fromkeys(f))

--- a/tools/stability/ou3_alt_contraction/endpoint_family_induction.py
+++ b/tools/stability/ou3_alt_contraction/endpoint_family_induction.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Outer induction from same-cell local Jacobian families to complete-word maps.
+
+This is the missing set-theoretic bridge between Phase-1's universal physical
+word relation and the projected common-storage LDLT backend.
+
+At literal event k let F_k be a finite family of outward interval matrices such
+that every *actual same-history* local homogeneous Jacobian belongs to at least
+one member of F_k.  If E_k encloses every reachable prefix product through k,
+then
+
+    E_{k+1} = hull { A E : A in F_{k+1}, E in E_k }
+
+contains every reachable product through k+1.  The hull is an OUTER inclusion
+only.  It is never interpreted as a realizable source history, and it is formed
+only after each local map has been generated from one correlated estimator-owned
+source cell.  Hence coefficient/source correlations are not broken in the
+local shipping operation; only the image set is conservatively enlarged.
+
+Keeping several partition labels avoids forcing unrelated modes/event geometries
+into one Cartesian matrix box.  Labels have no theorem semantics beyond set
+partitioning: every successor must name a parent partition and every local map
+must already have a source-uniform same-cell qualification.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+from ou3_interval import Interval, matrix_identity, matrix_mul
+from tools.stability.ou3_alt_contraction import phase1_closure as PHASE1
+
+QUALIFICATION="OU3_ALT_ENDPOINT_FAMILY_OUTER_INDUCTION_V1"
+
+
+def _shape(A):
+    r=len(A); c=len(A[0]) if r else 0
+    if any(len(x)!=c for x in A): raise ValueError("ragged matrix")
+    return r,c
+
+
+def _check_interval_matrix(A,n=None):
+    r,c=_shape(A)
+    if r==0 or r!=c or (n is not None and r!=n): raise ValueError("matrix must be nonempty square")
+    if any(not isinstance(v,Interval) for row in A for v in row): raise TypeError("matrix entries must be outward Interval")
+    return r
+
+
+def hull_interval(a:Interval,b:Interval)->Interval:
+    return Interval(min(a.lo,b.lo),max(a.hi,b.hi))
+
+
+def hull_matrices(mats:Sequence[Sequence[Sequence[Interval]]]):
+    if not mats: raise ValueError("cannot hull empty matrix family")
+    n=_check_interval_matrix(mats[0])
+    for A in mats[1:]: _check_interval_matrix(A,n)
+    out=[[mats[0][i][j] for j in range(n)] for i in range(n)]
+    for A in mats[1:]:
+        out=[[hull_interval(out[i][j],A[i][j]) for j in range(n)] for i in range(n)]
+    return out
+
+
+def matrix_encloses(outer,inner)->bool:
+    if _shape(outer)!=_shape(inner): return False
+    return all(outer[i][j].lo<=inner[i][j].lo and outer[i][j].hi>=inner[i][j].hi
+               for i in range(len(outer)) for j in range(len(outer[0])))
+
+
+@dataclass(frozen=True)
+class QualifiedLocalFamily:
+    label:str
+    matrices:tuple
+    source_uniform_same_cell_qualified:bool
+    replay_or_finite_sample_derived:bool=False
+
+    def validate(self,n:int)->None:
+        if not isinstance(self.label,str) or not self.label: raise ValueError("local family label required")
+        if not self.matrices: raise ValueError("local family cannot be empty")
+        for A in self.matrices:_check_interval_matrix(A,n)
+        if self.source_uniform_same_cell_qualified is not True:
+            raise ValueError("local family lacks source-uniform same-cell qualification")
+        if self.replay_or_finite_sample_derived:
+            raise ValueError("replay/finite-sample family cannot qualify theorem induction")
+
+
+@dataclass(frozen=True)
+class PartitionSuccessor:
+    child_label:str
+    parent_labels:tuple[str,...]
+    local_family:QualifiedLocalFamily
+
+
+def initial_partition(n:int,label="root"):
+    return {label:matrix_identity(n)}
+
+
+def advance_partitions(prefixes:dict[str,object], successors:Sequence[PartitionSuccessor]):
+    """One exact set-inclusion induction step.
+
+    Each child hull contains the union of A*E for every named parent E and every
+    locally-qualified A.  Missing parents and unqualified maps fail closed.
+    """
+    if not prefixes: raise ValueError("empty predecessor partition")
+    n=None
+    for E in prefixes.values(): n=_check_interval_matrix(E,n)
+    if not successors: raise ValueError("empty successor relation")
+    grouped:dict[str,list]= {}
+    for s in successors:
+        if not isinstance(s.child_label,str) or not s.child_label: raise ValueError("child label required")
+        if not s.parent_labels: raise ValueError("successor must retain at least one parent")
+        s.local_family.validate(n)
+        images=[]
+        for p in s.parent_labels:
+            if p not in prefixes: raise ValueError("successor names unreachable/missing parent "+repr(p))
+            E=prefixes[p]
+            for A in s.local_family.matrices: images.append(matrix_mul(A,E))
+        grouped.setdefault(s.child_label,[]).extend(images)
+    return {label:hull_matrices(images) for label,images in grouped.items()}
+
+
+def prove_endpoint_outer_induction(n:int, steps:Sequence[Sequence[PartitionSuccessor]], root_label="root"):
+    """Construct endpoint outer partitions and an explicit induction ledger."""
+    if n<=0: raise ValueError("positive dimension required")
+    prefixes=initial_partition(n,root_label); ledger=[]
+    for k,succ in enumerate(steps):
+        before=tuple(sorted(prefixes))
+        prefixes=advance_partitions(prefixes,succ)
+        after=tuple(sorted(prefixes))
+        ledger.append({"step":k,"parents":before,"children":after,
+                       "all_successors_retained":True,"outer_hull_is_realizable_history":False})
+    return {"endpoint_partitions":prefixes,"ledger":ledger,
+            "steps":len(steps),"outer_union_inclusion_by_induction":True,
+            "outer_hull_is_realizable_source_history":False}
+
+
+def build():
+    p=PHASE1.build(); f=PHASE1.validate(p)
+    if f: raise RuntimeError("Phase-1 prerequisite failed: "+repr(f))
+    return {
+      "qualification":QUALIFICATION,"canonical_source":"COMPLETE_BRMM_NORMAL_LIVE_WORD",
+      "phase1_storage_search_allowed_consumed":bool(p["storage_search_allowed"]),
+      "local_maps_must_be_estimator_owned_same_cell_before_hull":True,
+      "replay_or_finite_sample_local_family_forbidden":True,
+      "entrywise_hull_used_only_as_outer_union_inclusion":True,
+      "outer_hull_may_generate_theorem_history":False,
+      "all_successors_required_each_induction_step":True,
+      "partitioned_hulls_supported":True,
+      "endpoint_outer_inclusion_induction_materialized":True,
+      "actual_600_step_source_family_bound":False,
+      "ALT_LIVE_PASS":False,
+      "next_obligation":"instantiate every step's QualifiedLocalFamily from the universal estimator-owned source-cell relation for H18 and A21, retaining all literal guard/event partitions; then feed each endpoint partition to projected_storage_certificate with one common M,rho",
+    }
+
+
+def validate(d):
+    f=[]
+    if d.get("qualification")!=QUALIFICATION or d.get("canonical_source")!="COMPLETE_BRMM_NORMAL_LIVE_WORD":f.append("qualification/source mismatch")
+    for k in ("phase1_storage_search_allowed_consumed","local_maps_must_be_estimator_owned_same_cell_before_hull","replay_or_finite_sample_local_family_forbidden","entrywise_hull_used_only_as_outer_union_inclusion","all_successors_required_each_induction_step","partitioned_hulls_supported","endpoint_outer_inclusion_induction_materialized"):
+        if d.get(k) is not True:f.append(k+" not true")
+    for k in ("outer_hull_may_generate_theorem_history","actual_600_step_source_family_bound","ALT_LIVE_PASS"):
+        if d.get(k) is not False:f.append(k+" not false")
+    return f

--- a/tools/stability/ou3_alt_contraction/exact_endpoint_relation.py
+++ b/tools/stability/ou3_alt_contraction/exact_endpoint_relation.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Exact universal endpoint-map relation for ALT common storage.
+
+The source-reachable selector theorem on main already proves that every member
+of the correlated source relation O^601_BRMM has every shipping branch retained
+as one selector-family path, together with all three absolute bias lineages.
+ALT's physical_word theorem proves that every such selector path has one
+joint24 physical cocycle, and hybrid_word proves the configured H18/A21 splice.
+
+Their composition defines the exact (generally infinite) set W of homogeneous
+joint24 endpoint maps to which the common-storage inequality must apply.  This
+module closes that quantifier binding.  It intentionally does not replace W by
+finite source samples or claim that a numerical interval representation of W
+has already been built.
+"""
+from __future__ import annotations
+
+import ou3_p4_source_reachable_selector_family as REACH
+from tools.stability.ou3_alt_contraction import physical_word as WORD
+from tools.stability.ou3_alt_contraction import hybrid_word as HYBRID
+from tools.stability.ou3_alt_contraction import phase1_closure as PHASE1
+
+QUALIFICATION="OU3_ALT_EXACT_UNIVERSAL_JOINT24_ENDPOINT_RELATION_V1"
+SOURCE_RELATION="O^601_BRMM"
+
+
+def build():
+    reach=REACH.build(); rf=REACH.validate(reach)
+    word=WORD.induction_theorem(); wf=WORD.validate(word)
+    hybrid=HYBRID.build(); hf=HYBRID.validate(hybrid)
+    phase1=PHASE1.build(); pf=PHASE1.validate(phase1)
+    bad={k:v for k,v in (("reach",rf),("word",wf),("hybrid",hf),("phase1",pf)) if v}
+    if bad: raise RuntimeError("endpoint relation prerequisites failed: "+repr(bad))
+    exact=bool(
+      reach["source_reachable_COMPLETE_BRMM_selector_family_relation_closed"]
+      and reach["all_branch_successors_retained"]
+      and reach["all_bias_absolute_prefix_relations_attached"]
+      and word["every_prefix_and_endpoint_has_single_mode_physical_cocycle"]
+      and word["all_physical_blocks_tied_to_global_relation"] if "all_physical_blocks_tied_to_global_relation" in word else True
+    )
+    # word.induction_theorem expresses the same property by the finite-induction
+    # premises and the H/A construction flags; no endpoint enumeration is used.
+    exact=bool(exact and word["finite_induction_premises_closed"]
+               and word["H18_complete_word_construction_closed"]
+               and word["A21_complete_word_construction_closed"]
+               and hybrid["hybrid_H18_A21_word_closed"]
+               and phase1["storage_search_allowed"])
+    return {
+      "qualification":QUALIFICATION,"canonical_source":"COMPLETE_BRMM_NORMAL_LIVE_WORD",
+      "source_relation":SOURCE_RELATION,"word_transitions":600,"source_samples":601,"joint_dimension":24,
+      "source_reachable_selector_family_relation_consumed":True,
+      "all_branch_successors_retained":reach["all_branch_successors_retained"],
+      "all_bias_lineages_retained":reach["all_bias_absolute_prefix_relations_attached"],
+      "every_selector_endpoint_has_physical_joint24_cocycle":word["every_prefix_and_endpoint_has_single_mode_physical_cocycle"],
+      "configured_H18_A21_hybrid_splice_closed":hybrid["hybrid_H18_A21_word_closed"],
+      "exact_universal_endpoint_map_relation_defined":exact,
+      "endpoint_map_set_symbol":"W_ALT_joint24(O^601_BRMM)",
+      "endpoint_map_set_definition":"{J_joint24(path,bias,guard): path in source-reachable selector-family relation, bias in BIAS0/1/2, guard in configured H18/A21 outcomes}",
+      "finite_source_enumeration_used":False,"trajectory_replay_used":False,"independent_sample_boxes_used":False,
+      "numeric_interval_endpoint_representation_closed":False,
+      "common_storage_quantifier":"for every A in W_ALT_joint24(O^601_BRMM)",
+      "common_M_source_uniform_projected_LDLT_closed":False,"ALT_LIVE_PASS":False,
+      "next_obligation":"construct a certified finite outer representation W_hat containing this exact endpoint relation (prefer partitioned structured intervals); then certify the projected common-storage LMI on every partition with one M,rho",
+    }
+
+
+def validate(d):
+    f=[]
+    if d.get("qualification")!=QUALIFICATION or d.get("source_relation")!=SOURCE_RELATION:f.append("qualification/source mismatch")
+    for k in ("source_reachable_selector_family_relation_consumed","all_branch_successors_retained","all_bias_lineages_retained","every_selector_endpoint_has_physical_joint24_cocycle","configured_H18_A21_hybrid_splice_closed","exact_universal_endpoint_map_relation_defined"):
+        if d.get(k) is not True:f.append(k+" not true")
+    for k in ("finite_source_enumeration_used","trajectory_replay_used","independent_sample_boxes_used","numeric_interval_endpoint_representation_closed","common_M_source_uniform_projected_LDLT_closed","ALT_LIVE_PASS"):
+        if d.get(k) is not False:f.append(k+" not false")
+    if d.get("joint_dimension")!=24 or d.get("word_transitions")!=600 or d.get("source_samples")!=601:f.append("dimension/window mismatch")
+    return f

--- a/tools/stability/ou3_alt_contraction/finite_measurement_graph.py
+++ b/tools/stability/ou3_alt_contraction/finite_measurement_graph.py
@@ -1,0 +1,257 @@
+"""Exact finite measurement descriptor for the physical joint24 ALT state.
+
+This is a real-arithmetic graph, NOT a Jacobian or a shipping stability gate.
+The proof is in docs/ou3-alt-finite-measurement-proof.md.  Rational operations
+below allow exact regression; polynomial identities also hold for real inputs.
+The scalar quaternion and projection parameters remain hard graph variables.
+No sample/parameter table here qualifies their reachable source family.
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+from fractions import Fraction as F
+from typing import Sequence
+
+NSTATE = 24
+NEST = 21
+
+
+def rational(x):
+    if isinstance(x, (float, bool)):
+        raise TypeError('exact graph accepts integers, Fraction or rational strings, not float/bool')
+    return F(x)
+
+
+def vec(x: Sequence, n: int):
+    if len(x) != n:
+        raise ValueError(f'expected vector of length {n}')
+    return [rational(v) for v in x]
+
+
+def mat(x: Sequence[Sequence], rows: int, cols: int):
+    if len(x) != rows or any(len(r) != cols for r in x):
+        raise ValueError(f'expected {rows} by {cols} matrix')
+    return [vec(r, cols) for r in x]
+
+
+def zeros(rows, cols):
+    return [[F(0) for _ in range(cols)] for _ in range(rows)]
+
+
+def eye(n):
+    return [[F(i == j) for j in range(n)] for i in range(n)]
+
+
+def transpose(a):
+    return list(map(list, zip(*a)))
+
+
+def mm(a, b):
+    if not a or not b or len(a[0]) != len(b):
+        raise ValueError('matrix product shape mismatch')
+    return [[sum((x*y for x, y in zip(row, col)), 0)
+             for col in zip(*b)] for row in a]
+
+
+def mv(a, x):
+    return [r[0] for r in mm(a, [[v] for v in x])]
+
+
+def plus(a, b, scale=1):
+    if len(a) != len(b) or any(len(ar) != len(br) for ar, br in zip(a, b)):
+        raise ValueError('matrix addition shape mismatch')
+    return [[x+scale*y for x, y in zip(ar, br)] for ar, br in zip(a, b)]
+
+
+def scaled(a, s):
+    return [[s*x for x in row] for row in a]
+
+
+def dot(a, b):
+    return sum((x*y for x, y in zip(a, b)), 0)
+
+
+def skew(c):
+    x, y, z = c
+    return [[0, -z, y], [z, 0, -x], [-y, x, 0]]
+
+
+def cayley_polynomials(c):
+    """Polynomial U,D,E_num; accepts formal indeterminates as well as rationals.
+
+    T=(I-[c]x/2)^-1=U/D, E=E_num/D, E-I=T[c]x.
+    c=2*tan(theta/2)*axis, not a rotation vector.
+    """
+    C = skew(c)
+    D = 4+dot(c, c)
+    U = plus(plus(scaled(eye(3), 4), scaled(C, 2)),
+             [[x*y for y in c] for x in c])
+    E_num = plus(plus(scaled(eye(3), D), scaled(C, 4)), scaled(mm(C, C), 2))
+    return U, D, E_num
+
+
+def right_reset_polynomials(c, d, w, k):
+    """For E+=E(c)Q(d)^T: W(c+-c)+k U d=0, no differentiation.
+
+    Q is the normalization of (w,k*d). Normalization cancels in this identity.
+    Both the polynomial and axis-angle shipping branches satisfy it.
+    """
+    U, _, _ = cayley_polynomials(c)
+    v = [k*x for x in d]
+    W = 2*w+dot(c, v)
+    cv = mv(skew(c), v)
+    twice_V = [2*(w*c[i]-2*v[i]-cv[i]) for i in range(3)]
+    return W, twice_V, scaled(U, k)
+
+
+def small_quaternion_parameters(d):
+    """Exact real branch only; do not replace the axis branch by this helper."""
+    d = vec(d, 3)
+    u = dot(d, d)
+    if u >= F(1, 10000):
+        raise ValueError('not in the strict theta<1/100 polynomial branch')
+    return 1-u/F(8)+u*u/F(384), F(1, 2)-u/F(48)+u*u/F(3840)
+
+
+def residual_factors(kind, c, *, f_hat=None, R_hat=None, m_hat=None):
+    """Return actual linearization H and exact finite secant Hbar.
+
+    r=Hbar*z+nu for sensors. For S, nu=-S_phys, with its single Live
+    primitive origin; nu is NOT a new independently admissible source input.
+    Hbar need not be the Jacobian. Its coefficients retain their c/source graph.
+    Both H18 and A21 accel residuals include held/active e_ba.
+    """
+    c = vec(c, 3)
+    U, D, E_num = cayley_polynomials(c)
+    H = zeros(3, NEST)
+    Hbar = zeros(3, NSTATE)
+    if kind in ('accelerometer', 'magnetometer'):
+        f = vec(f_hat if kind == 'accelerometer' else m_hat, 3)
+        Htheta = scaled(skew(f), -1)
+        Hfinite = scaled(mm(U, Htheta), 1/D)
+        for i in range(3):
+            H[i][:3], Hbar[i][:3] = Htheta[i], Hfinite[i]
+        if kind == 'accelerometer':
+            R = mat(R_hat, 3, 3)
+            ER = scaled(mm(E_num, R), 1/D)
+            for i in range(3):
+                H[i][15:18], Hbar[i][15:18] = R[i], ER[i]
+                H[i][18+i] = Hbar[i][18+i] = F(1)
+    elif kind == 'S_zero':
+        for i in range(3):
+            H[i][12+i] = Hbar[i][12+i] = F(1)
+    else:
+        raise ValueError('unsupported measurement kind')
+    return H, Hbar
+
+
+def measurement_operands(P21, R, H, *, active_bias):
+    """Actual zero-lever symmetric-real branch, including held BA uncertainty.
+
+    All 21 covariance coordinates are required also in H18. S uses the full
+    residual model; N uses the held column AND row masks. This function does
+    not prove PSD/acceptance or reachable covariance membership. The parent
+    source relation must do so, and attach any safe-LDLT repair separately.
+    """
+    if type(active_bias) is not bool:
+        raise TypeError('active_bias must be a literal branch boolean')
+    P, R, H = mat(P21, 21, 21), mat(R, 3, 3), mat(H, 3, 21)
+    if P != transpose(P) or R != transpose(R):
+        raise ValueError('real symmetric branch required; numerical asymmetry is a separate defect')
+    Hg = [row[:] for row in H]
+    if not active_bias:
+        for row in Hg:
+            row[18:21] = [F(0)]*3
+    N = mm(P, transpose(Hg))
+    if not active_bias:
+        N[18:21] = zeros(3, 3)
+    S = plus(mm(mm(H, P), transpose(H)), R)
+    return N, S
+
+
+def projection_matrix(alpha):
+    """Exact e_ba+=alpha*e_ba_pre+(1-alpha)*beta; keep its hard radial graph."""
+    alpha = rational(alpha)
+    if not 0 < alpha <= 1:
+        raise ValueError('positive radial projection factor in (0,1] required')
+    P = eye(24)
+    for i in range(3):
+        P[18+i][18+i] = alpha
+        P[18+i][21+i] = 1-alpha
+    return P
+
+
+def projection_graph_holds(pre_bias_error, beta, alpha, radius):
+    """Exact branch predicates; no arbitrary alpha can satisfy this admission."""
+    e, b = vec(pre_bias_error, 3), vec(beta, 3)
+    a, R = rational(alpha), rational(radius)
+    if R <= 0 or not 0 < a <= 1:
+        return False
+    n2 = sum((b[i]-e[i])**2 for i in range(3))
+    return (a == 1 and n2 <= R*R) or (a < 1 and n2 > R*R and a*a*n2 == R*R)
+
+
+@dataclass(frozen=True)
+class FiniteDescriptor:
+    # chi=(z24,q3,nu3,h); h=1. E*chi=0 retains c=z[:3], d=N_theta*q.
+    equality: list
+    before: list
+    after: list
+    B: list
+    denominator: F
+
+
+def descriptor(c, d, w, k, N, S, Hbar, *, alpha):
+    """Exact finite descriptor, conditional on d=N_theta*q and branch graphs.
+
+    Returns no closed/pass flag. Supplying a numerical coefficient matrix is
+    not proof of these hard graphs or of a complete physical word.
+    """
+    c, d = vec(c, 3), vec(d, 3)
+    w, k = rational(w), rational(k)
+    N, S, Hbar = mat(N, 21, 3), mat(S, 3, 3), mat(Hbar, 3, 24)
+    W, _, Lnum = right_reset_polynomials(c, d, w, k)
+    if W == 0:
+        raise ValueError('finite Cayley chart denominator is zero')
+    B = zeros(24, 3)
+    B[:3] = scaled(mm(Lnum, N[:3]), 1/W)
+    B[3:21] = [row[:] for row in N[3:21]]
+    P = projection_matrix(alpha)
+    before = [eye(24)[i]+[F(0)]*7 for i in range(24)]
+    pre = [eye(24)[i]+[-x for x in B[i]]+[F(0)]*4 for i in range(24)]
+    equality = [[-x for x in Hbar[i]]+S[i]+[-F(i == j) for j in range(3)]+[F(0)] for i in range(3)]
+    for i in range(3):
+        equality.append([F(0)]*24+N[i]+[F(0)]*3+[-d[i]])
+        equality.append([F(i == j) for j in range(24)]+[F(0)]*6+[-c[i]])
+    return FiniteDescriptor(equality, before, mm(P, pre), B, W)
+
+
+def projected_metric(M, alpha):
+    """P_alpha' M P_alpha via the three bias columns/rows, no dense congruence."""
+    M = mat(M, 24, 24)
+    a = rational(alpha)
+    projection_matrix(a)  # Validate the branch factor, not its radial graph.
+    MP = [row[:] for row in M]
+    for i in range(24):
+        for j in range(3):
+            MP[i][18+j] = a*M[i][18+j]
+            MP[i][21+j] = M[i][21+j]+(1-a)*M[i][18+j]
+    out = [row[:] for row in MP]
+    for i in range(3):
+        for j in range(24):
+            out[18+i][j] = a*MP[18+i][j]
+            out[21+i][j] = MP[21+i][j]+(1-a)*MP[18+i][j]
+    return out
+
+
+def finite_storage_change(M, z, q, B, *, alpha):
+    """Exact joint-storage ledger using a 24x3 factor and a 3x3 core.
+
+    Measurement and radial projection, not covariance transport, are accounted
+    for here. M may contain ALL motion/bias/truth cross terms.
+    """
+    M, B, z, q = mat(M, 24, 24), mat(B, 24, 3), vec(z, 24), vec(q, 3)
+    if M != transpose(M):
+        raise ValueError('symmetric storage required')
+    Mp = projected_metric(M, alpha)
+    MB = mm(Mp, B)
+    return dot(z, mv(plus(Mp, M, -1), z))-2*dot(z, mv(MB, q))+dot(q, mv(mm(transpose(B), MB), q))

--- a/tools/stability/ou3_alt_contraction/finite_prediction_deployed_step.py
+++ b/tools/stability/ou3_alt_contraction/finite_prediction_deployed_step.py
@@ -1,0 +1,50 @@
+"""Bind the exact finite predictor to shipping's deployed small-step quaternion.
+
+`prediction_quaternion_branch` proves that every nominal and shadow prediction
+increment in the declared regional Live domain is strictly inside the 0.01 rad
+polynomial branch.  Therefore no free quaternion coefficient remains here:
+q_nominal and q_shadow are generated from the same omega_hat, e_bg and h that
+feed the prediction.
+
+This is exact real arithmetic. Binary32 FMA and normalization residuals remain
+separate deployment supplies.
+"""
+from __future__ import annotations
+from fractions import Fraction as F
+from tools.stability.ou3_alt_contraction import finite_prediction_graph as G
+from tools.stability.ou3_alt_contraction import prediction_quaternion_branch as BRANCH
+
+
+def step_quaternion_polynomial(dtheta):
+    d=G.vec(dtheta,3);u=sum((x*x for x in d),F(0))
+    if u>=F(1,10000): raise ValueError('shipping polynomial branch requires ||dtheta|| < 0.01')
+    u2=u*u
+    w=F(1)-u/F(8)+u2/F(384)
+    k=F(1,2)-u/F(48)+u2/F(3840)
+    return [w,*[k*x for x in d]]
+
+
+def prediction(mode,z,*,omega_hat,h,q15,coeff,w_bias,phi_true,phi_hat=None):
+    z=G.vec(z,24);omega=G.vec(omega_hat,3);dt=G.rational(h)
+    d_nom=[-omega[i]*dt for i in range(3)]
+    d_shadow=[(-omega[i]+z[3+i])*dt for i in range(3)]
+    qn=step_quaternion_polynomial(d_nom);qs=step_quaternion_polynomial(d_shadow)
+    return G.prediction(mode,z,q_shadow=qs,q_nominal=qn,q15=q15,coeff=coeff,w_bias=w_bias,phi_true=phi_true,phi_hat=phi_hat)
+
+
+def readiness():
+    branch=BRANCH.build();fail=BRANCH.validate(branch)
+    return {
+      'qualification':'OU3_ALT_FINITE_DEPLOYED_PREDICTION_STEP_V1',
+      'finite_prediction_graph_consumed':True,
+      'source_uniform_polynomial_quaternion_branch_consumed':not fail,
+      'same_omega_bg_h_generate_nominal_and_shadow_steps':True,
+      'free_step_quaternion_coefficients_used':False,
+      'trigonometric_branch_needed_in_regional_domain':False if not fail else None,
+      'q15_same_history_source_relation_attached_to_finite_word':False,
+      'bias_root_driver_temporal_relation_attached_to_finite_word':False,
+      'covariance_frontend_successor_attached':False,
+      'finite_precision_attached':False,
+      'complete_word_finite_identity':False,
+      'ALT_LIVE_PASS':False,
+    }

--- a/tools/stability/ou3_alt_contraction/finite_prediction_graph.py
+++ b/tools/stability/ou3_alt_contraction/finite_prediction_graph.py
@@ -1,0 +1,141 @@
+"""Exact finite real-arithmetic prediction graph for ALT joint24.
+
+This module closes the deterministic *mean/error algebra* for one prediction
+step.  It does not certify source reachability, covariance propagation,
+finite precision, or a storage inequality.
+
+The finite attitude error uses homogeneous quaternions.  If
+
+  q_s = shipping step for (-omega_hat + e_bg) h,
+  q_e ~ (2,c) for current Cayley error,
+  q_n = shipping step for (-omega_hat) h,
+
+then the true-minus-estimate relative attitude after prediction is represented
+exactly by
+
+  q_plus ~ q_s * q_e * conj(q_n),
+  c_plus = 2 v_plus / w_plus,
+
+provided w_plus != 0.  Normalization of each step quaternion cancels in this
+projective identity, so both deployed quat_from_delta_theta branches can be
+retained as hard graph variables rather than linearized.
+
+Translation uses the already-proved same-history q15 forcing recurrence, and
+accelerometer-bias truth/error uses one shared physical driver w_b.  No source
+coordinate is independently re-boxed here.
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+from fractions import Fraction as F
+from typing import Sequence
+
+NSTATE=24
+
+
+def rational(x):
+    if isinstance(x,(float,bool)):
+        raise TypeError('exact graph accepts integers, Fraction or rational strings')
+    return F(x)
+
+
+def vec(x,n):
+    if len(x)!=n: raise ValueError(f'expected vector length {n}')
+    return [rational(v) for v in x]
+
+
+def quat_mul(a,b):
+    aw,*av=a; bw,*bv=b
+    ax,ay,az=av; bx,by,bz=bv
+    return [
+      aw*bw-ax*bx-ay*by-az*bz,
+      aw*bx+bw*ax+ay*bz-az*by,
+      aw*by+bw*ay+az*bx-ax*bz,
+      aw*bz+bw*az+ax*by-ay*bx,
+    ]
+
+
+def quat_conj(q): return [q[0],-q[1],-q[2],-q[3]]
+
+
+def relative_attitude_prediction(c, q_shadow, q_nominal):
+    """Exact projective finite Cayley prediction.
+
+    q_shadow and q_nominal are any nonzero scalar multiples of the deployed
+    step quaternions. Their normalization therefore need not be repeated.
+    """
+    c=vec(c,3); qs=vec(q_shadow,4); qn=vec(q_nominal,4)
+    qe=[F(2),*c]
+    qp=quat_mul(quat_mul(qs,qe),quat_conj(qn))
+    if qp[0]==0: raise ValueError('predicted relative attitude hits Cayley pole')
+    return [F(2)*qp[i]/qp[0] for i in range(1,4)]
+
+
+def translation_axis_coefficients(phi_va,phi_pa,phi_Sa,alpha,h):
+    return tuple(map(rational,(phi_va,phi_pa,phi_Sa,alpha,h)))
+
+
+def translation_prediction(error12,q15,coeff):
+    """Exact [e_v,e_p,e_S,e_aw] xyz update from one correlated q15 witness.
+
+    error12 block order: v_xyz,p_xyz,S_xyz,aw_xyz.
+    q15 order: a0_xyz,a1_xyz,J0_xyz,J1_xyz,J2_xyz.
+    """
+    e=vec(error12,12); q=vec(q15,15)
+    phi_va,phi_pa,phi_Sa,alpha,h=coeff
+    out=[F(0)]*12
+    h2=h*h
+    for a in range(3):
+        ev,ep,eS,ea=e[a],e[3+a],e[6+a],e[9+a]
+        a0,a1,J0,J1,J2=q[a],q[3+a],q[6+a],q[9+a],q[12+a]
+        out[a]=ev+phi_va*ea+(J0-phi_va*a0)
+        out[3+a]=ep+h*ev+phi_pa*ea+(J1-phi_pa*a0)
+        out[6+a]=eS+h*ep+h2*ev/F(2)+phi_Sa*ea+(J2-phi_Sa*a0)
+        out[9+a]=alpha*ea+(a1-alpha*a0)
+    return out
+
+
+def bias_prediction(e_ba,beta,w_bias,phi_hat,phi_true):
+    """One-history exact recurrence with the SAME physical driver in both rows."""
+    e=vec(e_ba,3); b=vec(beta,3); w=vec(w_bias,3)
+    ph=rational(phi_hat); pt=rational(phi_true)
+    return ([ph*e[i]+(pt-ph)*b[i]+w[i] for i in range(3)],
+            [pt*b[i]+w[i] for i in range(3)])
+
+
+@dataclass(frozen=True)
+class FinitePrediction:
+    state_after:list
+    attitude_denominator:F
+
+
+def prediction(mode,z,*,q_shadow,q_nominal,q15,coeff,w_bias,phi_true,phi_hat=None):
+    """Exact joint24 mean/error prediction conditional on hard source graphs."""
+    if mode not in ('H','A'): raise ValueError('mode must be H or A')
+    z=vec(z,24)
+    cplus=relative_attitude_prediction(z[:3],q_shadow,q_nominal)
+    qp=quat_mul(quat_mul(vec(q_shadow,4),[F(2),*z[:3]]),quat_conj(vec(q_nominal,4)))
+    trans=translation_prediction(z[6:18],q15,coeff)
+    out=[F(0)]*24
+    out[:3]=cplus
+    out[3:6]=z[3:6]
+    out[6:18]=trans
+    ph=F(1) if mode=='H' else rational(phi_hat)
+    eba,beta=bias_prediction(z[18:21],z[21:24],w_bias,ph,phi_true)
+    out[18:21]=eba;out[21:24]=beta
+    return FinitePrediction(out,qp[0])
+
+
+def readiness():
+    return {
+      'map_representation':'finite_physical_prediction_descriptor',
+      'finite_attitude_prediction_identity':True,
+      'finite_translation_q15_forcing_identity':True,
+      'finite_shared_bias_driver_identity':True,
+      'source_uniform_step_quaternion_graph_attached':False,
+      'source_uniform_q15_same_history_relation_attached':False,
+      'source_uniform_bias_parameter_root_attached':False,
+      'covariance_successor_attached':False,
+      'finite_precision_attached':False,
+      'complete_word_finite_identity':False,
+      'ALT_LIVE_PASS':False,
+    }

--- a/tools/stability/ou3_alt_contraction/finite_prediction_source_attachment.py
+++ b/tools/stability/ou3_alt_contraction/finite_prediction_source_attachment.py
@@ -1,0 +1,75 @@
+"""Attach the finite prediction variables to admitted same-history source contracts.
+
+The finite predictor uses q15=(a0,a1,J0,J1,J2) and one physical bias driver w.
+This module binds exactly those variables to the already-certified COMPLETE-BRMM
+q15 quadratic sectors and to one selected BIAS0/1/2 contract.  It does not
+replace either relation by componentwise boxes.
+
+This is a one-transition attachment. The 600-step word must still preserve one
+BRMM generator/primitive chain and one bias parameter/root token by induction.
+"""
+from __future__ import annotations
+from ou3_interval import Interval
+from tools.stability.ou3_alt_contraction import finite_prediction_deployed_step as FINITE
+from tools.stability.ou3_alt_contraction import physical_lineage as LINEAGE
+from tools.stability.ou3_alt_contraction import bias_families as BIAS
+import ou3_p4_brmm_physical_prediction_forcing as FORCING
+
+QUALIFICATION='OU3_ALT_FINITE_PREDICTION_SOURCE_ATTACHMENT_V1'
+Q15_ORDER=('a0_xyz','a1_xyz','J0_xyz','J1_xyz','J2_xyz')
+
+
+def attach(*,mode,tau,h,bias_contract):
+    if mode not in ('H','A'): raise ValueError('mode must be H/A')
+    if not isinstance(tau,Interval) or not isinstance(h,Interval) or tau.lo<=0 or h.lo<=0:
+        raise ValueError('positive interval tau/h required')
+    if not isinstance(bias_contract,BIAS.BiasFamilyContract):
+        raise TypeError('explicit BIAS0/1/2 contract required')
+    finite=FINITE.readiness()
+    qmap=FORCING.source_matrix(tau,h)
+    sectors=LINEAGE._q15_sector_for_h(h)
+    driver=BIAS.driver_ball_iqc(bias_contract)
+    truth=BIAS.true_bias_ball_iqc(bias_contract)
+    return {
+      'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD','mode':mode,
+      'finite_deployed_prediction_graph_consumed':finite['finite_prediction_graph_consumed'],
+      'source_uniform_polynomial_quaternion_branch_consumed':finite['source_uniform_polynomial_quaternion_branch_consumed'],
+      'q15_coordinate_order':Q15_ORDER,'q15_dimension':15,'q15_forcing_matrix':qmap,'q15_joint_quadratic_sectors':sectors,
+      'q15_same_history_relation_attached_to_finite_prediction':True,
+      'independent_q15_component_boxes_used':False,
+      'bias_family':bias_contract.name,'bias_parameter_token':bias_contract.parameter_token,
+      'bias_phi_true_interval':bias_contract.phi_true,'bias_driver_ball_iqc':driver,'true_bias_ball_iqc':truth,
+      'same_physical_bias_driver_used_by_error_and_truth':True,
+      'bias_parameter_root_token_attached_to_finite_prediction':True,
+      'independent_bias_driver_copies_used':False,
+      'one_transition_source_attachment_closed':True,
+      'multi_transition_BRMM_primitive_chain_closed_here':False,
+      'multi_transition_bias_parameter_token_continuity_closed_here':False,
+      'covariance_frontend_successor_attached':False,
+      'complete_word_finite_identity':False,'ALT_LIVE_PASS':False,
+    }
+
+
+def build():
+    rows=[]
+    for c in BIAS.contracts():
+        rows.append(attach(mode='H',tau=Interval.point(1.0),h=Interval.point(0.005),bias_contract=c))
+        rows.append(attach(mode='A',tau=Interval.point(1.0),h=Interval.point(0.005),bias_contract=c))
+    return {
+      'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD','rows':rows,
+      'all_H_A_BIAS_families_have_one_step_finite_source_attachment':all(r['one_transition_source_attachment_closed'] for r in rows),
+      'no_independent_q15_or_bias_boxes':all(not r['independent_q15_component_boxes_used'] and not r['independent_bias_driver_copies_used'] for r in rows),
+      'complete_word_finite_identity':False,'ALT_LIVE_PASS':False,
+      'next_obligation':'replace the derivative event composer by a finite event composer that carries these q15 sectors and one bias parameter token through every successor and couples them to actual covariance/frontend postimages',
+    }
+
+
+def validate(d):
+    f=[]
+    if d.get('qualification')!=QUALIFICATION:f.append('qualification mismatch')
+    for k in ('all_H_A_BIAS_families_have_one_step_finite_source_attachment','no_independent_q15_or_bias_boxes'):
+        if d.get(k) is not True:f.append(k+' not true')
+    for k in ('complete_word_finite_identity','ALT_LIVE_PASS'):
+        if d.get(k) is not False:f.append(k+' not false')
+    if len(d.get('rows',()))!=6:f.append('H/A x BIAS family coverage changed')
+    return f

--- a/tools/stability/ou3_alt_contraction/first_common_metric_attempt.py
+++ b/tools/stability/ou3_alt_contraction/first_common_metric_attempt.py
@@ -1,43 +1,37 @@
 #!/usr/bin/env python3
-"""First actual common-joint24 storage certificate attempt for ALT.
+"""Guarded entry to the first ALT common-joint24 storage calculation.
 
-The candidate M is deliberately source-independent: a diagonal normalization
-from the declared deterministic regional error scales, extended by positive
-weights on the two physical bias/reference blocks.  It is not fitted to a
-trajectory, endpoint sample, or individual word.
+The retained candidate calculation is not allowed to run on the current
+Jacobian cocycle. A finite physical descriptor with reference forcing and all
+branch/product graphs is a prerequisite. The assembly flags alone do not
+establish that prerequisite. See docs/ou3-alt-finite-measurement-proof.md.
 
-For each rho candidate, the exact same M is tested against every finite H18/A21
-x BIAS0/1/2 600-step IMU-core endpoint outer using
-``projected_storage_certificate``.  Promotion requires outward interval LDLT on
-ALL six families.  A failed candidate is evidence only about this M / coarse
-outer representation and leaves ALT_LIVE_PASS false.
-
-Asynchronous magnetometer star closure is intentionally separate and remains
-required with the SAME M even if the IMU-core endpoint passes.
+If a valid complete finite master is attached, the same source-independent M
+must be checked for every H18/A21 x BIAS family and asynchronous event branch.
 """
 from __future__ import annotations
 
 import math
 import numpy as np
-import ou3_p4_hard_entry_set as ENTRY
-from tools.stability.ou3_alt_contraction import bias_families as BIAS
-from tools.stability.ou3_alt_contraction import coarse_endpoint_outer_attempt as ENDPOINT
-from tools.stability.ou3_alt_contraction import projected_storage_certificate as CERT
+from tools.stability.ou3_alt_contraction import proof_plan as PLAN
+from tools.stability.ou3_alt_contraction import physical_word as WORD
 
 QUALIFICATION='OU3_ALT_FIRST_COMMON_JOINT24_METRIC_ATTEMPT_V1'
 RHO_CANDIDATES=(0.9,0.99,0.999,0.9999,0.99999)
 
 
 def normalized_diagonal_metric():
+    PLAN.assert_finite_storage_master(WORD.finite_storage_readiness())
+    # Imports remain behind the finite-word guard in build(); a hard-entry
+    # builder and a covariance outer cannot repair a missing finite identity.
+    import ou3_p4_hard_entry_set as ENTRY
+    from tools.stability.ou3_alt_contraction import bias_families as BIAS
     e=ENTRY.build();f=ENTRY.validate(e)
     if f:raise RuntimeError('hard regional scale prerequisite failed: '+repr(f))
     r=e['coordinate_radii']
     scales=[]
     for name in ('attitude_cayley_norm','gyro_bias_norm_rad_s','velocity_norm_mps','position_norm_m','integral_displacement_norm_m_s','latent_acceleration_norm_mps2'):
         scales.extend([float(r[name])]*3)
-    # Use one common neutral/reference scale large enough for every declared
-    # family. These coordinates remain part of coercive M even though the
-    # Finsler strictness test projects their bounded input directions.
     contracts=BIAS.contracts()
     beta=max(c.true_bias_norm_bound for c in contracts)
     eba=max(float(r['accelerometer_bias_error_norm_mps2']), beta+float(r['accelerometer_bias_error_norm_mps2']))
@@ -48,6 +42,9 @@ def normalized_diagonal_metric():
     return M,scales
 
 def build():
+    PLAN.assert_finite_storage_master(WORD.finite_storage_readiness())
+    from tools.stability.ou3_alt_contraction import coarse_endpoint_outer_attempt as ENDPOINT
+    from tools.stability.ou3_alt_contraction import projected_storage_certificate as CERT
     ep=ENDPOINT.build();ef=ENDPOINT.validate(ep)
     if ef:raise RuntimeError('endpoint outer prerequisite failed: '+repr(ef))
     M,scales=normalized_diagonal_metric();attempts=[];winner=None

--- a/tools/stability/ou3_alt_contraction/first_common_metric_attempt.py
+++ b/tools/stability/ou3_alt_contraction/first_common_metric_attempt.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""First actual common-joint24 storage certificate attempt for ALT.
+
+The candidate M is deliberately source-independent: a diagonal normalization
+from the declared deterministic regional error scales, extended by positive
+weights on the two physical bias/reference blocks.  It is not fitted to a
+trajectory, endpoint sample, or individual word.
+
+For each rho candidate, the exact same M is tested against every finite H18/A21
+x BIAS0/1/2 600-step IMU-core endpoint outer using
+``projected_storage_certificate``.  Promotion requires outward interval LDLT on
+ALL six families.  A failed candidate is evidence only about this M / coarse
+outer representation and leaves ALT_LIVE_PASS false.
+
+Asynchronous magnetometer star closure is intentionally separate and remains
+required with the SAME M even if the IMU-core endpoint passes.
+"""
+from __future__ import annotations
+
+import math
+import numpy as np
+import ou3_p4_hard_entry_set as ENTRY
+from tools.stability.ou3_alt_contraction import bias_families as BIAS
+from tools.stability.ou3_alt_contraction import coarse_endpoint_outer_attempt as ENDPOINT
+from tools.stability.ou3_alt_contraction import projected_storage_certificate as CERT
+
+QUALIFICATION='OU3_ALT_FIRST_COMMON_JOINT24_METRIC_ATTEMPT_V1'
+RHO_CANDIDATES=(0.9,0.99,0.999,0.9999,0.99999)
+
+
+def normalized_diagonal_metric():
+    e=ENTRY.build();f=ENTRY.validate(e)
+    if f:raise RuntimeError('hard regional scale prerequisite failed: '+repr(f))
+    r=e['coordinate_radii']
+    scales=[]
+    for name in ('attitude_cayley_norm','gyro_bias_norm_rad_s','velocity_norm_mps','position_norm_m','integral_displacement_norm_m_s','latent_acceleration_norm_mps2'):
+        scales.extend([float(r[name])]*3)
+    # Use one common neutral/reference scale large enough for every declared
+    # family. These coordinates remain part of coercive M even though the
+    # Finsler strictness test projects their bounded input directions.
+    contracts=BIAS.contracts()
+    beta=max(c.true_bias_norm_bound for c in contracts)
+    eba=max(float(r['accelerometer_bias_error_norm_mps2']), beta+float(r['accelerometer_bias_error_norm_mps2']))
+    scales.extend([eba]*3);scales.extend([beta]*3)
+    if len(scales)!=24 or any(not math.isfinite(x) or x<=0 for x in scales):raise RuntimeError('invalid normalization scales')
+    diag=[1.0/(x*x) for x in scales]
+    M=np.diag(diag)
+    return M,scales
+
+def build():
+    ep=ENDPOINT.build();ef=ENDPOINT.validate(ep)
+    if ef:raise RuntimeError('endpoint outer prerequisite failed: '+repr(ef))
+    M,scales=normalized_diagonal_metric();attempts=[];winner=None
+    endpoints_finite=bool(ep['all_600_step_IMU_endpoint_outers_finite'])
+    if endpoints_finite:
+        for rho in RHO_CANDIDATES:
+            rows={};all_pass=True
+            for mode,modes in ep['reports'].items():
+                rows[mode]={}
+                for family,row in modes.items():
+                    cert=CERT.certify_joint24_bias_supply_family(row['endpoint_outer'],M,rho)
+                    rows[mode][family]=cert
+                    all_pass=all_pass and bool(cert['metric_spd'] and cert['projected_strict'])
+            attempts.append({'rho':rho,'all_families_projected_strict':all_pass,'families':rows})
+            if all_pass and winner is None:winner=rho
+    return {
+      'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD',
+      'candidate_metric_source':'declared regional coordinate normalization only',
+      'trajectory_or_replay_fit_used_for_M':False,'per_mode_metric_used':False,'per_bias_family_metric_used':False,
+      'metric_dimension':24,'metric_coercive_point_candidate':True,'normalization_scales':scales,
+      'same_M_used_for_all_H_A_BIAS_families':True,'rho_candidates':list(RHO_CANDIDATES),
+      'endpoint_outer_families_finite':endpoints_finite,'attempts':attempts,'first_passing_rho':winner,
+      'common_M_projected_IMU_endpoint_LDLT_closed':winner is not None,
+      'async_magnetometer_nonexpansive_same_M_closed':False,
+      'common_joint24_storage_complete':False,'ALT_LIVE_PASS':False,
+      'next_obligation':('certify every admitted asynchronous magnetometer event nonexpansive with this same M, then add bounded physical source/bias supplies' if winner is not None else ('optimize one common coercive M against the certified endpoint outers; every candidate must still pass outward LDLT on all six families' if endpoints_finite else 'refine the coarse universal endpoint representation before metric search'))
+    }
+def summary(d):
+    out={'endpoint_outer_families_finite':d['endpoint_outer_families_finite'],'first_passing_rho':d['first_passing_rho'],'attempts':[]}
+    for a in d['attempts']:
+        piv={m:{f:r.get('worst_projected_ldlt_pivot_lower') for f,r in rows.items()} for m,rows in a['families'].items()}
+        out['attempts'].append({'rho':a['rho'],'all_pass':a['all_families_projected_strict'],'worst_pivots':piv})
+    return out
+def validate(d):
+    f=[]
+    if d.get('qualification')!=QUALIFICATION or d.get('metric_dimension')!=24:f.append('qualification/dimension mismatch')
+    for k in ('metric_coercive_point_candidate','same_M_used_for_all_H_A_BIAS_families'):
+        if d.get(k) is not True:f.append(k+' not true')
+    for k in ('trajectory_or_replay_fit_used_for_M','per_mode_metric_used','per_bias_family_metric_used','async_magnetometer_nonexpansive_same_M_closed','common_joint24_storage_complete','ALT_LIVE_PASS'):
+        if d.get(k) is not False:f.append(k+' not false')
+    if d.get('common_M_projected_IMU_endpoint_LDLT_closed') is not (d.get('first_passing_rho') is not None):f.append('winner flag mismatch')
+    return f

--- a/tools/stability/ou3_alt_contraction/h18_a21_edge.py
+++ b/tools/stability/ou3_alt_contraction/h18_a21_edge.py
@@ -3,8 +3,9 @@
 
 The deployed filter is physically 21-state even while the proof calls the held
 mode H18.  When bias learning is disabled shipping zeros every BA cross block,
-uses phi_b=1 with no BA process covariance, omits BA from the accelerometer
-innovation and freezes BA gain rows.  Hence the hidden held covariance is
+uses phi_b=1 with no BA process covariance, omits BA from the accelerometer gain
+numerator and freezes BA gain rows, but retains its uncertainty in the
+innovation covariance.  Hence the hidden held covariance is
 
     P_hold21 = diag_block(P_H18, sigma_bacc0^2 I3).
 
@@ -47,18 +48,22 @@ def held_covariance_from_H18(P18,sigma_bacc0=DEFAULT_SIGMA_BACC0):
     P=zero(21,21)
     for i in range(18):
         for j in range(18):P[i][j]=P18[i][j]
-    v=I(s*s)
+    v=I(s).square()  # Outward real product; a point at rounded s*s is not an enclosure.
     for i in range(3):P[18+i][18+i]=v
     return P
 
 def enable_covariance_floor(P21,sigma_bacc0=DEFAULT_SIGMA_BACC0):
     """Outward image of the three deployed diagonal max operations."""
     if _shape(P21)!=(21,21):raise ValueError('held covariance must be 21x21')
-    floor=float(sigma_bacc0)**2; out=[list(r) for r in P21]
+    s=float(sigma_bacc0)
+    if not(math.isfinite(s) and s>=0):raise ValueError('finite nonnegative sigma_bacc0 required')
+    floor=I(s).square(); out=[list(r) for r in P21]
     for i in range(3):
         x=P21[18+i][18+i]
         # exact image of max(x,floor) for interval x
-        out[18+i][18+i]=Interval.outward_bounds(max(x.lo,floor),max(x.hi,floor))
+        out[18+i][18+i]=Interval(max(x.lo,floor.lo),max(x.hi,floor.hi))
+        # max selects existing endpoints exactly. No extra arithmetic rounding
+        # is needed, and widening here would destroy the represented fixed point.
     return out
 
 def joint24_mean_edge():

--- a/tools/stability/ou3_alt_contraction/h18_a21_edge.py
+++ b/tools/stability/ou3_alt_contraction/h18_a21_edge.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Exact shipping H18 -> A21 bias-learning release edge for ALT.
+
+The deployed filter is physically 21-state even while the proof calls the held
+mode H18.  When bias learning is disabled shipping zeros every BA cross block,
+uses phi_b=1 with no BA process covariance, omits BA from the accelerometer
+innovation and freezes BA gain rows.  Hence the hidden held covariance is
+
+    P_hold21 = diag_block(P_H18, sigma_bacc0^2 I3).
+
+On enable, shipping only applies
+
+    P_ba(ii) <- max(P_ba(ii), sigma_bacc0^2),
+
+so this held invariant is a fixed point of the release covariance map.  The
+joint24 physical mean/error state [e18,e_ba,beta] is continuous and the one-time
+Live S origin is not reset.
+
+The release *guard* is also bound to source text: Live, accepted magnetometer
+count >= configured threshold, finite first-mag time, elapsed > 1 s, and no
+external hold.  This module proves the conditional edge map.  Source-uniform
+reachability of that guard in the complete word remains a separate obligation.
+"""
+from __future__ import annotations
+import math
+from pathlib import Path
+
+from ou3_interval import Interval
+
+REPO=Path(__file__).resolve().parents[3]
+MEKF=REPO/'src/kalman_ou_iii/Kalman3D_Wave_OU_III.h'
+WRAPPER=REPO/'src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h'
+QUALIFICATION='OU3_ALT_EXACT_H18_A21_RELEASE_EDGE_V1'
+DEFAULT_SIGMA_BACC0=0.004
+DEFAULT_MAG_UPDATES_TO_UNLOCK=250
+
+
+def I(x):return Interval.point(float(x))
+def zero(r,c):return [[I(0) for _ in range(c)] for _ in range(r)]
+
+def _shape(A):return len(A),len(A[0]) if A else 0
+
+def held_covariance_from_H18(P18,sigma_bacc0=DEFAULT_SIGMA_BACC0):
+    if _shape(P18)!=(18,18):raise ValueError('H18 covariance must be 18x18')
+    s=float(sigma_bacc0)
+    if not(math.isfinite(s) and s>=0):raise ValueError('finite nonnegative sigma_bacc0 required')
+    P=zero(21,21)
+    for i in range(18):
+        for j in range(18):P[i][j]=P18[i][j]
+    v=I(s*s)
+    for i in range(3):P[18+i][18+i]=v
+    return P
+
+def enable_covariance_floor(P21,sigma_bacc0=DEFAULT_SIGMA_BACC0):
+    """Outward image of the three deployed diagonal max operations."""
+    if _shape(P21)!=(21,21):raise ValueError('held covariance must be 21x21')
+    floor=float(sigma_bacc0)**2; out=[list(r) for r in P21]
+    for i in range(3):
+        x=P21[18+i][18+i]
+        # exact image of max(x,floor) for interval x
+        out[18+i][18+i]=Interval.outward_bounds(max(x.lo,floor),max(x.hi,floor))
+    return out
+
+def joint24_mean_edge():
+    A=zero(24,24)
+    for i in range(24):A[i][i]=I(1)
+    return A
+
+def covariance_fixed_point(P18,sigma_bacc0=DEFAULT_SIGMA_BACC0):
+    before=held_covariance_from_H18(P18,sigma_bacc0);after=enable_covariance_floor(before,sigma_bacc0)
+    return all(before[i][j].lo==after[i][j].lo and before[i][j].hi==after[i][j].hi for i in range(21) for j in range(21))
+
+def release_guard(*,startup_live,accel_bias_locked,mag_updates_applied,mag_updates_to_unlock,first_mag_finite,elapsed_since_first_mag_s,external_hold):
+    """Literal shipping unlock condition plus the no-external-hold enable condition."""
+    unlock=bool(accel_bias_locked and startup_live and mag_updates_applied>=mag_updates_to_unlock and first_mag_finite and elapsed_since_first_mag_s>1.0)
+    return {'unlock_guard':unlock,'learning_enabled_after_edge':bool(unlock and not external_hold)}
+
+def source_parity():
+    m=MEKF.read_text();w=WRAPPER.read_text()
+    checks={
+      'disable_zeros_base_cross':'Pext.template block<3,BASE_N>(OFF_BA, 0).setZero();' in m,
+      'disable_zeros_linear_cross':'Pext.template block<3,12>(OFF_BA, OFF_V).setZero();' in m,
+      'enable_diagonal_floor':'Pba(i,i) = std::max(Pba(i,i), target_var);' in m and 'target_var = sigma_bacc0_ * sigma_bacc0_' in m,
+      'default_sigma_literal':'sigma_bacc0_ = T(0.004)' in m,
+      'held_prediction_phi_one':'acc_bias_updates_enabled_ ? std::exp(-Ts / tau_b) : T(1)' in m,
+      'held_prediction_no_Q':'if (acc_bias_updates_enabled_)' in m and 'Q_bacc_' in m,
+      'held_accelerometer_masks_BA':'if (!use_ba) freeze_acc_bias_rows_(PCt);' in m and 'if (!use_ba) freeze_acc_bias_rows_(K);' in m,
+      'release_requires_Live':'startup_stage_ == StartupStage::Live' in w,
+      'release_requires_count':'mag_updates_applied_ >= mag_updates_to_unlock_' in w,
+      'release_requires_finite_first_mag':'std::isfinite(first_mag_update_time_)' in w,
+      'release_requires_one_second':'first_mag_update_time_) > 1.0f' in w,
+      'default_unlock_count':'MAG_UPDATES_TO_UNLOCK = 250' in w,
+      'external_hold_blocks_enable':'if (!acc_bias_hold_)' in w and 'set_acc_bias_updates_enabled(true);' in w,
+    }
+    return checks
+
+def build():
+    parity=source_parity();all_parity=all(parity.values())
+    P18=zero(18,18)
+    for i in range(18):P18[i][i]=I(1+i/100)
+    fixed=covariance_fixed_point(P18)
+    return {
+      'qualification':QUALIFICATION,'canonical_source':'CURRENT_SHIPPING_IMPLEMENTATION',
+      'shipping_source_parity':parity,'shipping_source_parity_closed':all_parity,
+      'physical_joint24_mean_edge_identity':True,'one_time_Live_S_origin_preserved':True,'true_bias_history_preserved':True,
+      'held_BA_cross_covariances_zero':True,'held_BA_marginal_is_seed_variance_I3':True,
+      'held_covariance_lift_from_H18_available':True,'enable_floor_fixed_on_held_invariant':fixed,
+      'default_sigma_bacc0_mps2':DEFAULT_SIGMA_BACC0,'default_mag_updates_to_unlock':DEFAULT_MAG_UPDATES_TO_UNLOCK,
+      'conditional_H18_A21_state_and_covariance_edge_closed':bool(all_parity and fixed),
+      'release_guard_literal_relation_closed':all_parity,
+      'release_guard_source_uniform_reachability_closed':False,
+      'external_hold_release_source_uniformly_closed':False,
+      'H18_A21_complete_word_edge_attached':False,'storage_search_allowed':False,'ALT_LIVE_PASS':False,
+      'next_obligation':'carry the latent held covariance lift alongside every H18 source lineage; when the literal release guard is reached, replace the hypothetical pre-release active covariance by this exact lifted covariance and continue A21 from its fixed-point enable image',
+    }
+def validate(d):
+    f=[]
+    if d.get('qualification')!=QUALIFICATION:f.append('qualification mismatch')
+    for k in ('shipping_source_parity_closed','physical_joint24_mean_edge_identity','one_time_Live_S_origin_preserved','true_bias_history_preserved','held_BA_cross_covariances_zero','held_BA_marginal_is_seed_variance_I3','held_covariance_lift_from_H18_available','enable_floor_fixed_on_held_invariant','conditional_H18_A21_state_and_covariance_edge_closed','release_guard_literal_relation_closed'):
+        if d.get(k) is not True:f.append(k+' not true')
+    for k in ('release_guard_source_uniform_reachability_closed','external_hold_release_source_uniformly_closed','H18_A21_complete_word_edge_attached','storage_search_allowed','ALT_LIVE_PASS'):
+        if d.get(k) is not False:f.append(k+' not false')
+    if d.get('default_sigma_bacc0_mps2')!=DEFAULT_SIGMA_BACC0:f.append('sigma_bacc0 changed')
+    if d.get('default_mag_updates_to_unlock')!=DEFAULT_MAG_UPDATES_TO_UNLOCK:f.append('unlock count changed')
+    return f

--- a/tools/stability/ou3_alt_contraction/hybrid_word.py
+++ b/tools/stability/ou3_alt_contraction/hybrid_word.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Configured Normal-Live hybrid composition for ALT.
+
+The declared operating domain says Normal-Live same-mode words contain no
+hybrid events and lists ``held_to_active`` separately.  Therefore the theorem
+factorization is
+
+    H18 word* -> [optional held_to_active edge] -> A21 word*
+
+rather than pretending the parallel A21 covariance generated during held mode
+is the actual release covariance.
+
+For the configured certificate, the public external bias-hold override is not a
+source coordinate.  The shipping default is ``acc_bias_hold_=false``.  If an
+external caller changes that runtime control, it is outside this configured
+certificate and requires a separate hybrid-control theorem.
+
+The held->active guard has two literal outcomes:
+  * false: remain H18 with the same physical/covariance lineage;
+  * true: joint24 mean state is continuous and A21 covariance is formed from the
+    H18 covariance plus the latent held BA marginal, then the shipping enable
+    floor is applied.  The held invariant is a fixed point of that floor.
+
+This closes compatibility/coverage of the configured edge.  It does NOT prove
+that startup or a particular 3 s word necessarily reaches the release guard;
+finite-time release is a later capture/progress obligation.
+"""
+from __future__ import annotations
+import json
+from pathlib import Path
+
+from tools.stability.ou3_alt_contraction import h18_a21_edge as EDGE
+from tools.stability.ou3_alt_contraction import physical_word as WORD
+
+REPO=Path(__file__).resolve().parents[3]
+DOMAIN=REPO/'tools/stability/ou3_proof_operating_domain.json'
+WRAPPER=REPO/'src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h'
+QUALIFICATION='OU3_ALT_CONFIGURED_H18_A21_HYBRID_WORD_V1'
+
+
+def build():
+    domain=json.loads(DOMAIN.read_text());normal=domain['normal_live'];edge=EDGE.build();ef=EDGE.validate(edge);word=WORD.induction_theorem();wf=WORD.validate(word)
+    if ef or wf:raise RuntimeError(f'hybrid prerequisites failed edge={ef} word={wf}')
+    text=WRAPPER.read_text()
+    config={
+      'same_mode_has_no_internal_hybrid_events':normal.get('hybrid_events_inside_same_mode_word')==[],
+      'held_to_active_declared_separate':'held_to_active' in normal.get('hybrid_events_separate_from_P3_word',[]),
+      'shipping_external_hold_default_false':'bool acc_bias_hold_ = false;' in text,
+      'shipping_release_calls_enable':'if (!acc_bias_hold_)' in text and 'mekf_->set_acc_bias_updates_enabled(true);' in text,
+    }
+    closed=bool(all(config.values()) and edge['conditional_H18_A21_state_and_covariance_edge_closed'] and edge['release_guard_literal_relation_closed'] and word['H18_complete_word_construction_closed'] and word['A21_complete_word_construction_closed'])
+    return {
+      'qualification':QUALIFICATION,'canonical_source':'DECLARED_OU3_DEPLOYMENT_THEOREM_OPERATING_DOMAIN',
+      'configured_scope':config,
+      'H18_same_mode_word_closed':word['H18_complete_word_construction_closed'],'A21_same_mode_word_closed':word['A21_complete_word_construction_closed'],
+      'guard_false_branch':'remain_H18_identity_mode_edge','guard_true_branch':'splice_exact_held_covariance_then_enable_A21',
+      'both_configured_guard_outcomes_covered':closed,'joint24_mean_continuous_across_release':edge['physical_joint24_mean_edge_identity'],
+      'one_time_Live_S_origin_preserved_across_release':edge['one_time_Live_S_origin_preserved'],'true_bias_history_preserved_across_release':edge['true_bias_history_preserved'],
+      'actual_A21_release_covariance_comes_from_H18_held_covariance':True,'parallel_hypothetical_A21_covariance_used_at_release':False,
+      'enable_covariance_floor_fixed_on_initial_held_invariant':edge['enable_floor_fixed_on_held_invariant'],
+      'H18_A21_edge_attached':closed,'all_literal_configured_hybrid_branches_attached':closed,'hybrid_H18_A21_word_closed':closed,
+      'release_guard_eventual_reachability_closed_here':False,'startup_capture_consumed':False,
+      'external_runtime_bias_hold_override_admitted_by_certificate':False,
+      'storage_search_allowed_here':False,'ALT_LIVE_PASS':False,
+      'next_obligation':'assemble the Phase-1 closure ledger from the regional source relation, physical word induction and this configured hybrid edge; if all physical-word guards close, begin the first common joint24 storage feasibility search while keeping release progress/startup separate'}
+def validate(d):
+    f=[]
+    if d.get('qualification')!=QUALIFICATION:f.append('qualification mismatch')
+    if not all(d.get('configured_scope',{}).values()):f.append('configured hybrid scope parity failed')
+    for k in ('H18_same_mode_word_closed','A21_same_mode_word_closed','both_configured_guard_outcomes_covered','joint24_mean_continuous_across_release','one_time_Live_S_origin_preserved_across_release','true_bias_history_preserved_across_release','actual_A21_release_covariance_comes_from_H18_held_covariance','enable_covariance_floor_fixed_on_initial_held_invariant','H18_A21_edge_attached','all_literal_configured_hybrid_branches_attached','hybrid_H18_A21_word_closed'):
+        if d.get(k) is not True:f.append(k+' not true')
+    for k in ('parallel_hypothetical_A21_covariance_used_at_release','release_guard_eventual_reachability_closed_here','startup_capture_consumed','external_runtime_bias_hold_override_admitted_by_certificate','storage_search_allowed_here','ALT_LIVE_PASS'):
+        if d.get(k) is not False:f.append(k+' not false')
+    return f

--- a/tools/stability/ou3_alt_contraction/inverse_free_common_metric_attempt.py
+++ b/tools/stability/ou3_alt_contraction/inverse_free_common_metric_attempt.py
@@ -1,18 +1,17 @@
 #!/usr/bin/env python3
-"""First common-M outward certificate on the corrected inverse-free endpoint family.
+"""Guarded common-M attempt; inverse-free gains do not supply a finite-state bridge.
 
-The same source-independent coercive 24x24 diagonal candidate is tested against
-all H/A x BIAS0/1/2 600-step endpoint outers.  Only outward projected LDLT can
-close an endpoint candidate.  Async magnetometer nonexpansiveness remains a
-separate same-M obligation, so this module never promotes ALT_LIVE_PASS alone.
+The derivative endpoint family is not yet the actual finite error map. Require
+that bridge before building an endpoint outer or testing any common metric.
 """
 from __future__ import annotations
-from tools.stability.ou3_alt_contraction import inverse_free_endpoint_outer_attempt as END
 from tools.stability.ou3_alt_contraction import first_common_metric_attempt as BASE
-from tools.stability.ou3_alt_contraction import projected_storage_certificate as CERT
 QUALIFICATION='OU3_ALT_INVERSE_FREE_COMMON_JOINT24_METRIC_ATTEMPT_V1'
 RHO=(0.9,0.99,0.999,0.9999,0.99999)
 def build():
+    BASE.PLAN.assert_finite_storage_master(BASE.WORD.finite_storage_readiness())
+    from tools.stability.ou3_alt_contraction import inverse_free_endpoint_outer_attempt as END
+    from tools.stability.ou3_alt_contraction import projected_storage_certificate as CERT
     ep=END.build();ef=END.validate(ep)
     if ef:raise RuntimeError('inverse-free endpoint prerequisite invalid: '+repr(ef))
     M,scales=BASE.normalized_diagonal_metric();attempts=[];winner=None;finite=ep['all_endpoint_outers_finite']

--- a/tools/stability/ou3_alt_contraction/inverse_free_common_metric_attempt.py
+++ b/tools/stability/ou3_alt_contraction/inverse_free_common_metric_attempt.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""First common-M outward certificate on the corrected inverse-free endpoint family.
+
+The same source-independent coercive 24x24 diagonal candidate is tested against
+all H/A x BIAS0/1/2 600-step endpoint outers.  Only outward projected LDLT can
+close an endpoint candidate.  Async magnetometer nonexpansiveness remains a
+separate same-M obligation, so this module never promotes ALT_LIVE_PASS alone.
+"""
+from __future__ import annotations
+from tools.stability.ou3_alt_contraction import inverse_free_endpoint_outer_attempt as END
+from tools.stability.ou3_alt_contraction import first_common_metric_attempt as BASE
+from tools.stability.ou3_alt_contraction import projected_storage_certificate as CERT
+QUALIFICATION='OU3_ALT_INVERSE_FREE_COMMON_JOINT24_METRIC_ATTEMPT_V1'
+RHO=(0.9,0.99,0.999,0.9999,0.99999)
+def build():
+    ep=END.build();ef=END.validate(ep)
+    if ef:raise RuntimeError('inverse-free endpoint prerequisite invalid: '+repr(ef))
+    M,scales=BASE.normalized_diagonal_metric();attempts=[];winner=None;finite=ep['all_endpoint_outers_finite']
+    if finite:
+        for rho in RHO:
+            rows={};ok=True
+            for mode,modes in ep['reports'].items():
+                rows[mode]={}
+                for fam,row in modes.items():
+                    c=CERT.certify_joint24_bias_supply_family(row['endpoint'],M,rho);rows[mode][fam]=c;ok=ok and c['metric_spd'] and c['projected_strict']
+            attempts.append({'rho':rho,'all_pass':bool(ok),'families':rows})
+            if ok and winner is None:winner=rho
+    return {'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD','corrected_inverse_free_endpoint_outer_consumed':True,'superseded_endpoint_Pbar_local_route_consumed':False,'same_M_all_modes_bias_families':True,'trajectory_replay_fit_used':False,'metric_scales':scales,'endpoint_outers_finite':finite,'attempts':attempts,'passing_rho':winner,'common_M_IMU_endpoint_projected_LDLT_closed':winner is not None,'async_magnetometer_nonexpansive_same_M_closed':False,'bounded_source_supply_completion_closed':False,'ALT_LIVE_PASS':False,'next_obligation':('prove every admitted async magnetometer event nonexpansive with this exact M and complete bounded physical supplies' if winner is not None else ('search/optimize one common M against this certified endpoint family' if finite else 'refine the inverse-free endpoint partition before common-M search'))}
+def summary(d):
+    return {'endpoint_outers_finite':d['endpoint_outers_finite'],'passing_rho':d['passing_rho'],'attempts':[{'rho':a['rho'],'all_pass':a['all_pass'],'pivots':{m:{f:r.get('worst_projected_ldlt_pivot_lower') for f,r in rows.items()} for m,rows in a['families'].items()}} for a in d['attempts']]}
+def validate(d):
+    f=[]
+    if d.get('qualification')!=QUALIFICATION:f.append('qualification mismatch')
+    for k in ('corrected_inverse_free_endpoint_outer_consumed','same_M_all_modes_bias_families'):
+        if d.get(k) is not True:f.append(k+' not true')
+    for k in ('superseded_endpoint_Pbar_local_route_consumed','trajectory_replay_fit_used','async_magnetometer_nonexpansive_same_M_closed','bounded_source_supply_completion_closed','ALT_LIVE_PASS'):
+        if d.get(k) is not False:f.append(k+' not false')
+    if d.get('common_M_IMU_endpoint_projected_LDLT_closed') is not (d.get('passing_rho') is not None):f.append('winner mismatch')
+    return f

--- a/tools/stability/ou3_alt_contraction/inverse_free_endpoint_outer_attempt.py
+++ b/tools/stability/ou3_alt_contraction/inverse_free_endpoint_outer_attempt.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""First 600-step endpoint outer built from the valid inverse-free local family.
+
+For each H/A x BIAS family, the two IMU-core maps are first hulled and then
+raised to the 600-step product set with outward interval multiplication.  This
+is a conservative representation of all S-due/not-due schedules.  It is not a
+source generator.  Async magnetometer events remain separate.
+"""
+from __future__ import annotations
+import math
+from ou3_interval import matrix_identity,matrix_mul
+from tools.stability.ou3_alt_contraction import inverse_free_universal_local_outer as LOCAL
+from tools.stability.ou3_alt_contraction import endpoint_family_induction as OUTER
+QUALIFICATION='OU3_ALT_INVERSE_FREE_600_STEP_ENDPOINT_OUTER_V1';N=600
+
+def power(A,n=N):
+    r=matrix_identity(len(A));b=A;k=int(n)
+    while k:
+        if k&1:r=matrix_mul(b,r)
+        k//=2
+        if k:b=matrix_mul(b,b)
+    return r
+def finite(A):return all(math.isfinite(x.lo) and math.isfinite(x.hi) for row in A for x in row)
+def width(A):return max((x.hi-x.lo for row in A for x in row),default=0.0)
+def magnitude(A):return max((max(abs(x.lo),abs(x.hi)) for row in A for x in row),default=0.0)
+def build():
+    local=LOCAL.build();lf=LOCAL.validate(local)
+    if lf:raise RuntimeError('local inverse-free outer invalid: '+repr(lf))
+    reports={}
+    for mode,rows in local['reports'].items():
+        reports[mode]={}
+        for fam,row in rows.items():
+            out={'local_core_finite':row['imu_core_family_finite'],'endpoint':None,'endpoint_finite':False,'max_width':None,'max_abs':None,'failure':None}
+            if row['imu_core_family_finite']:
+                try:
+                    H=OUTER.hull_matrices(row['imu_core_family']);E=power(H);out.update(endpoint=E,endpoint_finite=finite(E),max_width=width(E),max_abs=magnitude(E))
+                    if not out['endpoint_finite']:out['failure']='interval product became nonfinite'
+                except Exception as exc:out['failure']=type(exc).__name__+': '+str(exc)
+            else:out['failure']='valid inverse-free local IMU core was not finite'
+            reports[mode][fam]=out
+    closed=all(r['endpoint_finite'] for rows in reports.values() for r in rows.values())
+    return {'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD','inverse_free_local_family_consumed':True,'endpoint_Pbar_route_consumed':False,'word_transitions':N,'outward_hull_power_is_outer_only':True,'reports':reports,'all_endpoint_outers_finite':closed,'numeric_600_step_IMU_outer_materialized':closed,'async_magnetometer_star_still_separate':True,'common_storage_closed':False,'ALT_LIVE_PASS':False,'next_obligation':('test one common coercive M with outward projected LDLT on every endpoint outer and separately on async magnetic nonexpansiveness' if closed else 'partition the valid inverse-free local outer before multiplication; do not return to endpoint Pbar or replay')}
+def summary(d):return {m:{f:{k:r[k] for k in ('local_core_finite','endpoint_finite','max_width','max_abs','failure')} for f,r in rows.items()} for m,rows in d['reports'].items()}
+def validate(d):
+    f=[]
+    if d.get('qualification')!=QUALIFICATION or d.get('word_transitions')!=N:f.append('qualification/window mismatch')
+    for k in ('inverse_free_local_family_consumed','outward_hull_power_is_outer_only','async_magnetometer_star_still_separate'):
+        if d.get(k) is not True:f.append(k+' not true')
+    for k in ('endpoint_Pbar_route_consumed','common_storage_closed','ALT_LIVE_PASS'):
+        if d.get(k) is not False:f.append(k+' not false')
+    return f

--- a/tools/stability/ou3_alt_contraction/inverse_free_gain_outer.py
+++ b/tools/stability/ou3_alt_contraction/inverse_free_gain_outer.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Inverse-free source-uniform Kalman-gain outer for ALT.
+
+For every estimator-owned Joseph cell the actual shipping gain is
+
+    K = P H' (H P H' + R)^-1.
+
+The local covariance theorem supplies ||P||_2 <= pbar at *every event*.  Since
+P>=0 and R>=r I,
+
+    HPH' + R >= R >= r I,
+    ||(HPH'+R)^-1||_2 <= 1/r,
+    ||K||_2 <= pbar ||H||_2 / r.
+
+Thus every gain entry lies in [-kbar,kbar].  This is an explicit outer relation
+for the exact same-cell gain; no independent covariance history, interval
+innovation inverse, endpoint Pbar, or replay is introduced.
+"""
+from __future__ import annotations
+
+import math
+from ou3_interval import Interval
+import ou3_brmm_complete_window_execution_kernel as KERNEL
+import ou3_p4_complete_brmm_differential_events as EVENTS
+from tools.stability.ou3_alt_contraction import local_covariance_norm_envelope as COV
+from tools.stability.ou3_alt_contraction import physical_numeric_bounds as PHYS
+
+QUALIFICATION='OU3_ALT_INVERSE_FREE_EVENT_GAIN_OUTER_V1'
+
+def B(x):x=float(x);return Interval.outward_bounds(-x,x)
+def gershgorin_spd_lower(R):
+    n=len(R)
+    if n==0 or any(len(r)!=n for r in R):raise ValueError('square R required')
+    lo=math.inf
+    for i in range(n):
+        s=0.0
+        for j in range(n):
+            if i!=j:s=math.nextafter(s+R[i][j].abs_upper(),math.inf)
+        lo=min(lo,math.nextafter(R[i][i].lo-s,-math.inf))
+    if not math.isfinite(lo) or lo<=0:raise ValueError('R Gershgorin lower is not positive')
+    return lo
+def gain_entry_box(pnorm,H,R):
+    hnorm=COV.interval_matrix_norm2_upper(H);rmin=gershgorin_spd_lower(R)
+    kmax=math.nextafter(math.nextafter(float(pnorm)*hnorm,math.inf)/rmin,math.inf)
+    if not math.isfinite(kmax):raise ValueError('nonfinite gain outer')
+    return [[B(kmax) for _ in range(3)] for _ in range(len(H[0]))],{'P_norm_upper':float(pnorm),'H_norm_upper':hnorm,'R_lambda_min_lower':rmin,'K_norm_upper':kmax}
+def _event_H(mode,kind,phys):
+    if kind=='S_zero':return EVENTS._event_H(mode,kind)
+    if kind=='accelerometer':
+        fcap=float(phys['specific_force_norm_upper_mps2']);f=[B(fcap) for _ in range(3)];Rhat=[[Interval(-1.0,1.0) for _ in range(3)] for _ in range(3)]
+        return EVENTS._event_H(mode,kind,f_hat=f,R_hat=Rhat)
+    if kind=='magnetometer':
+        mcap=200.0;m=[B(mcap) for _ in range(3)]
+        return EVENTS._event_H(mode,kind,m_body=m)
+    raise ValueError(kind)
+def build():
+    cov=COV.build();cf=COV.validate(cov);phys=PHYS.build();pf=PHYS.validate(phys)
+    if cf or pf:raise RuntimeError(f'gain outer prerequisites failed cov={cf} phys={pf}')
+    kc=KERNEL._process_constants(KERNEL.DEFAULT_DOMAIN);reports={}
+    for mode in ('H','A'):
+        p=cov['reports'][mode]['every_event_covariance_norm_upper'];rows={}
+        for kind,R in (('S_zero',None),('accelerometer',kc.Racc),('magnetometer',kc.Rmag)):
+            H=_event_H(mode,kind,phys)
+            if kind=='S_zero':
+                # R_S is tuner-dependent; its smallest admitted per-axis std is
+                # bounded below by the scheduler's rs_min times the positive
+                # declared axis factors. Build it from the committed scheduler.
+                import ou3_brmm_tuner_scheduler_step as TUNER
+                import ou3_brmm_full_normal_live_word as WORD
+                tc=TUNER.constants();active=TUNER.ActiveSchedule(Interval.outward_bounds(tc.tau_min,tc.tau_max),Interval.outward_bounds(max(tc.acc_noise_floor_sigma,1e-9),tc.sigma_max),Interval.outward_bounds(tc.rs_min,tc.rs_max),Interval.outward_bounds(tc.pseudo_min_s,tc.pseudo_max_s));R=WORD.R_S_zero(TUNER.active_rs_std_xyz(active,tc))
+            K,meta=gain_entry_box(p,H,R);rows[kind]={'H':H,'K':K,**meta}
+        reports[mode]=rows
+    closed=all(math.isfinite(r['K_norm_upper']) for rows in reports.values() for r in rows.values())
+    return {'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD','event_local_covariance_envelope_consumed':cov['event_local_covariance_norm_envelope_closed'],'innovation_inverse_computed':False,'endpoint_Pbar_used_for_local_gain':False,'independent_covariance_box_used':False,'same_cell_gain_contained_by_outer_relation':True,'reports':reports,'all_event_gain_outers_finite':closed,'next_obligation':'evaluate exact physical Joseph/reset formulas over these source-uniform K outers and certified physical/state domains, retaining magnetometer as a separate arbitrary-finite event star'}
+def validate(d):
+    f=[]
+    if d.get('qualification')!=QUALIFICATION:f.append('qualification mismatch')
+    for k in ('event_local_covariance_envelope_consumed','same_cell_gain_contained_by_outer_relation','all_event_gain_outers_finite'):
+        if d.get(k) is not True:f.append(k+' not true')
+    for k in ('innovation_inverse_computed','endpoint_Pbar_used_for_local_gain','independent_covariance_box_used'):
+        if d.get(k) is not False:f.append(k+' not false')
+    return f

--- a/tools/stability/ou3_alt_contraction/inverse_free_universal_local_outer.py
+++ b/tools/stability/ou3_alt_contraction/inverse_free_universal_local_outer.py
@@ -1,17 +1,16 @@
 #!/usr/bin/env python3
 """Universal physical joint24 local-event outer using inverse-free gain bounds.
 
-This supersedes the earlier experimental covariance-box local outer.  Actual
+This supersedes the earlier experimental covariance-box local outer. Actual
 same-cell Kalman gains are enclosed by ``inverse_free_gain_outer`` from a proved
 event-local covariance norm and S>=R; no endpoint covariance is reused locally.
+The state domain comes from ALT's conditional regional Normal-Live binding and
+does not execute or assume startup reachability.
 
-For each H/A x BIAS family this module emits:
-  * prediction homogeneous outer;
-  * finite physical S event outer using qualified D_S=1100 m*s;
-  * accelerometer physical Joseph/reset outer;
-  * magnetometer physical Joseph/reset outer;
-  * two finite IMU-core patterns: pred->acc and pred->S->acc.
-The magnetometer map remains separate for arbitrary-finite star composition.
+For each H/A x BIAS family this module emits prediction, physical S,
+accelerometer, and magnetometer homogeneous outers. The two IMU-core patterns
+are pred->acc and pred->S->acc. Magnetometer remains a separate event outer for
+arbitrary-finite star composition.
 """
 from __future__ import annotations
 import json,math
@@ -19,17 +18,17 @@ from pathlib import Path
 from ou3_interval import Interval,matrix_identity,matrix_mul
 import ou3_p4_complete_brmm_differential_prediction as PRED
 import ou3_p4_complete_brmm_differential_events as EVENTS
-import ou3_p4_hard_entry_set as ENTRY
 import ou3_brmm_complete_window_execution_kernel as KERNEL
 import ou3_brmm_tuner_scheduler_step as TUNER
 from tools.stability.ou3_alt_contraction import joint24_events as J24
 from tools.stability.ou3_alt_contraction import bias_families as BIAS
 from tools.stability.ou3_alt_contraction import physical_numeric_bounds as PHYS
 from tools.stability.ou3_alt_contraction import inverse_free_gain_outer as GAIN
+from tools.stability.ou3_alt_contraction import regional_error_domain as REGION
 
 REPO=Path(__file__).resolve().parents[3]
 DOMAIN=REPO/'tools/stability/ou3_proof_operating_domain.json'
-QUALIFICATION='OU3_ALT_INVERSE_FREE_UNIVERSAL_LOCAL_PHYSICAL_OUTER_V1'
+QUALIFICATION='OU3_ALT_INVERSE_FREE_UNIVERSAL_LOCAL_PHYSICAL_OUTER_V2'
 def I(x):return Interval.point(float(x))
 def B(x):x=float(x);return Interval.outward_bounds(-x,x)
 def _zero(r,c):return [[I(0) for _ in range(c)] for _ in range(r)]
@@ -73,10 +72,10 @@ def _a_event(kind,state,K,beta,radius,*,f=None,Rhat=None,m=None,Sphys=None):
     for i in range(3):row=[I(0) for _ in range(total)];row[21+i]=I(1);J.append(row)
     return [r[:24] for r in J]
 def build():
-    gain=GAIN.build();gf=GAIN.validate(gain);phys=PHYS.build();pf=PHYS.validate(phys);entry=ENTRY.build();ef=ENTRY.validate(entry)
-    if gf or pf or ef:raise RuntimeError(f'local outer prerequisites failed gain={gf} phys={pf} entry={ef}')
+    gain=GAIN.build();gf=GAIN.validate(gain);phys=PHYS.build();pf=PHYS.validate(phys);region=REGION.build();rf=REGION.validate(region)
+    if gf or pf or rf:raise RuntimeError(f'local outer prerequisites failed gain={gf} phys={pf} region={rf}')
     d=json.loads(DOMAIN.read_text())['normal_live'];kc=KERNEL._process_constants(DOMAIN);tc=TUNER.constants();tau=Interval.outward_bounds(tc.tau_min,tc.tau_max);omega=[B(math.radians(float(phys['body_rate_norm_upper_deg_s'])))]*3
-    f=[B(float(phys['specific_force_norm_upper_mps2']))]*3;Rhat=[[Interval(-1.0,1.0) for _ in range(3)] for _ in range(3)];m=[B(float(d['magnetic_vector_norm_upper_uT']))]*3;Sphys=[B(float(phys['centered_S_norm_upper_m_s']))]*3;radii=entry['coordinate_radii'];radius=float(d['active_accelerometer_bias_projection_limit_mps2']);reports={}
+    f=[B(float(phys['specific_force_norm_upper_mps2']))]*3;Rhat=[[Interval(-1.0,1.0) for _ in range(3)] for _ in range(3)];m=[B(float(d['magnetic_vector_norm_upper_uT']))]*3;Sphys=[B(float(phys['centered_S_norm_upper_m_s']))]*3;radii=region['coordinate_radii'];radius=float(d['active_accelerometer_bias_projection_limit_mps2']);reports={}
     for mode in ('H','A'):
         state=_state_box(mode,radii);reports[mode]={}
         for contract in BIAS.contracts():
@@ -89,20 +88,19 @@ def build():
                 attempt('S_zero',lambda:_h_event('S_zero',state,Krow['S_zero']['K'],held,beta,Sphys=Sphys));attempt('accelerometer',lambda:_h_event('accelerometer',state,Krow['accelerometer']['K'],held,beta,f=f,Rhat=Rhat));attempt('magnetometer',lambda:_h_event('magnetometer',state,Krow['magnetometer']['K'],held,beta,m=m))
             else:
                 attempt('S_zero',lambda:_a_event('S_zero',state,Krow['S_zero']['K'],beta,radius,Sphys=Sphys));attempt('accelerometer',lambda:_a_event('accelerometer',state,Krow['accelerometer']['K'],beta,radius,f=f,Rhat=Rhat));attempt('magnetometer',lambda:_a_event('magnetometer',state,Krow['magnetometer']['K'],beta,radius,m=m))
-            core=all(row.get(k+'_finite') for k in ('prediction','S_zero','accelerometer'));mag=bool(row.get('magnetometer_finite'))
-            row['imu_core_family']=[]
+            core=all(row.get(k+'_finite') for k in ('prediction','S_zero','accelerometer'));mag=bool(row.get('magnetometer_finite'));row['imu_core_family']=[]
             if core:
                 P=row['maps']['prediction'];S=row['maps']['S_zero'];A=row['maps']['accelerometer'];Id=matrix_identity(24);row['imu_core_family']=[_compose(P,Id,A),_compose(P,S,A)]
-            row['imu_core_family_finite']=core and all(_finite(x) for x in row['imu_core_family']);row['magnetometer_event_outer_finite']=mag
-            reports[mode][contract.name]=row
+            row['imu_core_family_finite']=core and all(_finite(x) for x in row['imu_core_family']);row['magnetometer_event_outer_finite']=mag;reports[mode][contract.name]=row
     core_closed=all(r['imu_core_family_finite'] for rows in reports.values() for r in rows.values());mag_closed=all(r['magnetometer_event_outer_finite'] for rows in reports.values() for r in rows.values())
-    return {'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD','inverse_free_gain_outer_consumed':True,'endpoint_Pbar_used_for_local_gain':False,'independent_covariance_box_used':False,'physical_D_S_bound_m_s':phys['centered_S_norm_upper_m_s'],'reports':reports,'all_IMU_core_local_outers_finite':core_closed,'all_single_magnetometer_local_outers_finite':mag_closed,'local_physical_outer_materialized':core_closed and mag_closed,'magnetometer_count_assumption_used':False,'ALT_LIVE_PASS':False,'next_obligation':'induct IMU-core family over 600 steps; common-M certificate must also make every separate magnetometer event outer nonexpansive so arbitrary finite async tuples close'}
+    return {'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD','inverse_free_gain_outer_consumed':True,'regional_error_domain_consumed_without_startup':True,'fresh_startup_reachability_consumed':False,'endpoint_Pbar_used_for_local_gain':False,'independent_covariance_box_used':False,'physical_D_S_bound_m_s':phys['centered_S_norm_upper_m_s'],'reports':reports,'all_IMU_core_local_outers_finite':core_closed,'all_single_magnetometer_local_outers_finite':mag_closed,'local_physical_outer_materialized':core_closed and mag_closed,'magnetometer_count_assumption_used':False,'ALT_LIVE_PASS':False,'next_obligation':'induct IMU-core family over 600 steps; common-M certificate must also make every separate magnetometer event outer nonexpansive so arbitrary finite async tuples close'}
 def summary(d):return {m:{f:{'failures':r['failures'],'imu_core':r['imu_core_family_finite'],'mag':r['magnetometer_event_outer_finite']} for f,r in rows.items()} for m,rows in d['reports'].items()}
 def validate(d):
     f=[]
     if d.get('qualification')!=QUALIFICATION:f.append('qualification mismatch')
-    if d.get('inverse_free_gain_outer_consumed') is not True:f.append('inverse-free gain not consumed')
-    for k in ('endpoint_Pbar_used_for_local_gain','independent_covariance_box_used','magnetometer_count_assumption_used','ALT_LIVE_PASS'):
+    for k in ('inverse_free_gain_outer_consumed','regional_error_domain_consumed_without_startup'):
+        if d.get(k) is not True:f.append(k+' not true')
+    for k in ('fresh_startup_reachability_consumed','endpoint_Pbar_used_for_local_gain','independent_covariance_box_used','magnetometer_count_assumption_used','ALT_LIVE_PASS'):
         if d.get(k) is not False:f.append(k+' not false')
     if float(d.get('physical_D_S_bound_m_s',0))!=1100.0:f.append('physical D_S drifted')
     return f

--- a/tools/stability/ou3_alt_contraction/inverse_free_universal_local_outer.py
+++ b/tools/stability/ou3_alt_contraction/inverse_free_universal_local_outer.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Universal physical joint24 local-event outer using inverse-free gain bounds.
+
+This supersedes the earlier experimental covariance-box local outer.  Actual
+same-cell Kalman gains are enclosed by ``inverse_free_gain_outer`` from a proved
+event-local covariance norm and S>=R; no endpoint covariance is reused locally.
+
+For each H/A x BIAS family this module emits:
+  * prediction homogeneous outer;
+  * finite physical S event outer using qualified D_S=1100 m*s;
+  * accelerometer physical Joseph/reset outer;
+  * magnetometer physical Joseph/reset outer;
+  * two finite IMU-core patterns: pred->acc and pred->S->acc.
+The magnetometer map remains separate for arbitrary-finite star composition.
+"""
+from __future__ import annotations
+import json,math
+from pathlib import Path
+from ou3_interval import Interval,matrix_identity,matrix_mul
+import ou3_p4_complete_brmm_differential_prediction as PRED
+import ou3_p4_complete_brmm_differential_events as EVENTS
+import ou3_p4_hard_entry_set as ENTRY
+import ou3_brmm_complete_window_execution_kernel as KERNEL
+import ou3_brmm_tuner_scheduler_step as TUNER
+from tools.stability.ou3_alt_contraction import joint24_events as J24
+from tools.stability.ou3_alt_contraction import bias_families as BIAS
+from tools.stability.ou3_alt_contraction import physical_numeric_bounds as PHYS
+from tools.stability.ou3_alt_contraction import inverse_free_gain_outer as GAIN
+
+REPO=Path(__file__).resolve().parents[3]
+DOMAIN=REPO/'tools/stability/ou3_proof_operating_domain.json'
+QUALIFICATION='OU3_ALT_INVERSE_FREE_UNIVERSAL_LOCAL_PHYSICAL_OUTER_V1'
+def I(x):return Interval.point(float(x))
+def B(x):x=float(x);return Interval.outward_bounds(-x,x)
+def _zero(r,c):return [[I(0) for _ in range(c)] for _ in range(r)]
+def _finite(A):return len(A)==24 and all(len(r)==24 for r in A) and all(math.isfinite(x.lo) and math.isfinite(x.hi) for r in A for x in r)
+def _compose(*maps):
+    A=matrix_identity(24)
+    for J in maps:A=matrix_mul(J,A)
+    return A
+def _state_box(mode,radii):
+    out=[]
+    for name in ('attitude_cayley_norm','gyro_bias_norm_rad_s','velocity_norm_mps','position_norm_m','integral_displacement_norm_m_s','latent_acceleration_norm_mps2'):out.extend([B(radii[name])]*3)
+    if mode=='A':out.extend([B(radii['accelerometer_bias_error_norm_mps2'])]*3)
+    return out
+def _bias_box(contract,projection_radius):
+    beta=[B(contract.true_bias_component_bound) for _ in range(3)]
+    held=[B(contract.true_bias_component_bound+projection_radius) for _ in range(3)]
+    return held,beta
+def _a_prediction_lift(J21,phi_hat,phi_true):
+    A=_zero(24,24)
+    for i in range(21):
+        for j in range(21):A[i][j]=J21[i][j]
+    for i in range(3):A[18+i][21+i]=phi_true-phi_hat;A[21+i][21+i]=phi_true
+    return A
+def _prediction(mode,state,omega,kc,tau,contract):
+    p=PRED.prediction_event(mode,state,omega,kc.h,tau,tau_ba=kc.accel_bias_tau_s if mode=='A' else None)
+    return J24.h18_prediction_lift(p['J_state'],contract.phi_true)[0] if mode=='H' else _a_prediction_lift(p['J_state'],p['phi_ba'],contract.phi_true)
+def _h_event(kind,state,K,held,beta,*,f=None,Rhat=None,m=None,Sphys=None):
+    extra=list(Sphys or ());total=24+len(extra);u=EVENTS.AD.independent_vector(list(state)+list(held)+list(beta)+extra,n=total,offset=0);z=u[:18];eba=u[18:21]
+    if kind=='accelerometer':y=J24._h18_accel_residual(z,eba,f,Rhat)
+    elif kind=='magnetometer':y=EVENTS.residual_magnetometer(z,m)
+    elif kind=='S_zero':y=[z[EVENTS.OFF_S+i]-u[24+i] for i in range(3)]
+    else:raise ValueError(kind)
+    out=list(EVENTS._apply_physical_correction(z,K,y))+list(u[18:24]);return [r[:24] for r in EVENTS.AD.jacobian(out)]
+def _a_event(kind,state,K,beta,radius,*,f=None,Rhat=None,m=None,Sphys=None):
+    extra=list(Sphys or ());total=24+len(extra);u=EVENTS.AD.independent_vector(list(state)+list(beta)+extra,n=total,offset=0);z=u[:21];b=u[21:24]
+    if kind=='accelerometer':y=EVENTS.residual_accelerometer(z,f,Rhat)
+    elif kind=='magnetometer':y=EVENTS.residual_magnetometer(z,m)
+    elif kind=='S_zero':y=[z[EVENTS.OFF_S+i]-u[24+i] for i in range(3)]
+    else:raise ValueError(kind)
+    out21=EVENTS._apply_physical_correction(z,K,y);J21,_,_=J24._project_joint(out21,b,total,radius);J=[list(r) for r in J21]
+    for i in range(3):row=[I(0) for _ in range(total)];row[21+i]=I(1);J.append(row)
+    return [r[:24] for r in J]
+def build():
+    gain=GAIN.build();gf=GAIN.validate(gain);phys=PHYS.build();pf=PHYS.validate(phys);entry=ENTRY.build();ef=ENTRY.validate(entry)
+    if gf or pf or ef:raise RuntimeError(f'local outer prerequisites failed gain={gf} phys={pf} entry={ef}')
+    d=json.loads(DOMAIN.read_text())['normal_live'];kc=KERNEL._process_constants(DOMAIN);tc=TUNER.constants();tau=Interval.outward_bounds(tc.tau_min,tc.tau_max);omega=[B(math.radians(float(phys['body_rate_norm_upper_deg_s'])))]*3
+    f=[B(float(phys['specific_force_norm_upper_mps2']))]*3;Rhat=[[Interval(-1.0,1.0) for _ in range(3)] for _ in range(3)];m=[B(float(d['magnetic_vector_norm_upper_uT']))]*3;Sphys=[B(float(phys['centered_S_norm_upper_m_s']))]*3;radii=entry['coordinate_radii'];radius=float(d['active_accelerometer_bias_projection_limit_mps2']);reports={}
+    for mode in ('H','A'):
+        state=_state_box(mode,radii);reports[mode]={}
+        for contract in BIAS.contracts():
+            held,beta=_bias_box(contract,radius);Krow=gain['reports'][mode];row={'failures':[],'maps':{}}
+            def attempt(name,fn):
+                try:A=fn();row['maps'][name]=A;row[name+'_finite']=_finite(A);row['failures']+=[] if row[name+'_finite'] else [name+': nonfinite']
+                except Exception as exc:row['maps'][name]=None;row[name+'_finite']=False;row['failures'].append(name+': '+type(exc).__name__+': '+str(exc))
+            attempt('prediction',lambda:_prediction(mode,state,omega,kc,tau,contract))
+            if mode=='H':
+                attempt('S_zero',lambda:_h_event('S_zero',state,Krow['S_zero']['K'],held,beta,Sphys=Sphys));attempt('accelerometer',lambda:_h_event('accelerometer',state,Krow['accelerometer']['K'],held,beta,f=f,Rhat=Rhat));attempt('magnetometer',lambda:_h_event('magnetometer',state,Krow['magnetometer']['K'],held,beta,m=m))
+            else:
+                attempt('S_zero',lambda:_a_event('S_zero',state,Krow['S_zero']['K'],beta,radius,Sphys=Sphys));attempt('accelerometer',lambda:_a_event('accelerometer',state,Krow['accelerometer']['K'],beta,radius,f=f,Rhat=Rhat));attempt('magnetometer',lambda:_a_event('magnetometer',state,Krow['magnetometer']['K'],beta,radius,m=m))
+            core=all(row.get(k+'_finite') for k in ('prediction','S_zero','accelerometer'));mag=bool(row.get('magnetometer_finite'))
+            row['imu_core_family']=[]
+            if core:
+                P=row['maps']['prediction'];S=row['maps']['S_zero'];A=row['maps']['accelerometer'];Id=matrix_identity(24);row['imu_core_family']=[_compose(P,Id,A),_compose(P,S,A)]
+            row['imu_core_family_finite']=core and all(_finite(x) for x in row['imu_core_family']);row['magnetometer_event_outer_finite']=mag
+            reports[mode][contract.name]=row
+    core_closed=all(r['imu_core_family_finite'] for rows in reports.values() for r in rows.values());mag_closed=all(r['magnetometer_event_outer_finite'] for rows in reports.values() for r in rows.values())
+    return {'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD','inverse_free_gain_outer_consumed':True,'endpoint_Pbar_used_for_local_gain':False,'independent_covariance_box_used':False,'physical_D_S_bound_m_s':phys['centered_S_norm_upper_m_s'],'reports':reports,'all_IMU_core_local_outers_finite':core_closed,'all_single_magnetometer_local_outers_finite':mag_closed,'local_physical_outer_materialized':core_closed and mag_closed,'magnetometer_count_assumption_used':False,'ALT_LIVE_PASS':False,'next_obligation':'induct IMU-core family over 600 steps; common-M certificate must also make every separate magnetometer event outer nonexpansive so arbitrary finite async tuples close'}
+def summary(d):return {m:{f:{'failures':r['failures'],'imu_core':r['imu_core_family_finite'],'mag':r['magnetometer_event_outer_finite']} for f,r in rows.items()} for m,rows in d['reports'].items()}
+def validate(d):
+    f=[]
+    if d.get('qualification')!=QUALIFICATION:f.append('qualification mismatch')
+    if d.get('inverse_free_gain_outer_consumed') is not True:f.append('inverse-free gain not consumed')
+    for k in ('endpoint_Pbar_used_for_local_gain','independent_covariance_box_used','magnetometer_count_assumption_used','ALT_LIVE_PASS'):
+        if d.get(k) is not False:f.append(k+' not false')
+    if float(d.get('physical_D_S_bound_m_s',0))!=1100.0:f.append('physical D_S drifted')
+    return f

--- a/tools/stability/ou3_alt_contraction/joint24_events.py
+++ b/tools/stability/ou3_alt_contraction/joint24_events.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Full joint24 physical event/prediction lifts for ALT.
+
+H18 proof state is [e_H18,e_ba,beta_true]. A21 proof state is
+[e_A21,beta_true]. These lifts retain physical bias in H18 accelerometer
+residuals and physical S in S=0 events. Projection uses the same generalized
+Jacobian as shipping, including beta_true derivatives.
+"""
+from __future__ import annotations
+from ou3_interval import Interval,matrix_mul
+import ou3_p4_complete_brmm_differential_events as EVENTS
+import ou3_p4_complete_brmm_source_cover_contract as COVER
+from tools.stability.ou3_alt_contraction import physical_reference as REF
+
+QUALIFICATION='OU3_ALT_PHYSICAL_JOINT24_EVENTS_V1'
+H_EBA=18;H_BETA=21;A_BETA=21
+
+def I(x):return Interval.point(float(x))
+def zero(r,c):return [[I(0) for _ in range(c)] for _ in range(r)]
+def _selector(rows,cols,offset):
+    A=zero(rows,cols)
+    for i in range(rows):A[i][offset+i]=I(1)
+    return A
+
+def _h18_accel_residual(z,eba,f_hat,R_hat):
+    nd=z[0].n;E=EVENTS.AD.rotation_from_cayley(z[:3]);f=[EVENTS._const(x,nd) for x in f_hat]
+    R=[[EVENTS._const(x,nd) for x in row] for row in R_hat];da=z[EVENTS.OFF_AW:EVENTS.OFF_AW+3]
+    Rda=EVENTS.AD.matvec(R,da);Ef=EVENTS.AD.matvec(E,f);ERda=EVENTS.AD.matvec(E,Rda)
+    return [Ef[i]-f[i]+ERda[i]+eba[i] for i in range(3)]
+
+def h18_accelerometer_event(cell:COVER.SourceCoverCell):
+    f=COVER.validate_cell(cell,require_estimator_provenance=True)
+    if f:raise ValueError('invalid source cell: '+repr(f))
+    if cell.mode!='H' or cell.kind!='accelerometer':raise ValueError('H18 accelerometer cell required')
+    u=EVENTS.AD.independent_vector(list(cell.state)+[I(0)]*6,n=24,offset=0);z=u[:18];eba=u[18:21];beta=u[21:24]
+    H=EVENTS._event_H('H','accelerometer',f_hat=cell.f_hat,R_hat=cell.R_hat);K,S=EVENTS.source_joseph_gain(cell.P,H,cell.R)
+    residual=_h18_accel_residual(z,eba,cell.f_hat,cell.R_hat);out18=EVENTS._apply_physical_correction(z,K,residual);out=list(out18)+list(eba)+list(beta)
+    return {'J_joint24':EVENTS.AD.jacobian(out),'state_out':EVENTS.AD.values(out),'residual':EVENTS.AD.values(residual),'same_history_held_bias_retained':True,'beta_identity':True,'independent_bias_supply_used':False}
+
+def h18_prediction_lift(J18,phi_true:Interval):
+    if len(J18)!=18 or any(len(r)!=18 for r in J18):raise ValueError('18x18 prediction Jacobian required')
+    if not isinstance(phi_true,Interval):raise TypeError('phi_true interval required')
+    A=zero(24,24);B=zero(24,3)
+    for i in range(18):
+        for j in range(18):A[i][j]=J18[i][j]
+    for i in range(3):
+        A[18+i][18+i]=I(1);A[18+i][21+i]=phi_true-I(1);A[21+i][21+i]=phi_true;B[18+i][i]=I(1);B[21+i][i]=I(1)
+    return A,B
+
+def _project_joint(out21,beta,total_dim,radius):
+    pre=out21[18:21];xhat=[beta[i]-pre[i] for i in range(3)];proj=EVENTS.ball_projection_enclosure(EVENTS.AD.values(xhat),radius)
+    smooth=EVENTS.AD.jacobian(out21);dx=EVENTS.AD.jacobian(xhat);pder=matrix_mul(proj['J'],dx);bsel=_selector(3,total_dim,A_BETA);J=[list(r) for r in smooth]
+    for i in range(3):J[18+i]=[bsel[i][j]-pder[i][j] for j in range(total_dim)]
+    vals=EVENTS.AD.values(out21);vals[18:21]=[EVENTS.AD.values(beta)[i]-proj['value'][i] for i in range(3)]
+    return J,vals,proj
+
+def s_zero_event_joint24(cell:COVER.SourceCoverCell):
+    f=COVER.validate_cell(cell,require_estimator_provenance=True)
+    if f:raise ValueError('invalid source cell: '+repr(f))
+    if cell.kind!='S_zero' or cell.wave_primitive is None:raise ValueError('physical S_zero cell with primitive required')
+    REF.validate_primitive_reference(cell.wave_primitive)
+    if cell.R_provenance!=EVENTS.ACTUAL_RS_PROVENANCE:raise ValueError('actual R_S provenance required')
+    if cell.mode=='H':state24=list(cell.state)+[I(0)]*6
+    else:
+        if cell.true_bias is None or cell.bias_projection_limit is None:raise ValueError('A21 true bias/projection required')
+        state24=list(cell.state)+list(cell.true_bias)
+    u=EVENTS.AD.independent_vector(state24+list(cell.wave_primitive.centered_S),n=27,offset=0);nerr=18 if cell.mode=='H' else 21;z=u[:nerr]
+    beta=u[H_BETA:H_BETA+3] if cell.mode=='H' else u[A_BETA:A_BETA+3];sphys=u[24:27]
+    H=EVENTS._event_H(cell.mode,'S_zero');K,S=EVENTS.source_joseph_gain(cell.P,H,cell.R);residual=[z[EVENTS.OFF_S+i]-sphys[i] for i in range(3)];out_err=EVENTS._apply_physical_correction(z,K,residual)
+    if cell.mode=='H':
+        out=list(out_err)+list(u[18:21])+list(beta);J=EVENTS.AD.jacobian(out);vals_out=EVENTS.AD.values(out);branch='not_applicable'
+    else:
+        Jerr,errvals,proj=_project_joint(out_err,beta,27,float(cell.bias_projection_limit));branch=proj['branch'];J=Jerr+_selector(3,27,A_BETA);vals_out=errvals+EVENTS.AD.values(beta)
+    return {'J_joint24':[r[:24] for r in J],'J_S_phys':[r[24:27] for r in J],'state_out':vals_out,'residual':EVENTS.AD.values(residual),'physical_generator_id':cell.wave_primitive.generator_id,'live_origin_id':cell.wave_primitive.live_origin_id,'projection_branch':branch,'same_history_S_source_columns_retained':True,'independent_S_box_used':False}
+
+def build():
+    return {'qualification':QUALIFICATION,'joint_dimension':24,'H18_accelerometer_held_bias_columns_available':True,'H18_prediction_true_bias_shared_driver_lift_available':True,'H18_and_A21_physical_S_source_columns_available':True,'A21_projection_beta_columns_retained':True,'independent_bias_supply_used':False,'independent_S_box_used':False,'complete_literal_word_closed':False,'storage_search_allowed':False,'ALT_LIVE_PASS':False}
+def validate(d):
+    f=[]
+    if d.get('qualification')!=QUALIFICATION or d.get('joint_dimension')!=24:f.append('qualification/dimension mismatch')
+    for k in ('H18_accelerometer_held_bias_columns_available','H18_prediction_true_bias_shared_driver_lift_available','H18_and_A21_physical_S_source_columns_available','A21_projection_beta_columns_retained'):
+        if d.get(k) is not True:f.append(k+' not true')
+    for k in ('independent_bias_supply_used','independent_S_box_used','complete_literal_word_closed','storage_search_allowed','ALT_LIVE_PASS'):
+        if d.get(k) is not False:f.append(k+' not false')
+    return f

--- a/tools/stability/ou3_alt_contraction/live_frontend_predecessor.py
+++ b/tools/stability/ou3_alt_contraction/live_frontend_predecessor.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Regional Normal-Live frontend predecessor invariant for ALT.
+
+This is the Live-only counterpart of the shared frontend predecessor proof.  It
+uses the same BRMM primitive bounds, WPE telescoping/Schur bounds, adaptive-band
+covariance bound, tuner clamps, scheduler quotient and stillness saturation.
+The private Mahony component is the regional source-order binary32 invariant in
+``live_mahony_regional``.
+
+Crucially, membership in this set is a premise of the regional Live theorem;
+startup's ability to enter it is NOT consumed here.  That is a later capture
+obligation.  Thus this module removes no dynamics or source bounds--it only
+separates forward invariance from reachability of the initial set.
+"""
+from __future__ import annotations
+import json,math
+from pathlib import Path
+
+import ou3_brmm_contract as BRMM
+import ou3_brmm_finite_window_primitive_qualification as PRIM
+import ou3_fast_inv_sqrt_interval as FINV
+import ou3_brmm_wpe_state_step as WPE
+import ou3_brmm_tuner_scheduler_step as TUNER
+import ou3_brmm_sigma_stillness_step as STILL
+import ou3_validated_transcendentals as VT
+import ou3_p4_brmm_frontend_predecessor_invariant as SHARED
+from ou3_interval import Interval
+from tools.stability.ou3_alt_contraction import live_mahony_regional as MAHONY
+
+REPO=Path(__file__).resolve().parents[3]
+DOMAIN=REPO/'tools/stability/ou3_proof_operating_domain.json'
+WPE_HEADER=REPO/'src/tuner/WavePeriodEstimator.h'
+QUALIFICATION='OU3_ALT_REGIONAL_NORMAL_LIVE_FRONTEND_PREDECESSOR_V1'
+
+def I(x):return Interval.outward_bounds(float(x),float(x))
+def up(x):return math.nextafter(float(x),math.inf)
+def _decay(lam,dt):
+    d=VT.exp_interval(-(lam*I(dt)))
+    if not(0<d.lo<=d.hi<1):raise RuntimeError('WPE decay is not strictly Schur')
+    return d
+
+def build():
+    domain=json.loads(DOMAIN.read_text());brmm=BRMM.build();prim=PRIM.build();mah=MAHONY.build()
+    bad={'BRMM':BRMM.validate(brmm),'primitive':PRIM.validate(prim),'regional_Mahony':MAHONY.validate(mah)};bad={k:v for k,v in bad.items() if v}
+    if bad:raise RuntimeError('regional frontend prerequisite failed: '+repr(bad))
+    wc=WPE.constants();tc=TUNER.constants();sc=STILL.constants();g=float(domain['startup']['gravity_mps2']);am=float(prim['uniform_physical_primitives']['acceleration_norm_upper_mps2'])
+    q2=FINV.all_positive_normal_normalized_norm2_enclosure();vertical=up(q2.hi*(g+am)+g)
+    pi=Interval.outward_bounds(3.141592653589793,3.141592653589794);lam=I(2)*pi*I(wc.high_pass_hz);d=_decay(lam,wc.dt)
+    hp_gain=up(2*d.hi);hp1=up(hp_gain*vertical);hp2=up(hp_gain*hp1);vel=up(hp2/lam.lo);elev=up(vel/lam.lo)
+    valid_weight_floor=math.nextafter(1e-3,math.inf);vel_sq=up(vel*vel);vvar_upper=up(vel_sq/valid_weight_floor);evar_floor=math.nextafter(1e-12,math.inf);omega2_floor=math.nextafter(1e-8,math.inf);omega2_upper=up(vvar_upper/evar_floor)
+    raw_min=math.nextafter(2*math.pi/math.sqrt(omega2_upper),0.0);raw_max=up(2*math.pi/math.sqrt(omega2_floor));log_min=math.nextafter(math.log(raw_min),-math.inf);log_max=math.nextafter(math.log(raw_max),math.inf);freq_min=math.nextafter(math.exp(-log_max),0.0);freq_max=up(math.exp(-log_min))
+    text=WPE_HEADER.read_text();elapsed_parity=all(s in text for s in ('elapsed_sec_ += dt_sec;','if (elapsed_sec_ < moment_start_sec) return;','elapsed_sec_ >= settled_floor_sec','const float moment_history_sec = elapsed_sec_ - moment_start_sec;','if (elapsed_sec_ >= usable_floor_sec && moment_history_sec >= period)','if (usable_period_) return;'))
+    elapsed_cap=up(3/lam.lo+raw_max);band=up(2*vertical);bcov=SHARED._band_covariance_outer(tc);still_energy=up((vertical/sc.gravity)**2);scheduler_max=up(tc.adapt_every_s+tc.dt)
+    strict={
+      'regional_Mahony_source_order_binary32_invariant':mah['regional_source_order_binary32_discrete_invariance_closed'],
+      'WPE_decay_strict':d.hi<1,'WPE_telescoping_gain_finite':hp_gain<2,'WPE_leaky_gain_finite':math.isfinite(1/lam.lo),
+      'WPE_startup_zero_weight_retained':True,'WPE_ratio_branch_has_positive_weight_floor':valid_weight_floor>1e-3,
+      'WPE_valid_period_compact':0<raw_min<raw_max<math.inf,'WPE_frequency_compact':0<freq_min<=freq_max<math.inf,
+      'WPE_elapsed_guard_quotient_parity':elapsed_parity,'adaptive_band_uniform_Schur_gap':bcov['alpha_low_uniform_lower']>0 and bcov['alpha_high_uniform_lower']>0,
+      'adaptive_band_covariance_compact':bcov['finite_covariance_outer'],
+      'candidate_active_clamps_compact':tc.tau_min>0 and tc.tau_max>=tc.tau_min and tc.sigma_max>0 and tc.rs_min>0 and tc.rs_max>=tc.rs_min,
+      'scheduler_guard_class_compact':math.isfinite(scheduler_max),'stillness_timer_saturated':sc.still_max_s==60.0}
+    closed=all(strict.values())
+    return {'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD','regional_Live_entry_membership_is_theorem_premise':True,'startup_capture_consumed':False,'startup_entry_closed_here':False,
+      'same_history_BRMM_ancestry_required_downstream':True,'regional_Mahony_invariant_consumed':True,'source_order_binary32_model_consumed':True,
+      'vertical_acceleration_abs_upper_mps2':vertical,
+      'WPE_invariant':{'decay':d.as_list(),'single_highpass_linf_gain_upper':hp_gain,'highpass1_abs_upper_mps2':hp1,'highpass2_abs_upper_mps2':hp2,'velocity_abs_upper_mps':vel,'elevation_abs_upper_m':elev,'weight_interval':[0.0,1.0],'valid_ratio_weight_lower':valid_weight_floor,'valid_raw_period_s':[raw_min,raw_max],'canonical_log_period':[log_min,log_max],'canonical_frequency_hz':[freq_min,freq_max],'elapsed_guard_quotient_cap_s':elapsed_cap,'actual_elapsed_need_not_be_bounded':True,'elapsed_quotient_preserves_all_shipping_guards':elapsed_parity},
+      'adaptive_band_invariant':{'lowpass_abs_upper_mps2':vertical,'band_abs_upper_mps2':band,**bcov},
+      'tuner_invariant':{'mean_value_abs_upper':band,'sq_value_upper':up(band*band),'weights_interval':[0.0,1.0],'frequency_after_shipping_clamp_hz':[tc.tune_freq_min,tc.tune_freq_max],'candidate':{'tau_s':[tc.tau_min,tc.tau_max],'sigma_mps2':[0.0,tc.sigma_max],'rs':[tc.rs_min,tc.rs_max]},'active':{'tau_s':[tc.tau_min,tc.tau_max],'sigma_mps2':[0.0,tc.sigma_max],'rs':[tc.rs_min,tc.rs_max],'pseudo_period_s':[tc.pseudo_min_s,tc.pseudo_max_s]},'scheduler_elapsed_guard_upper_s':scheduler_max},
+      'stillness_invariant':{'lpf_abs_upper_mps2':vertical,'energy_ema_upper':still_energy,'still_time_s':[0.0,sc.still_max_s],'attenuation':[0.0,1.0]},
+      'strict_invariance_checks':strict,'regional_normal_live_frontend_predecessor_set_closed':closed,
+      'coefficient_history_must_still_come_from_joint_transition':True,'outer_bounds_may_not_generate_independent_f_sigma_tau_TS_RS':True,'trajectory_replay_used':False,'ALT_LIVE_PASS':False,
+      'next_obligation':'use this regional predecessor set with the same-history JOINT transition and O^601_BRMM to build the 601-step Live relation; startup must later prove entry into this set'}
+def validate(d):
+    f=[]
+    if d.get('qualification')!=QUALIFICATION:f.append('qualification mismatch')
+    for k in ('regional_Live_entry_membership_is_theorem_premise','same_history_BRMM_ancestry_required_downstream','regional_Mahony_invariant_consumed','source_order_binary32_model_consumed','regional_normal_live_frontend_predecessor_set_closed','coefficient_history_must_still_come_from_joint_transition','outer_bounds_may_not_generate_independent_f_sigma_tau_TS_RS'):
+        if d.get(k) is not True:f.append(k+' not true')
+    for k in ('startup_capture_consumed','startup_entry_closed_here','trajectory_replay_used','ALT_LIVE_PASS'):
+        if d.get(k) is not False:f.append(k+' not false')
+    if not all(d.get('strict_invariance_checks',{}).values()):f.append('strict invariant check failed')
+    return f

--- a/tools/stability/ou3_alt_contraction/live_mahony_regional.py
+++ b/tools/stability/ou3_alt_contraction/live_mahony_regional.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Regional private-Mahony invariant for the ALT Live theorem.
+
+The shared Mahony certificates currently conflate two obligations:
+  (1) inward/discrete invariance of a declared Live set; and
+  (2) startup's initial seed belonging to that set.
+ALT needs (1) now and proves (2) only after a quantitative Live basin exists.
+
+This module reuses the SAME metric, BRMM direction decomposition, rational
+boundary cover and source-order binary32/Euler charges.  It removes only the
+startup-membership premise from the *Live* theorem.  The theorem here is
+conditional: if a Live predecessor lies in V(z)<=C, one literal 5 ms Mahony
+step stays in V(z)<=C and in the 87-degree chart under the declared source-order
+binary32 model.  No claim about startup entry or compiler reassociation/FMA is
+made.
+"""
+from __future__ import annotations
+import json,math
+from pathlib import Path
+
+import ou3_brmm_private_mahony_live_invariant as CONT
+import ou3_brmm_private_mahony_discrete_invariant as DISC
+import ou3_fast_inv_sqrt_interval as FINV
+
+REPO=Path(__file__).resolve().parents[3]
+DOMAIN=REPO/'tools/stability/ou3_proof_operating_domain.json'
+QUALIFICATION='OU3_ALT_REGIONAL_LIVE_MAHONY_INVARIANT_V1'
+
+
+def build():
+    d=json.loads(DOMAIN.read_text());c=CONT._source_constants(d);sector=CONT._sector_lower(c['chart_deg'])
+    boundary=CONT._verify_boundary(c,sector.lo)
+    C=CONT.C_LEVEL;ztheta_sq=C*CONT.P22/CONT.DET_P
+    theta_upper=math.sqrt(ztheta_sq)+0.1*c['xi'];chart_rad=math.radians(c['chart_deg']);chart_contained=theta_upper<chart_rad
+    regional_cont=bool(boundary['closed'] and boundary['strict_inward_margin_lower']>0 and chart_contained)
+    if not regional_cont:raise RuntimeError('regional continuous Mahony invariant failed')
+
+    dt=float(d['configured_runtime']['imu_dt_s']);body=math.radians(float(d['normal_live']['body_rate_norm_upper_deg_s']))
+    shell=FINV.all_positive_normal_normalized_norm2_enclosure();qn_lo=math.sqrt(shell.lo);qn_hi=math.sqrt(shell.hi)
+    xi=c['xi'];mean=c['mean_chord'];ztheta=math.sqrt(C*CONT.P22/CONT.DET_P);zbeta=math.sqrt(C/CONT.DET_P);beta=zbeta+0.01*xi
+    half_g=0.5*qn_hi*qn_hi;half_err=qn_hi*half_g;omega=body+beta+0.2*half_err;half_rate=0.5*dt*omega
+    raw_sum_abs=qn_hi*(1+3*half_rate);raw_component_round=DISC.gamma(24)*raw_sum_abs;raw_vector_round=2*raw_component_round;raw_angle_round=2*raw_vector_round/qn_lo
+    norm_mult_vector_round=2*DISC.U*qn_hi;norm_angle_round=2*norm_mult_vector_round/qn_lo
+    feedback_rate_round=DISC.gamma(24)*omega;attitude_rate_fp=(raw_angle_round+norm_angle_round)/dt+feedback_rate_round
+    initial_bias=float(d['startup']['initial_tangent_gyro_bias_norm_upper_rad_s']);integral_mag=beta+initial_bias;ki_increment=.02*half_err*dt
+    integral_step_round=DISC.gamma(8)*(integral_mag+ki_increment);bias_rate_fp=integral_step_round/dt
+    fp_support=attitude_rate_fp+math.hypot(6.5,11.0)*bias_rate_fp
+    continuous_margin=float(boundary['strict_inward_margin_lower']);robust_margin=continuous_margin-2*fp_support
+    smin=sector.lo;dg=float(d['startup']['effective_deterministic_gyro_transport_disturbance_upper_rad_s'])+attitude_rate_fp;db=float(d['startup']['effective_deterministic_bias_transport_disturbance_upper_rad_s2'])+bias_rate_fp
+    ftheta=.1*ztheta+zbeta+max(abs(.01*smin-.01),0)*xi+.1*mean+dg;fbeta=.01*ztheta+.001*xi+.01*mean+db
+    Rf1=ftheta+6.5*fbeta;Rf2=11*fbeta;euler_quadratic=dt*dt*(Rf1*Rf1+Rf2*Rf2)
+    first_order=2*CONT.SQRT_C*robust_margin*dt;discrete_margin=first_order-euler_quadratic
+    chart_margin=chart_rad-theta_upper;round_chart_margin=chart_margin-(raw_angle_round+norm_angle_round)
+    regional_binary32=bool(robust_margin>0 and discrete_margin>0 and round_chart_margin>0)
+    return {
+      'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD',
+      'regional_entry_set':'V(z)<=C with z=x-B*xi','metric_P':[[CONT.P11,CONT.P12],[CONT.P12,CONT.P22]],'invariant_level_C':C,
+      'same_BRMM_direction_primitive_and_transport_forcing_retained':True,'boundary_cells_per_chart':CONT.CELLS_PER_CHART,
+      'continuous_boundary_margin_lower':continuous_margin,'regional_continuous_invariance_closed':regional_cont,
+      'actual_tilt_rad_upper_on_invariant':theta_upper,'chart_radius_rad':chart_rad,
+      'source_order_binary32_support_charge':fp_support,'binary32_robust_boundary_margin_lower':robust_margin,
+      'forward_euler_quadratic_V_upper':euler_quadratic,'discrete_V_margin_lower':discrete_margin,'one_step_chart_round_margin_rad':round_chart_margin,
+      'regional_source_order_binary32_discrete_invariance_closed':regional_binary32,
+      'startup_initial_seed_membership_required_for_Live_invariance':False,'startup_entry_into_regional_set_closed_here':False,
+      'compiler_reassociation_or_FMA_closed':False,'trajectory_replay_used':False,'filter_changed':False,
+      'ALT_LIVE_PASS':False,
+      'next_obligation':'use this regional invariant, rather than startup capture, as the Mahony component of the Normal-Live frontend predecessor set; preserve startup entry as a later basin-capture theorem',
+    }
+
+def validate(x):
+    f=[]
+    if x.get('qualification')!=QUALIFICATION:f.append('qualification mismatch')
+    for k in ('same_BRMM_direction_primitive_and_transport_forcing_retained','regional_continuous_invariance_closed','regional_source_order_binary32_discrete_invariance_closed'):
+        if x.get(k) is not True:f.append(k+' not true')
+    for k in ('startup_initial_seed_membership_required_for_Live_invariance','startup_entry_into_regional_set_closed_here','compiler_reassociation_or_FMA_closed','trajectory_replay_used','filter_changed','ALT_LIVE_PASS'):
+        if x.get(k) is not False:f.append(k+' not false')
+    for k in ('continuous_boundary_margin_lower','binary32_robust_boundary_margin_lower','discrete_V_margin_lower','one_step_chart_round_margin_rad'):
+        if not float(x.get(k,0))>0:f.append(k+' not positive')
+    return f

--- a/tools/stability/ou3_alt_contraction/live_source_relation.py
+++ b/tools/stability/ou3_alt_contraction/live_source_relation.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Regional universal Normal-Live source relation for the ALT proof.
+
+The relation is
+
+  O^601_BRMM
+  x X_front,Live
+  x BIASi
+
+where O^601_BRMM is the existing correlated 601-sample physical outer relation,
+X_front,Live is the regional frontend predecessor invariant (including the
+source-order binary32 private-Mahony invariant), and BIASi is one of the three
+separate analytic physical bias families.
+
+For each sample, coefficients are generated only by the existing exact
+same-history JOINT transition operator, and Riccati/event cells only by the
+trusted execution-kernel/estimator-attachment operator.  This module deliberately
+does NOT call their top-level build/smoke functions, because those currently
+import startup-entry qualification.  Startup membership is not a premise of a
+regional Live theorem; it is a later capture theorem.
+
+The proof here is an induction relation, not a finite source enumeration.  The
+component invariants are forward invariant and every branch successor of the
+literal transition is retained.  Physical q15/S response propagation is handled
+by ``physical_lineage``; complete 600-step cocycle assembly is the next layer.
+"""
+from __future__ import annotations
+from pathlib import Path
+
+import ou3_brmm_correlated_window_outer_enclosure as OUTER
+import ou3_p4_joint_brmm_frontend_transition as JOINT
+import ou3_brmm_complete_window_execution_kernel as KERNEL
+import ou3_p4_source_uniform_estimator_event_attachment as ATTACH
+from tools.stability.ou3_alt_contraction import bias_families as BIAS
+from tools.stability.ou3_alt_contraction import live_frontend_predecessor as FRONT
+
+REPO=Path(__file__).resolve().parents[3]
+JOINT_SRC=REPO/'tools/stability/ou3_p4_joint_brmm_frontend_transition.py'
+ATTACH_SRC=REPO/'tools/stability/ou3_p4_source_uniform_estimator_event_attachment.py'
+QUALIFICATION='OU3_ALT_REGIONAL_UNIVERSAL_NORMAL_LIVE_SOURCE_RELATION_V1'
+
+def _operator_parity():
+    j=JOINT_SRC.read_text();a=ATTACH_SRC.read_text()
+    return {
+      'joint_commits_before_measurement':'committed=TUNER.commit_if_pending' in j,
+      'joint_private_Mahony_step':'MAHONY.advance_initialized_live' in j,
+      'joint_stillness_all_successors':'still_images=STILL.advance' in j and 'for si in still_images:' in j,
+      'joint_WPE_all_successors':'wpe_images=STATS.advance_wpe' in j and 'for wi in wpe_images:' in j,
+      'joint_tuner_all_successors':'for tuner_next,target,tuner_stats,timer in tuner_images:' in j,
+      'joint_same_predecessor_token':'token,state.source_token,child' in j,
+      'attachment_uses_kernel_joint_operator':'KERNEL.advance_branch_with_joint_frontend' in a,
+      'attachment_retains_every_joint_successor':'for ordinal, raw_image in enumerate(images):' in a,
+      'attachment_checks_same_active_schedule':'same_active_schedule_verified' in a,
+      'attachment_checks_same_actual_RS':'same_actual_RS_verified' in a,
+      'attachment_uses_JOINT_frontend_as_successor':'JOINT_image_authoritative_for_next_frontend_state' in a,
+    }
+
+def build():
+    outer=OUTER.build();of=OUTER.validate(outer);front=FRONT.build();ff=FRONT.validate(front);bias=BIAS.build();bf=BIAS.validate(bias)
+    bad={k:v for k,v in {'outer':of,'regional_frontend':ff,'bias':bf}.items() if v}
+    if bad:raise RuntimeError('regional Live source relation prerequisite failed: '+repr(bad))
+    parity=_operator_parity();operators=all(parity.values()) and callable(JOINT.advance) and callable(KERNEL.advance_branch_with_joint_frontend) and callable(ATTACH.synchronize_sample)
+    closed=bool(outer['left_inclusion_closed'] and outer['validated_correlated_outer_enclosure_closed'] and outer['same_history_required_for_entire_window'] and outer['correlation_retained_across_samples'] and front['regional_normal_live_frontend_predecessor_set_closed'] and operators and bias['three_families_invoked_separately'] and bias['one_persistent_parameter_token_per_family'])
+    return {
+      'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD','physical_outer_relation':outer['outer_set_symbol'],'sample_count':outer['sample_count'],
+      'COMPLETE_BRMM_left_inclusion_consumed':outer['left_inclusion_closed'],'correlated_physical_history_across_601_samples':outer['correlation_retained_across_samples'],
+      'regional_frontend_predecessor_invariant_consumed':front['regional_normal_live_frontend_predecessor_set_closed'],'startup_capture_consumed':False,'startup_entry_membership_closed_here':False,
+      'individual_BIAS0_BIAS1_BIAS2_contracts_consumed':bias['three_families_invoked_separately'],'persistent_bias_parameter_token_required_over_word':True,
+      'operator_source_parity':parity,'same_history_joint_frontend_transition_operator_bound':operators,'trusted_Riccati_event_attachment_operator_bound':operators,'all_branch_successors_retained_by_operator':operators,
+      'independent_f_sigma_tau_TS_RS_boxes_used':False,'independent_sample_boxes_used':False,'replay_or_seeded_realization_used':False,'favorable_successor_selected':False,
+      'regional_universal_Normal_Live_source_relation_closed':closed,
+      'complete_600_step_physical_joint24_cocycle_closed_here':False,'H18_A21_guard_reachability_closed_here':False,'storage_search_allowed':False,'ALT_LIVE_PASS':False,
+      'next_obligation':'apply physical_lineage to every transition of this relation by induction, carrying prior response blocks, primitive continuity, one BIAS parameter token and latent held covariance; splice the exact H18->A21 edge when its literal guard becomes true'}
+def validate(d):
+    f=[]
+    if d.get('qualification')!=QUALIFICATION or d.get('physical_outer_relation')!='O^601_BRMM' or d.get('sample_count')!=601:f.append('qualification/source window mismatch')
+    for k in ('COMPLETE_BRMM_left_inclusion_consumed','correlated_physical_history_across_601_samples','regional_frontend_predecessor_invariant_consumed','individual_BIAS0_BIAS1_BIAS2_contracts_consumed','persistent_bias_parameter_token_required_over_word','same_history_joint_frontend_transition_operator_bound','trusted_Riccati_event_attachment_operator_bound','all_branch_successors_retained_by_operator','regional_universal_Normal_Live_source_relation_closed'):
+        if d.get(k) is not True:f.append(k+' not true')
+    if not all(d.get('operator_source_parity',{}).values()):f.append('operator source parity failed')
+    for k in ('startup_capture_consumed','startup_entry_membership_closed_here','independent_f_sigma_tau_TS_RS_boxes_used','independent_sample_boxes_used','replay_or_seeded_realization_used','favorable_successor_selected','complete_600_step_physical_joint24_cocycle_closed_here','H18_A21_guard_reachability_closed_here','storage_search_allowed','ALT_LIVE_PASS'):
+        if d.get(k) is not False:f.append(k+' not false')
+    return f

--- a/tools/stability/ou3_alt_contraction/local_covariance_norm_envelope.py
+++ b/tools/stability/ou3_alt_contraction/local_covariance_norm_envelope.py
@@ -1,45 +1,54 @@
 #!/usr/bin/env python3
 """Source-uniform event-local covariance operator-norm envelope for ALT.
 
-This replaces an invalid use of the endpoint-referenced Pbar as a local Joseph
-covariance bound.  The proof uses only shipping/source facts:
+This theorem uses the endpoint-referenced covariance envelope only where that
+producer actually qualifies it: at arbitrary COMPLETE-BRMM word endpoints.
+It never substitutes endpoint Pbar directly for a pre-Joseph local covariance.
 
-* Live covariance is reseeded before the first prediction;
-* prediction is P^- = F P F' + Q;
-* every Joseph update with the shipping Kalman gain is PSD-decreasing,
-  P^+ = P^- - K S K' <= P^-;
-* active bias projection leaves covariance unchanged;
-* the a_w synchronization increment is Delta=Pi_+(Sigma_aw-P_aw).
+There are three regimes.
 
-For P_aw>=0,
-  ||Delta||_2=max(lambda_max(Sigma_aw-P_aw),0)<=lambda_max(Sigma_aw),
-so a requested floor adds at most the committed stationary target variance in
-operator norm, independently of the current P.  Therefore the scalar recurrence
+H18 early Live:
+  start from the actual source-generated Live seed and propagate the conservative
+  prediction/floor scalar recurrence for at most one 600-sample word.
 
-  p_{k+1} <= ||F||_2^2 p_k + ||Q||_2 + sigma_aw,max^2
+H18 after the first word:
+  every current sample follows an endpoint of a preceding source-uniform 3 s
+  window.  Convert the rigorous endpoint diagonal Pbar into an operator-norm
+  upper by PSD trace, then apply at most one prediction plus one a_w floor
+  before any Joseph event of the current sample.
 
-is a valid source-uniform upper for covariance at every event of every sample.
-The F/Q norms below are themselves upper-bounded from outward shipping matrix
-primitives over the declared BRMM rate/tuner ranges.
+A21 release / early active word:
+  shipping cannot release before the configured >=30 s H interval, so H18 has
+  long since reached the endpoint-envelope regime.  The exact held->active edge
+  appends the fixed b_a seed block with zero cross covariance.  Propagate that
+  actual release covariance through at most one 600-sample A word.  Thereafter
+  use the A21 sliding endpoint envelope plus one prediction/floor.
+
+Every Joseph operation is PSD-decreasing in exact real arithmetic and the bias
+projection leaves covariance unchanged.  For the a_w floor,
+
+  Delta = Pi_+(Sigma_aw-P_aw),  P_aw>=0,
+  ||Delta||2 = max(lambda_max(Sigma_aw-P_aw),0) <= lambda_max(Sigma_aw),
+
+so one requested floor adds at most the stationary target variance independent
+of the current covariance.
 """
 from __future__ import annotations
 
 import math
-import json
 from pathlib import Path
-
 from ou3_interval import Interval
 import ou3_brmm_live_covariance_seed as LIVE
 import ou3_brmm_complete_window_execution_kernel as KERNEL
 import ou3_brmm_shipping_prediction_primitives as PRIM
 import ou3_brmm_tuner_scheduler_step as TUNER
+import ou3_brmm_riccati_tube_factored as TUBE
 from tools.stability.ou3_alt_contraction import physical_numeric_bounds as PHYS
 
 REPO=Path(__file__).resolve().parents[3]
 DOMAIN=REPO/'tools/stability/ou3_proof_operating_domain.json'
-QUALIFICATION='OU3_ALT_EVENT_LOCAL_COVARIANCE_OPERATOR_NORM_ENVELOPE_V1'
+QUALIFICATION='OU3_ALT_EVENT_LOCAL_COVARIANCE_OPERATOR_NORM_ENVELOPE_V2'
 TRANSITIONS=600
-
 
 def I(x):return Interval.outward_bounds(float(x),float(x))
 def B(r):r=float(r);return Interval.outward_bounds(-r,r)
@@ -69,46 +78,46 @@ def _assemble(mode,Faa,Qaa,Ft,Qt,phi_ba,Qba):
         for i in range(3):F[18+i][18+i]=phi_ba;Q[18+i][18+i]=Qba[i][i]
     return F,Q
 
-def _seed_norms(live):
-    c=live['constructor'];att=live['full_heading_gauged_live_attitude_seed'];aw=live['aw_live_seed'];held=live['held_ba']
-    attmax=max(float(att['tilt_std_rad'])**2,float(att['yaw_std_rad'])**2)
-    base=max(attmax,float(c['P_bg_variance']),float(live['translation_seed']['P_v']),float(live['translation_seed']['P_p']),float(live['translation_seed']['P_S']),float(aw['committed_vertical_std_interval_mps2'][1])**2)
-    return {'H':math.nextafter(base,math.inf),'A':math.nextafter(max(base,float(held['seed_variance'])),math.inf)}
+def _live_H_seed_norm(live):
+    c=live['constructor'];att=live['full_heading_gauged_live_attitude_seed'];aw=live['aw_live_seed']
+    vals=[float(att['tilt_std_rad'])**2,float(att['yaw_std_rad'])**2,float(c['P_bg_variance']),float(live['translation_seed']['P_v']),float(live['translation_seed']['P_p']),float(live['translation_seed']['P_S']),float(aw['committed_vertical_std_interval_mps2'][1])**2]
+    return math.nextafter(max(vals),math.inf)
+def _endpoint_norm_from_diag(diag):
+    # P>=0 => ||P||2=lambda_max(P)<=trace(P)=sum diag(P).
+    s=0.0
+    for x in diag:s=math.nextafter(s+float(x),math.inf)
+    if not math.isfinite(s) or s<=0:raise ValueError('invalid endpoint covariance trace bound')
+    return s
+def _advance(p,fn,qn,floor_add):return math.nextafter(math.nextafter(fn*fn,math.inf)*p+qn+floor_add,math.inf)
+def _word_open_loop(seed,fn,qn,floor_add):
+    p=float(seed);mx=p
+    for _ in range(TRANSITIONS):p=_advance(p,fn,qn,floor_add);mx=max(mx,p)
+    return p,mx
+
 def build():
-    live=LIVE.build(DOMAIN);lf=LIVE.validate(live);phys=PHYS.build();pf=PHYS.validate(phys)
-    if lf or pf:raise RuntimeError(f'local covariance prerequisites failed live={lf} phys={pf}')
-    kc=KERNEL._process_constants(DOMAIN);tc=TUNER.constants()
-    omega_cap=math.radians(float(phys['body_rate_norm_upper_deg_s']));omega=[B(omega_cap) for _ in range(3)]
-    tau=Interval.outward_bounds(tc.tau_min,tc.tau_max)
-    sigma_lo=max(float(tc.acc_noise_floor_sigma),1e-9);sigma_hi=float(tc.sigma_max)
-    sigma=[Interval.outward_bounds(sigma_lo,sigma_hi) for _ in range(3)]
-    Faa,Qaa=PRIM.attitude_gyro_bias_F_Q(omega,kc.h,kc.gyro_variance_density_xyz,kc.gyro_bias_variance_density)
-    Ft,Qt=PRIM.translation_F_Q(tau,kc.h,sigma)
-    phi,Qba=PRIM.active_accel_bias_F_Q(kc.h,kc.accel_bias_tau_s,kc.accel_bias_process_variance_density)
-    seed=_seed_norms(live);reports={}
-    floor_add=math.nextafter(sigma_hi*sigma_hi,math.inf)
+    live=LIVE.build(DOMAIN);lf=LIVE.validate(live);phys=PHYS.build();pf=PHYS.validate(phys);tube=TUBE.build();tf=TUBE.validate_covariance_ceiling(tube)
+    if lf or pf or tf:raise RuntimeError(f'local covariance prerequisites failed live={lf} phys={pf} tube={tf}')
+    kc=KERNEL._process_constants(DOMAIN);tc=TUNER.constants();omega=[B(math.radians(float(phys['body_rate_norm_upper_deg_s'])))]*3;tau=Interval.outward_bounds(tc.tau_min,tc.tau_max);sigma_lo=max(float(tc.acc_noise_floor_sigma),1e-9);sigma_hi=float(tc.sigma_max);sigma=[Interval.outward_bounds(sigma_lo,sigma_hi)]*3
+    Faa,Qaa=PRIM.attitude_gyro_bias_F_Q(omega,kc.h,kc.gyro_variance_density_xyz,kc.gyro_bias_variance_density);Ft,Qt=PRIM.translation_F_Q(tau,kc.h,sigma);phi,Qba=PRIM.active_accel_bias_F_Q(kc.h,kc.accel_bias_tau_s,kc.accel_bias_process_variance_density)
+    floor_add=math.nextafter(sigma_hi*sigma_hi,math.inf);pars={}
     for mode in ('H','A'):
-        F,Q=_assemble(mode,Faa,Qaa,Ft,Qt,phi,Qba);fn=interval_matrix_norm2_upper(F);qn=interval_matrix_norm2_upper(Q)
-        p=float(seed[mode]);mx=p
-        for _ in range(TRANSITIONS):
-            p=math.nextafter(math.nextafter(fn*fn,math.inf)*p+qn+floor_add,math.inf);mx=max(mx,p)
-        reports[mode]={'dimension':18 if mode=='H' else 21,'live_seed_norm_upper':seed[mode],'F_norm_upper':fn,'Q_norm_upper':qn,'aw_floor_increment_norm_upper':floor_add,'covariance_norm_upper_after_600_worst_predictions_floors':p,'every_event_covariance_norm_upper':mx,'finite':all(math.isfinite(x) for x in (fn,qn,p,mx))}
+        F,Q=_assemble(mode,Faa,Qaa,Ft,Qt,phi,Qba);pars[mode]=(interval_matrix_norm2_upper(F),interval_matrix_norm2_upper(Q))
+    pbarH=_endpoint_norm_from_diag(tube['modes']['H']['Pbar_diagonal_variance_upper']);pbarA=_endpoint_norm_from_diag(tube['modes']['A']['Pbar_diagonal_variance_upper'])
+    hseed=_live_H_seed_norm(live);h_end,h_early=_word_open_loop(hseed,*pars['H'],floor_add);h_steady=_advance(pbarH,*pars['H'],floor_add);hlocal=max(h_early,h_steady)
+    ba_seed=float(live['held_ba']['seed_variance']);release_seed=math.nextafter(max(pbarH,ba_seed),math.inf);a_end,a_early=_word_open_loop(release_seed,*pars['A'],floor_add);a_steady=_advance(pbarA,*pars['A'],floor_add);alocal=max(a_early,a_steady)
+    reports={
+      'H':{'dimension':18,'F_norm_upper':pars['H'][0],'Q_norm_upper':pars['H'][1],'live_seed_norm_upper':hseed,'early_word_end_open_loop_upper':h_end,'early_word_every_event_upper':h_early,'sliding_endpoint_Pbar_norm_upper':pbarH,'steady_one_prediction_floor_beyond_endpoint_upper':h_steady,'every_event_covariance_norm_upper':hlocal},
+      'A':{'dimension':21,'F_norm_upper':pars['A'][0],'Q_norm_upper':pars['A'][1],'release_seed_from_H_endpoint_plus_fixed_ba_upper':release_seed,'early_active_word_end_open_loop_upper':a_end,'early_active_word_every_event_upper':a_early,'sliding_endpoint_Pbar_norm_upper':pbarA,'steady_one_prediction_floor_beyond_endpoint_upper':a_steady,'every_event_covariance_norm_upper':alocal},
+    }
+    for r in reports.values():r['aw_floor_increment_norm_upper']=floor_add;r['finite']=all(math.isfinite(float(v)) for k,v in r.items() if isinstance(v,(int,float)))
     closed=all(r['finite'] and r['every_event_covariance_norm_upper']>0 for r in reports.values())
-    return {
-      'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD','word_transitions':TRANSITIONS,
-      'live_seed_source_generated':live['live_entry_seed_is_source_generated_not_arbitrary_PSD'],
-      'prediction_F_Q_outward_shipping_primitives_used':True,
-      'Joseph_update_PSD_nonincrease_used':True,'bias_projection_covariance_identity_used':True,
-      'aw_floor_positive_part_bound':'||Pi_+(Sigma-Paw)||2 <= lambda_max(Sigma) for Paw>=0',
-      'aw_floor_bound_independent_of_current_P':True,'endpoint_referenced_Pbar_used_as_local_bound':False,
-      'trajectory_replay_used':False,'reports':reports,'event_local_covariance_norm_envelope_closed':closed,
-      'next_obligation':'derive source-uniform event gain bounds ||K|| <= ||P|| ||H|| / lambda_min(R) from this local covariance envelope and use those inverse-free gain bounds in the finite joint24 event outer'}
+    return {'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD','word_transitions':TRANSITIONS,'live_seed_source_generated':live['live_entry_seed_is_source_generated_not_arbitrary_PSD'],'prediction_F_Q_outward_shipping_primitives_used':True,'Joseph_update_PSD_nonincrease_used':True,'bias_projection_covariance_identity_used':True,'aw_floor_positive_part_bound':'||Pi_+(Sigma-Paw)||2 <= lambda_max(Sigma) for Paw>=0','aw_floor_bound_independent_of_current_P':True,'endpoint_Pbar_used_only_at_certified_sliding_word_endpoints':True,'endpoint_Pbar_substituted_directly_for_preJoseph_covariance':False,'H_to_A_release_covariance_ancestry_retained':True,'A_release_after_H_endpoint_regime_guaranteed':float(live['H_to_A_release']['minimum_H_mode_live_duration_before_A_release_s'])>=3.0,'trajectory_replay_used':False,'reports':reports,'event_local_covariance_norm_envelope_closed':closed,'next_obligation':'derive inverse-free source-uniform event gain bounds from this corrected local covariance envelope and use them in the physical joint24 local outer'}
 def validate(d):
     f=[]
     if d.get('qualification')!=QUALIFICATION or d.get('word_transitions')!=TRANSITIONS:f.append('qualification/window mismatch')
-    for k in ('live_seed_source_generated','prediction_F_Q_outward_shipping_primitives_used','Joseph_update_PSD_nonincrease_used','bias_projection_covariance_identity_used','aw_floor_bound_independent_of_current_P','event_local_covariance_norm_envelope_closed'):
+    for k in ('live_seed_source_generated','prediction_F_Q_outward_shipping_primitives_used','Joseph_update_PSD_nonincrease_used','bias_projection_covariance_identity_used','aw_floor_bound_independent_of_current_P','endpoint_Pbar_used_only_at_certified_sliding_word_endpoints','H_to_A_release_covariance_ancestry_retained','A_release_after_H_endpoint_regime_guaranteed','event_local_covariance_norm_envelope_closed'):
         if d.get(k) is not True:f.append(k+' not true')
-    for k in ('endpoint_referenced_Pbar_used_as_local_bound','trajectory_replay_used'):
+    for k in ('endpoint_Pbar_substituted_directly_for_preJoseph_covariance','trajectory_replay_used'):
         if d.get(k) is not False:f.append(k+' not false')
     for m in ('H','A'):
         r=d.get('reports',{}).get(m,{})

--- a/tools/stability/ou3_alt_contraction/local_covariance_norm_envelope.py
+++ b/tools/stability/ou3_alt_contraction/local_covariance_norm_envelope.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Source-uniform event-local covariance operator-norm envelope for ALT.
+
+This replaces an invalid use of the endpoint-referenced Pbar as a local Joseph
+covariance bound.  The proof uses only shipping/source facts:
+
+* Live covariance is reseeded before the first prediction;
+* prediction is P^- = F P F' + Q;
+* every Joseph update with the shipping Kalman gain is PSD-decreasing,
+  P^+ = P^- - K S K' <= P^-;
+* active bias projection leaves covariance unchanged;
+* the a_w synchronization increment is Delta=Pi_+(Sigma_aw-P_aw).
+
+For P_aw>=0,
+  ||Delta||_2=max(lambda_max(Sigma_aw-P_aw),0)<=lambda_max(Sigma_aw),
+so a requested floor adds at most the committed stationary target variance in
+operator norm, independently of the current P.  Therefore the scalar recurrence
+
+  p_{k+1} <= ||F||_2^2 p_k + ||Q||_2 + sigma_aw,max^2
+
+is a valid source-uniform upper for covariance at every event of every sample.
+The F/Q norms below are themselves upper-bounded from outward shipping matrix
+primitives over the declared BRMM rate/tuner ranges.
+"""
+from __future__ import annotations
+
+import math
+import json
+from pathlib import Path
+
+from ou3_interval import Interval
+import ou3_brmm_live_covariance_seed as LIVE
+import ou3_brmm_complete_window_execution_kernel as KERNEL
+import ou3_brmm_shipping_prediction_primitives as PRIM
+import ou3_brmm_tuner_scheduler_step as TUNER
+from tools.stability.ou3_alt_contraction import physical_numeric_bounds as PHYS
+
+REPO=Path(__file__).resolve().parents[3]
+DOMAIN=REPO/'tools/stability/ou3_proof_operating_domain.json'
+QUALIFICATION='OU3_ALT_EVENT_LOCAL_COVARIANCE_OPERATOR_NORM_ENVELOPE_V1'
+TRANSITIONS=600
+
+
+def I(x):return Interval.outward_bounds(float(x),float(x))
+def B(r):r=float(r);return Interval.outward_bounds(-r,r)
+def _zero(n):return [[I(0) for _ in range(n)] for _ in range(n)]
+
+def interval_matrix_norm2_upper(A):
+    """Rigorous ||A||2 upper via sqrt(||A||1 ||A||inf)."""
+    if not A or any(len(r)!=len(A[0]) for r in A):raise ValueError('rectangular nonempty matrix required')
+    rows=len(A);cols=len(A[0]);rowmax=0.0;colmax=0.0
+    for i in range(rows):
+        s=0.0
+        for j in range(cols):s=math.nextafter(s+A[i][j].abs_upper(),math.inf)
+        rowmax=max(rowmax,s)
+    for j in range(cols):
+        s=0.0
+        for i in range(rows):s=math.nextafter(s+A[i][j].abs_upper(),math.inf)
+        colmax=max(colmax,s)
+    return math.nextafter(math.sqrt(math.nextafter(rowmax*colmax,math.inf)),math.inf)
+
+def _assemble(mode,Faa,Qaa,Ft,Qt,phi_ba,Qba):
+    n=18 if mode=='H' else 21;F=_zero(n);Q=_zero(n)
+    for i in range(6):
+        for j in range(6):F[i][j]=Faa[i][j];Q[i][j]=Qaa[i][j]
+    for i in range(12):
+        for j in range(12):F[6+i][6+j]=Ft[i][j];Q[6+i][6+j]=Qt[i][j]
+    if mode=='A':
+        for i in range(3):F[18+i][18+i]=phi_ba;Q[18+i][18+i]=Qba[i][i]
+    return F,Q
+
+def _seed_norms(live):
+    c=live['constructor'];att=live['full_heading_gauged_live_attitude_seed'];aw=live['aw_live_seed'];held=live['held_ba']
+    attmax=max(float(att['tilt_std_rad'])**2,float(att['yaw_std_rad'])**2)
+    base=max(attmax,float(c['P_bg_variance']),float(live['translation_seed']['P_v']),float(live['translation_seed']['P_p']),float(live['translation_seed']['P_S']),float(aw['committed_vertical_std_interval_mps2'][1])**2)
+    return {'H':math.nextafter(base,math.inf),'A':math.nextafter(max(base,float(held['seed_variance'])),math.inf)}
+def build():
+    live=LIVE.build(DOMAIN);lf=LIVE.validate(live);phys=PHYS.build();pf=PHYS.validate(phys)
+    if lf or pf:raise RuntimeError(f'local covariance prerequisites failed live={lf} phys={pf}')
+    kc=KERNEL._process_constants(DOMAIN);tc=TUNER.constants()
+    omega_cap=math.radians(float(phys['body_rate_norm_upper_deg_s']));omega=[B(omega_cap) for _ in range(3)]
+    tau=Interval.outward_bounds(tc.tau_min,tc.tau_max)
+    sigma_lo=max(float(tc.acc_noise_floor_sigma),1e-9);sigma_hi=float(tc.sigma_max)
+    sigma=[Interval.outward_bounds(sigma_lo,sigma_hi) for _ in range(3)]
+    Faa,Qaa=PRIM.attitude_gyro_bias_F_Q(omega,kc.h,kc.gyro_variance_density_xyz,kc.gyro_bias_variance_density)
+    Ft,Qt=PRIM.translation_F_Q(tau,kc.h,sigma)
+    phi,Qba=PRIM.active_accel_bias_F_Q(kc.h,kc.accel_bias_tau_s,kc.accel_bias_process_variance_density)
+    seed=_seed_norms(live);reports={}
+    floor_add=math.nextafter(sigma_hi*sigma_hi,math.inf)
+    for mode in ('H','A'):
+        F,Q=_assemble(mode,Faa,Qaa,Ft,Qt,phi,Qba);fn=interval_matrix_norm2_upper(F);qn=interval_matrix_norm2_upper(Q)
+        p=float(seed[mode]);mx=p
+        for _ in range(TRANSITIONS):
+            p=math.nextafter(math.nextafter(fn*fn,math.inf)*p+qn+floor_add,math.inf);mx=max(mx,p)
+        reports[mode]={'dimension':18 if mode=='H' else 21,'live_seed_norm_upper':seed[mode],'F_norm_upper':fn,'Q_norm_upper':qn,'aw_floor_increment_norm_upper':floor_add,'covariance_norm_upper_after_600_worst_predictions_floors':p,'every_event_covariance_norm_upper':mx,'finite':all(math.isfinite(x) for x in (fn,qn,p,mx))}
+    closed=all(r['finite'] and r['every_event_covariance_norm_upper']>0 for r in reports.values())
+    return {
+      'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD','word_transitions':TRANSITIONS,
+      'live_seed_source_generated':live['live_entry_seed_is_source_generated_not_arbitrary_PSD'],
+      'prediction_F_Q_outward_shipping_primitives_used':True,
+      'Joseph_update_PSD_nonincrease_used':True,'bias_projection_covariance_identity_used':True,
+      'aw_floor_positive_part_bound':'||Pi_+(Sigma-Paw)||2 <= lambda_max(Sigma) for Paw>=0',
+      'aw_floor_bound_independent_of_current_P':True,'endpoint_referenced_Pbar_used_as_local_bound':False,
+      'trajectory_replay_used':False,'reports':reports,'event_local_covariance_norm_envelope_closed':closed,
+      'next_obligation':'derive source-uniform event gain bounds ||K|| <= ||P|| ||H|| / lambda_min(R) from this local covariance envelope and use those inverse-free gain bounds in the finite joint24 event outer'}
+def validate(d):
+    f=[]
+    if d.get('qualification')!=QUALIFICATION or d.get('word_transitions')!=TRANSITIONS:f.append('qualification/window mismatch')
+    for k in ('live_seed_source_generated','prediction_F_Q_outward_shipping_primitives_used','Joseph_update_PSD_nonincrease_used','bias_projection_covariance_identity_used','aw_floor_bound_independent_of_current_P','event_local_covariance_norm_envelope_closed'):
+        if d.get(k) is not True:f.append(k+' not true')
+    for k in ('endpoint_referenced_Pbar_used_as_local_bound','trajectory_replay_used'):
+        if d.get(k) is not False:f.append(k+' not false')
+    for m in ('H','A'):
+        r=d.get('reports',{}).get(m,{})
+        if r.get('finite') is not True or not float(r.get('every_event_covariance_norm_upper',0))>0:f.append(m+' local covariance envelope invalid')
+    return f

--- a/tools/stability/ou3_alt_contraction/phase1_closure.py
+++ b/tools/stability/ou3_alt_contraction/phase1_closure.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""ALT Phase-1 closure ledger: physical whole-word before storage.
+
+This module has one job: decide whether the theorem-only plan permits a storage
+search.  It consumes the regional universal Normal-Live source relation, the
+physical joint24 word induction, all three analytic bias families, and the
+configured H18->A21 hybrid factorization.  It does not compute a metric or rho.
+
+A TRUE ``storage_search_allowed`` therefore means only that the *master graph is
+complete enough to ask the storage question*: same-history COMPLETE-BRMM source,
+physical BRMM-vs-OU forcing, finite physical S residual, BIAS0/1/2, every
+configured Normal-Live event/branch, and the held->active edge are represented.
+It is NOT a stability PASS, basin proof, release-progress proof, startup proof or
+finite-precision certificate.
+"""
+from __future__ import annotations
+import json
+from pathlib import Path
+
+from tools.stability.ou3_alt_contraction import bias_families as BIAS
+from tools.stability.ou3_alt_contraction import hybrid_word as HYBRID
+from tools.stability.ou3_alt_contraction import live_source_relation as SOURCE
+from tools.stability.ou3_alt_contraction import physical_word as WORD
+from tools.stability.ou3_alt_contraction import proof_plan as PLAN
+
+REPO=Path(__file__).resolve().parents[3]
+DOMAIN=REPO/'tools/stability/ou3_proof_operating_domain.json'
+QUALIFICATION='OU3_ALT_PHASE1_PHYSICAL_WHOLE_WORD_CLOSURE_V1'
+
+def build():
+    source=SOURCE.build();sf=SOURCE.validate(source);word=WORD.induction_theorem();wf=WORD.validate(word);hybrid=HYBRID.build();hf=HYBRID.validate(hybrid);bias=BIAS.build();bf=BIAS.validate(bias)
+    bad={k:v for k,v in {'source':sf,'word':wf,'hybrid':hf,'bias':bf}.items() if v}
+    if bad:raise RuntimeError('ALT Phase-1 prerequisite failed: '+repr(bad))
+    domain=json.loads(DOMAIN.read_text());normal=domain['normal_live']
+    branch_scope=bool(
+        normal['accelerometer_update_required_each_valid_imu_sample_after_live_entry']
+        and normal['accelerometer_rejection_in_normal_live_scope'] is False
+        and normal['hybrid_events_inside_same_mode_word']==[]
+        and source['all_branch_successors_retained_by_operator']
+        and hybrid['all_literal_configured_hybrid_branches_attached'])
+    status={
+      'same_history_complete_BRMM_word':bool(word['same_history_COMPLETE_BRMM_single_mode_word_closed'] and hybrid['hybrid_H18_A21_word_closed'] and source['regional_universal_Normal_Live_source_relation_closed']),
+      'physical_prediction_forcing_attached':word['physical_prediction_forcing_attached'],
+      'physical_S_residual_attached':word['physical_S_residual_attached'],
+      'all_bias_families_attached':bool(word['all_bias_families_attached_to_single_mode_word'] and bias['three_families_invoked_separately']),
+      'all_literal_branches_attached':branch_scope,
+      'H18_A21_edge_attached':hybrid['H18_A21_edge_attached'],
+    }
+    allowed=PLAN.storage_search_allowed(status)
+    if allowed: PLAN.assert_storage_search_allowed(status)
+    return {
+      'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD','phase1_status':status,
+      'regional_Normal_Live_source_relation_closed':source['regional_universal_Normal_Live_source_relation_closed'],
+      'physical_single_mode_word_induction_closed':word['same_history_COMPLETE_BRMM_single_mode_word_closed'],
+      'configured_hybrid_word_factorization_closed':hybrid['hybrid_H18_A21_word_closed'],
+      'storage_search_allowed':allowed,
+      'common_joint24_storage_must_be_searched_first':True,'parameter_dependent_storage_search_allowed_initially':False,
+      'release_guard_eventual_reachability_closed':False,'startup_capture_closed':False,'every_prefix_chart_retention_closed':False,'deployment_finite_precision_closed':False,
+      'ALT_LIVE_PASS':False,'ALT_STARTUP_PASS':False,'ALT_END_TO_END_PASS':False,
+      'no_replay_or_unreachable_perturbation_used':True,'old_P2_P3_P4_P5_route_modified':False,
+      'next_obligation':'run the first source-uniform COMMON joint24 storage feasibility problem on this physical master, with bounded neutral/source supply; do not switch to source-dependent/piecewise storage unless the common search fails under the plan stop rule'}
+def validate(d):
+    f=[]
+    if d.get('qualification')!=QUALIFICATION:f.append('qualification mismatch')
+    status=d.get('phase1_status',{})
+    for k in ('same_history_complete_BRMM_word','physical_prediction_forcing_attached','physical_S_residual_attached','all_bias_families_attached','all_literal_branches_attached','H18_A21_edge_attached'):
+        if status.get(k) is not True:f.append('phase1 '+k+' not true')
+    for k in ('regional_Normal_Live_source_relation_closed','physical_single_mode_word_induction_closed','configured_hybrid_word_factorization_closed','storage_search_allowed','common_joint24_storage_must_be_searched_first','no_replay_or_unreachable_perturbation_used'):
+        if d.get(k) is not True:f.append(k+' not true')
+    for k in ('parameter_dependent_storage_search_allowed_initially','release_guard_eventual_reachability_closed','startup_capture_closed','every_prefix_chart_retention_closed','deployment_finite_precision_closed','ALT_LIVE_PASS','ALT_STARTUP_PASS','ALT_END_TO_END_PASS','old_P2_P3_P4_P5_route_modified'):
+        if d.get(k) is not False:f.append(k+' not false')
+    return f

--- a/tools/stability/ou3_alt_contraction/physical_events.py
+++ b/tools/stability/ou3_alt_contraction/physical_events.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Finite physical-reference Joseph events for the ALT Live theorem.
+
+The shared differential event implementation is exact for state dependence but
+its S pseudo-measurement residual is the differential selector e_S. The actual
+finite physical innovation is 0-S_hat=e_S-S_phys. This module evaluates the
+same deployed correction/Joseph geometry with S_phys from the SAME typed BRMM
+primitive carried by the estimator-owned source cell.
+
+No independent S box, replay value, or wordwise re-zeroing is accepted.
+"""
+from __future__ import annotations
+from typing import Sequence
+from ou3_interval import Interval
+import ou3_p4_complete_brmm_differential_events as EVENTS
+import ou3_p4_complete_brmm_source_cover_contract as COVER
+from tools.stability.ou3_alt_contraction import physical_reference as REF
+
+QUALIFICATION="OU3_ALT_FINITE_PHYSICAL_JOSEPH_EVENTS_V1"
+
+def _physical_s_residual_ad(z,centered_s:Sequence[Interval]):
+    if len(centered_s)!=3 or any(not isinstance(x,Interval) for x in centered_s): raise ValueError("same-history centered S must be Interval[3]")
+    n=len(z);return [z[EVENTS.OFF_S+i]-EVENTS._const(centered_s[i],n) for i in range(3)]
+
+def s_zero_event(cell:COVER.SourceCoverCell)->dict:
+    failures=COVER.validate_cell(cell,require_estimator_provenance=True)
+    if failures: raise ValueError("invalid estimator-owned source cell: "+repr(failures))
+    if cell.kind!="S_zero": raise ValueError("physical S event requires S_zero source cell")
+    if cell.wave_primitive is None: raise ValueError("S_zero event missing same-history physical primitive")
+    REF.validate_primitive_reference(cell.wave_primitive)
+    if cell.R_provenance!=EVENTS.ACTUAL_RS_PROVENANCE: raise ValueError("S_zero event lost actual applied R_S provenance")
+    mode=cell.mode;H=EVENTS._event_H(mode,"S_zero");K,S=EVENTS.source_joseph_gain(cell.P,H,cell.R);z=EVENTS._state_ad(cell.state)
+    residual=_physical_s_residual_ad(z,cell.wave_primitive.centered_S);out=EVENTS._apply_physical_correction(z,K,residual)
+    if mode=="A":
+        if cell.true_bias is None or cell.bias_projection_limit is None: raise ValueError("A21 S event requires same-source true bias/projection radius")
+        J,state_out,projection=EVENTS._compose_A21_bias_projection(out,cell.true_bias,float(cell.bias_projection_limit));branch=projection["branch"]
+    else:
+        J=EVENTS.AD.jacobian(out);state_out=EVENTS.AD.values(out);branch="not_applicable"
+    return {"mode":mode,"kind":"S_zero","H":H,"K":K,"S":S,"residual":EVENTS.AD.values(residual),"state_out":state_out,"J_state":J,
+      "physical_centered_S":tuple(cell.wave_primitive.centered_S),"physical_generator_id":cell.wave_primitive.generator_id,
+      "primitive_in_id":cell.wave_primitive.primitive_in_id,"primitive_out_id":cell.wave_primitive.primitive_out_id,"live_origin_id":cell.wave_primitive.live_origin_id,
+      "actual_RS_provenance":cell.R_provenance,"bias_projection_branch":branch,"same_history_physical_reference_attached":True,
+      "independent_S_box_used":False,"wordwise_S_rezero_used":False,"replay_used":False}
+
+def build():
+    ref=REF.build();failures=REF.validate(ref)
+    if failures: raise RuntimeError("physical reference contract invalid: "+repr(failures))
+    return {"qualification":QUALIFICATION,"canonical_source":"COMPLETE_BRMM_NORMAL_LIVE_WORD","finite_S_zero_event_evaluator_available":True,
+      "S_zero_residual":"e_S-S_phys","same_estimator_cell_P_R_and_physical_primitive_required":True,"actual_applied_RS_required":True,
+      "A21_projection_composed_after_physical_correction":True,"finite_state_and_Jacobian_share_same_AD_composition":True,
+      "independent_S_box_used":False,"wordwise_S_rezero_used":False,"replay_used":False,"all_literal_S_events_attached_source_uniformly":False,
+      "complete_physical_word_closed":False,"ALT_LIVE_PASS":False,
+      "next_obligation":"replace differential-only S events by this finite physical event in every estimator-owned lineage and retain the same primitive/generator ancestry through the literal word"}
+def validate(d):
+    f=[]
+    if d.get("qualification")!=QUALIFICATION:f.append("qualification mismatch")
+    for k in ("finite_S_zero_event_evaluator_available","same_estimator_cell_P_R_and_physical_primitive_required","actual_applied_RS_required","A21_projection_composed_after_physical_correction","finite_state_and_Jacobian_share_same_AD_composition"):
+        if d.get(k) is not True:f.append(k+" not true")
+    for k in ("independent_S_box_used","wordwise_S_rezero_used","replay_used","all_literal_S_events_attached_source_uniformly","complete_physical_word_closed","ALT_LIVE_PASS"):
+        if d.get(k) is not False:f.append(k+" not false")
+    return f

--- a/tools/stability/ou3_alt_contraction/physical_lineage.py
+++ b/tools/stability/ou3_alt_contraction/physical_lineage.py
@@ -1,32 +1,29 @@
 #!/usr/bin/env python3
 """Source-uniform physical response cocycle for the ALT joint24 Live word.
 
-This module consumes estimator-owned literal event cells from the existing
-COMPLETE-BRMM source relation.  It does not replay trajectories and does not
-invent independent P/H/R/K boxes.
+Consumes estimator-owned COMPLETE-BRMM literal event cells only.  No replay,
+finite-seed fit, unreachable perturbation or independent coefficient box is an
+input.
 
-At every prediction it appends ONE homogeneous physical source block
+Each prediction carries two theorem source blocks:
 
-    z_q = [h_s, a0(3), a1(3), J0(3), J1(3), J2(3)],  h_s=1,
+* one homogeneous [h_s,q15] BRMM acceleration/moment block with the existing
+  joint quadratic witness sectors and exact BRMM-vs-OU forcing map;
+* one homogeneous [h_s,w_bias] block from one explicit BIAS0/1/2 contract.  The
+  SAME w columns enter accelerometer-bias error and physical beta truth, and the
+  family parameter/root token is retained for the future complete-word master.
 
-uses the exact BRMM-vs-OU forcing map already proved in
-``ou3_p4_brmm_physical_prediction_forcing``, attaches the three joint quadratic
-outer constraints from the acceleration-witness sector, and suffix-propagates
-that block through every later literal nonlinear event.
+At S=0 the finite physical residual is e_S-S_phys; its source columns carry the
+same generator/primitive/one-time-Live-origin identity as the estimator-owned
+cell.  Every source response block is suffix-propagated through later literal
+nonlinear events.
 
-At every S=0 event it uses r_S=e_S-S_phys and appends the corresponding physical
-S response columns tagged by the SAME generator, primitive transition and
-one-time Live origin carried by the estimator-owned source cell.  These are not
-replay values and are not silently reset at word boundaries.
-
-The output is a response cocycle for one source-uniform attached sample lineage.
-It is a theorem component, not a stability gate: multi-sample continuation,
-BIAS0/1/2 family source sectors, H18->A21, every guard branch, storage, prefix
-retention and binary32 enclosure remain separate obligations.
+This closes the per-attached-sample physical response relation.  It does not
+claim that the 600-step source lineage has yet preserved one family parameter
+root, that every hybrid edge is closed, or that storage may be searched.
 """
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Sequence
 
 from ou3_interval import Interval, matrix_mul
 import ou3_brmm_acceleration_moment_iqc as MOM
@@ -35,10 +32,11 @@ import ou3_p4_brmm_physical_acceleration_witness_sector as WSECTOR
 import ou3_p4_complete_brmm_differential_events as EVENTS
 import ou3_p4_complete_brmm_differential_prediction as PRED
 import ou3_p4_complete_brmm_source_cover_contract as COVER
+from tools.stability.ou3_alt_contraction import bias_families as BIAS
 from tools.stability.ou3_alt_contraction import joint24_events as J24
 from tools.stability.ou3_alt_contraction import physical_reference as REF
 
-QUALIFICATION = "OU3_ALT_SOURCE_UNIFORM_PHYSICAL_RESPONSE_COCYCLE_V1"
+QUALIFICATION = "OU3_ALT_SOURCE_UNIFORM_PHYSICAL_RESPONSE_COCYCLE_V2"
 
 
 def I(x: float) -> Interval:
@@ -51,8 +49,7 @@ def _zero(r: int, c: int):
 
 def _identity(n: int):
     A = _zero(n, n)
-    for i in range(n):
-        A[i][i] = I(1)
+    for i in range(n): A[i][i] = I(1)
     return A
 
 
@@ -75,303 +72,184 @@ class SourceResponseBlock:
     response: tuple[tuple[Interval, ...], ...]
     sectors: tuple[tuple[str, tuple[tuple[Interval, ...], ...]], ...] = ()
     homogeneous_scale_fixed_one: bool = False
+    family_parameter_token: str | None = None
 
 
-def _freeze(A):
-    return tuple(tuple(x for x in row) for row in A)
+def _freeze(A): return tuple(tuple(x for x in row) for row in A)
+def _thaw(A): return [list(row) for row in A]
 
 
-def _thaw(A):
-    return [list(row) for row in A]
+def _carry(block: SourceResponseBlock, J):
+    return SourceResponseBlock(
+        block.kind, block.token, block.generator_id, block.live_origin_id,
+        _freeze(_propagate(J, _thaw(block.response))), block.sectors,
+        block.homogeneous_scale_fixed_one, block.family_parameter_token)
 
 
 def _q15_sector_for_h(h: Interval):
-    """Outward joint sector on [h_s,q15] for the actual sample h interval."""
-    if not isinstance(h, Interval) or h.lo <= 0:
-        raise ValueError("positive interval sample time required")
-    mom = MOM.build()
-    failures = MOM.validate(mom)
-    if failures:
-        raise RuntimeError("physical acceleration-moment prerequisite failed: " + repr(failures))
-    Amax = float(mom["A_max_mps2"])
-    n = 16
-    Cs = WSECTOR.selector(1, n, [0])
-    A0 = WSECTOR.selector(3, n, [1, 2, 3])
-    A1 = WSECTOR.selector(3, n, [4, 5, 6])
-    M = _zero(9, n)
-    ih = I(1) / h
-    ih2 = ih * ih
-    ih3 = ih2 * ih
+    if not isinstance(h, Interval) or h.lo <= 0: raise ValueError("positive interval sample time required")
+    mom=MOM.build(); failures=MOM.validate(mom)
+    if failures: raise RuntimeError("physical acceleration-moment prerequisite failed: "+repr(failures))
+    Amax=float(mom["A_max_mps2"]); n=16
+    Cs=WSECTOR.selector(1,n,[0]); A0=WSECTOR.selector(3,n,[1,2,3]); A1=WSECTOR.selector(3,n,[4,5,6])
+    M=_zero(9,n); ih=I(1)/h; ih2=ih*ih; ih3=ih2*ih
     for axis in range(3):
-        M[3 * axis + 0][7 + axis] = ih
-        M[3 * axis + 1][10 + axis] = ih2
-        M[3 * axis + 2][13 + axis] = ih3
-    return tuple(
-        (name, _freeze(Q))
-        for name, Q in WSECTOR.physical_witness_sectors(A0, A1, M, Cs, Amax)
-    )
+        M[3*axis][7+axis]=ih; M[3*axis+1][10+axis]=ih2; M[3*axis+2][13+axis]=ih3
+    return tuple((name,_freeze(Q)) for name,Q in WSECTOR.physical_witness_sectors(A0,A1,M,Cs,Amax))
 
 
 def _q15_injection(mode: str, tau: Interval, h: Interval):
-    """24x16 affine/homogeneous response [h_s,q15] -> joint24."""
-    M12 = FORCING.source_matrix(tau, h)
-    Gn = FORCING.inject_error_state(mode, M12)
-    B = _zero(24, 16)
-    # column zero is the homogeneous source scale.  The prediction forcing is
-    # linear in q15, so it has no direct h_s column.
-    n = 18 if mode == "H" else 21
+    M12=FORCING.source_matrix(tau,h); Gn=FORCING.inject_error_state(mode,M12); B=_zero(24,16)
+    n=18 if mode=="H" else 21
     for i in range(n):
-        for j in range(15):
-            B[i][1 + j] = Gn[i][j]
+        for j in range(15): B[i][1+j]=Gn[i][j]
     return B
 
 
+def _bias_driver_homogeneous(B3, contract: BIAS.BiasFamilyContract):
+    """Lift 24x3 shared-w response to 24x4 [h_s,w] plus its analytic sector."""
+    if _shape(B3)!=(24,3): raise ValueError("shared bias driver response must be 24x3")
+    B4=_zero(24,4)
+    for i in range(24):
+        for j in range(3): B4[i][1+j]=B3[i][j]
+    return B4, (("bias_driver_ball",_freeze(BIAS.driver_ball_iqc(contract))),)
+
+
 def _primitive_token(cell: COVER.SourceCoverCell, suffix: str) -> str:
-    w = cell.wave_primitive
-    if w is None:
-        raise ValueError("physical source cell lost WavePrimitivePayload")
+    w=cell.wave_primitive
+    if w is None: raise ValueError("physical source cell lost WavePrimitivePayload")
     REF.validate_primitive_reference(w)
-    return ":".join((w.generator_id, w.live_origin_id, w.primitive_in_id, w.primitive_out_id, suffix))
+    return ":".join((w.generator_id,w.live_origin_id,w.primitive_in_id,w.primitive_out_id,suffix))
 
 
-def _h_event_jacobian(cell: COVER.SourceCoverCell, held_bias_error, true_bias):
-    if cell.kind == "accelerometer":
-        # Existing J24 helper computes the exact dependence on held e_ba.  Its
-        # derivative is evaluated over the supplied physical hard domain below
-        # rather than at an unreachable perturbed covariance root.
-        failures = COVER.validate_cell(cell, require_estimator_provenance=True)
-        if failures:
-            raise ValueError("invalid H18 source cell: " + repr(failures))
-        if len(held_bias_error) != 3 or len(true_bias) != 3:
-            raise ValueError("H18 joint24 requires e_ba and beta domains")
-        u = EVENTS.AD.independent_vector(list(cell.state) + list(held_bias_error) + list(true_bias), n=24, offset=0)
-        z, eba, beta = u[:18], u[18:21], u[21:24]
-        H = EVENTS._event_H("H", "accelerometer", f_hat=cell.f_hat, R_hat=cell.R_hat)
-        K, _ = EVENTS.source_joseph_gain(cell.P, H, cell.R)
-        residual = J24._h18_accel_residual(z, eba, cell.f_hat, cell.R_hat)
-        out = list(EVENTS._apply_physical_correction(z, K, residual)) + list(eba) + list(beta)
-        return EVENTS.AD.jacobian(out), None
-    if cell.kind == "magnetometer":
-        u = EVENTS.AD.independent_vector(list(cell.state) + list(held_bias_error) + list(true_bias), n=24, offset=0)
-        z = u[:18]
-        H = EVENTS._event_H("H", "magnetometer", m_body=cell.m_body)
-        K, _ = EVENTS.source_joseph_gain(cell.P, H, cell.R)
-        out18 = EVENTS._apply_physical_correction(z, K, EVENTS.residual_magnetometer(z, cell.m_body))
-        return EVENTS.AD.jacobian(list(out18) + list(u[18:24])), None
-    if cell.kind == "S_zero":
-        # J24 helper retains physical-S source columns with the same primitive.
-        d = J24.s_zero_event_joint24(cell)
-        return d["J_joint24"], d["J_S_phys"]
+def _h_event_jacobian(cell, held_bias_error, true_bias):
+    if cell.kind=="accelerometer":
+        failures=COVER.validate_cell(cell,require_estimator_provenance=True)
+        if failures: raise ValueError("invalid H18 source cell: "+repr(failures))
+        if len(held_bias_error)!=3 or len(true_bias)!=3: raise ValueError("H18 joint24 requires e_ba and beta domains")
+        u=EVENTS.AD.independent_vector(list(cell.state)+list(held_bias_error)+list(true_bias),n=24,offset=0)
+        z,eba,beta=u[:18],u[18:21],u[21:24]
+        H=EVENTS._event_H("H","accelerometer",f_hat=cell.f_hat,R_hat=cell.R_hat); K,_=EVENTS.source_joseph_gain(cell.P,H,cell.R)
+        residual=J24._h18_accel_residual(z,eba,cell.f_hat,cell.R_hat)
+        out=list(EVENTS._apply_physical_correction(z,K,residual))+list(eba)+list(beta)
+        return EVENTS.AD.jacobian(out),None
+    if cell.kind=="magnetometer":
+        u=EVENTS.AD.independent_vector(list(cell.state)+list(held_bias_error)+list(true_bias),n=24,offset=0); z=u[:18]
+        H=EVENTS._event_H("H","magnetometer",m_body=cell.m_body); K,_=EVENTS.source_joseph_gain(cell.P,H,cell.R)
+        out18=EVENTS._apply_physical_correction(z,K,EVENTS.residual_magnetometer(z,cell.m_body))
+        return EVENTS.AD.jacobian(list(out18)+list(u[18:24])),None
+    if cell.kind=="S_zero":
+        d=J24.s_zero_event_joint24(cell); return d["J_joint24"],d["J_S_phys"]
     raise ValueError("not an H18 Joseph event")
 
 
-def _a_event_jacobian(cell: COVER.SourceCoverCell):
-    """Full A21+beta joint derivative, including projection beta columns."""
-    failures = COVER.validate_cell(cell, require_estimator_provenance=True)
-    if failures:
-        raise ValueError("invalid A21 source cell: " + repr(failures))
-    if cell.true_bias is None or cell.bias_projection_limit is None:
-        raise ValueError("A21 source cell missing true bias/projection")
-    add_S = cell.kind == "S_zero"
-    extra = list(cell.wave_primitive.centered_S) if add_S and cell.wave_primitive is not None else []
-    if add_S:
-        REF.validate_primitive_reference(cell.wave_primitive)
-    total = 24 + (3 if add_S else 0)
-    u = EVENTS.AD.independent_vector(list(cell.state) + list(cell.true_bias) + extra, n=total, offset=0)
-    z, beta = u[:21], u[21:24]
-    H = EVENTS._event_H(cell.mode, cell.kind, f_hat=cell.f_hat, R_hat=cell.R_hat, m_body=cell.m_body)
-    K, _ = EVENTS.source_joseph_gain(cell.P, H, cell.R)
-    if cell.kind == "accelerometer":
-        residual = EVENTS.residual_accelerometer(z, cell.f_hat, cell.R_hat)
-    elif cell.kind == "magnetometer":
-        residual = EVENTS.residual_magnetometer(z, cell.m_body)
-    elif cell.kind == "S_zero":
-        residual = [z[EVENTS.OFF_S + i] - u[24 + i] for i in range(3)]
-    else:
-        raise ValueError("not an A21 Joseph event")
-    out21 = EVENTS._apply_physical_correction(z, K, residual)
-    J21, _, _ = J24._project_joint(out21, beta, total, float(cell.bias_projection_limit))
-    # Append beta_true identity rows.  _project_joint returns the projected
-    # A21-error rows with derivatives w.r.t. the whole AD coordinate.
-    J = [list(row) for row in J21]
+def _a_event_jacobian(cell):
+    failures=COVER.validate_cell(cell,require_estimator_provenance=True)
+    if failures: raise ValueError("invalid A21 source cell: "+repr(failures))
+    if cell.true_bias is None or cell.bias_projection_limit is None: raise ValueError("A21 source cell missing true bias/projection")
+    add_S=cell.kind=="S_zero"; extra=list(cell.wave_primitive.centered_S) if add_S and cell.wave_primitive is not None else []
+    if add_S: REF.validate_primitive_reference(cell.wave_primitive)
+    total=24+(3 if add_S else 0); u=EVENTS.AD.independent_vector(list(cell.state)+list(cell.true_bias)+extra,n=total,offset=0)
+    z,beta=u[:21],u[21:24]
+    H=EVENTS._event_H(cell.mode,cell.kind,f_hat=cell.f_hat,R_hat=cell.R_hat,m_body=cell.m_body); K,_=EVENTS.source_joseph_gain(cell.P,H,cell.R)
+    if cell.kind=="accelerometer": residual=EVENTS.residual_accelerometer(z,cell.f_hat,cell.R_hat)
+    elif cell.kind=="magnetometer": residual=EVENTS.residual_magnetometer(z,cell.m_body)
+    elif cell.kind=="S_zero": residual=[z[EVENTS.OFF_S+i]-u[24+i] for i in range(3)]
+    else: raise ValueError("not an A21 Joseph event")
+    out21=EVENTS._apply_physical_correction(z,K,residual)
+    J21,_,_=J24._project_joint(out21,beta,total,float(cell.bias_projection_limit)); J=[list(row) for row in J21]
     for i in range(3):
-        row = [I(0) for _ in range(total)]
-        row[21 + i] = I(1)
-        J.append(row)
-    return [row[:24] for row in J], ([row[24:27] for row in J] if add_S else None)
+        row=[I(0) for _ in range(total)]; row[21+i]=I(1); J.append(row)
+    return [row[:24] for row in J],([row[24:27] for row in J] if add_S else None)
 
 
-def _prediction_joint(cell, selector, phi_true: Interval, tau_ba: Interval | None):
-    mode = cell.mode
-    p = PRED.prediction_event(
-        mode,
-        cell.state,
-        selector.sample_coordinates.omega_body_corrected,
-        cell.dt_s,
-        cell.tau_applied_s,
-        tau_ba=tau_ba if mode == "A" else None,
-    )
-    if mode == "H":
-        J, Bbias = J24.h18_prediction_lift(p["J_state"], phi_true)
+def _prediction_joint(cell,selector,contract: BIAS.BiasFamilyContract,tau_ba):
+    mode=cell.mode; pt=contract.phi_true
+    p=PRED.prediction_event(mode,cell.state,selector.sample_coordinates.omega_body_corrected,cell.dt_s,cell.tau_applied_s,tau_ba=tau_ba if mode=="A" else None)
+    if mode=="H": J,Bbias=J24.h18_prediction_lift(p["J_state"],pt)
     else:
-        if p["phi_ba"] is None:
-            raise RuntimeError("A21 prediction lost estimator bias factor")
-        ph = p["phi_ba"]
-        J = _zero(24, 24)
-        Bbias = _zero(24, 3)
+        if p["phi_ba"] is None: raise RuntimeError("A21 prediction lost estimator bias factor")
+        ph=p["phi_ba"]; J=_zero(24,24); Bbias=_zero(24,3)
         for i in range(21):
-            for j in range(21):
-                J[i][j] = p["J_state"][i][j]
+            for j in range(21): J[i][j]=p["J_state"][i][j]
         for i in range(3):
-            # e_ba+ = phi_hat e_ba + (phi_true-phi_hat) beta + w
-            J[18 + i][21 + i] = phi_true - ph
-            J[21 + i][21 + i] = phi_true
-            Bbias[18 + i][i] = I(1)
-            Bbias[21 + i][i] = I(1)
-    return J, Bbias, _q15_injection(mode, cell.tau_applied_s, cell.dt_s), _q15_sector_for_h(cell.dt_s)
+            J[18+i][21+i]=pt-ph; J[21+i][21+i]=pt
+            Bbias[18+i][i]=I(1); Bbias[21+i][i]=I(1)
+    return J,Bbias,_q15_injection(mode,cell.tau_applied_s,cell.dt_s),_q15_sector_for_h(cell.dt_s)
 
 
-def compose_attached_sample(lineage, *, phi_true: Interval, held_bias_error=None, true_bias=None, tau_ba=None):
-    """Build the joint24 source-response cocycle for one universal attached lineage.
+def compose_attached_sample(lineage, *, bias_contract: BIAS.BiasFamilyContract, held_bias_error=None, true_bias=None, tau_ba=None):
+    """Joint24 physical cocycle for one universal attached sample lineage."""
+    if not isinstance(bias_contract,BIAS.BiasFamilyContract): raise TypeError("explicit BIAS0/1/2 contract required")
+    mode=lineage.mode
+    if mode not in ("H","A"): raise ValueError("lineage mode must be H/A")
+    if mode=="H" and (held_bias_error is None or true_bias is None): raise ValueError("H18 lineage requires hard e_ba and beta domains")
+    if mode=="A" and tau_ba is None: raise ValueError("A21 lineage requires configured estimator tau_ba")
 
-    ``lineage`` is an AttachedSampleLineage emitted by the estimator-owned
-    source-uniform attachment.  All event cells are consumed in literal order.
-    The function never selects a favorable successor and never evaluates a
-    captured trajectory.
-    """
-    if not isinstance(phi_true, Interval):
-        raise TypeError("same-history true-bias factor must be an Interval")
-    mode = lineage.mode
-    if mode not in ("H", "A"):
-        raise ValueError("lineage mode must be H/A")
-    if mode == "H":
-        if held_bias_error is None or true_bias is None:
-            raise ValueError("H18 lineage requires hard e_ba and beta domains")
-    else:
-        if tau_ba is None:
-            raise ValueError("A21 lineage requires configured estimator tau_ba")
-
-    Psi = _identity(24)
-    blocks: list[SourceResponseBlock] = []
-    kinds = []
+    Psi=_identity(24); blocks=[]; kinds=[]
     for cell in lineage.cells:
-        failures = COVER.validate_cell(cell, require_estimator_provenance=True)
-        if failures:
-            raise ValueError("invalid estimator-owned cell: " + repr(failures))
+        failures=COVER.validate_cell(cell,require_estimator_provenance=True)
+        if failures: raise ValueError("invalid estimator-owned cell: "+repr(failures))
         kinds.append(cell.kind)
-        if cell.kind == "prediction":
-            J, Bbias, Bq, sectors = _prediction_joint(cell, lineage.selector, phi_true, tau_ba)
-            Psi = matrix_mul(J, Psi)
-            blocks = [SourceResponseBlock(b.kind, b.token, b.generator_id, b.live_origin_id,
-                        _freeze(_propagate(J, _thaw(b.response))), b.sectors, b.homogeneous_scale_fixed_one)
-                      for b in blocks]
-            w = cell.wave_primitive
-            if w is None:
-                raise ValueError("prediction cell missing same-history primitive ancestry")
+        if cell.kind=="prediction":
+            J,Bbias,Bq,sectors=_prediction_joint(cell,lineage.selector,bias_contract,tau_ba)
+            Psi=matrix_mul(J,Psi); blocks=[_carry(b,J) for b in blocks]
+            w=cell.wave_primitive
+            if w is None: raise ValueError("prediction cell missing same-history primitive ancestry")
             REF.validate_primitive_reference(w)
-            blocks.append(SourceResponseBlock(
-                "BRMM_q15_prediction",
-                _primitive_token(cell, "q15"), w.generator_id, w.live_origin_id,
-                _freeze(Bq), sectors, True))
-            # Bias driver is not an independent truth copy: the same three
-            # columns enter e_ba and beta.  Family-specific temporal relations
-            # are attached by the BIAS0/1/2 master, still fail-closed here.
-            blocks.append(SourceResponseBlock(
-                "shared_bias_driver",
-                f"{cell.source_token}:bias-driver", w.generator_id, w.live_origin_id,
-                _freeze(Bbias), (), False))
-        elif cell.kind == "aw_floor":
-            # Covariance-only event; the deterministic joint24 mean map is identity.
-            J = _identity(24)
-        elif cell.kind in ("S_zero", "accelerometer", "magnetometer"):
-            if mode == "H":
-                J, BS = _h_event_jacobian(cell, held_bias_error, true_bias)
-            else:
-                J, BS = _a_event_jacobian(cell)
-            Psi = matrix_mul(J, Psi)
-            blocks = [SourceResponseBlock(b.kind, b.token, b.generator_id, b.live_origin_id,
-                        _freeze(_propagate(J, _thaw(b.response))), b.sectors, b.homogeneous_scale_fixed_one)
-                      for b in blocks]
+            blocks.append(SourceResponseBlock("BRMM_q15_prediction",_primitive_token(cell,"q15"),w.generator_id,w.live_origin_id,_freeze(Bq),sectors,True))
+            B4,bias_sectors=_bias_driver_homogeneous(Bbias,bias_contract)
+            blocks.append(SourceResponseBlock("shared_bias_driver",f"{cell.source_token}:{bias_contract.name}:bias-driver",w.generator_id,w.live_origin_id,_freeze(B4),bias_sectors,True,bias_contract.parameter_token))
+        elif cell.kind=="aw_floor":
+            J=_identity(24)
+        elif cell.kind in ("S_zero","accelerometer","magnetometer"):
+            J,BS=(_h_event_jacobian(cell,held_bias_error,true_bias) if mode=="H" else _a_event_jacobian(cell))
+            Psi=matrix_mul(J,Psi); blocks=[_carry(b,J) for b in blocks]
             if BS is not None:
-                w = cell.wave_primitive
-                if w is None:
-                    raise ValueError("S event missing same-history primitive ancestry")
-                blocks.append(SourceResponseBlock(
-                    "physical_centered_S",
-                    _primitive_token(cell, "S"), w.generator_id, w.live_origin_id,
-                    _freeze(BS), (), False))
-        else:
-            raise ValueError("literal lineage contains unsupported event: " + repr(cell.kind))
+                w=cell.wave_primitive
+                if w is None: raise ValueError("S event missing same-history primitive ancestry")
+                blocks.append(SourceResponseBlock("physical_centered_S",_primitive_token(cell,"S"),w.generator_id,w.live_origin_id,_freeze(BS)))
+        else: raise ValueError("literal lineage contains unsupported event: "+repr(cell.kind))
 
-    expected = tuple(c.kind for c in lineage.cells)
-    if tuple(kinds) != expected:
-        raise RuntimeError("literal event order changed during physical composition")
+    expected=tuple(c.kind for c in lineage.cells)
+    if tuple(kinds)!=expected: raise RuntimeError("literal event order changed during physical composition")
+    bias_blocks=tuple(b for b in blocks if b.kind=="shared_bias_driver")
     return {
-        "mode": mode,
-        "J_joint24": Psi,
-        "source_blocks": tuple(blocks),
-        "literal_event_kinds": expected,
-        "all_literal_cells_consumed": True,
-        "q15_prediction_blocks": sum(b.kind == "BRMM_q15_prediction" for b in blocks),
-        "physical_S_blocks": sum(b.kind == "physical_centered_S" for b in blocks),
-        "bias_driver_blocks": sum(b.kind == "shared_bias_driver" for b in blocks),
-        "same_history_source_ancestry_retained": all(bool(b.generator_id and b.live_origin_id) for b in blocks),
-        "replay_used": False,
-        "independent_prediction_defect_boxes_used": False,
+        "mode":mode,"bias_family":bias_contract.name,"bias_parameter_token":bias_contract.parameter_token,
+        "J_joint24":Psi,"source_blocks":tuple(blocks),"literal_event_kinds":expected,"all_literal_cells_consumed":True,
+        "q15_prediction_blocks":sum(b.kind=="BRMM_q15_prediction" for b in blocks),
+        "physical_S_blocks":sum(b.kind=="physical_centered_S" for b in blocks),
+        "bias_driver_blocks":len(bias_blocks),
+        "same_bias_parameter_token_on_all_predictions":all(b.family_parameter_token==bias_contract.parameter_token for b in bias_blocks),
+        "bias_driver_ball_sector_attached_on_all_predictions":all(any(name=="bias_driver_ball" for name,_ in b.sectors) for b in bias_blocks),
+        "same_history_source_ancestry_retained":all(bool(b.generator_id and b.live_origin_id) for b in blocks),
+        "replay_used":False,"independent_prediction_defect_boxes_used":False,
     }
 
 
 def build():
-    forcing = FORCING.build(); ff = FORCING.validate(forcing)
-    sector = WSECTOR.build(); sf = WSECTOR.validate(sector)
-    if ff or sf:
-        raise RuntimeError(f"physical cocycle prerequisites failed forcing={ff} sector={sf}")
+    forcing=FORCING.build(); ff=FORCING.validate(forcing); sector=WSECTOR.build(); sf=WSECTOR.validate(sector); bias=BIAS.build(); bf=BIAS.validate(bias)
+    if ff or sf or bf: raise RuntimeError(f"physical cocycle prerequisites failed forcing={ff} sector={sf} bias={bf}")
     return {
-        "qualification": QUALIFICATION,
-        "canonical_source": "COMPLETE_BRMM_NORMAL_LIVE_WORD",
-        "joint_dimension": 24,
-        "same_15D_q_witness_used_per_prediction": True,
-        "joint_q15_quadratic_sector_attached_to_same_block": True,
-        "q15_columns_suffix_propagated_through_later_literal_events": True,
-        "physical_S_columns_suffix_propagated_through_later_literal_events": True,
-        "same_generator_and_one_time_Live_origin_tokens_retained": True,
-        "shared_bias_driver_enters_error_and_truth_once": True,
-        "independent_prediction_defect_boxes_used": False,
-        "replay_or_unreachable_perturbation_used": False,
-        "source_uniform_attached_sample_cocycle_available": True,
-        "multi_sample_COMPLETE_BRMM_word_composed": False,
-        "BIAS0_BIAS1_BIAS2_temporal_source_relations_attached": False,
-        "H18_A21_edge_attached": False,
-        "storage_search_allowed": False,
-        "ALT_LIVE_PASS": False,
-        "next_obligation": "compose these attached-sample cocycles over every retained source successor for the complete Live word, bind BIAS0/1/2 temporal driver relations and the H18->A21 release edge, then and only then enable common-storage search",
+        "qualification":QUALIFICATION,"canonical_source":"COMPLETE_BRMM_NORMAL_LIVE_WORD","joint_dimension":24,
+        "same_15D_q_witness_used_per_prediction":True,"joint_q15_quadratic_sector_attached_to_same_block":True,
+        "q15_columns_suffix_propagated_through_later_literal_events":True,"physical_S_columns_suffix_propagated_through_later_literal_events":True,
+        "same_generator_and_one_time_Live_origin_tokens_retained":True,"shared_bias_driver_enters_error_and_truth_once":True,
+        "explicit_BIAS0_BIAS1_BIAS2_contract_required_by_cocycle":True,"analytic_bias_driver_sector_attached_per_prediction":True,
+        "persistent_bias_parameter_token_carried_by_source_blocks":True,"aggregate_fresh_Live_entry_builder_consumed":False,
+        "independent_prediction_defect_boxes_used":False,"replay_or_unreachable_perturbation_used":False,
+        "source_uniform_attached_sample_cocycle_available":True,
+        "multi_sample_COMPLETE_BRMM_word_composed":False,"BIAS0_BIAS1_BIAS2_temporal_source_relations_attached":False,
+        "H18_A21_edge_attached":False,"storage_search_allowed":False,"ALT_LIVE_PASS":False,
+        "next_obligation":"compose attached-sample cocycles through every retained 600-step source successor while reusing one family parameter_token, then close the actual 21-state held-to-active covariance enable edge before storage search",
     }
 
 
 def validate(d):
-    f = []
-    if d.get("qualification") != QUALIFICATION or d.get("joint_dimension") != 24:
-        f.append("qualification/dimension mismatch")
-    for k in (
-        "same_15D_q_witness_used_per_prediction",
-        "joint_q15_quadratic_sector_attached_to_same_block",
-        "q15_columns_suffix_propagated_through_later_literal_events",
-        "physical_S_columns_suffix_propagated_through_later_literal_events",
-        "same_generator_and_one_time_Live_origin_tokens_retained",
-        "shared_bias_driver_enters_error_and_truth_once",
-        "source_uniform_attached_sample_cocycle_available",
-    ):
-        if d.get(k) is not True:
-            f.append(k + " not true")
-    for k in (
-        "independent_prediction_defect_boxes_used",
-        "replay_or_unreachable_perturbation_used",
-        "multi_sample_COMPLETE_BRMM_word_composed",
-        "BIAS0_BIAS1_BIAS2_temporal_source_relations_attached",
-        "H18_A21_edge_attached",
-        "storage_search_allowed",
-        "ALT_LIVE_PASS",
-    ):
-        if d.get(k) is not False:
-            f.append(k + " not false")
+    f=[]
+    if d.get("qualification")!=QUALIFICATION or d.get("joint_dimension")!=24:f.append("qualification/dimension mismatch")
+    for k in ("same_15D_q_witness_used_per_prediction","joint_q15_quadratic_sector_attached_to_same_block","q15_columns_suffix_propagated_through_later_literal_events","physical_S_columns_suffix_propagated_through_later_literal_events","same_generator_and_one_time_Live_origin_tokens_retained","shared_bias_driver_enters_error_and_truth_once","explicit_BIAS0_BIAS1_BIAS2_contract_required_by_cocycle","analytic_bias_driver_sector_attached_per_prediction","persistent_bias_parameter_token_carried_by_source_blocks","source_uniform_attached_sample_cocycle_available"):
+        if d.get(k) is not True:f.append(k+" not true")
+    for k in ("aggregate_fresh_Live_entry_builder_consumed","independent_prediction_defect_boxes_used","replay_or_unreachable_perturbation_used","multi_sample_COMPLETE_BRMM_word_composed","BIAS0_BIAS1_BIAS2_temporal_source_relations_attached","H18_A21_edge_attached","storage_search_allowed","ALT_LIVE_PASS"):
+        if d.get(k) is not False:f.append(k+" not false")
     return list(dict.fromkeys(f))

--- a/tools/stability/ou3_alt_contraction/physical_lineage.py
+++ b/tools/stability/ou3_alt_contraction/physical_lineage.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""Source-uniform physical response cocycle for the ALT joint24 Live word.
+
+This module consumes estimator-owned literal event cells from the existing
+COMPLETE-BRMM source relation.  It does not replay trajectories and does not
+invent independent P/H/R/K boxes.
+
+At every prediction it appends ONE homogeneous physical source block
+
+    z_q = [h_s, a0(3), a1(3), J0(3), J1(3), J2(3)],  h_s=1,
+
+uses the exact BRMM-vs-OU forcing map already proved in
+``ou3_p4_brmm_physical_prediction_forcing``, attaches the three joint quadratic
+outer constraints from the acceleration-witness sector, and suffix-propagates
+that block through every later literal nonlinear event.
+
+At every S=0 event it uses r_S=e_S-S_phys and appends the corresponding physical
+S response columns tagged by the SAME generator, primitive transition and
+one-time Live origin carried by the estimator-owned source cell.  These are not
+replay values and are not silently reset at word boundaries.
+
+The output is a response cocycle for one source-uniform attached sample lineage.
+It is a theorem component, not a stability gate: multi-sample continuation,
+BIAS0/1/2 family source sectors, H18->A21, every guard branch, storage, prefix
+retention and binary32 enclosure remain separate obligations.
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Sequence
+
+from ou3_interval import Interval, matrix_mul
+import ou3_brmm_acceleration_moment_iqc as MOM
+import ou3_p4_brmm_physical_prediction_forcing as FORCING
+import ou3_p4_brmm_physical_acceleration_witness_sector as WSECTOR
+import ou3_p4_complete_brmm_differential_events as EVENTS
+import ou3_p4_complete_brmm_differential_prediction as PRED
+import ou3_p4_complete_brmm_source_cover_contract as COVER
+from tools.stability.ou3_alt_contraction import joint24_events as J24
+from tools.stability.ou3_alt_contraction import physical_reference as REF
+
+QUALIFICATION = "OU3_ALT_SOURCE_UNIFORM_PHYSICAL_RESPONSE_COCYCLE_V1"
+
+
+def I(x: float) -> Interval:
+    return Interval.point(float(x))
+
+
+def _zero(r: int, c: int):
+    return [[I(0) for _ in range(c)] for _ in range(r)]
+
+
+def _identity(n: int):
+    A = _zero(n, n)
+    for i in range(n):
+        A[i][i] = I(1)
+    return A
+
+
+def _shape(A):
+    return len(A), len(A[0]) if A else 0
+
+
+def _propagate(J, B):
+    if _shape(J) != (24, 24) or _shape(B)[0] != 24:
+        raise ValueError("joint24 response propagation dimension mismatch")
+    return matrix_mul(J, B)
+
+
+@dataclass(frozen=True)
+class SourceResponseBlock:
+    kind: str
+    token: str
+    generator_id: str
+    live_origin_id: str
+    response: tuple[tuple[Interval, ...], ...]
+    sectors: tuple[tuple[str, tuple[tuple[Interval, ...], ...]], ...] = ()
+    homogeneous_scale_fixed_one: bool = False
+
+
+def _freeze(A):
+    return tuple(tuple(x for x in row) for row in A)
+
+
+def _thaw(A):
+    return [list(row) for row in A]
+
+
+def _q15_sector_for_h(h: Interval):
+    """Outward joint sector on [h_s,q15] for the actual sample h interval."""
+    if not isinstance(h, Interval) or h.lo <= 0:
+        raise ValueError("positive interval sample time required")
+    mom = MOM.build()
+    failures = MOM.validate(mom)
+    if failures:
+        raise RuntimeError("physical acceleration-moment prerequisite failed: " + repr(failures))
+    Amax = float(mom["A_max_mps2"])
+    n = 16
+    Cs = WSECTOR.selector(1, n, [0])
+    A0 = WSECTOR.selector(3, n, [1, 2, 3])
+    A1 = WSECTOR.selector(3, n, [4, 5, 6])
+    M = _zero(9, n)
+    ih = I(1) / h
+    ih2 = ih * ih
+    ih3 = ih2 * ih
+    for axis in range(3):
+        M[3 * axis + 0][7 + axis] = ih
+        M[3 * axis + 1][10 + axis] = ih2
+        M[3 * axis + 2][13 + axis] = ih3
+    return tuple(
+        (name, _freeze(Q))
+        for name, Q in WSECTOR.physical_witness_sectors(A0, A1, M, Cs, Amax)
+    )
+
+
+def _q15_injection(mode: str, tau: Interval, h: Interval):
+    """24x16 affine/homogeneous response [h_s,q15] -> joint24."""
+    M12 = FORCING.source_matrix(tau, h)
+    Gn = FORCING.inject_error_state(mode, M12)
+    B = _zero(24, 16)
+    # column zero is the homogeneous source scale.  The prediction forcing is
+    # linear in q15, so it has no direct h_s column.
+    n = 18 if mode == "H" else 21
+    for i in range(n):
+        for j in range(15):
+            B[i][1 + j] = Gn[i][j]
+    return B
+
+
+def _primitive_token(cell: COVER.SourceCoverCell, suffix: str) -> str:
+    w = cell.wave_primitive
+    if w is None:
+        raise ValueError("physical source cell lost WavePrimitivePayload")
+    REF.validate_primitive_reference(w)
+    return ":".join((w.generator_id, w.live_origin_id, w.primitive_in_id, w.primitive_out_id, suffix))
+
+
+def _h_event_jacobian(cell: COVER.SourceCoverCell, held_bias_error, true_bias):
+    if cell.kind == "accelerometer":
+        # Existing J24 helper computes the exact dependence on held e_ba.  Its
+        # derivative is evaluated over the supplied physical hard domain below
+        # rather than at an unreachable perturbed covariance root.
+        failures = COVER.validate_cell(cell, require_estimator_provenance=True)
+        if failures:
+            raise ValueError("invalid H18 source cell: " + repr(failures))
+        if len(held_bias_error) != 3 or len(true_bias) != 3:
+            raise ValueError("H18 joint24 requires e_ba and beta domains")
+        u = EVENTS.AD.independent_vector(list(cell.state) + list(held_bias_error) + list(true_bias), n=24, offset=0)
+        z, eba, beta = u[:18], u[18:21], u[21:24]
+        H = EVENTS._event_H("H", "accelerometer", f_hat=cell.f_hat, R_hat=cell.R_hat)
+        K, _ = EVENTS.source_joseph_gain(cell.P, H, cell.R)
+        residual = J24._h18_accel_residual(z, eba, cell.f_hat, cell.R_hat)
+        out = list(EVENTS._apply_physical_correction(z, K, residual)) + list(eba) + list(beta)
+        return EVENTS.AD.jacobian(out), None
+    if cell.kind == "magnetometer":
+        u = EVENTS.AD.independent_vector(list(cell.state) + list(held_bias_error) + list(true_bias), n=24, offset=0)
+        z = u[:18]
+        H = EVENTS._event_H("H", "magnetometer", m_body=cell.m_body)
+        K, _ = EVENTS.source_joseph_gain(cell.P, H, cell.R)
+        out18 = EVENTS._apply_physical_correction(z, K, EVENTS.residual_magnetometer(z, cell.m_body))
+        return EVENTS.AD.jacobian(list(out18) + list(u[18:24])), None
+    if cell.kind == "S_zero":
+        # J24 helper retains physical-S source columns with the same primitive.
+        d = J24.s_zero_event_joint24(cell)
+        return d["J_joint24"], d["J_S_phys"]
+    raise ValueError("not an H18 Joseph event")
+
+
+def _a_event_jacobian(cell: COVER.SourceCoverCell):
+    """Full A21+beta joint derivative, including projection beta columns."""
+    failures = COVER.validate_cell(cell, require_estimator_provenance=True)
+    if failures:
+        raise ValueError("invalid A21 source cell: " + repr(failures))
+    if cell.true_bias is None or cell.bias_projection_limit is None:
+        raise ValueError("A21 source cell missing true bias/projection")
+    add_S = cell.kind == "S_zero"
+    extra = list(cell.wave_primitive.centered_S) if add_S and cell.wave_primitive is not None else []
+    if add_S:
+        REF.validate_primitive_reference(cell.wave_primitive)
+    total = 24 + (3 if add_S else 0)
+    u = EVENTS.AD.independent_vector(list(cell.state) + list(cell.true_bias) + extra, n=total, offset=0)
+    z, beta = u[:21], u[21:24]
+    H = EVENTS._event_H(cell.mode, cell.kind, f_hat=cell.f_hat, R_hat=cell.R_hat, m_body=cell.m_body)
+    K, _ = EVENTS.source_joseph_gain(cell.P, H, cell.R)
+    if cell.kind == "accelerometer":
+        residual = EVENTS.residual_accelerometer(z, cell.f_hat, cell.R_hat)
+    elif cell.kind == "magnetometer":
+        residual = EVENTS.residual_magnetometer(z, cell.m_body)
+    elif cell.kind == "S_zero":
+        residual = [z[EVENTS.OFF_S + i] - u[24 + i] for i in range(3)]
+    else:
+        raise ValueError("not an A21 Joseph event")
+    out21 = EVENTS._apply_physical_correction(z, K, residual)
+    J21, _, _ = J24._project_joint(out21, beta, total, float(cell.bias_projection_limit))
+    # Append beta_true identity rows.  _project_joint returns the projected
+    # A21-error rows with derivatives w.r.t. the whole AD coordinate.
+    J = [list(row) for row in J21]
+    for i in range(3):
+        row = [I(0) for _ in range(total)]
+        row[21 + i] = I(1)
+        J.append(row)
+    return [row[:24] for row in J], ([row[24:27] for row in J] if add_S else None)
+
+
+def _prediction_joint(cell, selector, phi_true: Interval, tau_ba: Interval | None):
+    mode = cell.mode
+    p = PRED.prediction_event(
+        mode,
+        cell.state,
+        selector.sample_coordinates.omega_body_corrected,
+        cell.dt_s,
+        cell.tau_applied_s,
+        tau_ba=tau_ba if mode == "A" else None,
+    )
+    if mode == "H":
+        J, Bbias = J24.h18_prediction_lift(p["J_state"], phi_true)
+    else:
+        if p["phi_ba"] is None:
+            raise RuntimeError("A21 prediction lost estimator bias factor")
+        ph = p["phi_ba"]
+        J = _zero(24, 24)
+        Bbias = _zero(24, 3)
+        for i in range(21):
+            for j in range(21):
+                J[i][j] = p["J_state"][i][j]
+        for i in range(3):
+            # e_ba+ = phi_hat e_ba + (phi_true-phi_hat) beta + w
+            J[18 + i][21 + i] = phi_true - ph
+            J[21 + i][21 + i] = phi_true
+            Bbias[18 + i][i] = I(1)
+            Bbias[21 + i][i] = I(1)
+    return J, Bbias, _q15_injection(mode, cell.tau_applied_s, cell.dt_s), _q15_sector_for_h(cell.dt_s)
+
+
+def compose_attached_sample(lineage, *, phi_true: Interval, held_bias_error=None, true_bias=None, tau_ba=None):
+    """Build the joint24 source-response cocycle for one universal attached lineage.
+
+    ``lineage`` is an AttachedSampleLineage emitted by the estimator-owned
+    source-uniform attachment.  All event cells are consumed in literal order.
+    The function never selects a favorable successor and never evaluates a
+    captured trajectory.
+    """
+    if not isinstance(phi_true, Interval):
+        raise TypeError("same-history true-bias factor must be an Interval")
+    mode = lineage.mode
+    if mode not in ("H", "A"):
+        raise ValueError("lineage mode must be H/A")
+    if mode == "H":
+        if held_bias_error is None or true_bias is None:
+            raise ValueError("H18 lineage requires hard e_ba and beta domains")
+    else:
+        if tau_ba is None:
+            raise ValueError("A21 lineage requires configured estimator tau_ba")
+
+    Psi = _identity(24)
+    blocks: list[SourceResponseBlock] = []
+    kinds = []
+    for cell in lineage.cells:
+        failures = COVER.validate_cell(cell, require_estimator_provenance=True)
+        if failures:
+            raise ValueError("invalid estimator-owned cell: " + repr(failures))
+        kinds.append(cell.kind)
+        if cell.kind == "prediction":
+            J, Bbias, Bq, sectors = _prediction_joint(cell, lineage.selector, phi_true, tau_ba)
+            Psi = matrix_mul(J, Psi)
+            blocks = [SourceResponseBlock(b.kind, b.token, b.generator_id, b.live_origin_id,
+                        _freeze(_propagate(J, _thaw(b.response))), b.sectors, b.homogeneous_scale_fixed_one)
+                      for b in blocks]
+            w = cell.wave_primitive
+            if w is None:
+                raise ValueError("prediction cell missing same-history primitive ancestry")
+            REF.validate_primitive_reference(w)
+            blocks.append(SourceResponseBlock(
+                "BRMM_q15_prediction",
+                _primitive_token(cell, "q15"), w.generator_id, w.live_origin_id,
+                _freeze(Bq), sectors, True))
+            # Bias driver is not an independent truth copy: the same three
+            # columns enter e_ba and beta.  Family-specific temporal relations
+            # are attached by the BIAS0/1/2 master, still fail-closed here.
+            blocks.append(SourceResponseBlock(
+                "shared_bias_driver",
+                f"{cell.source_token}:bias-driver", w.generator_id, w.live_origin_id,
+                _freeze(Bbias), (), False))
+        elif cell.kind == "aw_floor":
+            # Covariance-only event; the deterministic joint24 mean map is identity.
+            J = _identity(24)
+        elif cell.kind in ("S_zero", "accelerometer", "magnetometer"):
+            if mode == "H":
+                J, BS = _h_event_jacobian(cell, held_bias_error, true_bias)
+            else:
+                J, BS = _a_event_jacobian(cell)
+            Psi = matrix_mul(J, Psi)
+            blocks = [SourceResponseBlock(b.kind, b.token, b.generator_id, b.live_origin_id,
+                        _freeze(_propagate(J, _thaw(b.response))), b.sectors, b.homogeneous_scale_fixed_one)
+                      for b in blocks]
+            if BS is not None:
+                w = cell.wave_primitive
+                if w is None:
+                    raise ValueError("S event missing same-history primitive ancestry")
+                blocks.append(SourceResponseBlock(
+                    "physical_centered_S",
+                    _primitive_token(cell, "S"), w.generator_id, w.live_origin_id,
+                    _freeze(BS), (), False))
+        else:
+            raise ValueError("literal lineage contains unsupported event: " + repr(cell.kind))
+
+    expected = tuple(c.kind for c in lineage.cells)
+    if tuple(kinds) != expected:
+        raise RuntimeError("literal event order changed during physical composition")
+    return {
+        "mode": mode,
+        "J_joint24": Psi,
+        "source_blocks": tuple(blocks),
+        "literal_event_kinds": expected,
+        "all_literal_cells_consumed": True,
+        "q15_prediction_blocks": sum(b.kind == "BRMM_q15_prediction" for b in blocks),
+        "physical_S_blocks": sum(b.kind == "physical_centered_S" for b in blocks),
+        "bias_driver_blocks": sum(b.kind == "shared_bias_driver" for b in blocks),
+        "same_history_source_ancestry_retained": all(bool(b.generator_id and b.live_origin_id) for b in blocks),
+        "replay_used": False,
+        "independent_prediction_defect_boxes_used": False,
+    }
+
+
+def build():
+    forcing = FORCING.build(); ff = FORCING.validate(forcing)
+    sector = WSECTOR.build(); sf = WSECTOR.validate(sector)
+    if ff or sf:
+        raise RuntimeError(f"physical cocycle prerequisites failed forcing={ff} sector={sf}")
+    return {
+        "qualification": QUALIFICATION,
+        "canonical_source": "COMPLETE_BRMM_NORMAL_LIVE_WORD",
+        "joint_dimension": 24,
+        "same_15D_q_witness_used_per_prediction": True,
+        "joint_q15_quadratic_sector_attached_to_same_block": True,
+        "q15_columns_suffix_propagated_through_later_literal_events": True,
+        "physical_S_columns_suffix_propagated_through_later_literal_events": True,
+        "same_generator_and_one_time_Live_origin_tokens_retained": True,
+        "shared_bias_driver_enters_error_and_truth_once": True,
+        "independent_prediction_defect_boxes_used": False,
+        "replay_or_unreachable_perturbation_used": False,
+        "source_uniform_attached_sample_cocycle_available": True,
+        "multi_sample_COMPLETE_BRMM_word_composed": False,
+        "BIAS0_BIAS1_BIAS2_temporal_source_relations_attached": False,
+        "H18_A21_edge_attached": False,
+        "storage_search_allowed": False,
+        "ALT_LIVE_PASS": False,
+        "next_obligation": "compose these attached-sample cocycles over every retained source successor for the complete Live word, bind BIAS0/1/2 temporal driver relations and the H18->A21 release edge, then and only then enable common-storage search",
+    }
+
+
+def validate(d):
+    f = []
+    if d.get("qualification") != QUALIFICATION or d.get("joint_dimension") != 24:
+        f.append("qualification/dimension mismatch")
+    for k in (
+        "same_15D_q_witness_used_per_prediction",
+        "joint_q15_quadratic_sector_attached_to_same_block",
+        "q15_columns_suffix_propagated_through_later_literal_events",
+        "physical_S_columns_suffix_propagated_through_later_literal_events",
+        "same_generator_and_one_time_Live_origin_tokens_retained",
+        "shared_bias_driver_enters_error_and_truth_once",
+        "source_uniform_attached_sample_cocycle_available",
+    ):
+        if d.get(k) is not True:
+            f.append(k + " not true")
+    for k in (
+        "independent_prediction_defect_boxes_used",
+        "replay_or_unreachable_perturbation_used",
+        "multi_sample_COMPLETE_BRMM_word_composed",
+        "BIAS0_BIAS1_BIAS2_temporal_source_relations_attached",
+        "H18_A21_edge_attached",
+        "storage_search_allowed",
+        "ALT_LIVE_PASS",
+    ):
+        if d.get(k) is not False:
+            f.append(k + " not false")
+    return list(dict.fromkeys(f))

--- a/tools/stability/ou3_alt_contraction/physical_numeric_bounds.py
+++ b/tools/stability/ou3_alt_contraction/physical_numeric_bounds.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""ALT binding of the repaired COMPLETE-BRMM numerical physical envelope.
+
+The ALT common-storage enclosure needs numerical bounds on finite physical
+coordinates, especially centered S at S=0 events.  These bounds must come from
+the repaired physical BRMM theorem, never the legacy P4 error radius.
+"""
+from __future__ import annotations
+import json
+from pathlib import Path
+
+import ou3_brmm_physical_wave_condition as PHYS
+import ou3_brmm_centered_S_recurrence as SREC
+import ou3_brmm_complete_physical_envelope as ENV
+
+REPO=Path(__file__).resolve().parents[3]
+DOMAIN=REPO/'tools/stability/ou3_proof_operating_domain.json'
+QUALIFICATION='OU3_ALT_REPAIRED_BRMM_NUMERIC_PHYSICAL_ENVELOPE_BINDING_V1'
+
+
+def build():
+    p=PHYS.build(); pf=PHYS.validate(p)
+    s=SREC.build(); sf=SREC.validate(s)
+    e=ENV.build(); ef=ENV.validate(e)
+    if pf or sf or ef: raise RuntimeError(f'physical envelope prerequisites failed phys={pf} S={sf} env={ef}')
+    d=json.loads(DOMAIN.read_text())['complete_brmm_physical_envelope']
+    b=e['complete_BRMM_hard_bounds']
+    parity={
+      'Hs':float(d['significant_wave_height_Hs_upper_m'])==float(b['Hs_upper_m']),
+      'position':float(d['wave_position_norm_upper_m'])==float(b['wave_position_norm_upper_m']),
+      'velocity':float(d['wave_velocity_norm_upper_mps'])==float(b['wave_velocity_norm_upper_mps']),
+      'acceleration':float(d['wave_acceleration_norm_upper_mps2'])==float(b['wave_acceleration_norm_upper_mps2']),
+      'body_rate':float(d['body_rate_norm_upper_deg_s'])==float(b['body_rate_norm_upper_deg_s']),
+      'frequency':list(map(float,d['frequency_support_hz']))==list(map(float,b['frequency_support_hz'])),
+      'centered_S':float(d['centered_primitive_D_S_upper_m_s'])==float(b['centered_primitive_D_S_upper_m_s']),
+    }
+    closed=bool(all(parity.values()) and p['physical_D_S_numeric_qualification_closed_for_complete_family'] and s['D_S_numeric_qualification_closed'] and s['D_S_max_m_s']==b['centered_primitive_D_S_upper_m_s'])
+    return {
+      'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD',
+      'source':'ou3_brmm_physical_wave_condition + ou3_brmm_complete_physical_envelope',
+      'operating_domain_parity':parity,'numeric_complete_family_physical_envelope_closed':closed,
+      'wave_position_norm_upper_m':float(b['wave_position_norm_upper_m']),
+      'wave_velocity_norm_upper_mps':float(b['wave_velocity_norm_upper_mps']),
+      'wave_acceleration_norm_upper_mps2':float(b['wave_acceleration_norm_upper_mps2']),
+      'body_rate_norm_upper_deg_s':float(b['body_rate_norm_upper_deg_s']),
+      'frequency_support_hz':list(map(float,b['frequency_support_hz'])),
+      'centered_S_norm_upper_m_s':float(b['centered_primitive_D_S_upper_m_s']),
+      'specific_force_norm_lower_mps2':float(b['specific_force_norm_lower_mps2']),
+      'specific_force_norm_upper_mps2':float(b['specific_force_norm_upper_mps2']),
+      'D_S_comes_from_P4_working_radius':False,'legacy_300m_s_used_as_physical_bound':False,
+      'P4_certificate_used_to_choose_padding':False,'trajectory_replay_used':False,
+      'usable_by_ALT_finite_event_outer_enclosure':closed,
+    }
+
+
+def validate(d):
+    f=[]
+    if d.get('qualification')!=QUALIFICATION or d.get('canonical_source')!='COMPLETE_BRMM_NORMAL_LIVE_WORD':f.append('qualification/source mismatch')
+    if d.get('numeric_complete_family_physical_envelope_closed') is not True:f.append('numeric physical envelope not closed')
+    if not all(d.get('operating_domain_parity',{}).values()):f.append('operating-domain physical envelope drifted')
+    if d.get('usable_by_ALT_finite_event_outer_enclosure') is not True:f.append('physical bounds unavailable to ALT')
+    for k in ('D_S_comes_from_P4_working_radius','legacy_300m_s_used_as_physical_bound','P4_certificate_used_to_choose_padding','trajectory_replay_used'):
+        if d.get(k) is not False:f.append(k+' not false')
+    if float(d.get('centered_S_norm_upper_m_s',0))!=1100.0:f.append('qualified D_S changed')
+    return f

--- a/tools/stability/ou3_alt_contraction/physical_reference.py
+++ b/tools/stability/ou3_alt_contraction/physical_reference.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Physical-reference relations required by the ALT same-trajectory theorem.
+
+This module does not create a new sea model. It consumes the exact shared
+COMPLETE-BRMM prediction-forcing/source-sector interfaces and supplies finite
+reference terms that a differential-only word omits:
+
+* S=0 uses r_S=e_S-S_phys, not e_S;
+* bias prediction uses one physical beta history;
+* H18 accelerometer residual retains held accelerometer-bias error.
+"""
+from __future__ import annotations
+from typing import Sequence
+from ou3_interval import Interval
+import ou3_brmm_complete_window_execution_kernel as KERNEL
+import ou3_p4_brmm_physical_prediction_forcing as PRED_FORCE
+import ou3_p4_brmm_physical_acceleration_witness_sector as PRED_SECTOR
+import ou3_p4_S_origin_literal_prefix_invariant as S_ORIGIN
+import ou3_p4_bias0_family as BIAS0
+import ou3_p4_bias1_family as BIAS1
+import ou3_p4_bias2_family as BIAS2
+
+QUALIFICATION="OU3_ALT_PHYSICAL_REFERENCE_FORCING_V3"
+
+def _vec3(x: Sequence[Interval], name: str):
+    if len(x)!=3 or any(not isinstance(v,Interval) for v in x): raise ValueError(f"{name} must be Interval[3]")
+    return tuple(x)
+def _shape(A):
+    r=len(A);c=len(A[0]) if r else 0
+    if any(len(row)!=c for row in A): raise ValueError("ragged matrix")
+    return r,c
+def _matvec(A,x):
+    r,c=_shape(A)
+    if c!=len(x): raise ValueError("matrix/vector dimension mismatch")
+    out=[]
+    for i in range(r):
+        v=Interval.point(0)
+        for j in range(c): v=v+A[i][j]*x[j]
+        out.append(v)
+    return out
+
+def validate_primitive_reference(primitive: KERNEL.WavePrimitivePayload) -> None:
+    if not isinstance(primitive,KERNEL.WavePrimitivePayload): raise TypeError("typed physical primitive required")
+    if not primitive.generator_id or not primitive.primitive_in_id or not primitive.primitive_out_id: raise ValueError("physical primitive ancestry missing")
+    if not primitive.live_origin_id: raise ValueError("one-time Live origin missing")
+    _vec3(primitive.centered_S,"centered_S")
+
+def s_zero_residual(error_S,primitive):
+    validate_primitive_reference(primitive);e=_vec3(error_S,"e_S");s=_vec3(primitive.centered_S,"centered_S")
+    return tuple(e[i]-s[i] for i in range(3))
+def s_zero_residual_operator():
+    z=Interval.point(0);one=Interval.point(1);neg=Interval.point(-1)
+    return [[one if i==j else z for j in range(3)]+[neg if i==j else z for j in range(3)] for i in range(3)]
+def bias_error_prediction(error_before,beta_before,beta_after,phi_hat):
+    e=_vec3(error_before,"e_ba");b0=_vec3(beta_before,"beta_before");b1=_vec3(beta_after,"beta_after")
+    if not isinstance(phi_hat,Interval): raise TypeError("phi_hat must be Interval")
+    return tuple(phi_hat*e[i]+b1[i]-phi_hat*b0[i] for i in range(3))
+def bias_prediction_operator(phi_hat):
+    if not isinstance(phi_hat,Interval): raise TypeError("phi_hat must be Interval")
+    z=Interval.point(0);one=Interval.point(1)
+    return [[phi_hat if i==j else z for j in range(3)]+[-phi_hat if i==j else z for j in range(3)]+[one if i==j else z for j in range(3)] for i in range(3)]
+def h18_accelerometer_residual(base_residual,held_bias_error):
+    r=_vec3(base_residual,"base residual");e=_vec3(held_bias_error,"held e_ba")
+    return tuple(r[i]+e[i] for i in range(3))
+
+def _upstream_contracts():
+    expected={"prediction_forcing":"OU3_P4_BRMM_SAME_HISTORY_PHYSICAL_PREDICTION_FORCING_V1","prediction_sector":"OU3_P4_BRMM_PHYSICAL_ACCELERATION_WITNESS_SECTOR_V1","S_origin":"OU3_P4_SHARED_S_ORIGIN_LITERAL_PREFIX_INVARIANT_V1"}
+    actual={"prediction_forcing":getattr(PRED_FORCE,"QUALIFICATION",None),"prediction_sector":getattr(PRED_SECTOR,"QUALIFICATION",None),"S_origin":getattr(S_ORIGIN,"QUALIFICATION",None)}
+    if actual!=expected: raise RuntimeError(f"shared physical contract changed: {actual!r}")
+    for name,module in (("BIAS0",BIAS0),("BIAS1",BIAS1),("BIAS2",BIAS2)):
+        if not callable(getattr(module,"build",None)) or not callable(getattr(module,"validate",None)): raise RuntimeError(name+" definition/validator interface missing")
+    actual["bias_interfaces"]="BIAS0/BIAS1/BIAS2 build+validate";return actual
+
+def build():
+    upstream=_upstream_contracts()
+    return {"qualification":QUALIFICATION,"canonical_source":"COMPLETE_BRMM_NORMAL_LIVE_WORD","upstream_contracts":upstream,
+      "shared_exact_BRMM_vs_OU_prediction_forcing_required":True,"shared_exact_BRMM_vs_OU_prediction_forcing_consumed":True,
+      "shared_joint_15D_acceleration_witness_sector_required":True,"shared_joint_15D_acceleration_witness_sector_consumed":True,
+      "shared_one_time_S_origin_prefix_invariant_required":True,"shared_one_time_S_origin_prefix_invariant_consumed":True,
+      "all_BIAS0_BIAS1_BIAS2_definitions_required_separately":True,"S_zero_residual_identity":"r_S=e_S-S_phys",
+      "bias_error_identity":"e_ba+=phi_hat*e_ba+beta+-phi_hat*beta","H18_accelerometer_bias_identity":"r_acc_H18=r_acc_18+e_ba_held",
+      "physical_reference_algebra_closed":True,"homogeneous_OU_error_prediction_substituted_for_physical_truth":False,"S_phys_replaced_by_zero":False,
+      "legacy_300m_s_error_ball_used":False,"independent_bias_driver_used":False,"replay_or_unreachable_perturbation_used":False,
+      "attached_to_every_literal_source_cell":False,"complete_word_master_closed":False,"ALT_LIVE_PASS":False,
+      "next_obligation":"attach finite S and bias reference terms to every estimator-owned physical H18/A21 event while retaining upstream correlated q15 prediction forcing; then assemble the literal physical word before storage search"}
+def validate(d):
+    f=[]
+    if d.get("qualification")!=QUALIFICATION:f.append("qualification mismatch")
+    if d.get("canonical_source")!="COMPLETE_BRMM_NORMAL_LIVE_WORD":f.append("canonical source changed")
+    for k in ("shared_exact_BRMM_vs_OU_prediction_forcing_required","shared_joint_15D_acceleration_witness_sector_required","shared_one_time_S_origin_prefix_invariant_required","all_BIAS0_BIAS1_BIAS2_definitions_required_separately","physical_reference_algebra_closed"):
+        if d.get(k) is not True:f.append(k+" not true")
+    for k in ("homogeneous_OU_error_prediction_substituted_for_physical_truth","S_phys_replaced_by_zero","legacy_300m_s_error_ball_used","independent_bias_driver_used","replay_or_unreachable_perturbation_used","attached_to_every_literal_source_cell","complete_word_master_closed","ALT_LIVE_PASS"):
+        if d.get(k) is not False:f.append(k+" not false")
+    return f

--- a/tools/stability/ou3_alt_contraction/physical_word.py
+++ b/tools/stability/ou3_alt_contraction/physical_word.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Universal physical joint24 word induction for the ALT Live theorem.
+
+The theorem is relational, not an enumeration.  For every endpoint path of the
+regional universal Normal-Live relation, apply the source-uniform local cocycle
+of ``physical_lineage`` at each literal sample.  Since the transition retains
+ALL successors, induction gives a physical response cocycle on every endpoint
+path.
+
+The induction invariant is deliberately stronger than a matrix product:
+  * selector parent/child ancestry is consecutive;
+  * one BRMM generator and one Live S origin persist;
+  * primitive_out(k) == primitive_in(k+1);
+  * all q15 and physical-S blocks remain members of the ONE global
+    O^601_BRMM relation, never independent boxes;
+  * one BIAS0/1/2 parameter/root token is reused over the whole path;
+  * all prior source-response columns are suffix-propagated through each new
+    joint24 local map.
+
+This establishes the H18-only and A21-only complete-word construction once a
+mode path is supplied.  Hybrid H18->A21 splicing uses ``h18_a21_edge`` and is
+kept separate because the release covariance must be constructed from the
+actual held H18 covariance rather than the parallel hypothetical A21 branch.
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Sequence
+
+from ou3_interval import Interval, matrix_mul
+import ou3_brmm_correlated_window_outer_enclosure as OUTER
+import ou3_p4_projection_sector as PROJ
+from tools.stability.ou3_alt_contraction import bias_families as BIAS
+from tools.stability.ou3_alt_contraction import live_source_relation as SOURCE
+from tools.stability.ou3_alt_contraction import physical_lineage as LOCAL
+
+QUALIFICATION='OU3_ALT_UNIVERSAL_PHYSICAL_JOINT24_WORD_INDUCTION_V1'
+TRANSITIONS=600
+SOURCE_SAMPLES=601
+GLOBAL_PHYSICAL_RELATION='O^601_BRMM'
+
+
+def I(x):return Interval.point(float(x))
+def _shape(A):return len(A),len(A[0]) if A else 0
+def _freeze(A):return tuple(tuple(x for x in row) for row in A)
+def _thaw(A):return [list(row) for row in A]
+
+def _propagate(J,B):
+    if _shape(J)!=(24,24) or _shape(B)[0]!=24:raise ValueError('joint24 response propagation mismatch')
+    return matrix_mul(J,B)
+
+@dataclass(frozen=True)
+class WordSourceBlock:
+    kind:str
+    token:str
+    response:tuple[tuple[Interval,...],...]
+    sectors:tuple
+    global_relation:str
+    generator_id:str
+    live_origin_id:str
+    family_parameter_token:str|None=None
+
+
+def hard_bias_domains(contract:BIAS.BiasFamilyContract):
+    """Regional Live domains implied by true-bias cap + closed projection ball."""
+    p=PROJ.build();pf=PROJ.validate(p)
+    if pf:raise RuntimeError('projection prerequisite failed: '+repr(pf))
+    R=float(p['projection_radius_mps2']);B=float(contract.true_bias_component_bound)
+    true=[Interval(-B,B) for _ in range(3)]
+    # |bhat_i| <= ||bhat|| <= R and |beta_i|<=B.
+    E=R+B;held=[Interval(-E,E) for _ in range(3)]
+    return held,true
+
+
+def _selector_key(lineage):
+    s=lineage.selector
+    return int(s.prefix_length),str(s.parent_source_cell_id),str(s.source_cell_id)
+
+
+def _sample_primitive(lineage):
+    ps=[c.wave_primitive for c in lineage.cells if c.wave_primitive is not None]
+    if not ps:raise ValueError('attached sample has no physical primitive ancestry')
+    p=ps[0]
+    for q in ps[1:]:
+        if (q.generator_id,q.live_origin_id,q.primitive_in_id,q.primitive_out_id)!=(p.generator_id,p.live_origin_id,p.primitive_in_id,p.primitive_out_id):
+            raise ValueError('literal events inside one sample detached from physical primitive')
+    return p
+
+
+def compose_endpoint_lineage(lineages:Sequence,*,bias_contract:BIAS.BiasFamilyContract,tau_ba=None,require_complete_word=False):
+    if not lineages:raise ValueError('nonempty endpoint lineage required')
+    if not isinstance(bias_contract,BIAS.BiasFamilyContract):raise TypeError('explicit bias family contract required')
+    if require_complete_word and len(lineages)!=TRANSITIONS:raise ValueError(f'complete Live word requires {TRANSITIONS} transitions')
+    held,true=hard_bias_domains(bias_contract)
+    Psi=[[I(1 if i==j else 0) for j in range(24)] for i in range(24)]
+    blocks:list[WordSourceBlock]=[];prev_selector=None;prev_primitive=None;mode=lineages[0].mode
+    for ordinal,lineage in enumerate(lineages, start=1):
+        if lineage.mode!=mode:raise ValueError('single-mode word composer cannot cross H18/A21; use hybrid splice')
+        prefix,parent,child=_selector_key(lineage)
+        if prefix!=ordinal:raise ValueError('selector lineage skipped or duplicated a prefix')
+        if prev_selector is None:
+            if parent!='root':raise ValueError('first selector parent must be root')
+        elif parent!=prev_selector.source_cell_id:
+            raise ValueError('selector parent/child ancestry broken')
+        primitive=_sample_primitive(lineage)
+        if prev_primitive is not None:
+            if primitive.generator_id!=prev_primitive.generator_id:raise ValueError('BRMM generator changed inside one word')
+            if primitive.live_origin_id!=prev_primitive.live_origin_id:raise ValueError('one-time Live S origin changed inside one word')
+            if primitive.primitive_in_id!=prev_primitive.primitive_out_id:raise ValueError('physical primitive continuity broken between samples')
+        local=LOCAL.compose_attached_sample(lineage,bias_contract=bias_contract,held_bias_error=held if mode=='H' else None,true_bias=true if mode=='H' else None,tau_ba=tau_ba if mode=='A' else None)
+        J=local['J_joint24'];Psi=matrix_mul(J,Psi)
+        blocks=[WordSourceBlock(b.kind,b.token,_freeze(_propagate(J,_thaw(b.response))),b.sectors,b.global_relation,b.generator_id,b.live_origin_id,b.family_parameter_token) for b in blocks]
+        for b in local['source_blocks']:
+            blocks.append(WordSourceBlock(b.kind,b.token,b.response,b.sectors,GLOBAL_PHYSICAL_RELATION,b.generator_id,b.live_origin_id,b.family_parameter_token))
+        if not local['same_bias_parameter_token_on_all_predictions']:raise RuntimeError('local bias parameter token detached')
+        prev_selector=lineage.selector;prev_primitive=primitive
+    bias_blocks=[b for b in blocks if b.kind=='shared_bias_driver']
+    qblocks=[b for b in blocks if b.kind=='BRMM_q15_prediction'];sblocks=[b for b in blocks if b.kind=='physical_centered_S']
+    return {
+      'mode':mode,'transitions_composed':len(lineages),'J_joint24':Psi,'source_blocks':tuple(blocks),
+      'endpoint_source_cell_id':prev_selector.source_cell_id,'generator_id':prev_primitive.generator_id,'live_origin_id':prev_primitive.live_origin_id,
+      'selector_ancestry_continuous':True,'primitive_transition_continuity':True,'one_generator_over_word':True,'one_Live_S_origin_over_word':True,
+      'global_physical_relation':GLOBAL_PHYSICAL_RELATION,'all_physical_blocks_tied_to_global_relation':all(b.global_relation==GLOBAL_PHYSICAL_RELATION for b in blocks),
+      'bias_family':bias_contract.name,'bias_parameter_token':bias_contract.parameter_token,
+      'one_bias_parameter_token_over_word':all(b.family_parameter_token==bias_contract.parameter_token for b in bias_blocks),
+      'q15_prediction_block_count':len(qblocks),'physical_S_block_count':len(sblocks),'bias_driver_block_count':len(bias_blocks),
+      'every_prior_source_block_suffix_propagated':True,'replay_used':False,'independent_sample_source_boxes_used':False,
+      'complete_word_length':len(lineages)==TRANSITIONS,
+    }
+
+
+def induction_theorem():
+    source=SOURCE.build();sf=SOURCE.validate(source);outer=OUTER.build();of=OUTER.validate(outer);local=LOCAL.build();lf=LOCAL.validate(local);bias=BIAS.build();bf=BIAS.validate(bias)
+    bad={k:v for k,v in {'source':sf,'outer':of,'local':lf,'bias':bf}.items() if v}
+    if bad:raise RuntimeError('word induction prerequisites failed: '+repr(bad))
+    premise=bool(source['regional_universal_Normal_Live_source_relation_closed'] and source['all_branch_successors_retained_by_operator'] and outer['sample_count']==SOURCE_SAMPLES and outer['same_history_required_for_entire_window'] and outer['constraints']['translation']['primitive_out_is_next_primitive_in'] and outer['constraints']['translation']['one_live_centered_S_origin_for_all_samples'] and local['source_uniform_attached_sample_cocycle_available'] and bias['one_persistent_parameter_token_per_family'])
+    # Standard finite induction: root is covered by the regional predecessor set;
+    # if every covered prefix has every successor represented and the local
+    # cocycle is total on each attached successor, all prefixes 1..600 and every
+    # endpoint are covered. No numerical source enumeration is required.
+    return {
+      'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD','global_source_relation':GLOBAL_PHYSICAL_RELATION,
+      'source_samples':SOURCE_SAMPLES,'word_transitions':TRANSITIONS,
+      'regional_root_set_closed':source['regional_frontend_predecessor_invariant_consumed'],
+      'universal_transition_relation_closed':source['regional_universal_Normal_Live_source_relation_closed'],
+      'all_successors_retained':source['all_branch_successors_retained_by_operator'],
+      'local_physical_joint24_cocycle_total_on_attached_successor':local['source_uniform_attached_sample_cocycle_available'],
+      'primitive_out_equals_next_in_required':outer['constraints']['translation']['primitive_out_is_next_primitive_in'],
+      'one_Live_S_origin_required':outer['constraints']['translation']['one_live_centered_S_origin_for_all_samples'],
+      'one_bias_parameter_token_required':bias['one_persistent_parameter_token_per_family'],
+      'finite_induction_premises_closed':premise,
+      'every_prefix_and_endpoint_has_single_mode_physical_cocycle':premise,
+      'H18_complete_word_construction_closed':premise,
+      'A21_complete_word_construction_closed':premise,
+      'physical_prediction_forcing_attached':premise,
+      'physical_S_residual_attached':premise,
+      'all_bias_families_attached_to_single_mode_word':premise,
+      'same_history_COMPLETE_BRMM_single_mode_word_closed':premise,
+      'hybrid_H18_A21_word_closed':False,'H18_A21_edge_attached':False,
+      'all_literal_hybrid_branches_attached':False,'storage_search_allowed':False,'ALT_LIVE_PASS':False,
+      'replay_or_finite_source_enumeration_used':False,'independent_sample_source_boxes_used':False,
+      'next_obligation':'splice the exact held H18 covariance into A21 at every literal release guard branch while preserving this induction invariant; then the complete hybrid physical word can unlock common-storage search'}
+
+def validate(d):
+    f=[]
+    if d.get('qualification')!=QUALIFICATION or d.get('global_source_relation')!=GLOBAL_PHYSICAL_RELATION or d.get('source_samples')!=SOURCE_SAMPLES or d.get('word_transitions')!=TRANSITIONS:f.append('qualification/window mismatch')
+    for k in ('regional_root_set_closed','universal_transition_relation_closed','all_successors_retained','local_physical_joint24_cocycle_total_on_attached_successor','primitive_out_equals_next_in_required','one_Live_S_origin_required','one_bias_parameter_token_required','finite_induction_premises_closed','every_prefix_and_endpoint_has_single_mode_physical_cocycle','H18_complete_word_construction_closed','A21_complete_word_construction_closed','physical_prediction_forcing_attached','physical_S_residual_attached','all_bias_families_attached_to_single_mode_word','same_history_COMPLETE_BRMM_single_mode_word_closed'):
+        if d.get(k) is not True:f.append(k+' not true')
+    for k in ('hybrid_H18_A21_word_closed','H18_A21_edge_attached','all_literal_hybrid_branches_attached','storage_search_allowed','ALT_LIVE_PASS','replay_or_finite_source_enumeration_used','independent_sample_source_boxes_used'):
+        if d.get(k) is not False:f.append(k+' not false')
+    return f

--- a/tools/stability/ou3_alt_contraction/physical_word.py
+++ b/tools/stability/ou3_alt_contraction/physical_word.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Universal physical joint24 word induction for the ALT Live theorem.
+"""Joint24 derivative-word assembly retained for the ALT Live construction.
+
+Scope correction: the code below assembles pointwise state/source Jacobian
+data. Its legacy assembly labels do not prove an anchored finite error-map
+identity. The finite_storage_readiness guard therefore blocks its use as the
+finite endpoint in a common-storage search. See the finite-measurement proof
+for the missing bridge and the exact accepted-event replacement.
 
 The theorem is relational, not an enumeration.  For every endpoint path of the
 regional universal Normal-Live relation, apply the source-uniform local cocycle
@@ -117,6 +123,7 @@ def compose_endpoint_lineage(lineages:Sequence,*,bias_contract:BIAS.BiasFamilyCo
     qblocks=[b for b in blocks if b.kind=='BRMM_q15_prediction'];sblocks=[b for b in blocks if b.kind=='physical_centered_S']
     return {
       'mode':mode,'transitions_composed':len(lineages),'J_joint24':Psi,'source_blocks':tuple(blocks),
+      'map_representation':'pointwise_state_Jacobian_cocycle','finite_error_identity_established':False,
       'endpoint_source_cell_id':prev_selector.source_cell_id,'generator_id':prev_primitive.generator_id,'live_origin_id':prev_primitive.live_origin_id,
       'selector_ancestry_continuous':True,'primitive_transition_continuity':True,'one_generator_over_word':True,'one_Live_S_origin_over_word':True,
       'global_physical_relation':GLOBAL_PHYSICAL_RELATION,'all_physical_blocks_tied_to_global_relation':all(b.global_relation==GLOBAL_PHYSICAL_RELATION for b in blocks),
@@ -139,6 +146,7 @@ def induction_theorem():
     # endpoint are covered. No numerical source enumeration is required.
     return {
       'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD','global_source_relation':GLOBAL_PHYSICAL_RELATION,
+      'map_representation':'pointwise_state_Jacobian_cocycle','finite_error_identity_established':False,
       'source_samples':SOURCE_SAMPLES,'word_transitions':TRANSITIONS,
       'regional_root_set_closed':source['regional_frontend_predecessor_invariant_consumed'],
       'universal_transition_relation_closed':source['regional_universal_Normal_Live_source_relation_closed'],
@@ -168,3 +176,20 @@ def validate(d):
     for k in ('hybrid_H18_A21_word_closed','H18_A21_edge_attached','all_literal_hybrid_branches_attached','storage_search_allowed','ALT_LIVE_PASS','replay_or_finite_source_enumeration_used','independent_sample_source_boxes_used'):
         if d.get(k) is not False:f.append(k+' not false')
     return f
+
+
+def finite_storage_readiness():
+    """Actual limitation of this module's J products, not inferred PASS labels.
+
+    compose_endpoint_lineage composes pointwise state Jacobians and source
+    derivatives. It does not yet compose the finite descriptors proved in
+    finite_measurement_graph or a complete anchored mean-value identity.
+    The existing induction/ancestry report cannot replace that missing bridge.
+    """
+    return {
+        'map_representation': 'pointwise_state_Jacobian_cocycle',
+        'finite_error_identity_for_every_event': False,
+        'physical_reference_forcing_retained': False,
+        'all_coefficient_product_graphs_retained': False,
+        'all_configured_branches_bound_to_finite_graph': False,
+    }

--- a/tools/stability/ou3_alt_contraction/prediction_quaternion_branch.py
+++ b/tools/stability/ou3_alt_contraction/prediction_quaternion_branch.py
@@ -1,0 +1,72 @@
+"""Source-uniform branch certificate for shipping prediction quaternions.
+
+Under the declared regional Normal-Live domain, every nominal and true-shadow
+5 ms prediction increment is strictly below quat_from_delta_theta's 0.01 rad
+branch threshold.  Therefore the finite prediction graph needs only the exact
+polynomial (w,k*d) branch in real arithmetic; the trig branch cannot occur
+inside this regional theorem domain.
+
+This closes only branch selection. Binary32 FMA/normalization roundoff remains
+a separate finite-precision obligation.
+"""
+from __future__ import annotations
+import json,math
+from pathlib import Path
+
+REPO=Path(__file__).resolve().parents[3]
+OPERATING=REPO/'tools/stability/ou3_proof_operating_domain.json'
+CLOSURE=REPO/'tools/stability/ou3_p4_closure_domain.json'
+CORE=REPO/'src/kalman_ou_common/KalmanOUCoreMath.h'
+QUALIFICATION='OU3_ALT_PREDICTION_QUATERNION_SMALL_BRANCH_V1'
+THRESHOLD_RAD=1.0e-2
+
+
+def upward(x): return math.nextafter(float(x),math.inf)
+
+
+def small_branch_parameters(dtheta2):
+    """Real-arithmetic polynomial branch in terms of ||dtheta||^2."""
+    u=float(dtheta2)
+    if not (math.isfinite(u) and 0<=u<THRESHOLD_RAD**2):
+        raise ValueError('increment outside strict polynomial quaternion branch')
+    u2=u*u
+    return 1-u/8+u2/384, .5-u/48+u2/3840
+
+
+def build():
+    op=json.loads(OPERATING.read_text());cl=json.loads(CLOSURE.read_text());src=CORE.read_text()
+    h=upward(op['configured_runtime']['imu_dt_s'])
+    omega=upward(math.radians(op['normal_live']['body_rate_norm_upper_deg_s']))
+    bg=upward(cl['hard_entry_search']['base_coordinate_radii']['gyro_bias_norm_rad_s'])
+    nominal=upward(omega*h)
+    shadow=upward((omega+bg)*h)
+    threshold_source=('if (theta < T(1e-2))' in src)
+    source_prediction_call=('quat_from_delta_theta((-last_gyr_bias_corrected * Ts).eval())' in (REPO/'src/kalman_ou_iii/Kalman3D_Wave_OU_III.h').read_text())
+    closed=bool(threshold_source and source_prediction_call and nominal<THRESHOLD_RAD and shadow<THRESHOLD_RAD)
+    return {
+      'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD',
+      'runtime_dt_s_upper':h,'body_rate_norm_upper_rad_s':omega,'regional_gyro_bias_error_norm_upper_rad_s':bg,
+      'nominal_step_angle_norm_upper_rad':nominal,'shadow_step_angle_norm_upper_rad':shadow,
+      'shipping_quaternion_branch_threshold_rad':THRESHOLD_RAD,
+      'shadow_margin_to_threshold_rad':math.nextafter(THRESHOLD_RAD-shadow,-math.inf),
+      'shipping_threshold_source_parity':threshold_source,'shipping_prediction_call_source_parity':source_prediction_call,
+      'nominal_prediction_always_polynomial_branch':bool(nominal<THRESHOLD_RAD),
+      'shadow_prediction_always_polynomial_branch':bool(shadow<THRESHOLD_RAD),
+      'source_uniform_prediction_quaternion_branch_closed':closed,
+      'trigonometric_prediction_branch_reachable_in_regional_domain':False if closed else None,
+      'binary32_polynomial_and_normalization_roundoff_closed':False,
+      'ALT_LIVE_PASS':False,
+      'next_obligation':'substitute the polynomial step-quaternion hard graph into every finite prediction descriptor, retaining omega, e_bg and h ancestry; then attach q15 and bias-root source relations and covariance successors',
+    }
+
+
+def validate(d):
+    f=[]
+    if d.get('qualification')!=QUALIFICATION:f.append('qualification mismatch')
+    for k in ('shipping_threshold_source_parity','shipping_prediction_call_source_parity','nominal_prediction_always_polynomial_branch','shadow_prediction_always_polynomial_branch','source_uniform_prediction_quaternion_branch_closed'):
+        if d.get(k) is not True:f.append(k+' not true')
+    if d.get('trigonometric_prediction_branch_reachable_in_regional_domain') is not False:f.append('trig branch not excluded')
+    for k in ('binary32_polynomial_and_normalization_roundoff_closed','ALT_LIVE_PASS'):
+        if d.get(k) is not False:f.append(k+' not false')
+    if not 0<d.get('shadow_margin_to_threshold_rad',-1):f.append('no strict branch margin')
+    return f

--- a/tools/stability/ou3_alt_contraction/projected_storage_certificate.py
+++ b/tools/stability/ou3_alt_contraction/projected_storage_certificate.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Outward certificate for the ALT projected common-storage inequality.
+
+Given one interval family enclosure A in R^{n x n}, one point candidate M>0,
+rho in (0,1), and an admitted coordinate supply selector C, certify
+
+  Z' (A' M A - rho M) Z < 0   for every A in the interval family,
+
+where Z injects ker(C).  Combined with common_storage_master's coordinate
+Finsler lemma, this proves existence of a finite bounded-coordinate supply
+completion for the whole enclosed family.  The arithmetic here is entirely the
+repository's outward Interval + interval-LDLT backend.
+
+This module does NOT manufacture the source-uniform endpoint family.  A caller
+must provide an interval enclosure already proved to contain every physical
+word under consideration.  In particular, replay matrices and finite source
+samples cannot be passed off as a theorem family.
+"""
+from __future__ import annotations
+
+import math
+from typing import Sequence
+import numpy as np
+
+from ou3_interval import (
+    Interval, matrix_point, matrix_mul, matrix_transpose,
+    matrix_sub, symmetric_positive_definite_ldlt,
+)
+from ou3_interval_linear_algebra import matrix_symmetric_hull
+from tools.stability.ou3_alt_contraction import common_storage_master as MASTER
+
+QUALIFICATION="OU3_ALT_PROJECTED_COMMON_STORAGE_OUTWARD_LDLT_V1"
+
+
+def _shape(A):
+    r=len(A); c=len(A[0]) if r else 0
+    if any(len(row)!=c for row in A): raise ValueError("ragged interval matrix")
+    return r,c
+
+
+def _neg(A): return [[-x for x in row] for row in A]
+
+
+def _point_scaled_principal(M: np.ndarray, keep, rho: float):
+    return [[Interval.outward_bounds(rho*float(M[i,j]),rho*float(M[i,j])) for j in keep] for i in keep]
+
+
+def _interval_columns(A, keep):
+    return [[row[j] for j in keep] for row in A]
+
+
+def certify_projected_interval_family(
+    A_family: Sequence[Sequence[Interval]],
+    M,
+    rho: float,
+    supplied_indices,
+) -> dict:
+    """Certify the projected storage LMI for every A in one interval family."""
+    n,m=_shape(A_family)
+    if n==0 or n!=m: raise ValueError("A_family must be nonempty square")
+    if any(not isinstance(x,Interval) for row in A_family for x in row):
+        raise TypeError("A_family must be outward Interval entries")
+    M=np.asarray(M,dtype=float)
+    if M.shape!=(n,n) or not np.isfinite(M).all() or not np.allclose(M,M.T,rtol=0,atol=1e-12):
+        raise ValueError("M must be finite symmetric n x n")
+    if not math.isfinite(rho) or not 0.0<rho<1.0: raise ValueError("rho must lie in (0,1)")
+    idx=tuple(int(i) for i in supplied_indices)
+    if len(set(idx))!=len(idx) or any(i<0 or i>=n for i in idx): raise ValueError("invalid supplied indices")
+    keep=[i for i in range(n) if i not in set(idx)]
+    if not keep: raise ValueError("at least one unsupplied coordinate required")
+
+    Mint=matrix_point(M.tolist())
+    M_ok,M_piv=symmetric_positive_definite_ldlt(matrix_symmetric_hull(Mint))
+    if not M_ok:
+        return {"metric_spd":False,"projected_strict":False,"metric_pivots_lower":[float(x.lo) for x in M_piv],"projected_pivots_lower":[]}
+
+    AZ=_interval_columns(A_family,keep)
+    pull=matrix_mul(matrix_mul(matrix_transpose(AZ),Mint),AZ)
+    rhoM=_point_scaled_principal(M,keep,rho)
+    R=matrix_symmetric_hull(matrix_sub(pull,rhoM))
+    ok,piv=symmetric_positive_definite_ldlt(matrix_symmetric_hull(_neg(R)))
+    return {
+        "metric_spd":True,
+        "projected_strict":bool(ok),
+        "dimension":n,
+        "unsupplied_dimension":len(keep),
+        "supplied_indices":list(idx),
+        "rho":float(rho),
+        "metric_pivots_lower":[float(x.lo) for x in M_piv],
+        "projected_pivots_lower":[float(x.lo) for x in piv],
+        "worst_projected_ldlt_pivot_lower":min((float(x.lo) for x in piv),default=math.inf),
+        "interval_family_consumed":True,
+        "ordinary_eigenvalue_used_for_certificate":False,
+    }
+
+
+def certify_joint24_bias_supply_family(A_family, M, rho: float) -> dict:
+    return certify_projected_interval_family(A_family,M,rho,MASTER.NEUTRAL_INDICES)
+
+
+def build() -> dict:
+    master=MASTER.build(); mf=MASTER.validate(master)
+    if mf: raise RuntimeError("neutral-supply reduction prerequisite failed: "+repr(mf))
+    return {
+        "qualification":QUALIFICATION,
+        "canonical_source":"COMPLETE_BRMM_NORMAL_LIVE_WORD",
+        "phase1_storage_search_allowed_consumed":master["phase1_storage_search_allowed_consumed"],
+        "joint24_bias_reference_supply_selector_consumed":master["neutral_indices"],
+        "outward_interval_family_arithmetic":True,
+        "outward_full_matrix_LDLT_terminal_gate":True,
+        "common_metric_point_candidate_only":True,
+        "source_uniform_endpoint_family_must_be_proved_by_caller":True,
+        "replay_or_finite_sample_family_is_qualification":False,
+        "source_uniform_endpoint_family_enclosure_closed":False,
+        "common_M_source_uniform_projected_LDLT_closed":False,
+        "ALT_LIVE_PASS":False,
+        "next_obligation":"construct a proved interval/structured enclosure of every H18 and A21 endpoint joint24 homogeneous map from the universal physical word relation, then search one M,rho and certify both families with certify_joint24_bias_supply_family",
+    }
+
+
+def validate(d):
+    f=[]
+    if d.get("qualification")!=QUALIFICATION or d.get("canonical_source")!="COMPLETE_BRMM_NORMAL_LIVE_WORD": f.append("qualification/source mismatch")
+    for k in ("phase1_storage_search_allowed_consumed","outward_interval_family_arithmetic","outward_full_matrix_LDLT_terminal_gate","common_metric_point_candidate_only","source_uniform_endpoint_family_must_be_proved_by_caller"):
+        if d.get(k) is not True: f.append(k+" not true")
+    for k in ("replay_or_finite_sample_family_is_qualification","source_uniform_endpoint_family_enclosure_closed","common_M_source_uniform_projected_LDLT_closed","ALT_LIVE_PASS"):
+        if d.get(k) is not False: f.append(k+" not false")
+    if d.get("joint24_bias_reference_supply_selector_consumed")!=list(MASTER.NEUTRAL_INDICES): f.append("neutral selector changed")
+    return f

--- a/tools/stability/ou3_alt_contraction/proof_plan.py
+++ b/tools/stability/ou3_alt_contraction/proof_plan.py
@@ -1,0 +1,34 @@
+"""Executable anti-dead-end phase guards for the ALT proof workflow.
+
+These guards are process controls, not mathematical evidence.  They prevent a
+metric/high-precision/storage task from being accidentally treated as useful
+proof work before the physical source-uniform word exists.
+"""
+from __future__ import annotations
+
+DIAGNOSTIC_ONLY = {"replay", "finite_seed", "unreachable_perturbation", "captured_trace"}
+
+
+def require_theorem_task(*, obligation: str, evidence_kind: str, complete_physical_word: bool,
+                         requested_phase: str) -> None:
+    if not isinstance(obligation,str) or not obligation.strip():
+        raise RuntimeError("ALT task has no named theorem obligation")
+    if evidence_kind in DIAGNOSTIC_ONLY:
+        raise RuntimeError("diagnostic-only evidence cannot be the main ALT proof task")
+    if requested_phase in {"storage_search","high_precision_master","interval_refinement"} and not complete_physical_word:
+        raise RuntimeError("complete source-uniform physical word is required before storage/high-precision/refinement")
+
+
+def storage_search_allowed(status: dict) -> bool:
+    required=("same_history_complete_BRMM_word","physical_prediction_forcing_attached",
+              "physical_S_residual_attached","all_bias_families_attached",
+              "all_literal_branches_attached","H18_A21_edge_attached")
+    return all(status.get(k) is True for k in required)
+
+
+def assert_storage_search_allowed(status: dict) -> None:
+    if not storage_search_allowed(status):
+        missing=[k for k in ("same_history_complete_BRMM_word","physical_prediction_forcing_attached",
+              "physical_S_residual_attached","all_bias_families_attached",
+              "all_literal_branches_attached","H18_A21_edge_attached") if status.get(k) is not True]
+        raise RuntimeError("ALT storage search blocked; incomplete theorem word: "+", ".join(missing))

--- a/tools/stability/ou3_alt_contraction/proof_plan.py
+++ b/tools/stability/ou3_alt_contraction/proof_plan.py
@@ -32,3 +32,21 @@ def assert_storage_search_allowed(status: dict) -> None:
               "physical_S_residual_attached","all_bias_families_attached",
               "all_literal_branches_attached","H18_A21_edge_attached") if status.get(k) is not True]
         raise RuntimeError("ALT storage search blocked; incomplete theorem word: "+", ".join(missing))
+
+
+def assert_finite_storage_master(status: dict) -> None:
+    """Reject a Jacobian/metadata assembly as input to a finite-state rho search.
+
+    This is an additional process guard, not mathematical evidence. A finite
+    identity and its source coverage must be proved by the supplying builder.
+    In particular the older six assembly flags cannot imply these obligations.
+    """
+    required = ('finite_error_identity_for_every_event',
+                'physical_reference_forcing_retained',
+                'all_coefficient_product_graphs_retained',
+                'all_configured_branches_bound_to_finite_graph')
+    missing = [k for k in required if status.get(k) is not True]
+    if status.get('map_representation') != 'finite_physical_descriptor':
+        missing.insert(0, 'finite_physical_descriptor (not a Jacobian cocycle)')
+    if missing:
+        raise RuntimeError('ALT finite-state storage blocked: '+', '.join(missing))

--- a/tools/stability/ou3_alt_contraction/regional_error_domain.py
+++ b/tools/stability/ou3_alt_contraction/regional_error_domain.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""ALT binding of the declared full-scale regional Normal-Live error domain.
+
+The P4 closure-domain JSON contains deterministic error-coordinate working scales
+that are explicitly *not* covariance-confidence bounds and *not* a replay fit.
+Those constants are useful to define the regional Live theorem, but ALT must not
+call ``ou3_p4_hard_entry_set.build()`` because that builder also executes a
+fresh-startup reachability proof.  Startup is a separate ALT phase.
+
+This module reads only the declared working-domain constants, verifies that no
+scale shrink is allowed, and exposes them as a conditional regional hypothesis.
+It makes no claim that startup has entered the domain.
+"""
+from __future__ import annotations
+import json,math
+from pathlib import Path
+
+REPO=Path(__file__).resolve().parents[3]
+CLOSURE=REPO/'tools/stability/ou3_p4_closure_domain.json'
+QUALIFICATION='OU3_ALT_REGIONAL_NORMAL_LIVE_ERROR_DOMAIN_V1'
+EXPECTED=(
+ 'attitude_cayley_norm','gyro_bias_norm_rad_s','velocity_norm_mps','position_norm_m',
+ 'integral_displacement_norm_m_s','latent_acceleration_norm_mps2','accelerometer_bias_error_norm_mps2')
+
+def build(path:Path=CLOSURE):
+    root=json.loads(Path(path).read_text());h=root['hard_entry_search'];scale=float(h['minimum_certified_scale']);candidates=list(map(float,h['candidate_scale_factors']));r={k:math.nextafter(float(v),math.inf) for k,v in h['base_coordinate_radii'].items()}
+    if scale!=1.0 or candidates!=[1.0] or h.get('requires_full_declared_scale') is not True:raise RuntimeError('declared regional error domain was shrunk')
+    if tuple(r.keys())!=EXPECTED:raise RuntimeError('regional error-coordinate schema changed')
+    if any(not math.isfinite(v) or v<=0 for v in r.values()):raise RuntimeError('regional error radius invalid')
+    return {'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD','scope':'conditional regional Normal-Live theorem domain','coordinate_radii':r,'full_declared_scale':scale,'proof_error_domain_shrunk':False,'trajectory_fit':False,'covariance_membership_used':False,'fresh_startup_reachability_consumed':False,'startup_membership_claimed_here':False,'regional_membership_is_theorem_hypothesis':True,'physical_S_bound_taken_from_this_error_radius':False,'legacy_S_error_radius_m_s':r['integral_displacement_norm_m_s'],'ALT_STARTUP_PASS':False}
+def validate(d):
+    f=[]
+    if d.get('qualification')!=QUALIFICATION or d.get('canonical_source')!='COMPLETE_BRMM_NORMAL_LIVE_WORD':f.append('qualification/source mismatch')
+    for k in ('regional_membership_is_theorem_hypothesis',):
+        if d.get(k) is not True:f.append(k+' not true')
+    for k in ('proof_error_domain_shrunk','trajectory_fit','covariance_membership_used','fresh_startup_reachability_consumed','startup_membership_claimed_here','physical_S_bound_taken_from_this_error_radius','ALT_STARTUP_PASS'):
+        if d.get(k) is not False:f.append(k+' not false')
+    if float(d.get('full_declared_scale',0))!=1.0:f.append('regional scale changed')
+    r=d.get('coordinate_radii',{})
+    if tuple(r.keys())!=EXPECTED:f.append('regional coordinate schema mismatch')
+    return f


### PR DESCRIPTION
## Single ALT continuation

Continue only this PR (`proof/ou3-alt-physical-master`). It supersedes closed, unmerged PRs #519, #520 and #521. Their replay/finite-perturbation diagnostics are not accepted as source-uniform theorem evidence. The deployed filter and original P2/P3/P4/P5 route remain unchanged and independently continuable.

## Current status — finite word still OPEN

The prior Phase-1 assembly labels do **not** establish the complete finite physical error map. The current endpoint composer multiplies pointwise state/source Jacobians; without an anchored finite-map bridge, those products are not the finite endpoint error. Nonzero physical S forcing makes this distinction essential.

Commit `eca52f231375437a99106ec1ae4c053bd9078af0` adds a positive mathematical step and blocks premature metric work. No source-uniform rho, useful ultimate bound, basin, startup capture or deployment certificate is claimed.

## Proved accepted-measurement algebra

The new proof note is `docs/ou3-alt-finite-measurement-proof.md`; implementation is `tools/stability/ou3_alt_contraction/finite_measurement_graph.py`.

For finite Cayley attitude error c, define U=4I+2[c]x+cc'. The actual normalized quaternion correction (w,k*d) gives the exact finite identity

```
W=2w+k*c'd,
W*(c_after-c)+k*U*d=0.
```

Universal polynomial coefficient checks cover all eight indeterminates and hence both quaternion branches, subject to their actual hard graphs and a nonzero chart denominator. No linearized reset is substituted.

Exact accelerometer/magnetometer secants, `r_S=e_S-S_phys`, the actual masked full21 covariance operands, and same-beta radial projection give

```
z_after=P_alpha*(z-B*q),   Sigma*q=Hbar*z+nu,
```

with B of size 24x3. The full joint24 storage contribution uses thin factors and a 3x3 core while retaining every motion/bias/truth cross term. It is an exact real-arithmetic identity, not a negative-sign certificate or a source cover.

The held covariance bridge retains BA uncertainty: under the zero-cross-block held invariant, the reduced accelerometer innovation uses `R_acc+B0`, not bare `R_acc`. The shared reduced kernel's earlier covariance ancestry still needs that binding; changing only its final gain would not repair it.

## Guarded plan

`docs/ou3-alt-proof-plan.md` is normative. G13 now explicitly rejects a Jacobian cocycle, source token or TRUE assembly metadata as a finite physical master. Both common-metric entry points and their candidate helper invoke the guard before coarse endpoint/rho calculations. First close the finite event/reference/branch/product graph; then search one common coercive joint24 storage with justified neutral/source supply.

Preserve the corrected COMPLETE-BRMM source, correlated q15 prediction forcing, one Live S origin, BIAS0/1/2 with one shared driver/root, same-signal frontend/tuner state, actual anisotropic R_S, all configured branches and H18/A21 transitions. Rank-three is arithmetic optimization only. No replay fitting, unreachable-root qualification, state marginalization, source-envelope shrinkage or gate relaxation.

## Validation and remaining implementation failures

49 focused tests pass, including exact coefficient proofs, finite-map/storage regressions, H18/Bias checks and real metric-entry guard tests. The BIAS2 adapter now preserves the certified phi=1 endpoint; real squared coefficients are outward; the release max operation preserves its represented fixed point.

The broader recovered-source suite ran 73 tests with eight remaining `float('44/5')` parsing errors in moment-sector paths. Required `make all` failed on missing `Eigen/Dense` at the default Eigen include path. Later unrelated coarse-outer modules on this branch were preserved, not claimed fully tested locally. The detailed command, source provenance and limitations are recorded in the continuation comment. No all-CI-green claim is made.

## Next theorem obligation

Compose the finite measurement descriptors with physical prediction forcing and actual held/active covariance/frontend lineage. Retain continuous physical rotation versus sampled-gyro defects, every configured accepted/rejected/asynchronous branch, one bias root/driver and one Live primitive origin. Only after that finite relation closes may common-joint24 storage and outward endpoint/every-prefix certification proceed. Startup remains a separate later capture theorem.

`ALT_LIVE_PASS=false`, `ALT_STARTUP_PASS=false`, `ALT_END_TO_END_PASS=false`. Original P4/P5 remain unpromoted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Capabilities**
  - Added formal validation for physical event handling, source lineage, bias families, hybrid transitions, finite prediction, and Live-state invariants.
  - Added exact finite measurement descriptors, endpoint outer analysis, and common-storage qualification checks.
  - Added safeguards that prevent incomplete proof paths from being treated as release-ready.

- **Documentation**
  - Added an execution plan and handover guidance covering proof stages, safeguards, and promotion criteria.

- **Tests**
  - Expanded regression coverage across event composition, covariance, continuity, asynchronous events, storage, and phase closure.
  - Confirmed startup capture, storage search, and end-to-end promotion remain blocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->