### PR TITLE
OU-III non-ALT: magnetometer classes, two-phase Mahony certificate, and the frequency-response floor that rules out the route

### DIFF
--- a/.github/workflows/ou3-brmm-magnetic-assumptions.yml
+++ b/.github/workflows/ou3-brmm-magnetic-assumptions.yml
@@ -1,0 +1,122 @@
+name: ou3-brmm-magnetic-assumptions
+
+on:
+  push:
+    paths:
+      - "tools/stability/ou3_brmm_magnetic_source_envelope.py"
+      - "tools/stability/ou3_brmm_magnetic_call_schedule.py"
+      - "tools/stability/ou3_brmm_magnetic_startup_yaw_capture.py"
+      - "tools/stability/ou3_brmm_private_mahony_live_invariant.py"
+      - "tools/stability/ou3_brmm_gravity_direction_forcing_qualification.py"
+      - "tools/stability/ou3_proof_operating_domain.json"
+      - "tests/validation/test_ou3_brmm_magnetic_assumptions.py"
+      - "src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h"
+      - "src/tuner/MagAutoTuner.h"
+      - ".github/workflows/ou3-brmm-magnetic-assumptions.yml"
+  pull_request:
+    paths:
+      - "tools/stability/ou3_brmm_magnetic_source_envelope.py"
+      - "tools/stability/ou3_brmm_magnetic_call_schedule.py"
+      - "tools/stability/ou3_brmm_magnetic_startup_yaw_capture.py"
+      - "tools/stability/ou3_brmm_private_mahony_live_invariant.py"
+      - "tools/stability/ou3_brmm_gravity_direction_forcing_qualification.py"
+      - "tools/stability/ou3_proof_operating_domain.json"
+      - "tests/validation/test_ou3_brmm_magnetic_assumptions.py"
+      - "src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h"
+      - "src/tuner/MagAutoTuner.h"
+      - ".github/workflows/ou3-brmm-magnetic-assumptions.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ou3-brmm-magnetic-assumptions-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  magnetic-assumptions:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Compile magnetic assumption sources
+        run: |
+          python3 -m py_compile \
+            tools/stability/ou3_brmm_magnetic_source_envelope.py \
+            tools/stability/ou3_brmm_magnetic_call_schedule.py \
+            tools/stability/ou3_brmm_magnetic_startup_yaw_capture.py
+      - name: Execute the named magnetic certificates
+        run: |
+          mkdir -p /tmp/ou3-brmm-magnetic
+          python3 tools/stability/ou3_brmm_magnetic_source_envelope.py --output /tmp/ou3-brmm-magnetic/envelope.json
+          python3 tools/stability/ou3_brmm_magnetic_call_schedule.py --output /tmp/ou3-brmm-magnetic/schedule.json
+          python3 tools/stability/ou3_brmm_magnetic_startup_yaw_capture.py --output /tmp/ou3-brmm-magnetic/capture.json
+          python3 - <<'PY'
+          import json
+          root='/tmp/ou3-brmm-magnetic/'
+          e=json.load(open(root+'envelope.json'))
+          s=json.load(open(root+'schedule.json'))
+          c=json.load(open(root+'capture.json'))
+          for name,d in (('envelope',e),('schedule',s),('capture',c)):
+              assert d['validation_pass'], (name, d['validation_failures'])
+
+          # --- closed here -------------------------------------------------
+          assert e['assumption_id'] == 'MAG-BMM150-DET-v1'
+          assert e['measured_body_field_norm_lower_uT'] == 13.0
+          assert e['declared_PE_magnetic_floor_is_now_derived'] is True
+          assert e['declared_PE_magnetic_ceiling_is_now_derived'] is True
+          assert e['shipping_mag_norm_guard_cleared_unconditionally'] is True
+          assert s['assumption_id'] == 'MAG-CALL-SCHEDULE-v1'
+          assert s['H18_A21_RELEASE_TIME_CLOSED'] is True
+          assert abs(s['H18_A21_release_time_upper_s'] - 10.0) < 1e-12
+          assert s['release']['strict_one_second_guard_forced'] is True
+          assert c['DECLARED_SUPPLY_ENTRANCE_CLOSED'] is True
+          assert c['declared_supply_branch']['sin_yaw_error_upper_exact'] == '17/30'
+          assert abs(c['declared_supply_branch']['full_attitude_rad_upper'] - 0.63) < 1e-12
+          assert c['declared_supply_branch']['full_attitude_deg_upper'] < c['declared_entrance_full_attitude_deg']
+
+          # --- still open, fail-closed -------------------------------------
+          assert e['norm_ratio_gate']['universal_sample_admission_forced'] is False
+          assert e['accumulation_frame_error_supply_is_open_obligation'] is True
+          assert e['declared_startup_direction_error_is_the_accumulation_frame_error'] is False
+          assert e['magnetic_vector_sine_separation_derivable_from_this_class'] is False
+          assert s['eventual_A21_under_arbitrary_external_acc_bias_hold_claimed'] is False
+          assert s['H18_A21_covariance_transport_closed_here'] is False
+          assert c['CERTIFIED_SUPPLY_ENTRANCE_CLOSED'] is False
+          assert c['accumulation_frame_tilt_supply_discharged'] is False
+          assert c['timeout_branch_yaw_gauge_forced'] is False
+          assert c['certified_supply_branch']['magnetic_capture_forced_from_certified_supply'] is False
+          assert c['certified_supply_branch']['gate_shortfall_factor'] > 1.0
+          assert c['forcing_scaling_argument']['metric_refinement_alone_cannot_reach_requirement'] is True
+          assert len(c['alternatives']) >= 3
+          for d in (e, s, c):
+              assert d['filter_changed'] is False
+              assert d['quality_gates_changed'] is False
+              assert d['trajectory_replay_used'] is False
+          assert e['P4_promoted_here'] is False and e['P5_promoted_here'] is False
+          assert c['P4_basin_reached_here'] is False and c['P5_end_to_end_closed_here'] is False
+
+          r=e['derived_tilt_requirements']
+          print('BINDING_GATE', r['binding_requirement'])
+          print('REQUIRED_TILT_DEG', r['max_tilt_deg_for_horizontal_fraction_gate'])
+          print('NORTH_CAPTURE_TILT_DEG', r['max_tilt_deg_for_north_capture'])
+          print('CERTIFIED_TILT_DEG', c['certified_supply_branch']['certified_tilt_deg_upper'])
+          print('GATE_SHORTFALL_FACTOR', c['certified_supply_branch']['gate_shortfall_factor'])
+          print('METRIC_FREE_FLOOR_DEG', c['forcing_scaling_argument']['metric_free_tilt_floor_deg'])
+          print('METRIC_FREE_SHORTFALL_FACTOR', c['forcing_scaling_argument']['shortfall_factor'])
+          print('UNIVERSAL_ADMISSION_BUDGET_UT', e['norm_ratio_gate']['universal_admission_perturbation_budget_uT'])
+          print('H18_A21_RELEASE_S', s['H18_A21_release_time_upper_s'])
+          print('DECLARED_SUPPLY_FULL_ATTITUDE_DEG', c['declared_supply_branch']['full_attitude_deg_upper'])
+          PY
+      - name: Test magnetic assumption certificates
+        working-directory: tests/validation
+        run: python3 -m unittest -v test_ou3_brmm_magnetic_assumptions
+      - uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: ou3-brmm-magnetic-assumptions
+          path: /tmp/ou3-brmm-magnetic/
+          retention-days: 7

--- a/.github/workflows/ou3-brmm-magnetic-assumptions.yml
+++ b/.github/workflows/ou3-brmm-magnetic-assumptions.yml
@@ -88,9 +88,29 @@ jobs:
           assert c['CERTIFIED_SUPPLY_ENTRANCE_CLOSED'] is False
           assert c['accumulation_frame_tilt_supply_discharged'] is False
           assert c['timeout_branch_yaw_gauge_forced'] is False
-          assert c['certified_supply_branch']['magnetic_capture_forced_from_certified_supply'] is False
-          assert c['certified_supply_branch']['gate_shortfall_factor'] > 1.0
-          assert c['forcing_scaling_argument']['metric_refinement_alone_cannot_reach_requirement'] is True
+          assert c['private_observer_can_supply_the_declared_gates'] is False
+          assert c['quadratic_metric_class_ruled_out'] is True
+          cb=c['certified_supply_branch']
+          # The two-phase Mahony certificate closes, so the supply exists and is
+          # consumed; it is simply far too weak for the gates.
+          assert cb['invariant_closed_at_padded_envelope'] is True
+          assert cb['invariant_validation_failures'] == []
+          assert cb['two_phase_certificate_consumed'] is True
+          assert cb['magnetic_capture_forced_from_certified_supply'] is False
+          assert cb['magnetic_capture_forced_from_ultimate_supply'] is False
+          assert cb['gate_shortfall_factor'] > 1.0
+          assert cb['ultimate_gate_shortfall_factor'] > 1.0
+          assert cb['ultimate_north_capture_shortfall_factor'] > 1.0
+          # The formulation floor rules out any metric or level, not just one.
+          fl=c['declared_formulation_tilt_floor']
+          assert fl['is_formulation_lower_bound_not_physical_claim'] is True
+          assert fl['no_metric_or_level_can_reach_requirement'] is True
+          assert fl['peak_frequency_inside_declared_wave_band'] is True
+          import math as _m
+          assert _m.degrees(fl['declared_formulation_tilt_floor_rad']) > cb['required_tilt_deg_for_north_capture']
+          # Alternative 2 is quantified rather than asserted.
+          nar=c['required_envelope_narrowing_at_the_floor']
+          assert all(r['feasible_within_total_field'] for r in nar['rows'])
           assert len(c['alternatives']) >= 3
           for d in (e, s, c):
               assert d['filter_changed'] is False
@@ -103,10 +123,15 @@ jobs:
           print('BINDING_GATE', r['binding_requirement'])
           print('REQUIRED_TILT_DEG', r['max_tilt_deg_for_horizontal_fraction_gate'])
           print('NORTH_CAPTURE_TILT_DEG', r['max_tilt_deg_for_north_capture'])
-          print('CERTIFIED_TILT_DEG', c['certified_supply_branch']['certified_tilt_deg_upper'])
-          print('GATE_SHORTFALL_FACTOR', c['certified_supply_branch']['gate_shortfall_factor'])
-          print('METRIC_FREE_FLOOR_DEG', c['forcing_scaling_argument']['metric_free_tilt_floor_deg'])
-          print('METRIC_FREE_SHORTFALL_FACTOR', c['forcing_scaling_argument']['shortfall_factor'])
+          print('CERTIFIED_TILT_ALL_TIME_DEG', cb['certified_tilt_deg_upper'])
+          print('CERTIFIED_TILT_AT_150S_DEG', cb['certified_tilt_at_deployed_horizon_deg_upper'])
+          print('CERTIFIED_TILT_ULTIMATE_DEG', cb['certified_ultimate_tilt_deg_upper'])
+          print('GATE_SHORTFALL_FACTOR', cb['gate_shortfall_factor'])
+          print('ULTIMATE_GATE_SHORTFALL_FACTOR', cb['ultimate_gate_shortfall_factor'])
+          print('FORMULATION_FLOOR_DEG', fl['declared_formulation_tilt_floor_deg'])
+          print('FORMULATION_FLOOR_SHORTFALL_FACTOR', fl['shortfall_factor'])
+          print('PEAK_FREQUENCY_HZ', fl['peak_frequency_hz'], 'BAND', fl['declared_wave_band_hz'])
+          print('REQUIRED_NARROWING_AT_FLOOR', [(x['world_field_norm_upper_uT'], x['required_horizontal_floor_uT']) for x in nar['rows']])
           print('UNIVERSAL_ADMISSION_BUDGET_UT', e['norm_ratio_gate']['universal_admission_perturbation_budget_uT'])
           print('H18_A21_RELEASE_S', s['H18_A21_release_time_upper_s'])
           print('DECLARED_SUPPLY_FULL_ATTITUDE_DEG', c['declared_supply_branch']['full_attitude_deg_upper'])

--- a/.github/workflows/ou3-brmm-magnetic-assumptions.yml
+++ b/.github/workflows/ou3-brmm-magnetic-assumptions.yml
@@ -70,10 +70,16 @@ jobs:
           assert e['declared_PE_magnetic_ceiling_is_now_derived'] is True
           assert e['shipping_mag_norm_guard_cleared_unconditionally'] is True
           assert s['assumption_id'] == 'MAG-CALL-SCHEDULE-v1'
-          assert s['H18_A21_RELEASE_TIME_CLOSED'] is True
-          assert abs(s['H18_A21_release_time_upper_s'] - 10.0) < 1e-12
-          assert s['release']['strict_one_second_guard_forced'] is True
-          assert c['DECLARED_SUPPLY_ENTRANCE_CLOSED'] is True
+          # Release time after north lock, derived by a case split on which of
+          # the count and the strict guard binds last. The gap bound is an
+          # UPPER bound and cannot prove `elapsed > guard` on its own.
+          assert s['H18_A21_RELEASE_TIME_CLOSED_AFTER_NORTH_LOCK'] is True
+          assert abs(s['H18_A21_release_time_after_north_lock_upper_s'] - 10.0) < 1e-12
+          assert s['release']['release_derived_by_case_split_not_upper_bound_comparison'] is True
+          assert s['release']['lower_bound_on_call_spacing_assumed'] is False
+          assert s['shipping_parity']['counter_call_is_behind_north_lock_gate'] is True
+          # The magnetic yaw algebra closes; the supply for it does not.
+          assert c['magnetic_algebra_closed'] is True
           assert c['declared_supply_branch']['sin_yaw_error_upper_exact'] == '17/30'
           assert abs(c['declared_supply_branch']['full_attitude_rad_upper'] - 0.63) < 1e-12
           assert c['declared_supply_branch']['full_attitude_deg_upper'] < c['declared_entrance_full_attitude_deg']
@@ -85,6 +91,22 @@ jobs:
           assert e['magnetic_vector_sine_separation_derivable_from_this_class'] is False
           assert s['eventual_A21_under_arbitrary_external_acc_bias_hold_claimed'] is False
           assert s['H18_A21_covariance_transport_closed_here'] is False
+          # The counter sits behind the outer north-lock gate, so the release is
+          # unreachable on the admitted ungauged timeout path.
+          assert s['H18_A21_RELEASE_TIME_CLOSED_FROM_LIVE'] is False
+          assert s['counter_advances_without_north_lock'] is False
+          assert s['ungauged_timeout_path_reaches_the_release'] is False
+          assert s['north_lock_is_an_unmet_prerequisite_on_this_route'] is True
+          # The accumulation frame turns with the vessel; no declared quantity
+          # bounds a startup heading excursion, so both supply rows stay open.
+          assert e['derived_tilt_requirements']['parameter'] == 'TOTAL_ACCUMULATION_FRAME_ROTATION_EXCURSION_TILT_PLUS_HEADING'
+          assert e['accumulation_frame_retains_vessel_heading'] is True
+          assert e['heading_excursion_bounded_by_this_class'] is False
+          assert e['startup_heading_excursion_declared_in_operating_domain'] is False
+          assert c['DECLARED_SUPPLY_ENTRANCE_CLOSED'] is False
+          assert c['total_excursion_supply_exists'] is False
+          assert c['heading_excursion_charged_as_tilt'] is False
+          assert c['shipping_parity']['parity_compares_complete_expressions_not_tokens'] is True
           assert c['CERTIFIED_SUPPLY_ENTRANCE_CLOSED'] is False
           assert c['accumulation_frame_tilt_supply_discharged'] is False
           assert c['timeout_branch_yaw_gauge_forced'] is False
@@ -111,7 +133,7 @@ jobs:
           # Alternative 2 is quantified rather than asserted.
           nar=c['required_envelope_narrowing_at_the_floor']
           assert all(r['feasible_within_total_field'] for r in nar['rows'])
-          assert len(c['alternatives']) >= 3
+          assert len(c['alternatives']) >= 4
           for d in (e, s, c):
               assert d['filter_changed'] is False
               assert d['quality_gates_changed'] is False
@@ -133,7 +155,8 @@ jobs:
           print('PEAK_FREQUENCY_HZ', fl['peak_frequency_hz'], 'BAND', fl['declared_wave_band_hz'])
           print('REQUIRED_NARROWING_AT_FLOOR', [(x['world_field_norm_upper_uT'], x['required_horizontal_floor_uT']) for x in nar['rows']])
           print('UNIVERSAL_ADMISSION_BUDGET_UT', e['norm_ratio_gate']['universal_admission_perturbation_budget_uT'])
-          print('H18_A21_RELEASE_S', s['H18_A21_release_time_upper_s'])
+          print('H18_A21_RELEASE_AFTER_NORTH_LOCK_S', s['H18_A21_release_time_after_north_lock_upper_s'])
+          print('RELEASE_BINDING_CONDITION', s['release']['binding_condition'])
           print('DECLARED_SUPPLY_FULL_ATTITUDE_DEG', c['declared_supply_branch']['full_attitude_deg_upper'])
           PY
       - name: Test magnetic assumption certificates

--- a/.github/workflows/ou3-complete-brmm.yml
+++ b/.github/workflows/ou3-complete-brmm.yml
@@ -114,7 +114,13 @@ jobs:
           assert c['same_physical_motion_drives_translation_and_rotation'] is True
           assert c['only_same_history_BRMM_realization_may_generate_P3_words'] is True
           assert c['moment_or_probability_bound_may_not_generate_P3_word'] is True
-          assert c['pathwise_non_gravitational_cog_acceleration_norm_upper_mps2'] == 8.0
+          # The pathwise cap comes from the operating domain, so the assertion
+          # tracks the declared padded envelope rather than pinning the retired
+          # 8.0 m/s^2 surface.
+          _declared=json.load(open('tools/stability/ou3_proof_operating_domain.json'))['normal_live']['non_gravitational_cog_acceleration_norm_upper_mps2']
+          assert c['pathwise_non_gravitational_cog_acceleration_norm_upper_mps2'] == _declared, (
+              c['pathwise_non_gravitational_cog_acceleration_norm_upper_mps2'], _declared)
+          assert _declared >= 8.8
           s=d['stochastic_forcing_corollary']
           assert s['used_to_generate_P3_source_words'] is False
           assert s['used_to_prune_homogeneous_P3_family'] is False

--- a/.github/workflows/ou3-p5-startup-capture.yml
+++ b/.github/workflows/ou3-p5-startup-capture.yml
@@ -62,43 +62,72 @@ jobs:
           assert d['P4_promoted_here'] is False and d['P5_promoted_here'] is False
           print('PADDED_DIRECTION_ANGLE_DEG', d['instantaneous_direction_angle_upper_deg'])
           PY
-      - name: Record padded Mahony startup obstruction fail-closed
+      - name: Execute the two-phase padded Mahony certificate
         run: |
-          # The certificate is expected to fail at the padded envelope.  CI
-          # records the exact obstruction instead of crashing on a stale
-          # constant: the level needed to contain the accelerometer seed and the
-          # largest level inside the 87 deg chart form an empty window.
-          python3 tools/stability/ou3_brmm_private_mahony_live_invariant.py --output /tmp/ou3-p5-startup/continuous.json || true
+          python3 tools/stability/ou3_brmm_private_mahony_live_invariant.py --output /tmp/ou3-p5-startup/continuous.json
           python3 - <<'PY'
           import json
           c=json.load(open('/tmp/ou3-p5-startup/continuous.json'))
-          assert c['validation_pass'] is False, 'padded Mahony invariant unexpectedly closed; update this gate deliberately'
-          assert c['continuous_all_live_PI_invariant_closed'] is False
-          assert c['initial_set_inside_invariant'] is False
-          w=c['admissible_level_window']
-          assert w['window_nonempty'] is False
-          assert w['emptiness_factor'] > 1.0
-          g=c['BRMM_direction_geometry']
-          assert g['initial_seed_angle_closed'] is True
-          assert abs(g['initial_seed_tilt_rad_upper'] - 1.1137282529726653) < 1e-12
-          # Retained geometry that a successor certificate may still consume.
+          assert c['validation_pass'], c['validation_failures']
+          assert c['continuous_all_live_PI_invariant_closed'] is True
           assert c['invariant_strictly_inside_87deg_chart'] is True
-          assert c['boundary_validation']['strict_inward_margin_lower'] > 0.0
-          print('SEED_TILT_DEG', g['initial_seed_tilt_deg_upper'])
-          print('LEVEL_WINDOW', w['level_lower_required_to_contain_seed'], w['level_upper_allowed_by_proof_chart'])
-          print('EMPTINESS_FACTOR', w['emptiness_factor'])
+          assert c['invariant_strictly_inside_60deg_chart'] is False
+          # The seed angle is the source's own asin(8.8/g), not a frozen constant.
+          g=c['BRMM_direction_geometry']
+          assert g['seed_tilt_dominates_source_angle'] is True
+          assert 63.0 < g['seed_tilt_deg_upper'] < 64.0
+          # Three level constraints jointly satisfied by two nested levels.
+          w=c['two_phase_levels']
+          assert w['seed_level_required'] <= w['outer_level_C'] < w['chart_level_ceiling']
+          assert w['seed_contained_in_outer_level'] is True
+          assert w['outer_level_inside_chart'] is True
+          assert w['chart_headroom_relative'] > 0.0
+          assert w['inner_level_C'] < w['outer_level_C']
+          # Strict inward flow on both level boundaries.
+          for key in ('boundary_validation','inner_boundary_validation'):
+              assert c[key]['closed'] is True, key
+              assert c[key]['strict_inward_margin_lower'] > 0.0, key
+          # Exponential capture into the inner level, then an ultimate bound.
+          cap=c['capture']
+          assert cap['inner_level_above_minimal'] is True
+          assert cap['contraction_rate_lower_per_s'] > 0.0
+          assert cap['sqrt_level_at_horizon_upper'] < c['sqrt_C']
+          assert cap['capture_uses_deployed_timeout_as_hypothesis'] is False
+          assert c['ultimate_tilt_deg_upper'] < c['tilt_at_deployed_horizon_deg_upper'] < c['actual_tilt_deg_upper'] < 87.0
+          assert c['metric_tuned_toward_magnetic_requirement'] is False
+          assert c['P3_promoted'] is False
+          print('SEED_TILT_DEG', g['seed_tilt_deg_upper'])
+          print('LEVELS', w['seed_level_required'], w['outer_level_C'], w['chart_level_ceiling'])
+          print('CHART_HEADROOM', w['chart_headroom_relative'])
+          print('MARGINS', c['boundary_validation']['strict_inward_margin_lower'], c['inner_boundary_validation']['strict_inward_margin_lower'])
+          print('TILT_ALL_TIME_DEG', c['actual_tilt_deg_upper'])
+          print('TILT_AT_150S_DEG', c['tilt_at_deployed_horizon_deg_upper'])
+          print('TILT_ULTIMATE_DEG', c['ultimate_tilt_deg_upper'])
           PY
-      - name: Require the downstream startup chain to refuse, not compose
+      - name: Compose the downstream startup chain
         run: |
-          set +e
-          python3 tools/stability/ou3_brmm_private_mahony_discrete_invariant.py --output /tmp/ou3-p5-startup/discrete.json 2>/tmp/ou3-p5-startup/discrete.err
-          test $? -ne 0 || { echo 'discrete invariant must refuse on an unclosed continuous invariant'; exit 1; }
-          python3 tools/stability/ou3_startup_timeout_capture.py --output /tmp/ou3-p5-startup/capture.json 2>/tmp/ou3-p5-startup/capture.err
-          test $? -ne 0 || { echo 'timeout capture must refuse on an unclosed continuous invariant'; exit 1; }
-          set -e
-          grep -q 'continuous Mahony invariant invalid' /tmp/ou3-p5-startup/discrete.err
-          grep -q 'continuous Mahony invariant invalid' /tmp/ou3-p5-startup/capture.err
-          echo 'P5_STARTUP_CAPTURE_PADDED_FAIL_CLOSED'
+          python3 tools/stability/ou3_brmm_private_mahony_discrete_invariant.py --output /tmp/ou3-p5-startup/discrete.json
+          python3 tools/stability/ou3_startup_timeout_capture.py --output /tmp/ou3-p5-startup/capture.json
+          python3 - <<'PY'
+          import json
+          root='/tmp/ou3-p5-startup/'
+          b=json.load(open(root+'discrete.json')); p=json.load(open(root+'capture.json'))
+          for name,x in (('discrete',b),('capture',p)):
+              assert x['validation_pass'], (name, x['validation_failures'])
+          assert b['shipping_binary32_discrete_invariant_closed_conditionally_on_source_order'] is True
+          assert b['metric_read_from_continuous_certificate'] is True
+          # dot(V) carries ONE factor of sqrt(C); the retired form used two.
+          assert b['first_order_decrease_carries_single_sqrt_C'] is True
+          assert b['continuous_boundary_margin_after_binary32'] > 0.0
+          assert b['discrete_V_margin_lower'] > 0.0
+          assert b['toolchain_independent_binary32_invariant_closed'] is False
+          assert p['QUALIFIED_LIVE_HANDOFF_BY_150S_CLOSED'] is True
+          assert p['timeout_aligned_branch_margin_rad'] > 0.0
+          assert p['P4_basin_reached_here'] is False
+          assert p['P5_end_to_end_closed_here'] is False
+          print('BINARY32_DISCRETE_MARGIN', b['discrete_V_margin_lower'])
+          print('P5_STARTUP_CAPTURE_PADDED_PASS', p['qualified_proxy_tilt_upper_deg'], p['timeout_aligned_branch_margin_deg'])
+          PY
       - name: Test startup certificates
         working-directory: tests/validation
         run: |

--- a/.github/workflows/ou3-p5-startup-capture.yml
+++ b/.github/workflows/ou3-p5-startup-capture.yml
@@ -47,35 +47,67 @@ jobs:
             tools/stability/ou3_brmm_private_mahony_live_invariant.py \
             tools/stability/ou3_brmm_private_mahony_discrete_invariant.py \
             tools/stability/ou3_startup_timeout_capture.py
-      - name: Execute widened source and startup capture certificates
+      - name: Execute padded source qualification
         run: |
           mkdir -p /tmp/ou3-p5-startup
           python3 tools/stability/ou3_brmm_gravity_direction_forcing_qualification.py --output /tmp/ou3-p5-startup/direction.json
-          python3 tools/stability/ou3_brmm_private_mahony_live_invariant.py --output /tmp/ou3-p5-startup/continuous.json
-          python3 tools/stability/ou3_brmm_private_mahony_discrete_invariant.py --output /tmp/ou3-p5-startup/discrete.json
-          python3 tools/stability/ou3_startup_timeout_capture.py --output /tmp/ou3-p5-startup/capture.json
           python3 - <<'PY'
           import json
-          root='/tmp/ou3-p5-startup/'
-          d=json.load(open(root+'direction.json')); c=json.load(open(root+'continuous.json')); b=json.load(open(root+'discrete.json')); p=json.load(open(root+'capture.json'))
-          for name,x in [('direction',d),('continuous',c),('discrete',b),('capture',p)]:
-              assert x['validation_pass'], (name,x['validation_failures'])
-          assert d['pointwise_8mps2_cap_retained'] is True
-          assert 54.0 < d['instantaneous_direction_angle_upper_deg'] < 55.0
-          assert c['continuous_all_live_PI_invariant_closed'] is True
-          assert c['invariant_strictly_inside_87deg_chart'] is True
-          assert c['invariant_strictly_inside_60deg_chart'] is False
-          assert c['boundary_validation']['strict_inward_margin_lower'] > 0.0
-          assert b['shipping_binary32_discrete_invariant_closed_conditionally_on_source_order'] is True
-          assert b['continuous_boundary_margin_after_binary32'] > 0.0
-          assert b['discrete_V_margin_lower'] > 0.0
-          assert p['QUALIFIED_LIVE_HANDOFF_BY_150S_CLOSED'] is True
-          assert p['timeout_aligned_branch_margin_rad'] > 0.0
-          assert p['P4_basin_reached_here'] is False
-          assert p['P5_end_to_end_closed_here'] is False
-          print('P5_STARTUP_CAPTURE_8MPS2_PASS',p['qualified_proxy_tilt_upper_deg'],p['timeout_aligned_branch_margin_deg'])
+          d=json.load(open('/tmp/ou3-p5-startup/direction.json'))
+          assert d['validation_pass'], d['validation_failures']
+          assert d['pointwise_padded_acceleration_cap_retained'] is True
+          assert d['padded_acceleration_cap_mps2'] == 8.8
+          assert 63.0 < d['instantaneous_direction_angle_upper_deg'] < 64.0
+          assert d['low_frequency_false_gravity_is_explicitly_bounded'] is True
+          assert d['P4_promoted_here'] is False and d['P5_promoted_here'] is False
+          print('PADDED_DIRECTION_ANGLE_DEG', d['instantaneous_direction_angle_upper_deg'])
           PY
+      - name: Record padded Mahony startup obstruction fail-closed
+        run: |
+          # The certificate is expected to fail at the padded envelope.  CI
+          # records the exact obstruction instead of crashing on a stale
+          # constant: the level needed to contain the accelerometer seed and the
+          # largest level inside the 87 deg chart form an empty window.
+          python3 tools/stability/ou3_brmm_private_mahony_live_invariant.py --output /tmp/ou3-p5-startup/continuous.json || true
+          python3 - <<'PY'
+          import json
+          c=json.load(open('/tmp/ou3-p5-startup/continuous.json'))
+          assert c['validation_pass'] is False, 'padded Mahony invariant unexpectedly closed; update this gate deliberately'
+          assert c['continuous_all_live_PI_invariant_closed'] is False
+          assert c['initial_set_inside_invariant'] is False
+          w=c['admissible_level_window']
+          assert w['window_nonempty'] is False
+          assert w['emptiness_factor'] > 1.0
+          g=c['BRMM_direction_geometry']
+          assert g['initial_seed_angle_closed'] is True
+          assert abs(g['initial_seed_tilt_rad_upper'] - 1.1137282529726653) < 1e-12
+          # Retained geometry that a successor certificate may still consume.
+          assert c['invariant_strictly_inside_87deg_chart'] is True
+          assert c['boundary_validation']['strict_inward_margin_lower'] > 0.0
+          print('SEED_TILT_DEG', g['initial_seed_tilt_deg_upper'])
+          print('LEVEL_WINDOW', w['level_lower_required_to_contain_seed'], w['level_upper_allowed_by_proof_chart'])
+          print('EMPTINESS_FACTOR', w['emptiness_factor'])
+          PY
+      - name: Require the downstream startup chain to refuse, not compose
+        run: |
+          set +e
+          python3 tools/stability/ou3_brmm_private_mahony_discrete_invariant.py --output /tmp/ou3-p5-startup/discrete.json 2>/tmp/ou3-p5-startup/discrete.err
+          test $? -ne 0 || { echo 'discrete invariant must refuse on an unclosed continuous invariant'; exit 1; }
+          python3 tools/stability/ou3_startup_timeout_capture.py --output /tmp/ou3-p5-startup/capture.json 2>/tmp/ou3-p5-startup/capture.err
+          test $? -ne 0 || { echo 'timeout capture must refuse on an unclosed continuous invariant'; exit 1; }
+          set -e
+          grep -q 'continuous Mahony invariant invalid' /tmp/ou3-p5-startup/discrete.err
+          grep -q 'continuous Mahony invariant invalid' /tmp/ou3-p5-startup/capture.err
+          echo 'P5_STARTUP_CAPTURE_PADDED_FAIL_CLOSED'
+      - name: Test startup certificates
+        working-directory: tests/validation
+        run: |
+          python3 -m unittest -v \
+            test_ou3_brmm_private_mahony_live_invariant \
+            test_ou3_brmm_private_mahony_discrete_comparison \
+            test_ou3_brmm_private_mahony_state_step
       - uses: actions/upload-artifact@v6
+        if: always()
         with:
           name: ou3-p5-startup-capture
           path: /tmp/ou3-p5-startup/

--- a/docs/ou3-brmm-main-handover.md
+++ b/docs/ou3-brmm-main-handover.md
@@ -148,7 +148,37 @@ What they do not close:
 - eventual A21 under an arbitrary external `acc_bias_hold_`, and the
   `H18 -> A21` joint24 covariance transport itself.
 
-## Startup tilt supply is the limiting quantity
+## Two-phase private Mahony certificate
+
+The single-level formulation was infeasible at the padded `8.8 m/s^2` envelope:
+with the seed angle taken from the source's own `asin(8.8/g) = 1.1137 rad`, seed
+containment needed `C >= 1.8540056` while the 87 deg chart allowed
+`C < 1.4912551`. The boundary flow still closed with margin `0.0357940`, so the
+formulation, not the enclosure, was at fault.
+
+Because `q` and `sup` in
+
+`Vdot = -sqrt(C) [ sqrt(C) q - 2 sup ]`
+
+are level-*independent*, inward flow is a lower bound on the level and holds on
+*every* level above `W_in = 2 sup_max/q_min`. The certificate therefore uses two
+nested levels of one better-conditioned metric `p=3, c=11`
+(`P=[[1,-3],[-3,130]]`, `det=121`):
+
+- seed `1.6707881129` <= outer `1.7689` < chart ceiling `1.8726722863`
+  (headroom `5.5414%`), outer margin `0.0262974`;
+- inner level `sqrt(C_in)=1`, margin `0.0134738`, `W_in = 0.8578833`;
+- capture rate `q_min/2 = 0.0193788 /s`, time constant `51.6029 s`.
+
+Certified tilt: all-time `84.7161 deg`, at the deployed 150 s horizon
+`58.2102 deg`, asymptotic `56.6779 deg`. The dependent chain closes again —
+binary32/discrete charge, frontend transition, `ou3_startup_timeout_capture`
+(branch margin `4.1379 deg`) and `ou3_p4_brmm_frontend_predecessor_invariant`.
+
+Keep the metric read from the continuous certificate, never hardcoded, and keep
+the first-order decrease at **one** factor of `sqrt(C)`.
+
+## The private observer cannot supply the magnetic gates
 
 The shipping accumulation frame is the private observer's own tilt
 (`tiltOnlyQuatFromBoatQuat_(attitudeReferenceQuat_())`) and the handoff seed is
@@ -159,38 +189,46 @@ the rationals:
 - `min_horizontal_fraction = 0.05` binds at `delta <= 0.0495289` rad
   `= 2.8378 deg`;
 - non-vanishing north binds at `delta < 0.1067173` rad `= 6.1145 deg`;
-- the certified proxy tilt is `86.2567 deg`: shortfall `30.3957x` and
-  `14.1094x`, and `1.9168x` against the declared 45 deg entrance on its own.
+- certified all-time `84.7161 deg` (shortfall `29.8528x` / `13.8551x`) and
+  asymptotic `56.6779 deg` (`19.9725x` / `9.2695x`); the certified tilt alone
+  exceeds the declared 45 deg entrance by `1.8826x`, so no yaw gauge, however
+  accurate, repairs the entrance from this supply.
 
 The declared `world_averaged_gravity_direction_error = 0.02 rad` satisfies the
 binding requirement but is the low-passed world-gravity direction error, not the
 private observer's tilt error. Do not identify the two.
 
-The private Mahony level-set route is frozen. At the padded `8.8 m/s^2`
-envelope the seed angle is `asin(8.8/9.80665) = 1.1137 rad`, the level needed to
-contain it is `1.8540056`, the largest level inside the 87 deg chart is
-`1.4912551`, and the admissible level window is empty with factor `1.2432518`.
-The boundary flow still closes with margin `0.0357940`, so the obstruction is the
-level-set formulation, not the enclosure. A metric-free floor of
-`m/s_min + 0.1*xi = 0.17603 rad = 10.0855 deg` — `3.5540x` the binding
-requirement — rules out any further metric or subdivision work. The three
-permitted alternatives are recorded in `docs/ou3-proof-research-state.md`.
+This is a dead end for the whole route, not just for a metric choice. The
+certificate quantifies over the sector value `s` as an independent parameter, so
+its conclusion must hold for `s=1`, where the deployed gains give
+
+`theta/r = -(0.01 + 0.1 j w)/(0.01 s - w^2 + 0.1 s j w)`.
+
+An admitted primitive-bounded sinusoid peaks *inside* the declared band, at
+`0.0186 Hz` against `[0.018, 0.88] Hz`, contributing `0.14678877` rad; an
+admitted DC mean chord superposes `0.05` rad. So no metric, level or subdivision
+depth can certify a tilt below `0.19678877 rad = 11.2752 deg` — `3.9732x` the
+binding requirement and `1.8440x` north capture. Do not retry a static quadratic
+metric for the magnetic gates.
 
 ## Fail-closed state and next work
 
 `P4_PASS=false` and `P5_MAY_START=false`. Do not infer theorem closure from the
-H18 information lemma, the magnetic certificates, or green CI.
+H18 information lemma, the magnetic or startup certificates, or green CI.
 
 Immediate open items for the next PR are:
 
-1. Pick one of the three recorded startup-tilt alternatives and requalify the
-   private Mahony/proxy startup for the padded `||a_wave|| <= 8.8 m/s^2` family,
-   preserving both measured-period takeover and prior-frequency timeout paths.
-   Do not reopen the metric route.
-2. Discharge or replace the private-observer accumulation tilt-frame supply, and
-   close the ungauged 150 s timeout branch: `ready_by_timeout` does not require
-   `north_ready`, so that handoff still takes
-   `proxy_handoff_yaw_sigma_free_rad` with no yaw gauge at all.
+1. Attempt the tilt certificate with a frequency-dependent multiplier/IQC on the
+   primitive channel and measure the distance to the `11.2752 deg` floor. The
+   existing `ou3_p4_affine_hard_tube_iqc.py` and
+   `ou3_brmm_acceleration_moment_iqc.py` carry that machinery.
+2. Decide the magnetic side: narrow `MAG-BMM150-DET-v1` to a commissioned band
+   that forces the gates at the achieved tilt (`<= 55 uT` total needs
+   `>= 21.4462 uT` horizontal at the floor; all four tabulated rows in the
+   research state are feasible), or tighten the forcing qualification from the
+   COMPLETE-BRMM spectral support. Then close the ungauged 150 s timeout branch:
+   `ready_by_timeout` does not require `north_ready`, so that handoff still
+   takes `proxy_handoff_yaw_sigma_free_rad` with no yaw gauge at all.
 3. Complete same-history physical source attachment through frontend/tuner and
    actual P/H/R/K lineage for every H18/A21 word.
 4. Close downstream H18/A21 prior-free and finite-bias composition for

--- a/docs/ou3-brmm-main-handover.md
+++ b/docs/ou3-brmm-main-handover.md
@@ -1,9 +1,8 @@
 # BRMM stability proof handover
 
-This is the canonical handover for the continuation after PR #516. Read
-`AGENTS.md`, this file, and `docs/ou3-proof-research-state.md` before changing
-proof code. Start the next continuation from the latest `main` after #516 and
-open a new PR.
+This is the canonical handover for the non-ALT (BRMM) route. Read `AGENTS.md`,
+this file, and `docs/ou3-proof-research-state.md` before changing proof code.
+Start the next continuation from the latest `main` and open a new PR.
 
 ## Shipping/runtime invariants
 
@@ -105,20 +104,93 @@ with gate ratio `4.253919518541474`. The coupled `eta6/a_w` lower is
 Thus the eta6/a_w H18 information bottleneck is closed without changing the
 filter, source family, or 1e-18 gate.
 
+## Named magnetometer theorem classes
+
+The route carries two named magnetic classes with their own modules and no ALT
+dependency. Keep the value class and the call-cadence class separate.
+
+`MAG-BMM150-DET-v1` (`ou3_brmm_magnetic_source_envelope.py`) admits a
+commissioned installation with `20 <= ||B_W|| <= 75 uT`, horizontal field
+`>= 15 uT`, `||b_HI|| <= 5 uT` and `||n_m|| <= 2 uT` per theorem sample, for the
+exact identity `m_body = R_true B_W + b_HI + n_m`. It is an engineering source
+requirement, not a datasheet guarantee. `Rmag` is a model covariance and is
+never read as a deterministic bound.
+
+`MAG-CALL-SCHEDULE-v1` (`ou3_brmm_magnetic_call_schedule.py`) requires the first
+post-Live `updateMag()` call within 0.04 s and every later gap at most 0.04 s.
+That is 25 Hz, deliberately weaker than the sensor.
+
+What they close, at unchanged gates and with no filter change:
+
+- the declared magnetic PE band becomes a consequence. `||m_body||` lies in
+  `[13, 82] uT`, so `normal_live.magnetic_vector_norm_lower_uT = 10` and upper
+  `200` follow and the shipping `mag_init_min_mag_norm` guard clears
+  unconditionally;
+- the deterministic startup yaw capture. At a supplied tilt-frame error
+  `E = ||b_HI|| + ||n_m|| + 2 Bmax sin(delta/2)` and
+  `|sin(theta_yaw)| <= E/H_min`. At the declared 0.02 rad startup direction
+  error this is `E <= 8.5 uT`, `|sin(theta_yaw)| <= 17/30`, `theta_yaw < 0.61`
+  rad and a full attitude error `< 0.63` rad `= 36.0962 deg`, inside the
+  declared 45 deg `initial_filter_entrance.attitude` set. No `1/sqrt(N)`
+  statistical reduction is used anywhere on this path;
+- the finite `H18 -> A21` release *timing*. The shipping counter increments on
+  every post-delay `updateMag()` call regardless of innovation acceptance, so
+  250 counts land within `10.0 s` of Live and the elapsed `9.96 s` strictly
+  exceeds the 1 s guard.
+
+What they do not close:
+
+- universal per-sample admission at `max_sample_norm_ratio_from_mean = 0.35`
+  needs combined hard iron + residual `<= 7 Bmin/47 = 2.9787 uT` against the
+  declared `7 uT`;
+- the vector sine separation stays a declared PE hypothesis; it is not
+  derivable from this class;
+- eventual A21 under an arbitrary external `acc_bias_hold_`, and the
+  `H18 -> A21` joint24 covariance transport itself.
+
+## Startup tilt supply is the limiting quantity
+
+The shipping accumulation frame is the private observer's own tilt
+(`tiltOnlyQuatFromBoatQuat_(attitudeReferenceQuat_())`) and the handoff seed is
+`boatQuatWithAbsoluteYaw_(q_proxy, pending_yaw_abs_rad_)`, so the proxy tilt
+drives both the gauge error and the seed tilt. Derived requirements, exact over
+the rationals:
+
+- `min_horizontal_fraction = 0.05` binds at `delta <= 0.0495289` rad
+  `= 2.8378 deg`;
+- non-vanishing north binds at `delta < 0.1067173` rad `= 6.1145 deg`;
+- the certified proxy tilt is `86.2567 deg`: shortfall `30.3957x` and
+  `14.1094x`, and `1.9168x` against the declared 45 deg entrance on its own.
+
+The declared `world_averaged_gravity_direction_error = 0.02 rad` satisfies the
+binding requirement but is the low-passed world-gravity direction error, not the
+private observer's tilt error. Do not identify the two.
+
+The private Mahony level-set route is frozen. At the padded `8.8 m/s^2`
+envelope the seed angle is `asin(8.8/9.80665) = 1.1137 rad`, the level needed to
+contain it is `1.8540056`, the largest level inside the 87 deg chart is
+`1.4912551`, and the admissible level window is empty with factor `1.2432518`.
+The boundary flow still closes with margin `0.0357940`, so the obstruction is the
+level-set formulation, not the enclosure. A metric-free floor of
+`m/s_min + 0.1*xi = 0.17603 rad = 10.0855 deg` — `3.5540x` the binding
+requirement — rules out any further metric or subdivision work. The three
+permitted alternatives are recorded in `docs/ou3-proof-research-state.md`.
+
 ## Fail-closed state and next work
 
 `P4_PASS=false` and `P5_MAY_START=false`. Do not infer theorem closure from the
-H18 information lemma or green CI.
+H18 information lemma, the magnetic certificates, or green CI.
 
 Immediate open items for the next PR are:
 
-1. Reconcile the current metric-memory/PE domain consistency failure:
-   `declared PE does not refine vector certificate` in
-   `ou3_brmm_riccati_tube.py::_declared_vector_alpha6`. Treat it as a proof
-   representation/domain issue until evidence shows otherwise.
-2. Requalify the actual private Mahony/proxy startup invariant for the padded
-   `||a_wave|| <= 8.8 m/s^2` family and preserve both measured-period takeover
-   and prior-frequency timeout paths.
+1. Pick one of the three recorded startup-tilt alternatives and requalify the
+   private Mahony/proxy startup for the padded `||a_wave|| <= 8.8 m/s^2` family,
+   preserving both measured-period takeover and prior-frequency timeout paths.
+   Do not reopen the metric route.
+2. Discharge or replace the private-observer accumulation tilt-frame supply, and
+   close the ungauged 150 s timeout branch: `ready_by_timeout` does not require
+   `north_ready`, so that handoff still takes
+   `proxy_handoff_yaw_sigma_free_rad` with no yaw gauge at all.
 3. Complete same-history physical source attachment through frontend/tuner and
    actual P/H/R/K lineage for every H18/A21 word.
 4. Close downstream H18/A21 prior-free and finite-bias composition for
@@ -130,7 +202,8 @@ Immediate open items for the next PR are:
    rejected/not-due and tuner/scheduler transitions.
 7. Prove first-exit/domain retention over a physics-compatible working tube,
    determine the largest rigorously certifiable P4 basin, then prove finite H18
-   capture and H18->A21 transport.
+   capture and the H18->A21 joint24 covariance transport; only its release
+   timing is closed.
 8. Close deployment finite-precision enclosure and compose the indefinite
    end-to-end theorem.
 

--- a/docs/ou3-brmm-main-handover.md
+++ b/docs/ou3-brmm-main-handover.md
@@ -126,17 +126,15 @@ What they close, at unchanged gates and with no filter change:
   `[13, 82] uT`, so `normal_live.magnetic_vector_norm_lower_uT = 10` and upper
   `200` follow and the shipping `mag_init_min_mag_norm` guard clears
   unconditionally;
-- the deterministic startup yaw capture. At a supplied tilt-frame error
+- the startup yaw *algebra*. At a supplied accumulation-frame excursion
   `E = ||b_HI|| + ||n_m|| + 2 Bmax sin(delta/2)` and
-  `|sin(theta_yaw)| <= E/H_min`. At the declared 0.02 rad startup direction
-  error this is `E <= 8.5 uT`, `|sin(theta_yaw)| <= 17/30`, `theta_yaw < 0.61`
-  rad and a full attitude error `< 0.63` rad `= 36.0962 deg`, inside the
-  declared 45 deg `initial_filter_entrance.attitude` set. No `1/sqrt(N)`
-  statistical reduction is used anywhere on this path;
-- the finite `H18 -> A21` release *timing*. The shipping counter increments on
-  every post-delay `updateMag()` call regardless of innovation acceptance, so
-  250 counts land within `10.0 s` of Live and the elapsed `9.96 s` strictly
-  exceeds the 1 s guard.
+  `|sin(theta_yaw)| <= E/H_min`. At `delta <= 0.02` rad this is `E <= 8.5 uT`,
+  `|sin(theta_yaw)| <= 17/30`, `theta_yaw < 0.61` rad and a full attitude error
+  `< 0.63` rad `= 36.0962 deg`, inside the declared 45 deg
+  `initial_filter_entrance.attitude` set. No `1/sqrt(N)` statistical reduction
+  is used anywhere on this path;
+- the `H18 -> A21` release time **after north lock**: `<= 10.0 s`, by a case
+  split on whether the 250-count or the strict 1 s guard binds last.
 
 What they do not close:
 
@@ -146,7 +144,18 @@ What they do not close:
 - the vector sine separation stays a declared PE hypothesis; it is not
   derivable from this class;
 - eventual A21 under an arbitrary external `acc_bias_hold_`, and the
-  `H18 -> A21` joint24 covariance transport itself.
+  `H18 -> A21` joint24 covariance transport itself;
+- the release **from Live**. The counter-owning call sits behind
+  `if (mag_ref_set_ && stage_ == Stage::Live)`, so the admitted ungauged timeout
+  path never advances it. North lock is the shared unmet prerequisite of the
+  yaw gauge and the A21 release;
+- the *supply* for the yaw algebra. `tiltOnlyQuatFromBoatQuat_` strips the
+  estimator's yaw, not the vessel's, so the accumulation frame turns with the
+  boat and a legal heading excursion smears the mean. The parameter is the total
+  excursion `delta_tilt + delta_heading`, and nothing declared bounds the
+  heading part, so `DECLARED_SUPPLY_ENTRANCE_CLOSED` is false. Never charge a
+  heading excursion as tilt, and never read
+  `world_averaged_gravity_direction_error` as a total excursion.
 
 ## Two-phase private Mahony certificate
 

--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -126,18 +126,16 @@ Closed by them at the unchanged gates:
   `||m_body||` lies in `[13, 82] uT`, so the declared
   `normal_live.magnetic_vector_norm_lower_uT = 10` and upper `200` follow, and
   the shipping `mag_init_min_mag_norm = 1e-3` guard clears unconditionally;
-- the deterministic startup yaw capture: at a supplied tilt-frame error the mean
+- the startup yaw *algebra*: at a supplied accumulation-frame excursion the mean
   perturbation is `E = ||b_HI||+||n_m||+2 Bmax sin(delta/2)`, and
-  `|sin(theta_yaw)| <= E/H_min`. At the declared 0.02 rad startup direction
-  error `E <= 8.5 uT`, `|sin(theta_yaw)| <= 17/30`, and
-  `sin(0.61) >= 0.61 - 0.61^3/6 > 17/30` gives `theta_yaw < 0.61` rad. With the
-  SO(3) triangle inequality the full attitude error is `< 0.63` rad
-  `= 36.0962 deg`, strictly inside the declared 45 deg
-  `initial_filter_entrance.attitude` set. No `1/sqrt(N)` reduction is used;
-- finite-time `H18 -> A21` release timing: the shipping counter is incremented
-  on every post-delay `updateMag()` call regardless of innovation acceptance, so
-  250 counts are reached within `0.04 + 249*0.04 = 10.0 s` of Live and the
-  elapsed `9.96 s` strictly exceeds the 1 s guard.
+  `|sin(theta_yaw)| <= E/H_min`. At `delta <= 0.02` rad, `E <= 8.5 uT`,
+  `|sin(theta_yaw)| <= 17/30`, and `sin(0.61) >= 0.61 - 0.61^3/6 > 17/30` gives
+  `theta_yaw < 0.61` rad; the SO(3) triangle inequality gives a full attitude
+  error `< 0.63` rad `= 36.0962 deg`, inside the declared 45 deg
+  `initial_filter_entrance.attitude` set. No `1/sqrt(N)` reduction is used. The
+  algebra is closed; its *supply* is not -- see the heading finding below;
+- the `H18 -> A21` release time **after north lock**: `<= 10.0 s`, derived by a
+  case split on whether the 250-count or the strict 1 s guard binds last.
 
 Not closed by them, and explicitly fail-closed:
 
@@ -151,7 +149,39 @@ Not closed by them, and explicitly fail-closed:
   `B_W` within `asin(15/75) = 11.5` deg of it, so `0.1` stays a declared PE
   hypothesis;
 - eventual A21 under an arbitrary external `acc_bias_hold_` is not claimed, and
-  the `H18 -> A21` joint24 covariance transport edge is untouched.
+  the `H18 -> A21` joint24 covariance transport edge is untouched;
+- the release is **not** reachable from Live alone. The only call site of the
+  counter-owning inner method is
+  `if (mag_ref_set_ && stage_ == Stage::Live) { impl_.updateMag(...) }`, so a
+  host call schedule does not advance `mag_updates_applied_` until north lock.
+  On the admitted ungauged timeout path `mag_ref_set_` stays false and the
+  release is unreachable however fast the host calls. North lock is exactly
+  what the tilt floor below denies, so the yaw gauge and the A21 release share
+  one unmet prerequisite;
+- the accumulation mean is **not** bounded by a tilt error alone.
+  `tiltOnlyQuatFromBoatQuat_` strips the *estimator's* yaw, not the vessel's, so
+  `q_tilt * m_body` lives in a level frame that turns with the boat -- which is
+  why the gauge is north *relative to the boat*. A heading change during the
+  window rotates accepted samples in the horizontal plane and smears the mean,
+  and a large enough excursion cancels its horizontal component. The parameter
+  is therefore the total excursion `delta = delta_tilt + delta_heading`, and
+  neither MAG-BMM150-DET-v1 nor any declared operating-domain quantity bounds a
+  startup heading excursion. `DECLARED_SUPPLY_ENTRANCE_CLOSED` is false.
+
+### Corrections made to earlier claims in this route
+
+Three claims recorded earlier were unsound and have been retracted in place:
+
+1. the yaw/entrance certificate charged only tilt error into `E`, leaving a
+   legal heading excursion uncharged;
+2. the release certificate inferred the strict `> 1 s` guard from
+   `(n-1)*gap_max`, an *upper* bound on elapsed time -- 250 calls 1 ms apart
+   clear the count at `0.249 s` with the shipping predicate still false;
+3. the release certificate read parity from the *inner* method only and missed
+   the outer north-lock gate on its single call site.
+
+The discrete Mahony charge additionally claimed `2*sqrt(C)*margin` of
+first-order decrease where the derivation gives one factor of `sqrt(C)`.
 
 ## Current failure analysis
 
@@ -356,6 +386,15 @@ Do not:
   `instantaneous_direction_angle_upper_rad`;
 - claim a first-order Lyapunov decrease of `2*sqrt(C)*margin`: the derivation
   carries one factor of `sqrt(C)`;
+- charge a heading excursion as tilt error in the magnetic accumulation, or read
+  `world_averaged_gravity_direction_error` as a total accumulation-frame
+  excursion: it carries no heading content;
+- infer a strict elapsed-time guard from an upper bound on call spacing, or
+  claim the accelerometer-bias release from Live without north lock: the
+  counter-owning call sits behind `mag_ref_set_`;
+- certify shipping parity by loose token presence: compare the complete
+  assignment or condition so a branch cannot change semantics while the
+  certificate stays green;
 - read the declared `world_averaged_gravity_direction_error` as the private
   observer's accumulation tilt-frame error;
 - use `Rmag`, or any covariance, as a deterministic magnetic source bound;
@@ -421,6 +460,10 @@ Do not revisit the static-metric route for the magnetic gates: the
    forces the gates at the achieved tilt, or tighten the forcing qualification
    from the COMPLETE-BRMM spectral support. Then close the ungauged 150 s
    timeout branch.
+3. Supply the total accumulation-frame excursion: declare and justify a startup
+   heading-excursion bound over the window, or retain the heading history in the
+   accumulation so a legal turn cannot smear the mean. Without it the yaw
+   algebra has no input and the A21 release has no north lock.
 3. Complete continuous same-history physical source -> IMU/frontend -> tuner ->
    P/H/R/K attachment for every allowed word and BIAS family.
 4. Close the consecutive compatible joint24 endpoint inequality

--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -1,11 +1,10 @@
 # OU-III proof research state
 
-## Status after PR #516
+## Status
 
-PR #516 repairs the BRMM source-definition omission exposed by PR #515 and
-continues the OU-III proof without changing the shipping filter or the frozen
-`P3 delta = 1e-18` requirement. The next continuation must start from latest
-`main`, read `docs/ou3-brmm-main-handover.md`, and open a new PR.
+The non-ALT (BRMM) route now carries the named magnetometer theorem classes and
+has a quantified startup obstruction. The next continuation must start from
+latest `main`, read `docs/ou3-brmm-main-handover.md`, and open a new PR.
 
 The end-to-end theorem is still open. `P4_PASS=false` and
 `P5_MAY_START=false` remain intentional fail-closed outputs.
@@ -107,30 +106,146 @@ The former eta6/a_w blocker is therefore closed at the unchanged gate. This is
 about a 5.9978x improvement over the preceding H18 lower and does not promote
 P4/P5 by itself.
 
+## Named magnetometer theorem classes (non-ALT)
+
+Two named classes are now first-class on the non-ALT route, with their own
+modules and no ALT dependency:
+
+- `MAG-BMM150-DET-v1` (`ou3_brmm_magnetic_source_envelope.py`): commissioned
+  installation class `20 <= ||B_W|| <= 75 uT`, horizontal `>= 15 uT`,
+  `||b_HI|| <= 5 uT`, `||n_m|| <= 2 uT` per theorem sample, for the exact
+  identity `m_body = R_true B_W + b_HI + n_m`. `Rmag` is never read as a
+  deterministic bound.
+- `MAG-CALL-SCHEDULE-v1` (`ou3_brmm_magnetic_call_schedule.py`): first post-Live
+  `updateMag()` call within 0.04 s and every later gap at most 0.04 s. This is a
+  deployment call-cadence assumption, kept separate from magnetic values.
+
+Closed by them at the unchanged gates:
+
+- the declared magnetic PE band is now a consequence, not an extra hypothesis:
+  `||m_body||` lies in `[13, 82] uT`, so the declared
+  `normal_live.magnetic_vector_norm_lower_uT = 10` and upper `200` follow, and
+  the shipping `mag_init_min_mag_norm = 1e-3` guard clears unconditionally;
+- the deterministic startup yaw capture: at a supplied tilt-frame error the mean
+  perturbation is `E = ||b_HI||+||n_m||+2 Bmax sin(delta/2)`, and
+  `|sin(theta_yaw)| <= E/H_min`. At the declared 0.02 rad startup direction
+  error `E <= 8.5 uT`, `|sin(theta_yaw)| <= 17/30`, and
+  `sin(0.61) >= 0.61 - 0.61^3/6 > 17/30` gives `theta_yaw < 0.61` rad. With the
+  SO(3) triangle inequality the full attitude error is `< 0.63` rad
+  `= 36.0962 deg`, strictly inside the declared 45 deg
+  `initial_filter_entrance.attitude` set. No `1/sqrt(N)` reduction is used;
+- finite-time `H18 -> A21` release timing: the shipping counter is incremented
+  on every post-delay `updateMag()` call regardless of innovation acceptance, so
+  250 counts are reached within `0.04 + 249*0.04 = 10.0 s` of Live and the
+  elapsed `9.96 s` strictly exceeds the 1 s guard.
+
+Not closed by them, and explicitly fail-closed:
+
+- `MAG-BMM150-DET-v1` as declared does not force universal per-sample admission
+  at the shipping `MagAutoTuner::max_sample_norm_ratio_from_mean = 0.35` gate.
+  The sufficient condition is `2P/(Bmin-P) <= 0.35`, i.e.
+  `P <= 0.35*Bmin/2.35 = 2.9787 uT`, against a declared combined
+  hard-iron + residual budget of `7 uT`;
+- the vector sine separation is not derivable from this class: with
+  `||a_ng|| <= 8.8` the specific force can lie within 63.8 deg of vertical and
+  `B_W` within `asin(15/75) = 11.5` deg of it, so `0.1` stays a declared PE
+  hypothesis;
+- eventual A21 under an arbitrary external `acc_bias_hold_` is not claimed, and
+  the `H18 -> A21` joint24 covariance transport edge is untouched.
+
 ## Current failure analysis
 
-### C/D — PE / metric-memory domain consistency
+### D — PE / metric-memory domain consistency (CLOSED)
 
-A current metric-memory path fails before its intended diagnostic at
+`RuntimeError: declared PE does not refine vector certificate` from
+`ou3_brmm_riccati_tube.py::_declared_vector_alpha6` was a padding omission, not
+an enclosure defect. `ou3_vector_uco_certificate.PE` carried the *unpadded*
+`REFERENCE_BODY_RATE_DEG_S = 30.0`, while every declared COMPLETE-BRMM domain
+carries the padded `BODY_RATE_NORM_MAX_DEG_S = 35.0`, so the refinement test
+`rate > base rate` fired on every call. `PE["body_rate_norm_upper_deg_s"]` is now
+bound to `ou3_brmm_complete_physical_envelope.BODY_RATE_NORM_MAX_DEG_S`.
 
-`RuntimeError: declared PE does not refine vector certificate`
+The quantitative permission was checked before the change: the two-packet
+bracket moves from `0.98953` to `0.98778`, so `1+2/gamma^2` moves from
+`1277.5970` to `1282.1123` and `alpha_6` loses 0.353 per cent. Declared
+`alpha6 = 1.0605504334607669e-4 > 0`. `H18_information_lambda_min_lower` stays
+`4.253919518541475e-18` and the conditional P3 composition still validates.
+Raising a PE ceiling weakens the hypothesis, so the certificate is strictly
+stronger, not tuned.
 
-from `ou3_brmm_riccati_tube.py::_declared_vector_alpha6`.
+### C/F — padded-family startup/Mahony requalification (OBSTRUCTION QUANTIFIED)
 
-This is presently a proof-domain/representation consistency issue. It is
-separate from the now-gate-passing H18 eta6/a_w information certificate. Do not
-lower the 1e-18 gate or retune the filter to hide it. Inspect which declared PE
-object and vector certificate are being compared, preserve same-history source
-ancestry, and determine whether this is C (dependency/enclosure) or D
-(entry/working-domain modeling).
+The private Mahony live invariant does not close for the padded 8.8 m/s^2
+family, and the obstruction is now exact rather than a stale constant.
+`INITIAL_TILT_RAD_UPPER` was frozen at `0.955` rad from the 8.0 m/s^2 surface;
+it is now taken from the source's own
+`instantaneous_direction_angle_upper_rad = asin(8.8/9.80665) = 1.1137282529726653`
+rad `= 63.8119 deg`. With that seed:
 
-### F — padded-family startup/Mahony requalification
+- the level needed to contain the first-sample accelerometer seed is
+  `1.8540056178369713`;
+- the largest level whose `z_theta` projection still fits strictly inside the
+  87 deg proof chart is `1.4912551131561935`;
+- the admissible level window is therefore **empty**, emptiness factor
+  `1.2432518094861904`.
 
-The physical acceleration cap was widened from the earlier 8.0 m/s^2 proof
-surface to 8.8 m/s^2. The real private Mahony/proxy runtime handoff still needs
-a rigorous invariant/capture requalification over that padded family. Preserve
-both measured-period takeover and prior-frequency timeout Live entry. Do not
-make measured-period availability a hidden theorem prerequisite.
+No level of the fixed metric `P = [[1,-6.5],[-6.5,163.25]]` closes the
+invariant at the padded envelope. This is a proof-method failure of the
+level-set formulation, not an interval-enclosure failure: the boundary flow
+still closes with margin `0.03579398935526988` and the declared level is still
+inside the chart. The dependent chain fails closed — the discrete/binary32
+comparison, the frontend transition and `ou3_startup_timeout_capture` all refuse
+to build rather than composing on an unclosed invariant.
+
+### C/D — startup tilt supply for the magnetic classes (LIMITING QUANTITY)
+
+The shipping startup magnetic accumulation frame is
+`tiltOnlyQuatFromBoatQuat_(attitudeReferenceQuat_())`, i.e. the private
+observer's own tilt, and the handoff seed is
+`boatQuatWithAbsoluteYaw_(q_proxy, pending_yaw_abs_rad_)`, so the proxy tilt
+drives both the gauge error and the seed's tilt error. The magnetic classes
+therefore need a private-observer tilt *accuracy* bound, and the route only has
+a level-set radius. Exactly over the rationals:
+
+- `min_horizontal_fraction = 0.05` needs `E <= (15 - 0.05*75)/1.05 = 75/7 uT`,
+  hence `sin(delta/2) <= 13/525` and `delta <= 0.04952887185726867` rad
+  `= 2.8378 deg`. This is the binding requirement;
+- non-vanishing north (`E < H_min`) needs `sin(delta/2) < 4/75`, i.e.
+  `delta < 0.10671729940461795` rad `= 6.1145 deg`;
+- the certified proxy tilt is `1.5055` rad `= 86.2567 deg`, a shortfall factor
+  of `30.3957` against the binding gate and `14.1094` against north capture;
+- the certified proxy tilt alone already exceeds the declared 45 deg entrance
+  set by a factor `1.9168`, so no yaw gauge, however accurate, repairs the
+  entrance from this supply.
+
+The declared `startup.world_averaged_gravity_direction_error_upper_rad = 0.02`
+satisfies the binding requirement with margin (1.1459 deg against 2.8378 deg),
+but it is the low-passed world-gravity direction error, not the private
+observer's tilt error. It is recorded as an *unsupplied hypothesis*, and
+`declared_startup_direction_error_is_the_accumulation_frame_error` is false.
+
+Scaling argument before any further metric work (`AGENTS.md` quantitative
+permission): the observer's own integral channel forces
+`theta_ss = -m/s` at a constant admitted mean chord, and
+`theta = z_theta - 0.1 xi` carries the primitive term directly, so any metric
+whatsoever is bounded below by
+
+`m/s_min + 0.1*xi = 0.05/0.65767 + 0.1 = 0.17603` rad `= 10.0855 deg`,
+
+which is `3.5540` times the binding requirement. Metric or level refinement
+alone cannot reach the magnetic gates; the declared forcing qualification
+`(mean chord 0.05, primitive 1.0 s)` is itself the limiter.
+
+### F — timeout branch has no yaw gauge
+
+`ready_by_timeout` requires only `proxy_ready`, `t_ >= timeout_sec` and
+`mag_gravity_aligned_branch_`; it does not require `north_ready`. The handoff
+then takes `proxy_handoff_yaw_sigma_free_rad` with `pending_yaw_abs_rad_` NaN.
+`timeout_branch_yaw_gauge_forced` is false. Making `north_ready` a consequence
+rather than an assumption needs a forced-acquisition argument
+(`mag_tilt_fallback_sec = 30 s` plus `mag_min_window_sec = 15 s` against
+`timeout_sec = 150 s`), which in turn needs the un-forced `0.35` norm-ratio
+admission above.
 
 ### C/G — downstream same-history joint24 closure
 
@@ -159,7 +274,11 @@ Preserve:
 - Joseph/reset/projection splitting;
 - one-time Live S-origin handling;
 - finite-precision obligations;
-- joint24 compatible storage.
+- joint24 compatible storage;
+- `MAG-BMM150-DET-v1` and `MAG-CALL-SCHEDULE-v1` as *named* classes with their
+  own non-ALT modules, separating magnetic values from magnetic call cadence;
+- the private-Mahony boundary-flow certificate and its 87 deg chart containment,
+  which remain valid and are the reusable part of the unclosed invariant.
 
 Do not resurrect the A21 18-state marginal-motion storage. Prior diagnostics
 showed that discarding motion/bias cross-information can make the marginal
@@ -182,13 +301,52 @@ Do not:
 - use covariance consistency as hard entry membership;
 - lower P3 delta below `1e-18`;
 - change the shipping filter merely to stabilize the excluded DC-position
-  history.
+  history;
+- refine the private-Mahony metric, level or boundary subdivision again: the
+  metric-free tilt floor `m/s_min + 0.1*xi = 0.17603` rad is `3.5540` times the
+  binding magnetic requirement, so no metric can cross it (two-strike frozen);
+- freeze a startup seed angle as a constant detached from the source's own
+  `instantaneous_direction_angle_upper_rad`;
+- read the declared `world_averaged_gravity_direction_error` as the private
+  observer's accumulation tilt-frame error;
+- use `Rmag`, or any covariance, as a deterministic magnetic source bound;
+- claim eventual A21 under an arbitrary external `acc_bias_hold_`.
+
+## Alternatives for the startup tilt limiter
+
+The metric route is frozen, so the next attempt must come from this list. They
+are qualitatively different and each is quantified:
+
+1. **Tighten the gravity-direction forcing qualification.** The limiter is the
+   pair `(mean chord 0.05, primitive 1.0 s)` in
+   `ou3_brmm_gravity_direction_forcing_qualification.py`. An even split of the
+   binding `0.04952887185726867` rad budget needs mean chord `<= 0.0163`
+   (3.1x tighter) and primitive `<= 0.248 s` (4.0x tighter). This is a claim
+   about marine gravity-direction rectification and must be argued from the
+   COMPLETE-BRMM spectral support, not chosen to fit.
+2. **Narrow `MAG-BMM150-DET-v1` to a commissioned geomagnetic band.** The gates
+   depend on `Bmax` and `H_min`, not on tilt alone: `E <= (H - f Bmax)/(1+f)`.
+   A higher horizontal floor with a lower total ceiling admits a much larger
+   tilt at the same gates, at the cost of excluding installations near the
+   magnetic poles and in very strong fields. This route also has to fix the
+   un-forced `0.35` norm-ratio admission, which needs `P <= 7 Bmin/47`.
+3. **Prove the quality handoff strictly precedes the timeout handoff.** With
+   `mag_tilt_fallback_sec = 30 s`, `mag_min_window_sec = 15 s` and
+   `timeout_sec = 150 s`, forced acquisition would make `north_ready` a theorem
+   consequence and remove the ungauged branch entirely. It depends on route 2's
+   admission result, not on a new tilt bound.
+
+Do not revisit the metric route until one of these produces a new mathematical
+fact that makes the `3.5540` metric-free shortfall inapplicable.
 
 ## Next falsifiable sequence
 
-1. Fix/classify `declared PE does not refine vector certificate` while retaining
-   the now-canonical H18 information construction.
-2. Requalify Mahony/proxy startup for the 8.8 m/s^2 padded physical family.
+1. Choose one of the three recorded startup-tilt alternatives and requalify the
+   private Mahony/proxy startup for the 8.8 m/s^2 padded family; the level-set
+   route is frozen with an empty admissible level window.
+2. Discharge or replace the private-observer accumulation tilt-frame supply so
+   the startup magnetic capture composition stops being conditional, and close
+   the ungauged 150 s timeout branch.
 3. Complete continuous same-history physical source -> IMU/frontend -> tuner ->
    P/H/R/K attachment for every allowed word and BIAS family.
 4. Close the consecutive compatible joint24 endpoint inequality
@@ -197,8 +355,9 @@ Do not:
 5. Close literal every-prefix augmented LDLT for every shipping subevent.
 6. Prove first-exit chart/domain retention and determine the largest certifiable
    P4 basin from physics, not convenience.
-7. Prove finite H18 capture, actual H18->A21 release/guard transport, and
-   indefinite continuation.
+7. Prove finite H18 capture and the actual H18->A21 joint24 covariance
+   release/guard transport; only its release *timing* is closed
+   (`<= 10.0 s` of Live under `MAG-CALL-SCHEDULE-v1`).
 8. Add deployment finite-precision enclosure and compose the end-to-end theorem.
 
 Use failure classes A/B/C/D/E/F/G exactly as established. The old DC-position

--- a/docs/ou3-proof-research-state.md
+++ b/docs/ou3-proof-research-state.md
@@ -173,31 +173,57 @@ bracket moves from `0.98953` to `0.98778`, so `1+2/gamma^2` moves from
 Raising a PE ceiling weakens the hypothesis, so the certificate is strictly
 stronger, not tuned.
 
-### C/F — padded-family startup/Mahony requalification (OBSTRUCTION QUANTIFIED)
+### C/F — padded-family startup/Mahony requalification (CLOSED, two-phase)
 
-The private Mahony live invariant does not close for the padded 8.8 m/s^2
-family, and the obstruction is now exact rather than a stale constant.
-`INITIAL_TILT_RAD_UPPER` was frozen at `0.955` rad from the 8.0 m/s^2 surface;
-it is now taken from the source's own
-`instantaneous_direction_angle_upper_rad = asin(8.8/9.80665) = 1.1137282529726653`
-rad `= 63.8119 deg`. With that seed:
+The single-level formulation was infeasible at the padded 8.8 m/s^2 envelope.
+`INITIAL_TILT_RAD_UPPER` had been frozen at `0.955` rad from the retired
+8.0 m/s^2 surface; taken from the source's own
+`asin(8.8/9.80665) = 1.1137282529726653` rad `= 63.8119 deg` it left three
+mutually unsatisfiable level bounds under the old metric
+`P = [[1,-6.5],[-6.5,163.25]]`: seed containment needed `C >= 1.8540056`, the
+87 deg chart allowed `C < 1.4912551`, emptiness factor `1.2432518`. The boundary
+flow still closed with margin `0.0357940`, so it was a failure of the
+*formulation*, not of the enclosure.
 
-- the level needed to contain the first-sample accelerometer seed is
-  `1.8540056178369713`;
-- the largest level whose `z_theta` projection still fits strictly inside the
-  87 deg proof chart is `1.4912551131561935`;
-- the admissible level window is therefore **empty**, emptiness factor
-  `1.2432518094861904`.
+The replacement keeps one metric and splits the roles. Writing `u=Rz`, `y=u/||u||`
+and `M=R A_s R^-1`,
 
-No level of the fixed metric `P = [[1,-6.5],[-6.5,163.25]]` closes the
-invariant at the padded envelope. This is a proof-method failure of the
-level-set formulation, not an interval-enclosure failure: the boundary flow
-still closes with margin `0.03579398935526988` and the declared level is still
-inside the chart. The dependent chain fails closed — the discrete/binary32
-comparison, the frontend transition and `ou3_startup_timeout_capture` all refuse
-to build rather than composing on an unclosed invariant.
+`Vdot = C y'(M+M')y + 2 sqrt(C) y'Rw = -sqrt(C) [ sqrt(C) q - 2 sup ]`,
 
-### C/D — startup tilt supply for the magnetic classes (LIMITING QUANTITY)
+and `q`, `sup` are level-*independent*. So inward flow is a **lower** bound on
+the level, `sqrt(C) >= W_in := 2 sup_max/q_min`, and it holds on *every* level
+above `W_in`, not only on a certified boundary. That gives two nested levels of
+the better-conditioned metric `p=3, c=11` (`P=[[1,-3],[-3,130]]`, `det=121`):
+
+- seed level `1.6707881129` <= outer level `1.7689` < chart ceiling
+  `1.8726722863`, chart headroom `5.5414%`;
+- outer boundary margin `0.0262974`, inner boundary margin (`sqrt(C_in)=1`)
+  `0.0134738`;
+- `W = sqrt(V)` obeys `Wdot <= -(q_min/2)(W - W_in)` with
+  `q_min = 0.0387576`, so the capture rate is `0.0193788 /s`
+  (time constant `51.6029 s`) and `W_in = 0.8578833`.
+
+`{V <= C_out}` is therefore forward invariant and contains the seed, so the
+observer never leaves the chart, and the state enters the inner level
+exponentially. Certified tilt bounds:
+
+- all-time `84.7161 deg` (was a meaningless level radius of `86.2567 deg`);
+- at the deployed 150 s startup horizon `58.2102 deg`;
+- asymptotic `56.6779 deg`.
+
+The whole dependent chain closes again: the source-order binary32/discrete
+charge (`discrete_V_margin_lower = 1.518757e-4`), the frontend transition,
+`ou3_startup_timeout_capture` (`timeout_aligned_branch_margin = 4.1379 deg`) and
+`ou3_p4_brmm_frontend_predecessor_invariant`.
+
+Two corrections were made while doing this. The discrete charge had used
+`2*sqrt(C)*margin` as the guaranteed first-order decrease; the derivation above
+carries **one** factor of `sqrt(C)`, so it had claimed twice the decrease it had
+proved. With the factor corrected the margin is still comfortably positive. The
+charge also hardcoded the old Cholesky row `[-6.5, 11]`; it now reads the metric
+from the continuous certificate.
+
+### C/D — startup tilt supply for the magnetic classes (ROUTE RULED OUT)
 
 The shipping startup magnetic accumulation frame is
 `tiltOnlyQuatFromBoatQuat_(attitudeReferenceQuat_())`, i.e. the private
@@ -212,11 +238,12 @@ a level-set radius. Exactly over the rationals:
   `= 2.8378 deg`. This is the binding requirement;
 - non-vanishing north (`E < H_min`) needs `sin(delta/2) < 4/75`, i.e.
   `delta < 0.10671729940461795` rad `= 6.1145 deg`;
-- the certified proxy tilt is `1.5055` rad `= 86.2567 deg`, a shortfall factor
-  of `30.3957` against the binding gate and `14.1094` against north capture;
-- the certified proxy tilt alone already exceeds the declared 45 deg entrance
-  set by a factor `1.9168`, so no yaw gauge, however accurate, repairs the
-  entrance from this supply.
+- the certified all-time tilt is `84.7161 deg`, a shortfall factor of `29.8528`
+  against the binding gate and `13.8551` against north capture; the asymptotic
+  `56.6779 deg` still falls short by `19.9725` and `9.2695`;
+- the certified tilt alone already exceeds the declared 45 deg entrance set by a
+  factor `1.8826`, so no yaw gauge, however accurate, repairs the entrance from
+  this supply.
 
 The declared `startup.world_averaged_gravity_direction_error_upper_rad = 0.02`
 satisfies the binding requirement with margin (1.1459 deg against 2.8378 deg),
@@ -224,17 +251,31 @@ but it is the low-passed world-gravity direction error, not the private
 observer's tilt error. It is recorded as an *unsupplied hypothesis*, and
 `declared_startup_direction_error_is_the_accumulation_frame_error` is false.
 
-Scaling argument before any further metric work (`AGENTS.md` quantitative
-permission): the observer's own integral channel forces
-`theta_ss = -m/s` at a constant admitted mean chord, and
-`theta = z_theta - 0.1 xi` carries the primitive term directly, so any metric
-whatsoever is bounded below by
+**The route, not just the metric class, is ruled out.** The certificate
+quantifies over the sector value `s` as an independent parameter in
+`[sinc(87 deg),1]`, so its conclusion must also hold for the member `s=1`. For
+that member the deployed PI gains give the tilt transfer function
 
-`m/s_min + 0.1*xi = 0.05/0.65767 + 0.1 = 0.17603` rad `= 10.0855 deg`,
+`theta/r = -(0.01 + 0.1 j w) / (0.01 s - w^2 + 0.1 s j w)`,
 
-which is `3.5540` times the binding requirement. Metric or level refinement
-alone cannot reach the magnetic gates; the declared forcing qualification
-`(mean chord 0.05, primitive 1.0 s)` is itself the limiter.
+and an admitted primitive-bounded sinusoid `r = j w xi` produces
+`|theta| = w |theta/r| |xi|`. That response **peaks inside the declared physical
+band**, at `w = 0.117 rad/s = 0.0186 Hz` against a declared support of
+`[0.018, 0.88] Hz`, giving `0.14678877` rad from the primitive channel alone;
+superposing an admitted DC mean chord on the linear `z`-dynamics adds `0.05`
+rad. Hence no certificate in this formulation — any metric, any level, any
+subdivision depth — can bound the tilt below
+
+`0.19678877` rad `= 11.2752 deg`,
+
+which is `3.9732` times the binding requirement and `1.8440` times north
+capture. This supersedes the earlier `10.0855 deg` scaling estimate, which used
+the sector value at the chart edge rather than at the small equilibrium and was
+not a defensible lower bound. The limiter is the declared forcing pair
+`(mean chord 0.05, primitive 1.0 s)` together with the commissioned magnetic
+band — not the storage geometry. Because the obstruction is a frequency-response
+peak, a static quadratic metric cannot see it; a frequency-dependent
+multiplier/IQC on the primitive channel is the instrument that could.
 
 ### F — timeout branch has no yaw gauge
 
@@ -277,8 +318,11 @@ Preserve:
 - joint24 compatible storage;
 - `MAG-BMM150-DET-v1` and `MAG-CALL-SCHEDULE-v1` as *named* classes with their
   own non-ALT modules, separating magnetic values from magnetic call cadence;
-- the private-Mahony boundary-flow certificate and its 87 deg chart containment,
-  which remain valid and are the reusable part of the unclosed invariant.
+- the two-phase private-Mahony certificate: one metric, an outer level for seed
+  containment and chart retention, an inner level for the ultimate bound, and
+  the level-independence of `q` and `sup` that makes both work;
+- the exponential capture estimate `Wdot <= -(q_min/2)(W - W_in)` and its
+  `W_in = 2 sup_max/q_min`.
 
 Do not resurrect the A21 18-state marginal-motion storage. Prior diagnostics
 showed that discarding motion/bias cross-information can make the marginal
@@ -302,51 +346,81 @@ Do not:
 - lower P3 delta below `1e-18`;
 - change the shipping filter merely to stabilize the excluded DC-position
   history;
-- refine the private-Mahony metric, level or boundary subdivision again: the
-  metric-free tilt floor `m/s_min + 0.1*xi = 0.17603` rad is `3.5540` times the
-  binding magnetic requirement, so no metric can cross it (two-strike frozen);
+- refine the private-Mahony metric, level or boundary subdivision toward the
+  magnetic gates: the declared-formulation tilt floor `0.19678877` rad is
+  `3.9732` times the binding requirement and `1.8440` times north capture, and
+  that floor is metric-independent (two-strike frozen). Metric work aimed at
+  *chart retention* was permitted and is now done; metric work aimed at the
+  magnetic gates is not;
 - freeze a startup seed angle as a constant detached from the source's own
   `instantaneous_direction_angle_upper_rad`;
+- claim a first-order Lyapunov decrease of `2*sqrt(C)*margin`: the derivation
+  carries one factor of `sqrt(C)`;
 - read the declared `world_averaged_gravity_direction_error` as the private
   observer's accumulation tilt-frame error;
 - use `Rmag`, or any covariance, as a deterministic magnetic source bound;
 - claim eventual A21 under an arbitrary external `acc_bias_hold_`.
 
-## Alternatives for the startup tilt limiter
+## Alternatives for the magnetic capture
 
-The metric route is frozen, so the next attempt must come from this list. They
-are qualitatively different and each is quantified:
+The private observer cannot supply the declared gates in the current
+formulation, and no static quadratic metric can. Two independent gaps must both
+close, and they are now quantified:
 
-1. **Tighten the gravity-direction forcing qualification.** The limiter is the
-   pair `(mean chord 0.05, primitive 1.0 s)` in
-   `ou3_brmm_gravity_direction_forcing_qualification.py`. An even split of the
-   binding `0.04952887185726867` rad budget needs mean chord `<= 0.0163`
-   (3.1x tighter) and primitive `<= 0.248 s` (4.0x tighter). This is a claim
-   about marine gravity-direction rectification and must be argued from the
-   COMPLETE-BRMM spectral support, not chosen to fit.
-2. **Narrow `MAG-BMM150-DET-v1` to a commissioned geomagnetic band.** The gates
-   depend on `Bmax` and `H_min`, not on tilt alone: `E <= (H - f Bmax)/(1+f)`.
-   A higher horizontal floor with a lower total ceiling admits a much larger
-   tilt at the same gates, at the cost of excluding installations near the
-   magnetic poles and in very strong fields. This route also has to fix the
-   un-forced `0.35` norm-ratio admission, which needs `P <= 7 Bmin/47`.
-3. **Prove the quality handoff strictly precedes the timeout handoff.** With
-   `mag_tilt_fallback_sec = 30 s`, `mag_min_window_sec = 15 s` and
-   `timeout_sec = 150 s`, forced acquisition would make `north_ready` a theorem
-   consequence and remove the ungauged branch entirely. It depends on route 2's
-   admission result, not on a new tilt bound.
+**Gap A — a tilt certificate near the formulation floor.** The floor is
+`11.2752 deg`; the best *certified* member of the quadratic class is
+`56.6779 deg`, and a non-promoting scan of the whole `(p,c)` grid found nothing
+below about `41 deg`. Since the obstruction is a frequency-response peak at
+`0.0186 Hz`, the instrument is a frequency-dependent multiplier/IQC on the
+primitive channel, not a tighter static metric. `ou3_p4_affine_hard_tube_iqc.py`
+and `ou3_brmm_acceleration_moment_iqc.py` already carry that machinery.
 
-Do not revisit the metric route until one of these produces a new mathematical
-fact that makes the `3.5540` metric-free shortfall inapplicable.
+**Gap B — a commissioned band that forces the shipping gates at that tilt.** The
+gates depend on `Bmax` and `H_min`, not on tilt alone:
+`E <= (H - f Bmax)/(1+f)` with `E = P + 2 Bmax sin(delta/2)`. At the
+`11.2752 deg` floor the required horizontal floor is
+
+| `||B_W||` ceiling | required horizontal floor |
+| --- | --- |
+| 45 uT | 18.8833 uT |
+| 55 uT | 21.4462 uT |
+| 65 uT | 24.0092 uT |
+| 75 uT | 26.5721 uT |
+
+Every row is feasible within its own total field, so **Gap B is viable** — a
+commissioned mid-latitude class such as `||B_W|| <= 55 uT` with horizontal
+`>= 21.4462 uT` would force the gates, at the cost of excluding polar and
+very-strong-field installations. It must also fix the un-forced `0.35`
+norm-ratio admission, which needs `P <= 7 Bmin/47`.
+
+Two further routes remain open and do not depend on Gap A:
+
+- **Tighten the gravity-direction forcing qualification.** The primitive channel
+  contributes `w |theta/r| |xi|` at the in-band peak, so `(0.05, 1.0 s)` must
+  come down together; reaching the binding `0.0495289` rad budget needs roughly
+  mean chord `<= 0.0163` and primitive `<= 0.226 s`. This is a claim about
+  marine gravity-direction rectification and must be argued from the
+  COMPLETE-BRMM spectral support, not chosen to fit. Note the direction of the
+  risk: a pathwise primitive bound derived from the band's low-frequency edge
+  could be *larger* than 1.0 s, not smaller.
+- **Prove the quality handoff strictly precedes the timeout handoff.** With
+  `mag_tilt_fallback_sec = 30 s`, `mag_min_window_sec = 15 s` and
+  `timeout_sec = 150 s`, forced acquisition would make `north_ready` a theorem
+  consequence and remove the ungauged branch entirely. It depends on the
+  norm-ratio admission result, not on a new tilt bound.
+
+Do not revisit the static-metric route for the magnetic gates: the
+`3.9732` formulation-floor shortfall is metric-independent.
 
 ## Next falsifiable sequence
 
-1. Choose one of the three recorded startup-tilt alternatives and requalify the
-   private Mahony/proxy startup for the 8.8 m/s^2 padded family; the level-set
-   route is frozen with an empty admissible level window.
-2. Discharge or replace the private-observer accumulation tilt-frame supply so
-   the startup magnetic capture composition stops being conditional, and close
-   the ungauged 150 s timeout branch.
+1. Attempt Gap A with a frequency-dependent multiplier/IQC on the primitive
+   channel and measure how close to the `11.2752 deg` floor it gets. Do not
+   retry a static quadratic metric.
+2. Decide Gap B: either narrow `MAG-BMM150-DET-v1` to a commissioned band that
+   forces the gates at the achieved tilt, or tighten the forcing qualification
+   from the COMPLETE-BRMM spectral support. Then close the ungauged 150 s
+   timeout branch.
 3. Complete continuous same-history physical source -> IMU/frontend -> tuner ->
    P/H/R/K attachment for every allowed word and BIAS family.
 4. Close the consecutive compatible joint24 endpoint inequality

--- a/tests/validation/test_ou3_brmm_magnetic_assumptions.py
+++ b/tests/validation/test_ou3_brmm_magnetic_assumptions.py
@@ -48,6 +48,23 @@ class MagneticSourceEnvelopeTests(unittest.TestCase):
             g["universal_admission_perturbation_budget_uT"], 0.35 * 20.0 / 2.35, places=12
         )
 
+    def test_excursion_parameter_covers_vessel_heading(self):
+        r = self.d["derived_tilt_requirements"]
+        # The accumulation frame strips the estimator's yaw, not the vessel's,
+        # so a heading change during the window smears the mean.  The parameter
+        # is the total excursion and the heading supply is recorded as missing.
+        self.assertEqual(
+            r["parameter"], "TOTAL_ACCUMULATION_FRAME_ROTATION_EXCURSION_TILT_PLUS_HEADING"
+        )
+        self.assertTrue(self.d["accumulation_frame_retains_vessel_heading"])
+        self.assertFalse(self.d["heading_excursion_bounded_by_this_class"])
+        self.assertFalse(self.d["startup_heading_excursion_declared_in_operating_domain"])
+        self.assertTrue(self.d["declared_startup_direction_error_carries_no_heading_content"])
+        a = self.d["at_declared_startup_direction_error"]
+        self.assertFalse(a["supply_covers_heading_excursion"])
+        self.assertTrue(a["row_is_conditional_on_a_total_excursion_supply"])
+        self.assertTrue(ENV.derive(F(0), ENV.shipping_constants())["excursion_includes_vessel_heading"])
+
     def test_derived_tilt_requirements_are_exact_and_ordered(self):
         r = self.d["derived_tilt_requirements"]
         # min_horizontal_fraction: E <= (H - f*Bmax)/(1+f) = 75/7 uT, hence
@@ -91,16 +108,41 @@ class MagneticCallScheduleTests(unittest.TestCase):
     def setUpClass(cls):
         cls.d = SCHED.build()
 
-    def test_release_time_is_finite_and_forces_the_strict_guard(self):
+    def test_release_time_is_derived_by_a_case_split(self):
         self.assertEqual(SCHED.validate(self.d), [])
         self.assertEqual(self.d["assumption_id"], "MAG-CALL-SCHEDULE-v1")
         r = self.d["release"]
         self.assertEqual(r["unlock_count"], 250)
-        # 0.04 + 249*0.04 = 10.0 s from Live; 9.96 s from the first call.
-        self.assertAlmostEqual(r["live_to_unlock_upper_s"], 10.0, places=12)
-        self.assertAlmostEqual(r["elapsed_first_to_unlock_upper_s"], 9.96, places=12)
-        self.assertTrue(r["strict_one_second_guard_forced"])
-        self.assertTrue(self.d["H18_A21_RELEASE_TIME_CLOSED"])
+        # The gap bound is an UPPER bound, so `elapsed > guard` cannot be
+        # inferred from it: 250 calls 1 ms apart clear the count at 0.249 s with
+        # the shipping `> 1.0f` predicate still false.  Both conditions are
+        # monotone once true, so the release fires by the later of the two.
+        self.assertAlmostEqual(r["count_condition_satisfied_by_upper_s"], 10.0, places=12)
+        self.assertAlmostEqual(r["guard_condition_satisfied_by_upper_s"], 1.08, places=12)
+        self.assertAlmostEqual(
+            r["live_to_unlock_upper_s"],
+            max(r["count_condition_satisfied_by_upper_s"], r["guard_condition_satisfied_by_upper_s"]),
+            places=12,
+        )
+        self.assertEqual(r["binding_condition"], "count")
+        self.assertTrue(r["release_derived_by_case_split_not_upper_bound_comparison"])
+        self.assertFalse(r["lower_bound_on_call_spacing_assumed"])
+
+    def test_release_is_conditional_on_north_lock(self):
+        # The only call site of the counter-owning inner method sits behind
+        # `if (mag_ref_set_ && stage_ == Stage::Live)`, so a host call schedule
+        # alone does not advance the counter.
+        self.assertTrue(self.d["shipping_parity"]["counter_call_is_behind_north_lock_gate"])
+        self.assertTrue(self.d["H18_A21_RELEASE_TIME_CLOSED_AFTER_NORTH_LOCK"])
+        self.assertFalse(self.d["H18_A21_RELEASE_TIME_CLOSED_FROM_LIVE"])
+        self.assertFalse(self.d["counter_advances_without_north_lock"])
+        self.assertFalse(self.d["ungauged_timeout_path_reaches_the_release"])
+        self.assertTrue(self.d["north_lock_is_an_unmet_prerequisite_on_this_route"])
+        self.assertTrue(self.d["release"]["measured_from_north_lock_not_from_Live"])
+
+    def test_release_reachability_rejects_nonpositive_gap(self):
+        with self.assertRaises(ValueError):
+            SCHED.release_reachability(250, gap=F(0))
 
     def test_schedule_is_only_25_hz_and_separate_from_the_value_class(self):
         s = self.d["schedule"]
@@ -127,15 +169,24 @@ class StartupYawCaptureTests(unittest.TestCase):
     def setUpClass(cls):
         cls.d = CAP.build()
 
-    def test_declared_supply_lands_inside_the_declared_entrance_set(self):
+    def test_magnetic_algebra_closes_but_the_entrance_claim_is_retracted(self):
         self.assertEqual(CAP.validate(self.d), [])
         b = self.d["declared_supply_branch"]
         self.assertEqual(b["sin_yaw_error_upper_exact"], "17/30")
         self.assertAlmostEqual(b["yaw_rad_upper"], 0.61, places=12)
         self.assertAlmostEqual(b["full_attitude_rad_upper"], 0.63, places=12)
         self.assertLess(b["full_attitude_deg_upper"], self.d["declared_entrance_full_attitude_deg"])
-        self.assertTrue(self.d["DECLARED_SUPPLY_ENTRANCE_CLOSED"])
         self.assertFalse(b["sqrtN_statistical_reduction_used"])
+        # The algebra holds; the supply does not.  The declared quantity is a
+        # gravity-direction error and the perturbation bound needs the total
+        # accumulation-frame excursion, heading included.
+        self.assertTrue(self.d["magnetic_algebra_closed"])
+        self.assertTrue(b["inside_declared_entrance_set_if_supply_covered_heading"])
+        self.assertTrue(b["supply_is_gravity_direction_error_only"])
+        self.assertFalse(b["supply_covers_total_excursion"])
+        self.assertFalse(self.d["DECLARED_SUPPLY_ENTRANCE_CLOSED"])
+        self.assertFalse(self.d["total_excursion_supply_exists"])
+        self.assertFalse(self.d["heading_excursion_charged_as_tilt"])
 
     def test_taylor_bound_dominates_the_magnetic_sine_bound(self):
         lower = CAP._taylor_sin_lower(F(61, 100))
@@ -228,15 +279,18 @@ class StartupYawCaptureTests(unittest.TestCase):
             CAP._sqrt_lower(Frac(-1))
 
     def test_qualitatively_different_alternatives_are_recorded(self):
-        self.assertGreaterEqual(len(self.d["alternatives"]), 3)
-        self.assertIn("IQC", " ".join(self.d["alternatives"]))
+        self.assertGreaterEqual(len(self.d["alternatives"]), 4)
+        joined = " ".join(self.d["alternatives"])
+        self.assertIn("IQC", joined)
+        self.assertIn("heading-excursion", joined)
         self.assertEqual(
             self.d["limiting_quantity"],
             "declared gravity-direction forcing pair (mean chord, primitive) and the commissioned magnetic band",
         )
 
-    def test_shipping_handoff_parity_is_observed_not_assumed(self):
+    def test_shipping_handoff_parity_compares_complete_expressions(self):
         p = self.d["shipping_parity"]
+        self.assertTrue(p["parity_compares_complete_expressions_not_tokens"])
         self.assertTrue(p["seed_composes_proxy_tilt_with_gauge_yaw"])
         self.assertTrue(p["timeout_branch_needs_only_aligned_branch"])
         self.assertTrue(p["quality_branch_needs_north_ready"])

--- a/tests/validation/test_ou3_brmm_magnetic_assumptions.py
+++ b/tests/validation/test_ou3_brmm_magnetic_assumptions.py
@@ -1,0 +1,201 @@
+from pathlib import Path
+import sys
+import unittest
+from fractions import Fraction as F
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+sys.path.insert(0, str(ROOT / "tools" / "stability"))
+
+import ou3_brmm_magnetic_source_envelope as ENV  # noqa: E402
+import ou3_brmm_magnetic_call_schedule as SCHED  # noqa: E402
+import ou3_brmm_magnetic_startup_yaw_capture as CAP  # noqa: E402
+
+
+class MagneticSourceEnvelopeTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.d = ENV.build()
+
+    def test_named_class_matches_the_declared_numbers(self):
+        self.assertEqual(ENV.validate(self.d), [])
+        self.assertEqual(self.d["assumption_id"], "MAG-BMM150-DET-v1")
+        e = self.d["envelope"]
+        self.assertEqual(e["world_field_norm_lower_uT"], 20.0)
+        self.assertEqual(e["world_field_norm_upper_uT"], 75.0)
+        self.assertEqual(e["world_field_horizontal_lower_uT"], 15.0)
+        self.assertEqual(e["hard_iron_norm_upper_uT"], 5.0)
+        self.assertEqual(e["residual_norm_upper_uT"], 2.0)
+
+    def test_declared_PE_magnetic_bounds_become_consequences(self):
+        self.assertEqual(self.d["measured_body_field_norm_lower_uT"], 13.0)
+        self.assertEqual(self.d["measured_body_field_norm_upper_uT"], 82.0)
+        self.assertTrue(self.d["declared_PE_magnetic_floor_is_now_derived"])
+        self.assertTrue(self.d["declared_PE_magnetic_ceiling_is_now_derived"])
+        self.assertTrue(self.d["shipping_mag_norm_guard_cleared_unconditionally"])
+
+    def test_sine_separation_is_not_silently_derived(self):
+        self.assertFalse(self.d["magnetic_vector_sine_separation_derivable_from_this_class"])
+        self.assertTrue(self.d["sine_separation_remains_declared_PE_hypothesis"])
+
+    def test_norm_ratio_gate_is_not_forced_by_the_declared_class(self):
+        g = self.d["norm_ratio_gate"]
+        self.assertAlmostEqual(g["shipping_ratio"], 0.35)
+        self.assertFalse(g["universal_sample_admission_forced"])
+        # ratio*Bmin/(2+ratio) = 0.35*20/2.35
+        self.assertAlmostEqual(
+            g["universal_admission_perturbation_budget_uT"], 0.35 * 20.0 / 2.35, places=12
+        )
+
+    def test_derived_tilt_requirements_are_exact_and_ordered(self):
+        r = self.d["derived_tilt_requirements"]
+        # min_horizontal_fraction: E <= (H - f*Bmax)/(1+f) = 75/7 uT, hence
+        # sin(delta/2) <= (75/7 - 7)/150 = 13/525.
+        self.assertEqual(
+            F(r["max_sin_half_tilt_for_horizontal_fraction_gate"]).limit_denominator(10**6),
+            F(13, 525),
+        )
+        # north non-vanishing: E < H, hence sin(delta/2) < (15-7)/150 = 4/75.
+        self.assertEqual(
+            F(r["max_sin_half_tilt_for_north_capture"]).limit_denominator(10**6), F(4, 75)
+        )
+        self.assertEqual(r["binding_requirement"], "min_horizontal_fraction")
+        self.assertLess(
+            r["max_tilt_deg_for_horizontal_fraction_gate"], r["max_tilt_deg_for_north_capture"]
+        )
+
+    def test_declared_startup_direction_error_reproduces_17_over_30(self):
+        a = self.d["at_declared_startup_direction_error"]
+        self.assertEqual(a["mean_perturbation_upper_uT"], 8.5)
+        self.assertEqual(a["sin_yaw_error_upper_exact"], "17/30")
+        self.assertTrue(a["north_nonvanishing"])
+        self.assertTrue(a["horizontal_fraction_gate_satisfied"])
+
+    def test_supply_is_not_silently_discharged(self):
+        self.assertFalse(self.d["declared_startup_direction_error_is_the_accumulation_frame_error"])
+        self.assertTrue(self.d["accumulation_frame_error_supply_is_open_obligation"])
+        self.assertFalse(self.d["P4_promoted_here"])
+        self.assertFalse(self.d["P5_promoted_here"])
+
+    def test_derive_rejects_out_of_range_tilt_supply(self):
+        c = ENV.shipping_constants()
+        with self.assertRaises(ValueError):
+            ENV.derive(F(-1, 100), c)
+        with self.assertRaises(ValueError):
+            ENV.derive(F(2), c)
+
+
+class MagneticCallScheduleTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.d = SCHED.build()
+
+    def test_release_time_is_finite_and_forces_the_strict_guard(self):
+        self.assertEqual(SCHED.validate(self.d), [])
+        self.assertEqual(self.d["assumption_id"], "MAG-CALL-SCHEDULE-v1")
+        r = self.d["release"]
+        self.assertEqual(r["unlock_count"], 250)
+        # 0.04 + 249*0.04 = 10.0 s from Live; 9.96 s from the first call.
+        self.assertAlmostEqual(r["live_to_unlock_upper_s"], 10.0, places=12)
+        self.assertAlmostEqual(r["elapsed_first_to_unlock_upper_s"], 9.96, places=12)
+        self.assertTrue(r["strict_one_second_guard_forced"])
+        self.assertTrue(self.d["H18_A21_RELEASE_TIME_CLOSED"])
+
+    def test_schedule_is_only_25_hz_and_separate_from_the_value_class(self):
+        s = self.d["schedule"]
+        self.assertAlmostEqual(s["effective_rate_hz"], 25.0)
+        self.assertTrue(s["is_deployment_timing_assumption_not_sensor_guarantee"])
+        self.assertFalse(self.d["magnetic_value_class_used_here"])
+
+    def test_counter_parity_and_open_downstream_obligations(self):
+        p = self.d["shipping_parity"]
+        self.assertTrue(p["counter_increment_is_unconditional"])
+        self.assertTrue(p["release_requires_live_stage"])
+        self.assertTrue(p["external_hold_gates_enable"])
+        self.assertFalse(self.d["innovation_acceptance_used_for_counter"])
+        self.assertFalse(self.d["eventual_A21_under_arbitrary_external_acc_bias_hold_claimed"])
+        self.assertFalse(self.d["H18_A21_covariance_transport_closed_here"])
+
+    def test_release_reachability_rejects_nonpositive_count(self):
+        with self.assertRaises(ValueError):
+            SCHED.release_reachability(0)
+
+
+class StartupYawCaptureTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.d = CAP.build()
+
+    def test_declared_supply_lands_inside_the_declared_entrance_set(self):
+        self.assertEqual(CAP.validate(self.d), [])
+        b = self.d["declared_supply_branch"]
+        self.assertEqual(b["sin_yaw_error_upper_exact"], "17/30")
+        self.assertAlmostEqual(b["yaw_rad_upper"], 0.61, places=12)
+        self.assertAlmostEqual(b["full_attitude_rad_upper"], 0.63, places=12)
+        self.assertLess(b["full_attitude_deg_upper"], self.d["declared_entrance_full_attitude_deg"])
+        self.assertTrue(self.d["DECLARED_SUPPLY_ENTRANCE_CLOSED"])
+        self.assertFalse(b["sqrtN_statistical_reduction_used"])
+
+    def test_taylor_bound_dominates_the_magnetic_sine_bound(self):
+        lower = CAP._taylor_sin_lower(F(61, 100))
+        self.assertGreater(lower, F(17, 30))
+        with self.assertRaises(ValueError):
+            CAP._taylor_sin_lower(F(3, 2))
+
+    def test_certified_supply_branch_stays_fail_closed_with_a_reported_gap(self):
+        c = self.d["certified_supply_branch"]
+        self.assertFalse(c["invariant_closed_at_padded_envelope"])
+        self.assertFalse(c["magnetic_capture_forced_from_certified_supply"])
+        self.assertFalse(c["certified_tilt_alone_inside_declared_entrance_set"])
+        self.assertFalse(c["perfect_yaw_gauge_would_repair_entrance"])
+        self.assertGreater(c["gate_shortfall_factor"], 1.0)
+        self.assertGreater(c["entrance_shortfall_factor"], 1.0)
+        self.assertTrue(c["bound_is_level_set_radius_not_accuracy_bound"])
+        self.assertFalse(self.d["CERTIFIED_SUPPLY_ENTRANCE_CLOSED"])
+        self.assertFalse(self.d["accumulation_frame_tilt_supply_discharged"])
+        self.assertFalse(self.d["timeout_branch_yaw_gauge_forced"])
+
+    def test_scaling_argument_rules_out_metric_refinement_alone(self):
+        s = self.d["forcing_scaling_argument"]
+        self.assertTrue(s["is_scaling_argument_not_certificate"])
+        self.assertTrue(s["metric_refinement_alone_cannot_reach_requirement"])
+        self.assertGreater(s["shortfall_factor"], 1.0)
+        # theta_ss = -m/s from the observer's own integral channel, plus the
+        # 0.1*xi primitive term carried by z = x - B*xi.
+        self.assertAlmostEqual(
+            s["metric_free_tilt_floor_rad"],
+            s["declared_mean_direction_chord_norm_upper"] / s["endpoint_sector_s_lower"]
+            + 0.1 * s["declared_direction_primitive_norm_upper_s"],
+            places=12,
+        )
+
+    def test_three_qualitatively_different_alternatives_are_recorded(self):
+        self.assertGreaterEqual(len(self.d["alternatives"]), 3)
+        self.assertEqual(
+            self.d["limiting_quantity"],
+            "private-observer accumulation tilt-frame error bound",
+        )
+
+    def test_shipping_handoff_parity_is_observed_not_assumed(self):
+        p = self.d["shipping_parity"]
+        self.assertTrue(p["seed_composes_proxy_tilt_with_gauge_yaw"])
+        self.assertTrue(p["timeout_branch_needs_only_aligned_branch"])
+        self.assertTrue(p["quality_branch_needs_north_ready"])
+        self.assertTrue(p["ungauged_seed_uses_free_yaw_sigma"])
+        self.assertTrue(self.d["declared_entrance_ungauged_branch_is_tilt_only"])
+
+
+class NoReplayOrRetuningTests(unittest.TestCase):
+    def test_new_modules_do_not_replay_or_move_frozen_gates(self):
+        for name in (
+            "ou3_brmm_magnetic_source_envelope",
+            "ou3_brmm_magnetic_call_schedule",
+            "ou3_brmm_magnetic_startup_yaw_capture",
+        ):
+            text = (ROOT / "tools" / "stability" / f"{name}.py").read_text()
+            for forbidden in ("ou3_exact_replay", "np.quantile", "observed_min", "replay_min", "1e-19"):
+                self.assertNotIn(forbidden, text, name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/validation/test_ou3_brmm_magnetic_assumptions.py
+++ b/tests/validation/test_ou3_brmm_magnetic_assumptions.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import math
 import sys
 import unittest
 from fractions import Fraction as F
@@ -144,36 +145,94 @@ class StartupYawCaptureTests(unittest.TestCase):
 
     def test_certified_supply_branch_stays_fail_closed_with_a_reported_gap(self):
         c = self.d["certified_supply_branch"]
-        self.assertFalse(c["invariant_closed_at_padded_envelope"])
+        # The two-phase Mahony certificate now closes, so the supply exists -
+        # it is simply far too weak, which is a different fact and is reported
+        # as such rather than as a missing certificate.
+        self.assertTrue(c["invariant_closed_at_padded_envelope"])
+        self.assertEqual(c["invariant_validation_failures"], [])
+        self.assertTrue(c["two_phase_certificate_consumed"])
         self.assertFalse(c["magnetic_capture_forced_from_certified_supply"])
+        self.assertFalse(c["magnetic_capture_forced_from_ultimate_supply"])
         self.assertFalse(c["certified_tilt_alone_inside_declared_entrance_set"])
         self.assertFalse(c["perfect_yaw_gauge_would_repair_entrance"])
         self.assertGreater(c["gate_shortfall_factor"], 1.0)
+        self.assertGreater(c["ultimate_gate_shortfall_factor"], 1.0)
+        self.assertGreater(c["ultimate_north_capture_shortfall_factor"], 1.0)
         self.assertGreater(c["entrance_shortfall_factor"], 1.0)
-        self.assertTrue(c["bound_is_level_set_radius_not_accuracy_bound"])
+        # The accumulation frame can start well before the deployed horizon, so
+        # the sound supply is the all-time bound, not the asymptotic one.
+        self.assertTrue(c["accumulation_frame_may_start_before_the_horizon"])
+        self.assertTrue(c["sound_supply_for_accumulation_frame_is_all_time_bound"])
+        self.assertLess(c["certified_ultimate_tilt_deg_upper"], c["certified_tilt_deg_upper"])
         self.assertFalse(self.d["CERTIFIED_SUPPLY_ENTRANCE_CLOSED"])
         self.assertFalse(self.d["accumulation_frame_tilt_supply_discharged"])
         self.assertFalse(self.d["timeout_branch_yaw_gauge_forced"])
 
-    def test_scaling_argument_rules_out_metric_refinement_alone(self):
-        s = self.d["forcing_scaling_argument"]
-        self.assertTrue(s["is_scaling_argument_not_certificate"])
-        self.assertTrue(s["metric_refinement_alone_cannot_reach_requirement"])
+    def test_formulation_floor_rules_out_the_whole_route_not_just_a_metric(self):
+        s = self.d["declared_formulation_tilt_floor"]
+        self.assertTrue(s["is_formulation_lower_bound_not_physical_claim"])
+        self.assertTrue(s["frozen_sector_member_s_equals_one"])
+        self.assertTrue(s["no_metric_or_level_can_reach_requirement"])
         self.assertGreater(s["shortfall_factor"], 1.0)
-        # theta_ss = -m/s from the observer's own integral channel, plus the
-        # 0.1*xi primitive term carried by z = x - B*xi.
+        # The floor is the in-band primitive-channel peak plus an admitted DC
+        # mean chord; both are superposed on the linear z-dynamics.
+        self.assertTrue(s["peak_frequency_inside_declared_wave_band"])
+        lo, hi = s["declared_wave_band_hz"]
+        self.assertLessEqual(lo, s["peak_frequency_hz"])
+        self.assertLessEqual(s["peak_frequency_hz"], hi)
         self.assertAlmostEqual(
-            s["metric_free_tilt_floor_rad"],
-            s["declared_mean_direction_chord_norm_upper"] / s["endpoint_sector_s_lower"]
-            + 0.1 * s["declared_direction_primitive_norm_upper_s"],
+            s["declared_formulation_tilt_floor_rad"],
+            s["primitive_channel_tilt_floor_rad"] + s["mean_chord_tilt_floor_rad"],
             places=12,
         )
+        # It must also dominate the weaker north-capture requirement.
+        self.assertGreater(
+            math.degrees(s["declared_formulation_tilt_floor_rad"]),
+            self.d["certified_supply_branch"]["required_tilt_deg_for_north_capture"],
+        )
+        self.assertFalse(self.d["private_observer_can_supply_the_declared_gates"])
+        self.assertTrue(self.d["quadratic_metric_class_ruled_out"])
 
-    def test_three_qualitatively_different_alternatives_are_recorded(self):
+    def test_required_envelope_narrowing_is_quantified_at_the_floor(self):
+        n = self.d["required_envelope_narrowing_at_the_floor"]
+        self.assertAlmostEqual(
+            n["supplied_tilt_rad"],
+            self.d["declared_formulation_tilt_floor"]["declared_formulation_tilt_floor_rad"],
+            places=12,
+        )
+        self.assertEqual(n["declared_combined_perturbation_uT"], 7.0)
+        self.assertAlmostEqual(n["shipping_min_horizontal_fraction"], 0.05)
+        rows = n["rows"]
+        self.assertGreaterEqual(len(rows), 3)
+        # A narrower total-field ceiling needs a lower horizontal floor, and
+        # every declared row must stay inside its own total field.
+        for row in rows:
+            self.assertTrue(row["feasible_within_total_field"], row)
+            self.assertGreater(
+                row["required_horizontal_floor_uT"], n["declared_envelope_row"]["declared_horizontal_floor_uT"]
+            )
+        ceilings = [r["world_field_norm_upper_uT"] for r in rows]
+        floors = [r["required_horizontal_floor_uT"] for r in rows]
+        self.assertEqual(ceilings, sorted(ceilings))
+        self.assertEqual(floors, sorted(floors))
+
+    def test_rational_sqrt_lower_bound_is_sound(self):
+        from fractions import Fraction as Frac
+
+        for x in (Frac(2), Frac(1, 3), Frac(157, 1000), Frac(0)):
+            lo = CAP._sqrt_lower(x)
+            self.assertLessEqual(lo * lo, x, x)               # sound
+            step = Frac(1, 10**28)
+            self.assertGreater((lo + step) * (lo + step), x, x)  # and tight
+        with self.assertRaises(ValueError):
+            CAP._sqrt_lower(Frac(-1))
+
+    def test_qualitatively_different_alternatives_are_recorded(self):
         self.assertGreaterEqual(len(self.d["alternatives"]), 3)
+        self.assertIn("IQC", " ".join(self.d["alternatives"]))
         self.assertEqual(
             self.d["limiting_quantity"],
-            "private-observer accumulation tilt-frame error bound",
+            "declared gravity-direction forcing pair (mean chord, primitive) and the commissioned magnetic band",
         )
 
     def test_shipping_handoff_parity_is_observed_not_assumed(self):

--- a/tests/validation/test_ou3_brmm_private_mahony_discrete_comparison.py
+++ b/tests/validation/test_ou3_brmm_private_mahony_discrete_comparison.py
@@ -7,31 +7,40 @@ sys.path.insert(0, str(ROOT / "tools"))
 sys.path.insert(0, str(ROOT / "tools" / "stability"))
 
 import ou3_brmm_private_mahony_discrete_comparison as mod  # noqa: E402
-import ou3_brmm_private_mahony_live_invariant as CONT  # noqa: E402
+import ou3_brmm_private_mahony_discrete_invariant as DISC  # noqa: E402
 
 
 class BrmmPrivateMahonyDiscreteComparisonTest(unittest.TestCase):
-    """The discrete comparison is blocked by its continuous prerequisite.
+    def test_ideal_shipping_period_step_preserves_invariant(self):
+        d = mod.build()
+        self.assertEqual(mod.validate(d), [])
+        self.assertTrue(d["ideal_5ms_discrete_PI_invariant_closed"])
+        self.assertGreater(d["discrete_metric_decrease_lower"], 0.0)
+        self.assertTrue(d["same_BRMM_forcing_as_continuous_invariant"])
 
-    The padded 8.8 m/s^2 envelope leaves the 87 deg-chart PI invariant with an
-    empty admissible level window, so the discrete/binary32 comparison refuses
-    to build rather than composing a step on top of an unclosed invariant.  The
-    refusal is the certificate here; the discrete lemma cannot be reinstated
-    until the continuous invariant closes.
-    """
+    def test_binary32_source_order_composition_is_closed_but_toolchain_generalization_remains_fail_closed(self):
+        d = mod.build()
+        self.assertTrue(d["shipping_binary32_quaternion_map_error_composed"])
+        self.assertTrue(d["shipping_source_order_binary32_discrete_invariant_closed"])
+        self.assertFalse(d["toolchain_independent_binary32_invariant_closed"])
+        self.assertFalse(d["complete_BRMM_family_materialized_here"])
+        self.assertFalse(d["P3_promoted"])
+        self.assertFalse(d["source_generator"])
 
-    def test_refuses_to_compose_on_an_unclosed_continuous_invariant(self):
-        failures = CONT.validate(CONT.build())
-        self.assertNotEqual(failures, [])
-        with self.assertRaisesRegex(RuntimeError, "continuous Mahony invariant invalid"):
-            mod.build()
-
-    def test_refusal_names_the_seed_level_window_obstruction(self):
-        with self.assertRaises(RuntimeError) as ctx:
-            mod.build()
-        message = str(ctx.exception)
-        self.assertIn("continuous_all_live_PI_invariant_closed is not true", message)
-        self.assertIn("no metric level contains the seed", message)
+    def test_binary32_charge_reads_the_metric_instead_of_hardcoding_it(self):
+        d = DISC.build()
+        self.assertEqual(DISC.validate(d), [])
+        self.assertTrue(d["metric_read_from_continuous_certificate"])
+        # dot(V) <= -sqrt(C)[sqrt(C) q - 2 sup] carries ONE factor of sqrt(C);
+        # the retired form used two and claimed twice the proved decrease.
+        self.assertTrue(d["first_order_decrease_carries_single_sqrt_C"])
+        self.assertAlmostEqual(
+            d["guaranteed_first_order_V_decrease_lower"],
+            d["continuous_boundary_margin_after_binary32"] * d["dt_s"] * 1.33,
+            places=9,
+        )
+        self.assertGreater(d["discrete_V_margin_lower"], 0.0)
+        self.assertGreater(d["one_step_chart_round_margin_rad"], 0.0)
 
 
 if __name__ == "__main__":

--- a/tests/validation/test_ou3_brmm_private_mahony_discrete_comparison.py
+++ b/tests/validation/test_ou3_brmm_private_mahony_discrete_comparison.py
@@ -7,24 +7,31 @@ sys.path.insert(0, str(ROOT / "tools"))
 sys.path.insert(0, str(ROOT / "tools" / "stability"))
 
 import ou3_brmm_private_mahony_discrete_comparison as mod  # noqa: E402
+import ou3_brmm_private_mahony_live_invariant as CONT  # noqa: E402
 
 
 class BrmmPrivateMahonyDiscreteComparisonTest(unittest.TestCase):
-    def test_ideal_shipping_period_step_preserves_invariant(self):
-        d = mod.build()
-        self.assertEqual(mod.validate(d), [])
-        self.assertTrue(d["ideal_5ms_discrete_PI_invariant_closed"])
-        self.assertGreater(d["discrete_metric_decrease_lower"], 0.0)
-        self.assertTrue(d["same_BRMM_forcing_as_continuous_invariant"])
+    """The discrete comparison is blocked by its continuous prerequisite.
 
-    def test_binary32_source_order_composition_is_closed_but_toolchain_generalization_remains_fail_closed(self):
-        d = mod.build()
-        self.assertTrue(d["shipping_binary32_quaternion_map_error_composed"])
-        self.assertTrue(d["shipping_source_order_binary32_discrete_invariant_closed"])
-        self.assertFalse(d["toolchain_independent_binary32_invariant_closed"])
-        self.assertFalse(d["complete_BRMM_family_materialized_here"])
-        self.assertFalse(d["P3_promoted"])
-        self.assertFalse(d["source_generator"])
+    The padded 8.8 m/s^2 envelope leaves the 87 deg-chart PI invariant with an
+    empty admissible level window, so the discrete/binary32 comparison refuses
+    to build rather than composing a step on top of an unclosed invariant.  The
+    refusal is the certificate here; the discrete lemma cannot be reinstated
+    until the continuous invariant closes.
+    """
+
+    def test_refuses_to_compose_on_an_unclosed_continuous_invariant(self):
+        failures = CONT.validate(CONT.build())
+        self.assertNotEqual(failures, [])
+        with self.assertRaisesRegex(RuntimeError, "continuous Mahony invariant invalid"):
+            mod.build()
+
+    def test_refusal_names_the_seed_level_window_obstruction(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            mod.build()
+        message = str(ctx.exception)
+        self.assertIn("continuous_all_live_PI_invariant_closed is not true", message)
+        self.assertIn("no metric level contains the seed", message)
 
 
 if __name__ == "__main__":

--- a/tests/validation/test_ou3_brmm_private_mahony_live_invariant.py
+++ b/tests/validation/test_ou3_brmm_private_mahony_live_invariant.py
@@ -11,65 +11,98 @@ import ou3_brmm_private_mahony_live_invariant as mod  # noqa: E402
 import ou3_brmm_gravity_direction_forcing_qualification as DIR  # noqa: E402
 
 
-class BrmmPrivateMahonyLiveInvariantTest(unittest.TestCase):
-    """The 87 deg-chart PI invariant does not close for the padded envelope.
+class BrmmPrivateMahonyTwoPhaseInvariantTest(unittest.TestCase):
+    """Two nested levels of one metric close at the padded 8.8 m/s^2 envelope.
 
-    The certificate is retained as evidence, not as a passing lemma: the level
-    needed to contain the first-sample accelerometer seed and the largest level
-    that still fits inside the proof chart form an empty window.  Any future
-    closure attempt must move the metric or the forcing qualification, and must
-    consciously update these assertions.
+    The retired single-level formulation could not: the level needed to contain
+    the first-sample accelerometer seed exceeded the largest level fitting
+    inside the 87 deg proof chart.  The replacement keeps one metric and splits
+    the roles - an outer level for seed containment and chart retention, an
+    inner level for the ultimate bound - which works because inward flow holds
+    on every level above the minimal certifiable one, not only on a boundary.
     """
 
     @classmethod
     def setUpClass(cls):
         cls.d = mod.build()
 
-    def test_seed_angle_is_bound_to_the_padded_source_not_a_constant(self):
-        g = self.d["BRMM_direction_geometry"]
-        q = DIR.build()
-        self.assertAlmostEqual(
-            g["initial_seed_tilt_rad_upper"],
-            q["instantaneous_direction_angle_upper_rad"],
-            places=15,
-        )
-        # asin(8.8/9.80665) = 1.1137 rad, not the retired 0.955 rad constant.
-        self.assertAlmostEqual(g["initial_seed_tilt_rad_upper"], 1.1137282529726653, places=12)
-        self.assertTrue(g["initial_seed_angle_closed"])
-        self.assertTrue(g["same_history_decomposition_retained"])
-
-    def test_admissible_level_window_is_empty_at_the_padded_envelope(self):
-        w = self.d["admissible_level_window"]
-        self.assertFalse(w["window_nonempty"])
-        self.assertGreater(w["level_lower_required_to_contain_seed"], w["level_upper_allowed_by_proof_chart"])
-        self.assertGreater(w["emptiness_factor"], 1.0)
-        self.assertAlmostEqual(w["declared_level_C"], 1.4641, places=12)
-
-    def test_invariant_stays_fail_closed_with_its_failures_recorded(self):
-        failures = mod.validate(self.d)
-        self.assertFalse(self.d["initial_set_inside_invariant"])
-        self.assertFalse(self.d["continuous_all_live_PI_invariant_closed"])
-        self.assertIn("initial_set_inside_invariant is not true", failures)
-        self.assertTrue(any("no metric level contains the seed" in f for f in failures))
-
-    def test_retained_geometry_is_still_certified(self):
-        # The boundary flow and chart containment of the declared level are
-        # unaffected by the seed obstruction and stay available to a successor.
+    def test_certificate_closes(self):
+        self.assertEqual(mod.validate(self.d), [])
+        self.assertTrue(self.d["continuous_all_live_PI_invariant_closed"])
         self.assertTrue(self.d["invariant_strictly_inside_87deg_chart"])
         self.assertFalse(self.d["invariant_strictly_inside_60deg_chart"])
-        self.assertLess(self.d["actual_tilt_deg_upper"], 87.0)
-        self.assertGreater(self.d["boundary_validation"]["strict_inward_margin_lower"], 0.0)
 
-    def test_certified_tilt_is_a_level_radius_far_above_magnetic_needs(self):
-        # The certified number is the ellipse radius, not an accuracy bound, and
-        # it is what the magnetic capture composition has to consume.
-        self.assertGreater(self.d["actual_tilt_deg_upper"], 80.0)
-        self.assertAlmostEqual(
-            self.d["actual_tilt_rad_upper"],
-            math.sqrt(self.d["z_tilt_projection_sq_upper"])
-            + 0.1 * self.d["BRMM_direction_geometry"]["direction_primitive_norm_upper_s"],
-            places=12,
+    def test_seed_angle_is_bound_to_the_padded_source_not_a_constant(self):
+        g = self.d["BRMM_direction_geometry"]
+        # The declared rational bound must dominate the source's own angle.
+        self.assertTrue(g["seed_tilt_dominates_source_angle"])
+        self.assertGreaterEqual(
+            g["seed_tilt_rad_upper"], DIR.build()["instantaneous_direction_angle_upper_rad"]
         )
+        # asin(8.8/9.80665) = 1.1137 rad, not the retired 0.955 rad constant.
+        self.assertLess(g["seed_tilt_rad_upper"], 1.115)
+        self.assertGreater(g["seed_tilt_deg_upper"], 63.0)
+        self.assertTrue(g["same_history_decomposition_retained"])
+
+    def test_three_level_constraints_are_jointly_satisfied(self):
+        lv = self.d["two_phase_levels"]
+        self.assertLessEqual(lv["seed_level_required"], lv["outer_level_C"])
+        self.assertLess(lv["outer_level_C"], lv["chart_level_ceiling"])
+        self.assertTrue(lv["seed_contained_in_outer_level"])
+        self.assertTrue(lv["outer_level_inside_chart"])
+        self.assertGreater(lv["chart_headroom_relative"], 0.0)
+        self.assertLess(lv["inner_level_C"], lv["outer_level_C"])
+
+    def test_both_level_boundaries_have_strict_inward_flow(self):
+        for key in ("boundary_validation", "inner_boundary_validation"):
+            b = self.d[key]
+            self.assertTrue(b["closed"], key)
+            self.assertGreater(b["strict_inward_margin_lower"], 0.0, key)
+            self.assertEqual(b["cells_per_chart"], mod.CELLS_PER_CHART)
+            self.assertEqual(b["endpoint_sector_checks"], 2)
+
+    def test_capture_is_exponential_and_reaches_the_inner_level(self):
+        cap = self.d["capture"]
+        self.assertTrue(cap["inner_level_above_minimal"])
+        self.assertGreater(cap["contraction_rate_lower_per_s"], 0.0)
+        self.assertTrue(cap["monotone_decrease_above_inner_level"])
+        # W_in = 2*support/q, and the rate is q/2.
+        self.assertAlmostEqual(
+            cap["minimal_certifiable_sqrt_level"],
+            2.0 * cap["support_upper_ceiling"] / cap["q_lower_floor"],
+            places=9,
+        )
+        self.assertAlmostEqual(
+            cap["contraction_rate_lower_per_s"], cap["q_lower_floor"] / 2.0, places=12
+        )
+        self.assertLess(cap["sqrt_level_at_horizon_upper"], self.d["sqrt_C"])
+        self.assertFalse(cap["capture_uses_deployed_timeout_as_hypothesis"])
+
+    def test_tilt_bounds_are_ordered_and_inside_the_chart(self):
+        self.assertLess(
+            self.d["ultimate_tilt_deg_upper"], self.d["tilt_at_deployed_horizon_deg_upper"]
+        )
+        self.assertLess(
+            self.d["tilt_at_deployed_horizon_deg_upper"], self.d["actual_tilt_deg_upper"]
+        )
+        self.assertLess(self.d["actual_tilt_deg_upper"], 87.0)
+        self.assertLess(self.d["actual_tilt_rad_upper"], self.d["chart_radius_rad"])
+
+    def test_metric_is_generic_and_consistent(self):
+        p = self.d["metric_skew_p"]
+        c = self.d["metric_scale_c"]
+        self.assertEqual(self.d["metric_cholesky_R"], [[1.0, -p], [0.0, c]])
+        self.assertEqual(self.d["metric_P"], [[1.0, -p], [-p, p * p + c * c]])
+        self.assertAlmostEqual(self.d["metric_det"], c * c, places=12)
+        self.assertFalse(self.d["metric_tuned_toward_magnetic_requirement"])
+
+    def test_exp_bound_is_outward_and_composed(self):
+        # exp(-x) for x beyond the validated half-step range.
+        for x in (0.25, 1.0, 3.0, 4.0):
+            self.assertGreaterEqual(mod._exp_neg_upper(x), math.exp(-x))
+            self.assertLess(mod._exp_neg_upper(x), math.exp(-x) * 1.01)
+        with self.assertRaises(ValueError):
+            mod._exp_neg_upper(-1.0)
 
     def test_same_brmm_forcing_not_an_alternate_source(self):
         self.assertTrue(self.d["same_BRMM_specific_force_direction_required"])
@@ -79,7 +112,7 @@ class BrmmPrivateMahonyLiveInvariantTest(unittest.TestCase):
         self.assertFalse(self.d["trajectory_replay_used"])
         self.assertFalse(self.d["arbitrary_bounded_input_source_used"])
 
-    def test_discrete_shipping_composition_remains_fail_closed(self):
+    def test_downstream_obligations_remain_fail_closed(self):
         self.assertFalse(self.d["shipping_binary32_discrete_invariant_closed"])
         self.assertFalse(self.d["complete_BRMM_family_materialized_here"])
         self.assertFalse(self.d["P3_promoted"])

--- a/tests/validation/test_ou3_brmm_private_mahony_live_invariant.py
+++ b/tests/validation/test_ou3_brmm_private_mahony_live_invariant.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import math
 import sys
 import unittest
 
@@ -7,22 +8,67 @@ sys.path.insert(0, str(ROOT / "tools"))
 sys.path.insert(0, str(ROOT / "tools" / "stability"))
 
 import ou3_brmm_private_mahony_live_invariant as mod  # noqa: E402
+import ou3_brmm_gravity_direction_forcing_qualification as DIR  # noqa: E402
 
 
 class BrmmPrivateMahonyLiveInvariantTest(unittest.TestCase):
+    """The 87 deg-chart PI invariant does not close for the padded envelope.
+
+    The certificate is retained as evidence, not as a passing lemma: the level
+    needed to contain the first-sample accelerometer seed and the largest level
+    that still fits inside the proof chart form an empty window.  Any future
+    closure attempt must move the metric or the forcing qualification, and must
+    consciously update these assertions.
+    """
+
     @classmethod
     def setUpClass(cls):
         cls.d = mod.build()
 
-    def test_continuous_all_live_invariant_closes(self):
-        self.assertEqual(mod.validate(self.d), [])
-        self.assertTrue(self.d["continuous_all_live_PI_invariant_closed"])
-        self.assertTrue(self.d["initial_set_inside_invariant"])
+    def test_seed_angle_is_bound_to_the_padded_source_not_a_constant(self):
+        g = self.d["BRMM_direction_geometry"]
+        q = DIR.build()
+        self.assertAlmostEqual(
+            g["initial_seed_tilt_rad_upper"],
+            q["instantaneous_direction_angle_upper_rad"],
+            places=15,
+        )
+        # asin(8.8/9.80665) = 1.1137 rad, not the retired 0.955 rad constant.
+        self.assertAlmostEqual(g["initial_seed_tilt_rad_upper"], 1.1137282529726653, places=12)
+        self.assertTrue(g["initial_seed_angle_closed"])
+        self.assertTrue(g["same_history_decomposition_retained"])
+
+    def test_admissible_level_window_is_empty_at_the_padded_envelope(self):
+        w = self.d["admissible_level_window"]
+        self.assertFalse(w["window_nonempty"])
+        self.assertGreater(w["level_lower_required_to_contain_seed"], w["level_upper_allowed_by_proof_chart"])
+        self.assertGreater(w["emptiness_factor"], 1.0)
+        self.assertAlmostEqual(w["declared_level_C"], 1.4641, places=12)
+
+    def test_invariant_stays_fail_closed_with_its_failures_recorded(self):
+        failures = mod.validate(self.d)
+        self.assertFalse(self.d["initial_set_inside_invariant"])
+        self.assertFalse(self.d["continuous_all_live_PI_invariant_closed"])
+        self.assertIn("initial_set_inside_invariant is not true", failures)
+        self.assertTrue(any("no metric level contains the seed" in f for f in failures))
+
+    def test_retained_geometry_is_still_certified(self):
+        # The boundary flow and chart containment of the declared level are
+        # unaffected by the seed obstruction and stay available to a successor.
         self.assertTrue(self.d["invariant_strictly_inside_87deg_chart"])
         self.assertFalse(self.d["invariant_strictly_inside_60deg_chart"])
         self.assertLess(self.d["actual_tilt_deg_upper"], 87.0)
-        self.assertGreater(
-            self.d["boundary_validation"]["strict_inward_margin_lower"], 0.0
+        self.assertGreater(self.d["boundary_validation"]["strict_inward_margin_lower"], 0.0)
+
+    def test_certified_tilt_is_a_level_radius_far_above_magnetic_needs(self):
+        # The certified number is the ellipse radius, not an accuracy bound, and
+        # it is what the magnetic capture composition has to consume.
+        self.assertGreater(self.d["actual_tilt_deg_upper"], 80.0)
+        self.assertAlmostEqual(
+            self.d["actual_tilt_rad_upper"],
+            math.sqrt(self.d["z_tilt_projection_sq_upper"])
+            + 0.1 * self.d["BRMM_direction_geometry"]["direction_primitive_norm_upper_s"],
+            places=12,
         )
 
     def test_same_brmm_forcing_not_an_alternate_source(self):

--- a/tests/validation/test_ou3_brmm_private_mahony_state_step.py
+++ b/tests/validation/test_ou3_brmm_private_mahony_state_step.py
@@ -60,13 +60,23 @@ class BrmmPrivateMahonyStateStepTest(unittest.TestCase):
         self.assertGreater(inv["raw_quaternion_norm2_lower"], inv["raw_quaternion_norm2_guard"][0])
         self.assertIn("Mahony -> WPE -> tuner/scheduler", d["next_obligation"])
 
-    def test_connected_frontend_transition_is_blocked_by_its_prerequisite(self):
-        # The frontend transition consumes the private-Mahony live-entry
-        # invariant, which has an empty admissible level window at the padded
-        # 8.8 m/s^2 envelope.  It therefore refuses to build rather than
-        # composing the connected path on an unclosed invariant.
-        with self.assertRaisesRegex(RuntimeError, "continuous Mahony invariant invalid"):
-            frontend.build()
+    def test_connected_frontend_transition_is_same_brmm_path(self):
+        d = frontend.build()
+        self.assertEqual(frontend.validate(d), [])
+        self.assertTrue(d["shipping_source_parity_pass"])
+        self.assertTrue(d["same_BRMM_sample_drives_Mahony_tuner_WPE"])
+        self.assertTrue(d["private_Mahony_live_entry_invariant_consumed"])
+        self.assertTrue(d["current_Riccati_schedule_exported_before_current_measurement"])
+        self.assertTrue(d["actual_applied_per_axis_RS_exported_from_same_active_schedule"])
+        self.assertTrue(d["tuner_consumes_previous_WPE_state"])
+        self.assertTrue(d["same_current_vertical_acceleration_consumed_by_tuner_and_WPE"])
+        self.assertFalse(d["source_generator"])
+        self.assertFalse(d["independent_vertical_acceleration_input_allowed"])
+        self.assertFalse(d["independent_wave_frequency_input_allowed"])
+        self.assertFalse(d["independent_tuner_schedule_input_allowed"])
+        self.assertFalse(d["complete_BRMM_family_materialized_here"])
+        self.assertFalse(d["P3_promoted"])
+
 
     def test_point_step_is_finite_but_cannot_promote(self):
         d = mod.build()

--- a/tests/validation/test_ou3_brmm_private_mahony_state_step.py
+++ b/tests/validation/test_ou3_brmm_private_mahony_state_step.py
@@ -60,22 +60,13 @@ class BrmmPrivateMahonyStateStepTest(unittest.TestCase):
         self.assertGreater(inv["raw_quaternion_norm2_lower"], inv["raw_quaternion_norm2_guard"][0])
         self.assertIn("Mahony -> WPE -> tuner/scheduler", d["next_obligation"])
 
-    def test_connected_frontend_transition_is_same_brmm_path(self):
-        d = frontend.build()
-        self.assertEqual(frontend.validate(d), [])
-        self.assertTrue(d["shipping_source_parity_pass"])
-        self.assertTrue(d["same_BRMM_sample_drives_Mahony_tuner_WPE"])
-        self.assertTrue(d["private_Mahony_live_entry_invariant_consumed"])
-        self.assertTrue(d["current_Riccati_schedule_exported_before_current_measurement"])
-        self.assertTrue(d["actual_applied_per_axis_RS_exported_from_same_active_schedule"])
-        self.assertTrue(d["tuner_consumes_previous_WPE_state"])
-        self.assertTrue(d["same_current_vertical_acceleration_consumed_by_tuner_and_WPE"])
-        self.assertFalse(d["source_generator"])
-        self.assertFalse(d["independent_vertical_acceleration_input_allowed"])
-        self.assertFalse(d["independent_wave_frequency_input_allowed"])
-        self.assertFalse(d["independent_tuner_schedule_input_allowed"])
-        self.assertFalse(d["complete_BRMM_family_materialized_here"])
-        self.assertFalse(d["P3_promoted"])
+    def test_connected_frontend_transition_is_blocked_by_its_prerequisite(self):
+        # The frontend transition consumes the private-Mahony live-entry
+        # invariant, which has an empty admissible level window at the padded
+        # 8.8 m/s^2 envelope.  It therefore refuses to build rather than
+        # composing the connected path on an unclosed invariant.
+        with self.assertRaisesRegex(RuntimeError, "continuous Mahony invariant invalid"):
+            frontend.build()
 
     def test_point_step_is_finite_but_cannot_promote(self):
         d = mod.build()

--- a/tests/validation/test_ou3_source_domain_contract.py
+++ b/tests/validation/test_ou3_source_domain_contract.py
@@ -29,7 +29,12 @@ class SourceDomainContractTests(unittest.TestCase):
  def test_contract_names_every_hybrid_transition_required_for_deployment(self):
   d=mod.build(mod.DEFAULT_HEADER); self.assertEqual(set(d["hybrid_obligations"]),{"startup_handoff","held_to_active","magnetic_lock","magnetic_regauge_refinement","tilt_reset","tilt_relock","cooldown_reentry","periodic_aw_covariance_sync"}); self.assertEqual(d["periodic_aw_covariance_sync_proof"]["required_mode"],"PSD_NONEXPANSIVE")
  def test_physical_height_period_coupling_remains_fail_closed(self):
-  d=brmm_phys.build(); self.assertEqual(brmm_phys.validate(d),[]); self.assertTrue(d["three_partition_contract"]["independent_H_r_and_T_p_rectangular_extrema_forbidden"]); self.assertEqual(d["repository_total_Hs_upper_m"],8.5); self.assertFalse(d["left_language_inclusion_closed"])
+  # The total Hs cap is the declared padded deployment envelope, read from the
+  # domain rather than pinned to the unpadded 8.5 m reference sea, so the
+  # assertion cannot fall behind the next outward padding.
+  import json
+  expected=float(json.loads(brmm_phys.DEFAULT_DOMAIN.read_text(encoding="utf-8"))["initial_filter_entrance"]["position"]["significant_wave_height_Hs_upper_m"])
+  d=brmm_phys.build(); self.assertEqual(brmm_phys.validate(d),[]); self.assertTrue(d["three_partition_contract"]["independent_H_r_and_T_p_rectangular_extrema_forbidden"]); self.assertEqual(d["repository_total_Hs_upper_m"],expected); self.assertGreaterEqual(expected,9.35); self.assertFalse(d["left_language_inclusion_closed"])
  def test_cartesian_sea_x_rao_domain_is_forbidden_by_source_semantics_before_p1(self):
   d=brmm_p1.build(); self.assertEqual(brmm_p1.validate(d),[]); self.assertFalse(d["cartesian_product_refuted_by_analytical_witness"]); self.assertFalse(d["cartesian_product_refutation_required_for_canonical_BRMM"]); self.assertTrue(d["coupled_BRMM_domain_required"]); self.assertIsNone(d["independent_cartesian_sea_x_RAO_domain_is_P1_sound"]); self.assertTrue(d["coupled_domain_contract"]["sea_and_RAO_parameters_may_not_be_selected_independently"]); self.assertFalse(d["finite_window_realization_certificate_closed"]); self.assertFalse(d["L_actual_sea_subset_Lhat_BRMM_closed"])
  def test_wave_period_leak_subtraction_identity_stays_source_bound(self):

--- a/tools/stability/ou3_brmm_magnetic_call_schedule.py
+++ b/tools/stability/ou3_brmm_magnetic_call_schedule.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Deterministic magnetometer call schedule and H18->A21 release timing.
+
+The non-ALT BRMM route declares `hybrid_events_separate_from_P3_word` but has
+no timing assumption that makes the shipping accelerometer-bias release
+reachable in finite time. Without one, `H18` may persist forever and the
+`A21` half of the required `H=18` / `A=21` pair is unreachable by assumption
+rather than by proof.
+
+`MAG-CALL-SCHEDULE-v1` is the deployment/source timing class
+
+    first post-Live `updateMag()` call within 0.04 s of Live,
+    every subsequent `updateMag()` call gap at most 0.04 s,
+
+i.e. only 25 Hz. It is a call-cadence assumption on the host integration, kept
+strictly separate from the magnetic *value* class `MAG-BMM150-DET-v1`.
+
+Shipping `updateMag()` increments `mag_updates_applied_` immediately after the
+MEKF magnetometer update and does not gate that counter on innovation
+acceptance, so the release predicate
+
+    accel_bias_locked_ && Live && mag_updates_applied_ >= 250 &&
+    (time_ - first_mag_update_time_) > 1.0
+
+is driven by call count and wall time alone. This module certifies the finite
+release time from the schedule and the literal shipping constants, and states
+what it does *not* give: the external `acc_bias_hold_` branch can still keep
+`set_acc_bias_updates_enabled(true)` from firing, so eventual A21 under an
+arbitrary external hold is not claimed.
+"""
+from __future__ import annotations
+import argparse,json,re
+from fractions import Fraction as F
+from pathlib import Path
+
+REPO=Path(__file__).resolve().parents[2]
+WRAPPER=REPO/'src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h'
+DOMAIN=REPO/'tools/stability/ou3_proof_operating_domain.json'
+SCHEMA=1
+QUALIFICATION='OU3_BRMM_MAGNETIC_CALL_SCHEDULE_V1'
+ASSUMPTION_ID='MAG-CALL-SCHEDULE-v1'
+
+FIRST_CALL_AFTER_LIVE_MAX_S=F(1,25)
+CALL_GAP_MAX_S=F(1,25)
+
+
+def _one(pattern:str,text:str,label:str)->str:
+ m=re.search(pattern,text,flags=re.MULTILINE)
+ if not m:raise RuntimeError(f'cannot extract shipping constant {label}')
+ return m.group(1)
+
+
+def shipping_constants()->dict:
+ w=WRAPPER.read_text(encoding='utf-8')
+ return {
+  'MAG_UPDATES_TO_UNLOCK':int(_one(r'static\s+constexpr\s+int\s+MAG_UPDATES_TO_UNLOCK\s*=\s*([0-9]+)\s*;',w,'MAG_UPDATES_TO_UNLOCK')),
+  'acc_bias_unlock_mag_updates':int(_one(r'int\s+acc_bias_unlock_mag_updates\s*=\s*([0-9]+)\s*;',w,'acc_bias_unlock_mag_updates')),
+  'MAG_DELAY_SEC':float(_one(r'constexpr\s+float\s+MAG_DELAY_SEC\s*=\s*([0-9.eE+-]+)f',w,'MAG_DELAY_SEC')),
+  'strict_guard_sec':float(_one(r'first_mag_update_time_\)\s*>\s*([0-9.]+)f\)',w,'one-second guard')),
+  'counter_increment_is_unconditional':'mekf_->measurement_update_mag_only(mag_body_ned);\n        mag_updates_applied_++;' in w,
+  'release_requires_live_stage':'startup_stage_ == StartupStage::Live &&' in w,
+  'release_requires_count':'mag_updates_applied_ >= mag_updates_to_unlock_ &&' in w,
+  'external_hold_gates_enable':'if (!acc_bias_hold_) {' in w,
+  'proxy_startup_timeout_sec':float(_one(r'float\s+proxy_startup_timeout_sec\s*=\s*([0-9.eE+-]+)f',w,'proxy_startup_timeout_sec')),
+ }
+
+
+def release_reachability(n:int,gap:F=CALL_GAP_MAX_S,first:F=FIRST_CALL_AFTER_LIVE_MAX_S,guard:F=F(1))->dict:
+ if n<1:raise ValueError('positive unlock count required')
+ elapsed=(n-1)*gap                    # first call -> n-th call
+ total=first+elapsed                  # Live -> n-th call
+ return {'unlock_count':n,'first_call_after_live_upper_s':first,'elapsed_first_to_unlock_upper_s':elapsed,
+  'live_to_unlock_upper_s':total,'strict_guard_s':guard,'strict_guard_forced':elapsed>guard}
+
+
+def build()->dict:
+ c=shipping_constants();domain=json.loads(DOMAIN.read_text(encoding='utf-8'))
+ n=c['acc_bias_unlock_mag_updates']
+ if n!=c['MAG_UPDATES_TO_UNLOCK']:
+  raise RuntimeError('shipping unlock count is not the wrapper default; schedule certificate needs the configured value')
+ r=release_reachability(n)
+ events=list(domain['normal_live']['hybrid_events_separate_from_P3_word'])
+ closed=bool(r['strict_guard_forced'] and all(v is True for k,v in c.items() if isinstance(v,bool)))
+ return {
+  'schema':SCHEMA,'qualification':QUALIFICATION,'assumption_id':ASSUMPTION_ID,
+  'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD','filter_changed':False,'quality_gates_changed':False,
+  'trajectory_replay_used':False,'magnetic_value_class_used_here':False,
+  'schedule':{'first_post_live_call_upper_s':float(FIRST_CALL_AFTER_LIVE_MAX_S),
+   'call_gap_upper_s':float(CALL_GAP_MAX_S),'effective_rate_hz':float(1/CALL_GAP_MAX_S),
+   'is_deployment_timing_assumption_not_sensor_guarantee':True},
+  'shipping_constants':c,
+  'shipping_parity':{k:v for k,v in c.items() if isinstance(v,bool)},
+  'release':{'unlock_count':r['unlock_count'],
+   'live_to_unlock_upper_s':float(r['live_to_unlock_upper_s']),
+   'elapsed_first_to_unlock_upper_s':float(r['elapsed_first_to_unlock_upper_s']),
+   'strict_one_second_guard_s':float(r['strict_guard_s']),
+   'strict_one_second_guard_forced':r['strict_guard_forced']},
+  # The internal MAG_DELAY_SEC gate is measured on the impl clock, which starts
+  # at construction; both handoff paths are strictly later, so the delay never
+  # postpones the first post-Live call.
+  'mag_delay_precedes_live_on_timeout_path':c['MAG_DELAY_SEC']<c['proxy_startup_timeout_sec'],
+  'H18_A21_release_time_upper_s':float(r['live_to_unlock_upper_s']),
+  'H18_A21_RELEASE_TIME_CLOSED':closed,
+  'hybrid_events_outside_P3_word':events,
+  'innovation_acceptance_used_for_counter':False,
+  'eventual_A21_under_arbitrary_external_acc_bias_hold_claimed':False,
+  'H18_A21_covariance_transport_closed_here':False,
+  'P4_promoted_here':False,'P5_promoted_here':False,
+  'next_obligation':'attach this release time to the actual H18->A21 joint24 covariance transport edge and the reverse hold edge with BA cross-covariances zeroed',
+ }
+
+
+def validate(d:dict)->list:
+ f=[]
+ if d.get('schema')!=SCHEMA or d.get('qualification')!=QUALIFICATION:f.append('schema/qualification mismatch')
+ if d.get('assumption_id')!=ASSUMPTION_ID:f.append('wrong call-schedule assumption id')
+ if not all(d.get('shipping_parity',{}).values()):f.append('shipping magnetometer release parity failed')
+ for k in ('H18_A21_RELEASE_TIME_CLOSED','mag_delay_precedes_live_on_timeout_path'):
+  if d.get(k) is not True:f.append(k+' not true')
+ if d.get('release',{}).get('strict_one_second_guard_forced') is not True:f.append('strict one-second guard not forced')
+ for k in ('filter_changed','quality_gates_changed','trajectory_replay_used','magnetic_value_class_used_here',
+           'innovation_acceptance_used_for_counter','eventual_A21_under_arbitrary_external_acc_bias_hold_claimed',
+           'H18_A21_covariance_transport_closed_here','P4_promoted_here','P5_promoted_here'):
+  if d.get(k) is not False:f.append(k+' not false')
+ if not 0.0<float(d.get('H18_A21_release_time_upper_s',0.0))<=10.0:f.append('release time not finite and inside 10 s')
+ if 'magnetic_lock' not in d.get('hybrid_events_outside_P3_word',[]):f.append('magnetic hybrid events detached from declared domain')
+ return f
+
+
+def main()->int:
+ ap=argparse.ArgumentParser();ap.add_argument('--output',type=Path,required=True);a=ap.parse_args()
+ d=build();f=validate(d);d['validation_pass']=not f;d['validation_failures']=f
+ a.output.parent.mkdir(parents=True,exist_ok=True)
+ a.output.write_text(json.dumps(d,indent=2,sort_keys=True)+'\n')
+ print(json.dumps({'assumption':d['assumption_id'],'release_s':d['H18_A21_release_time_upper_s'],
+  'guard_forced':d['release']['strict_one_second_guard_forced'],
+  'closed':d['H18_A21_RELEASE_TIME_CLOSED'],'failures':f},sort_keys=True))
+ return int(bool(f))
+
+
+if __name__=='__main__':raise SystemExit(main())

--- a/tools/stability/ou3_brmm_magnetic_call_schedule.py
+++ b/tools/stability/ou3_brmm_magnetic_call_schedule.py
@@ -22,11 +22,35 @@ acceptance, so the release predicate
     accel_bias_locked_ && Live && mag_updates_applied_ >= 250 &&
     (time_ - first_mag_update_time_) > 1.0
 
-is driven by call count and wall time alone. This module certifies the finite
-release time from the schedule and the literal shipping constants, and states
-what it does *not* give: the external `acc_bias_hold_` branch can still keep
+is driven by call count and wall time alone.
+
+## Two things the schedule alone does not give
+
+**The counter is behind the outer north-lock gate.** The only call site of the
+counter-owning inner method is
+
+    if (mag_ref_set_ && stage_ == Stage::Live) {
+        impl_.updateMag(mag_body_ned - mag_hard_iron_body_uT_);
+    }
+
+so a host call schedule does *not* advance `mag_updates_applied_` until the
+startup magnetic reference is locked. On the explicitly admitted ungauged
+timeout path `mag_ref_set_` stays false, and the release is then unreachable
+however fast the host calls. The release time below is therefore conditional on
+north lock, and north lock is exactly what
+`ou3_brmm_magnetic_startup_yaw_capture` shows this route cannot supply. The two
+obligations share one prerequisite.
+
+**The count bound is an upper bound, so it cannot prove the strict guard.**
+`(n-1)*gap_max` bounds the elapsed time from above; calls faster than 25 Hz
+reach 250 sooner, and 250 calls 1 ms apart clear the count at `0.249 s` with the
+shipping `> 1.0f` predicate still false. The release time is therefore derived
+by a case split on whether the count or the guard binds last, never by comparing
+an upper bound against the guard.
+
+The external `acc_bias_hold_` branch can also keep
 `set_acc_bias_updates_enabled(true)` from firing, so eventual A21 under an
-arbitrary external hold is not claimed.
+arbitrary external hold is not claimed either.
 """
 from __future__ import annotations
 import argparse,json,re
@@ -61,16 +85,42 @@ def shipping_constants()->dict:
   'release_requires_live_stage':'startup_stage_ == StartupStage::Live &&' in w,
   'release_requires_count':'mag_updates_applied_ >= mag_updates_to_unlock_ &&' in w,
   'external_hold_gates_enable':'if (!acc_bias_hold_) {' in w,
+  # The counter-owning inner call is behind the outer north-lock gate; the exact
+  # guarded call is checked, not merely the presence of its name.
+  'counter_call_is_behind_north_lock_gate':(
+   'if (mag_ref_set_ && stage_ == Stage::Live) {\n            impl_.updateMag(mag_body_ned - mag_hard_iron_body_uT_);' in w),
   'proxy_startup_timeout_sec':float(_one(r'float\s+proxy_startup_timeout_sec\s*=\s*([0-9.eE+-]+)f',w,'proxy_startup_timeout_sec')),
  }
 
 
 def release_reachability(n:int,gap:F=CALL_GAP_MAX_S,first:F=FIRST_CALL_AFTER_LIVE_MAX_S,guard:F=F(1))->dict:
+ """Finite release time from the schedule, by a case split on the binding term.
+
+ `gap` bounds call spacing only from above, so `(n-1)*gap` is an upper bound on
+ the elapsed time to the n-th call and cannot establish the strict
+ `elapsed > guard` predicate. Instead:
+
+ * the count condition `applied >= n` holds from the n-th call onward, and that
+   call arrives no later than `first + (n-1)*gap`;
+ * the guard condition `time - first_call > guard` holds from the first call
+   strictly after `first_call + guard`, and with spacing at most `gap` such a
+   call arrives no later than `first_call + guard + gap`.
+
+ Both conditions are monotone once true, so the release fires no later than the
+ maximum of the two, which is finite without any lower bound on spacing.
+ """
  if n<1:raise ValueError('positive unlock count required')
- elapsed=(n-1)*gap                    # first call -> n-th call
- total=first+elapsed                  # Live -> n-th call
- return {'unlock_count':n,'first_call_after_live_upper_s':first,'elapsed_first_to_unlock_upper_s':elapsed,
-  'live_to_unlock_upper_s':total,'strict_guard_s':guard,'strict_guard_forced':elapsed>guard}
+ if gap<=0 or guard<0:raise ValueError('positive gap and nonnegative guard required')
+ count_upper=first+(n-1)*gap              # Live -> n-th call, upper bound
+ guard_upper=first+guard+gap              # Live -> first call past the guard
+ total=max(count_upper,guard_upper)
+ return {'unlock_count':n,'first_call_after_live_upper_s':first,
+  'count_condition_satisfied_by_upper_s':count_upper,
+  'guard_condition_satisfied_by_upper_s':guard_upper,
+  'binding_condition':'count' if count_upper>=guard_upper else 'strict_guard',
+  'live_to_unlock_upper_s':total,'strict_guard_s':guard,
+  'release_derived_by_case_split_not_upper_bound_comparison':True,
+  'lower_bound_on_call_spacing_assumed':False}
 
 
 def build()->dict:
@@ -80,7 +130,10 @@ def build()->dict:
   raise RuntimeError('shipping unlock count is not the wrapper default; schedule certificate needs the configured value')
  r=release_reachability(n)
  events=list(domain['normal_live']['hybrid_events_separate_from_P3_word'])
- closed=bool(r['strict_guard_forced'] and all(v is True for k,v in c.items() if isinstance(v,bool)))
+ parity_ok=all(v is True for k,v in c.items() if isinstance(v,bool))
+ # Finite release time is established, but only from north lock onward: the
+ # counter-owning call sits behind the outer mag_ref_set_ gate.
+ release_after_north_lock=bool(parity_ok and r['release_derived_by_case_split_not_upper_bound_comparison'])
  return {
   'schema':SCHEMA,'qualification':QUALIFICATION,'assumption_id':ASSUMPTION_ID,
   'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD','filter_changed':False,'quality_gates_changed':False,
@@ -92,21 +145,29 @@ def build()->dict:
   'shipping_parity':{k:v for k,v in c.items() if isinstance(v,bool)},
   'release':{'unlock_count':r['unlock_count'],
    'live_to_unlock_upper_s':float(r['live_to_unlock_upper_s']),
-   'elapsed_first_to_unlock_upper_s':float(r['elapsed_first_to_unlock_upper_s']),
+   'count_condition_satisfied_by_upper_s':float(r['count_condition_satisfied_by_upper_s']),
+   'guard_condition_satisfied_by_upper_s':float(r['guard_condition_satisfied_by_upper_s']),
+   'binding_condition':r['binding_condition'],
    'strict_one_second_guard_s':float(r['strict_guard_s']),
-   'strict_one_second_guard_forced':r['strict_guard_forced']},
+   'release_derived_by_case_split_not_upper_bound_comparison':r['release_derived_by_case_split_not_upper_bound_comparison'],
+   'lower_bound_on_call_spacing_assumed':r['lower_bound_on_call_spacing_assumed'],
+   'measured_from_north_lock_not_from_Live':True},
   # The internal MAG_DELAY_SEC gate is measured on the impl clock, which starts
   # at construction; both handoff paths are strictly later, so the delay never
   # postpones the first post-Live call.
   'mag_delay_precedes_live_on_timeout_path':c['MAG_DELAY_SEC']<c['proxy_startup_timeout_sec'],
-  'H18_A21_release_time_upper_s':float(r['live_to_unlock_upper_s']),
-  'H18_A21_RELEASE_TIME_CLOSED':closed,
+  'H18_A21_release_time_after_north_lock_upper_s':float(r['live_to_unlock_upper_s']),
+  'H18_A21_RELEASE_TIME_CLOSED_AFTER_NORTH_LOCK':release_after_north_lock,
+  'H18_A21_RELEASE_TIME_CLOSED_FROM_LIVE':False,
+  'counter_advances_without_north_lock':False,
+  'north_lock_is_an_unmet_prerequisite_on_this_route':True,
+  'ungauged_timeout_path_reaches_the_release':False,
   'hybrid_events_outside_P3_word':events,
   'innovation_acceptance_used_for_counter':False,
   'eventual_A21_under_arbitrary_external_acc_bias_hold_claimed':False,
   'H18_A21_covariance_transport_closed_here':False,
   'P4_promoted_here':False,'P5_promoted_here':False,
-  'next_obligation':'attach this release time to the actual H18->A21 joint24 covariance transport edge and the reverse hold edge with BA cross-covariances zeroed',
+  'next_obligation':'supply north lock -- the same prerequisite the startup magnetic capture cannot meet on this route -- then attach this release time to the actual H18->A21 joint24 covariance transport edge and the reverse hold edge with BA cross-covariances zeroed',
  }
 
 
@@ -115,14 +176,21 @@ def validate(d:dict)->list:
  if d.get('schema')!=SCHEMA or d.get('qualification')!=QUALIFICATION:f.append('schema/qualification mismatch')
  if d.get('assumption_id')!=ASSUMPTION_ID:f.append('wrong call-schedule assumption id')
  if not all(d.get('shipping_parity',{}).values()):f.append('shipping magnetometer release parity failed')
- for k in ('H18_A21_RELEASE_TIME_CLOSED','mag_delay_precedes_live_on_timeout_path'):
+ for k in ('H18_A21_RELEASE_TIME_CLOSED_AFTER_NORTH_LOCK','mag_delay_precedes_live_on_timeout_path',
+           'north_lock_is_an_unmet_prerequisite_on_this_route'):
   if d.get(k) is not True:f.append(k+' not true')
- if d.get('release',{}).get('strict_one_second_guard_forced') is not True:f.append('strict one-second guard not forced')
+ r=d.get('release',{})
+ if r.get('release_derived_by_case_split_not_upper_bound_comparison') is not True:
+  f.append('release time still derived by comparing an upper bound with the guard')
+ if r.get('lower_bound_on_call_spacing_assumed') is not False:f.append('a call-spacing lower bound was assumed')
+ if r.get('measured_from_north_lock_not_from_Live') is not True:f.append('release clock not anchored at north lock')
  for k in ('filter_changed','quality_gates_changed','trajectory_replay_used','magnetic_value_class_used_here',
            'innovation_acceptance_used_for_counter','eventual_A21_under_arbitrary_external_acc_bias_hold_claimed',
-           'H18_A21_covariance_transport_closed_here','P4_promoted_here','P5_promoted_here'):
+           'H18_A21_covariance_transport_closed_here','H18_A21_RELEASE_TIME_CLOSED_FROM_LIVE',
+           'counter_advances_without_north_lock','ungauged_timeout_path_reaches_the_release',
+           'P4_promoted_here','P5_promoted_here'):
   if d.get(k) is not False:f.append(k+' not false')
- if not 0.0<float(d.get('H18_A21_release_time_upper_s',0.0))<=10.0:f.append('release time not finite and inside 10 s')
+ if not 0.0<float(d.get('H18_A21_release_time_after_north_lock_upper_s',0.0))<=10.5:f.append('release time not finite and inside 10.5 s')
  if 'magnetic_lock' not in d.get('hybrid_events_outside_P3_word',[]):f.append('magnetic hybrid events detached from declared domain')
  return f
 
@@ -132,9 +200,11 @@ def main()->int:
  d=build();f=validate(d);d['validation_pass']=not f;d['validation_failures']=f
  a.output.parent.mkdir(parents=True,exist_ok=True)
  a.output.write_text(json.dumps(d,indent=2,sort_keys=True)+'\n')
- print(json.dumps({'assumption':d['assumption_id'],'release_s':d['H18_A21_release_time_upper_s'],
-  'guard_forced':d['release']['strict_one_second_guard_forced'],
-  'closed':d['H18_A21_RELEASE_TIME_CLOSED'],'failures':f},sort_keys=True))
+ print(json.dumps({'assumption':d['assumption_id'],
+  'release_after_north_lock_s':d['H18_A21_release_time_after_north_lock_upper_s'],
+  'binding':d['release']['binding_condition'],
+  'closed_after_north_lock':d['H18_A21_RELEASE_TIME_CLOSED_AFTER_NORTH_LOCK'],
+  'closed_from_live':d['H18_A21_RELEASE_TIME_CLOSED_FROM_LIVE'],'failures':f},sort_keys=True))
  return int(bool(f))
 
 

--- a/tools/stability/ou3_brmm_magnetic_source_envelope.py
+++ b/tools/stability/ou3_brmm_magnetic_source_envelope.py
@@ -26,12 +26,30 @@ acquisition path and derives, exactly over the rationals:
 3. the combined hard-iron + residual budget the shipping
    `MagAutoTuner::max_sample_norm_ratio_from_mean` gate needs before *every*
    qualified sample is admitted;
-4. the accumulation tilt-frame error the shipping
+4. the accumulation-frame rotation excursion the shipping
    `MagAutoTuner::min_horizontal_fraction` gate and the non-vanishing-north
    condition need before the startup reference/yaw gauge can be forced.
 
 Items 3 and 4 are derived *requirements*, not assumptions: they are reported
 whether or not the declared class and the certified startup tilt satisfy them.
+
+## The excursion parameter is not a tilt bound
+
+The shipping accumulation frame is `tiltOnlyQuatFromBoatQuat_`, which strips the
+*estimator's* yaw so its arbitrary startup heading cannot leak into the learned
+reference. It does **not** remove the vessel's own heading: `q_tilt * m_body`
+is the field in a level frame that still turns with the boat, which is precisely
+why `getYawGaugeCorrectionRad()` returns north *relative to the boat*. A heading
+change during the accumulation window therefore rotates accepted samples in the
+horizontal plane and smears the mean, and a large enough excursion can cancel
+its horizontal component entirely.
+
+So the parameter these derivations take is the **total accumulation-frame
+rotation excursion** over the window, `delta = delta_tilt + delta_heading`
+by the SO(3) triangle inequality -- not the tilt error alone. MAG-BMM150-DET-v1
+bounds magnetic *values* and says nothing about heading, and no declared
+quantity in the operating domain bounds a startup heading excursion. That supply
+is recorded as missing rather than silently charged as tilt.
 """
 from __future__ import annotations
 import argparse,json,math,re
@@ -87,9 +105,14 @@ def _sin_half_upper_from_angle(theta:F)->F:
  return theta/2
 
 
-def derive(sin_half_tilt_upper:F,c:dict)->dict:
- """Deterministic magnetic derivations at a supplied sin(delta_tilt/2) bound."""
- s=F(sin_half_tilt_upper)
+def derive(sin_half_excursion_upper:F,c:dict)->dict:
+ """Deterministic magnetic derivations at a supplied sin(delta/2) bound.
+
+ `delta` is the TOTAL accumulation-frame rotation excursion over the window,
+ tilt error plus vessel heading excursion. Passing a tilt-only bound here
+ understates the perturbation; see the module docstring.
+ """
+ s=F(sin_half_excursion_upper)
  if s<0 or s>1:raise ValueError('sin(delta/2) bound must lie in [0,1]')
  P=HARD_IRON_NORM_MAX_UT+RESIDUAL_NORM_MAX_UT            # combined deterministic body perturbation
  rot=2*WORLD_FIELD_NORM_MAX_UT*s                          # ||(Rhat Rtrue' - I) B|| chord bound
@@ -108,7 +131,7 @@ def derive(sin_half_tilt_upper:F,c:dict)->dict:
  # Non-vanishing north condition: E < H.
  s_capture=(H-P)/(2*WORLD_FIELD_NORM_MAX_UT) if H>P else F(0)
  return {
-  'sin_half_tilt_upper':s,'combined_body_perturbation_upper_uT':P,
+  'sin_half_excursion_upper':s,'combined_body_perturbation_upper_uT':P,
   'earth_field_rotation_chord_upper_uT':rot,'mean_perturbation_upper_uT':E,
   'horizontal_true_lower_uT':H,
   'measured_body_norm_lower_uT':WORLD_FIELD_NORM_MIN_UT-P,
@@ -120,8 +143,9 @@ def derive(sin_half_tilt_upper:F,c:dict)->dict:
   'horizontal_fraction_gate_satisfied':E<H and (H-E)/(WORLD_FIELD_NORM_MAX_UT+E)>=f,
   'universal_sample_admission_perturbation_budget_uT':P_budget,
   'universal_sample_admission_forced':P<=P_budget,
-  'max_sin_half_tilt_for_horizontal_gate':s_horiz,
-  'max_sin_half_tilt_for_north_capture':s_capture,
+  'max_sin_half_excursion_for_horizontal_gate':s_horiz,
+  'max_sin_half_excursion_for_north_capture':s_capture,
+  'excursion_includes_vessel_heading':True,
  }
 
 
@@ -141,8 +165,8 @@ def build()->dict:
  # Tilt-parameterised part, evaluated at the declared startup direction error.
  declared=derive(_sin_half_upper_from_angle(declared_tilt),c)
  thresholds=derive(F(0),c)
- s_horiz=thresholds['max_sin_half_tilt_for_horizontal_gate']
- s_capture=thresholds['max_sin_half_tilt_for_north_capture']
+ s_horiz=thresholds['max_sin_half_excursion_for_horizontal_gate']
+ s_capture=thresholds['max_sin_half_excursion_for_north_capture']
  tilt_horiz_rad=2*_asin_upper(s_horiz);tilt_capture_rad=2*_asin_upper(s_capture)
  return {
   'schema':SCHEMA,'qualification':QUALIFICATION,'assumption_id':ASSUMPTION_ID,
@@ -169,12 +193,16 @@ def build()->dict:
    'universal_sample_admission_forced':thresholds['universal_sample_admission_forced'],
    'note':'sufficient condition 2P/(Bmin-P) <= ratio; a weaker necessary condition needs an accepted-sample supply assumption that is not declared'},
   'derived_tilt_requirements':{
+   'parameter':'TOTAL_ACCUMULATION_FRAME_ROTATION_EXCURSION_TILT_PLUS_HEADING',
    'max_sin_half_tilt_for_north_capture':float(s_capture),'max_tilt_rad_for_north_capture':tilt_capture_rad,
    'max_tilt_deg_for_north_capture':math.degrees(tilt_capture_rad),
    'max_sin_half_tilt_for_horizontal_fraction_gate':float(s_horiz),
    'max_tilt_rad_for_horizontal_fraction_gate':tilt_horiz_rad,
    'max_tilt_deg_for_horizontal_fraction_gate':math.degrees(tilt_horiz_rad),
    'binding_requirement':'min_horizontal_fraction' if s_horiz<s_capture else 'north_nonvanishing'},
+  'accumulation_frame_retains_vessel_heading':c['tilt_frame_is_private_observer_tilt'],
+  'heading_excursion_bounded_by_this_class':False,
+  'startup_heading_excursion_declared_in_operating_domain':False,
   'at_declared_startup_direction_error':{
    'declared_tilt_rad_upper':float(declared_tilt),'declared_tilt_deg_upper':math.degrees(float(declared_tilt)),
    'mean_perturbation_upper_uT':float(declared['mean_perturbation_upper_uT']),
@@ -182,8 +210,11 @@ def build()->dict:
    'sin_yaw_error_upper_exact':f"{declared['sin_yaw_error_upper'].numerator}/{declared['sin_yaw_error_upper'].denominator}",
    'horizontal_fraction_lower':float(declared['horizontal_fraction_lower']),
    'north_nonvanishing':declared['north_nonvanishing'],
-   'horizontal_fraction_gate_satisfied':declared['horizontal_fraction_gate_satisfied']},
+   'horizontal_fraction_gate_satisfied':declared['horizontal_fraction_gate_satisfied'],
+   'supply_covers_heading_excursion':False,
+   'row_is_conditional_on_a_total_excursion_supply':True},
   'declared_startup_direction_error_is_the_accumulation_frame_error':False,
+  'declared_startup_direction_error_carries_no_heading_content':True,
   'accumulation_frame_error_supply_is_open_obligation':True,
   'magnetic_vector_sine_separation_derivable_from_this_class':False,
   'sine_separation_remains_declared_PE_hypothesis':True,
@@ -199,10 +230,15 @@ def validate(d:dict)->list:
  if not all(d.get('shipping_parity',{}).values()):f.append('shipping magnetic acquisition parity failed')
  for k in ('declared_PE_magnetic_floor_is_now_derived','declared_PE_magnetic_ceiling_is_now_derived',
            'shipping_mag_norm_guard_cleared_unconditionally','accumulation_frame_error_supply_is_open_obligation',
-           'sine_separation_remains_declared_PE_hypothesis'):
+           'sine_separation_remains_declared_PE_hypothesis','accumulation_frame_retains_vessel_heading',
+           'declared_startup_direction_error_carries_no_heading_content'):
   if d.get(k) is not True:f.append(k+' not true')
+ if d.get('derived_tilt_requirements',{}).get('parameter')!='TOTAL_ACCUMULATION_FRAME_ROTATION_EXCURSION_TILT_PLUS_HEADING':
+  f.append('excursion parameter mislabelled as a tilt-only bound')
  for k in ('filter_changed','quality_gates_changed','trajectory_replay_used','Rmag_used_as_deterministic_bound',
            'declared_startup_direction_error_is_the_accumulation_frame_error',
+           'heading_excursion_bounded_by_this_class',
+           'startup_heading_excursion_declared_in_operating_domain',
            'magnetic_vector_sine_separation_derivable_from_this_class','P4_promoted_here','P5_promoted_here'):
   if d.get(k) is not False:f.append(k+' not false')
  t=d.get('derived_tilt_requirements',{})
@@ -211,6 +247,8 @@ def validate(d:dict)->list:
  a=d.get('at_declared_startup_direction_error',{})
  if a.get('north_nonvanishing') is not True or a.get('horizontal_fraction_gate_satisfied') is not True:
   f.append('declared startup direction error does not clear the shipping magnetic gates')
+ if a.get('supply_covers_heading_excursion') is not False:
+  f.append('declared-supply row must not claim heading coverage')
  return f
 
 

--- a/tools/stability/ou3_brmm_magnetic_source_envelope.py
+++ b/tools/stability/ou3_brmm_magnetic_source_envelope.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Named deterministic magnetic source envelope for the non-ALT BRMM route.
+
+`MAG-BMM150-DET-v1` is the commissioned-installation admission class
+
+    20 uT <= ||B_W||_2 <= 75 uT,
+    ||(B_Wx,B_Wy)||_2 >= 15 uT,
+    ||b_HI||_2 <= 5 uT,
+    ||n_m||_2 <= 2 uT per theorem sample,
+
+for the exact startup magnetic identity
+
+    m_body = R_true B_W + b_HI + n_m.
+
+It is an engineering source requirement on a commissioned installation, not a
+sensor datasheet guarantee, and `Rmag` is never read as a deterministic bound.
+
+The non-ALT route had no magnetic source class at all: its magnetic PE numbers
+(`normal_live.magnetic_vector_norm_lower_uT = 10`, upper 200) were bare declared
+hypotheses. This module attaches the named class to the actual shipping startup
+acquisition path and derives, exactly over the rationals:
+
+1. the measured body-field norm band, hence whether the declared PE magnetic
+   floor/ceiling are consequences of the class rather than extra hypotheses;
+2. whether the class clears the shipping `mag_init_min_mag_norm` guard;
+3. the combined hard-iron + residual budget the shipping
+   `MagAutoTuner::max_sample_norm_ratio_from_mean` gate needs before *every*
+   qualified sample is admitted;
+4. the accumulation tilt-frame error the shipping
+   `MagAutoTuner::min_horizontal_fraction` gate and the non-vanishing-north
+   condition need before the startup reference/yaw gauge can be forced.
+
+Items 3 and 4 are derived *requirements*, not assumptions: they are reported
+whether or not the declared class and the certified startup tilt satisfy them.
+"""
+from __future__ import annotations
+import argparse,json,math,re
+from fractions import Fraction as F
+from pathlib import Path
+
+REPO=Path(__file__).resolve().parents[2]
+DOMAIN=REPO/'tools/stability/ou3_proof_operating_domain.json'
+WRAPPER=REPO/'src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h'
+TUNER=REPO/'src/tuner/MagAutoTuner.h'
+SCHEMA=1
+QUALIFICATION='OU3_BRMM_MAGNETIC_SOURCE_ENVELOPE_V1'
+ASSUMPTION_ID='MAG-BMM150-DET-v1'
+
+# MAG-BMM150-DET-v1, exactly as the named class declares it.
+WORLD_FIELD_NORM_MIN_UT=F(20)
+WORLD_FIELD_NORM_MAX_UT=F(75)
+WORLD_FIELD_HORIZONTAL_MIN_UT=F(15)
+HARD_IRON_NORM_MAX_UT=F(5)
+RESIDUAL_NORM_MAX_UT=F(2)
+
+
+def _one(pattern:str,text:str,label:str)->str:
+ m=re.search(pattern,text,flags=re.MULTILINE)
+ if not m:raise RuntimeError(f'cannot extract shipping constant {label}')
+ return m.group(1)
+
+
+def shipping_constants()->dict:
+ w=WRAPPER.read_text(encoding='utf-8');t=TUNER.read_text(encoding='utf-8')
+ return {
+  'mag_init_min_mag_norm_uT':float(_one(r'float\s+mag_init_min_mag_norm\s*=\s*([0-9.eE+-]+)f',w,'mag_init_min_mag_norm')),
+  'mag_min_samples':int(_one(r'int\s+mag_min_samples\s*=\s*([0-9]+)\s*;',w,'mag_min_samples')),
+  'mag_min_window_sec':float(_one(r'float\s+mag_min_window_sec\s*=\s*([0-9.eE+-]+)f',w,'mag_min_window_sec')),
+  'mag_max_window_sec':float(_one(r'float\s+mag_max_window_sec\s*=\s*([0-9.eE+-]+)f',w,'mag_max_window_sec')),
+  'mag_tilt_fallback_sec':float(_one(r'float\s+mag_tilt_fallback_sec\s*=\s*([0-9.eE+-]+)f',w,'mag_tilt_fallback_sec')),
+  'proxy_mag_settle_sec':float(_one(r'float\s+proxy_mag_settle_sec\s*=\s*([0-9.eE+-]+)f',w,'proxy_mag_settle_sec')),
+  'proxy_startup_timeout_sec':float(_one(r'float\s+proxy_startup_timeout_sec\s*=\s*([0-9.eE+-]+)f',w,'proxy_startup_timeout_sec')),
+  'mag_gravity_align_hold_sec':float(_one(r'float\s+mag_gravity_align_hold_sec\s*=\s*([0-9.eE+-]+)f',w,'mag_gravity_align_hold_sec')),
+  'mag_enable_quality_weighting':_one(r'bool\s+mag_enable_quality_weighting\s*=\s*(true|false)\s*;',w,'mag_enable_quality_weighting')=='true',
+  'mag_estimate_hard_iron':_one(r'bool\s+mag_estimate_hard_iron\s*=\s*(true|false)\s*;',w,'mag_estimate_hard_iron')=='true',
+  'max_sample_norm_ratio_from_mean':float(_one(r'float\s+max_sample_norm_ratio_from_mean\s*=\s*([0-9.eE+-]+)f',t,'max_sample_norm_ratio_from_mean')),
+  'min_horizontal_fraction':float(_one(r'float\s+min_horizontal_fraction\s*=\s*([0-9.eE+-]+)f',t,'min_horizontal_fraction')),
+  'tilt_frame_is_private_observer_tilt':'tiltOnlyQuatFromBoatQuat_(attitudeReferenceQuat_())' in w,
+  'world_sample_is_rotated_body_sample':'const Eigen::Vector3f mag_world_i = q * mag_body_ned;' in t,
+  'reference_gauge_fixed_to_horizontal_x':'mag_world_ref_ = Eigen::Vector3f(horiz, 0.0f, mean.z());' in t,
+ }
+
+
+def _sin_half_upper_from_angle(theta:F)->F:
+ """Rational upper bound for sin(theta/2) using sin x <= x."""
+ if theta<0:raise ValueError('nonnegative tilt angle required')
+ return theta/2
+
+
+def derive(sin_half_tilt_upper:F,c:dict)->dict:
+ """Deterministic magnetic derivations at a supplied sin(delta_tilt/2) bound."""
+ s=F(sin_half_tilt_upper)
+ if s<0 or s>1:raise ValueError('sin(delta/2) bound must lie in [0,1]')
+ P=HARD_IRON_NORM_MAX_UT+RESIDUAL_NORM_MAX_UT            # combined deterministic body perturbation
+ rot=2*WORLD_FIELD_NORM_MAX_UT*s                          # ||(Rhat Rtrue' - I) B|| chord bound
+ E=P+rot                                                  # accumulation-mean perturbation bound
+ H=WORLD_FIELD_HORIZONTAL_MIN_UT
+ f=F(c['min_horizontal_fraction']).limit_denominator(10**6)
+ ratio=F(c['max_sample_norm_ratio_from_mean']).limit_denominator(10**6)
+ # Universal per-sample admission at the norm-ratio gate:
+ #   every ||m_body|| and the running mean lie in [Bmin-P, Bmax+P]; a sufficient
+ #   condition is 2P/(Bmin-P) <= ratio, i.e. P <= ratio*Bmin/(2+ratio).
+ P_budget=ratio*WORLD_FIELD_NORM_MIN_UT/(2+ratio)
+ # min_horizontal_fraction gate on the finalized mean:
+ #   (H-E)/(Bmax+E) >= f  <=>  E <= (H - f*Bmax)/(1+f).
+ E_horiz=(H-f*WORLD_FIELD_NORM_MAX_UT)/(1+f)
+ s_horiz=(E_horiz-P)/(2*WORLD_FIELD_NORM_MAX_UT) if E_horiz>P else F(0)
+ # Non-vanishing north condition: E < H.
+ s_capture=(H-P)/(2*WORLD_FIELD_NORM_MAX_UT) if H>P else F(0)
+ return {
+  'sin_half_tilt_upper':s,'combined_body_perturbation_upper_uT':P,
+  'earth_field_rotation_chord_upper_uT':rot,'mean_perturbation_upper_uT':E,
+  'horizontal_true_lower_uT':H,
+  'measured_body_norm_lower_uT':WORLD_FIELD_NORM_MIN_UT-P,
+  'measured_body_norm_upper_uT':WORLD_FIELD_NORM_MAX_UT+P,
+  'mean_horizontal_lower_uT':H-E,'mean_norm_upper_uT':WORLD_FIELD_NORM_MAX_UT+E,
+  'horizontal_fraction_lower':(H-E)/(WORLD_FIELD_NORM_MAX_UT+E) if E<H else F(0),
+  'sin_yaw_error_upper':E/H,
+  'north_nonvanishing':E<H,
+  'horizontal_fraction_gate_satisfied':E<H and (H-E)/(WORLD_FIELD_NORM_MAX_UT+E)>=f,
+  'universal_sample_admission_perturbation_budget_uT':P_budget,
+  'universal_sample_admission_forced':P<=P_budget,
+  'max_sin_half_tilt_for_horizontal_gate':s_horiz,
+  'max_sin_half_tilt_for_north_capture':s_capture,
+ }
+
+
+def _asin_upper(x:F)->float:
+ return math.asin(float(x)) if 0<=float(x)<=1 else float('nan')
+
+
+def build()->dict:
+ d=json.loads(DOMAIN.read_text(encoding='utf-8'));live=d['normal_live'];c=shipping_constants()
+ declared_tilt=F(str(d['startup']['world_averaged_gravity_direction_error_upper_rad'])).limit_denominator(10**6)
+ # Unconditional part: no tilt bound is used.
+ P=HARD_IRON_NORM_MAX_UT+RESIDUAL_NORM_MAX_UT
+ measured_lo=WORLD_FIELD_NORM_MIN_UT-P;measured_hi=WORLD_FIELD_NORM_MAX_UT+P
+ pe_floor=F(str(live['magnetic_vector_norm_lower_uT'])).limit_denominator(10**6)
+ pe_ceiling=F(str(live['magnetic_vector_norm_upper_uT'])).limit_denominator(10**6)
+ guard=F(str(c['mag_init_min_mag_norm_uT'])).limit_denominator(10**9)
+ # Tilt-parameterised part, evaluated at the declared startup direction error.
+ declared=derive(_sin_half_upper_from_angle(declared_tilt),c)
+ thresholds=derive(F(0),c)
+ s_horiz=thresholds['max_sin_half_tilt_for_horizontal_gate']
+ s_capture=thresholds['max_sin_half_tilt_for_north_capture']
+ tilt_horiz_rad=2*_asin_upper(s_horiz);tilt_capture_rad=2*_asin_upper(s_capture)
+ return {
+  'schema':SCHEMA,'qualification':QUALIFICATION,'assumption_id':ASSUMPTION_ID,
+  'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD','filter_changed':False,'quality_gates_changed':False,
+  'trajectory_replay_used':False,'Rmag_used_as_deterministic_bound':False,
+  'source_identity':'m_body = R_true B_W + b_HI + n_m',
+  'envelope':{'world_field_norm_lower_uT':float(WORLD_FIELD_NORM_MIN_UT),'world_field_norm_upper_uT':float(WORLD_FIELD_NORM_MAX_UT),
+   'world_field_horizontal_lower_uT':float(WORLD_FIELD_HORIZONTAL_MIN_UT),'hard_iron_norm_upper_uT':float(HARD_IRON_NORM_MAX_UT),
+   'residual_norm_upper_uT':float(RESIDUAL_NORM_MAX_UT),'combined_body_perturbation_upper_uT':float(P)},
+  'shipping_constants':c,
+  'shipping_parity':{'accumulation_tilt_frame_is_private_observer':c['tilt_frame_is_private_observer_tilt'],
+   'world_sample_is_norm_preserving_rotation':c['world_sample_is_rotated_body_sample'],
+   'reference_is_gauge_fixed_to_horizontal_x':c['reference_gauge_fixed_to_horizontal_x'],
+   'startup_quality_weighting_disabled':c['mag_enable_quality_weighting'] is False,
+   'startup_hard_iron_solve_disabled':c['mag_estimate_hard_iron'] is False},
+  'measured_body_field_norm_lower_uT':float(measured_lo),'measured_body_field_norm_upper_uT':float(measured_hi),
+  'declared_PE_magnetic_floor_uT':float(pe_floor),'declared_PE_magnetic_ceiling_uT':float(pe_ceiling),
+  'declared_PE_magnetic_floor_is_now_derived':measured_lo>=pe_floor,
+  'declared_PE_magnetic_ceiling_is_now_derived':measured_hi<=pe_ceiling,
+  'shipping_mag_norm_guard_cleared_unconditionally':measured_lo>guard,
+  'norm_ratio_gate':{'shipping_ratio':c['max_sample_norm_ratio_from_mean'],
+   'universal_admission_perturbation_budget_uT':float(thresholds['universal_sample_admission_perturbation_budget_uT']),
+   'declared_combined_perturbation_uT':float(P),
+   'universal_sample_admission_forced':thresholds['universal_sample_admission_forced'],
+   'note':'sufficient condition 2P/(Bmin-P) <= ratio; a weaker necessary condition needs an accepted-sample supply assumption that is not declared'},
+  'derived_tilt_requirements':{
+   'max_sin_half_tilt_for_north_capture':float(s_capture),'max_tilt_rad_for_north_capture':tilt_capture_rad,
+   'max_tilt_deg_for_north_capture':math.degrees(tilt_capture_rad),
+   'max_sin_half_tilt_for_horizontal_fraction_gate':float(s_horiz),
+   'max_tilt_rad_for_horizontal_fraction_gate':tilt_horiz_rad,
+   'max_tilt_deg_for_horizontal_fraction_gate':math.degrees(tilt_horiz_rad),
+   'binding_requirement':'min_horizontal_fraction' if s_horiz<s_capture else 'north_nonvanishing'},
+  'at_declared_startup_direction_error':{
+   'declared_tilt_rad_upper':float(declared_tilt),'declared_tilt_deg_upper':math.degrees(float(declared_tilt)),
+   'mean_perturbation_upper_uT':float(declared['mean_perturbation_upper_uT']),
+   'sin_yaw_error_upper':float(declared['sin_yaw_error_upper']),
+   'sin_yaw_error_upper_exact':f"{declared['sin_yaw_error_upper'].numerator}/{declared['sin_yaw_error_upper'].denominator}",
+   'horizontal_fraction_lower':float(declared['horizontal_fraction_lower']),
+   'north_nonvanishing':declared['north_nonvanishing'],
+   'horizontal_fraction_gate_satisfied':declared['horizontal_fraction_gate_satisfied']},
+  'declared_startup_direction_error_is_the_accumulation_frame_error':False,
+  'accumulation_frame_error_supply_is_open_obligation':True,
+  'magnetic_vector_sine_separation_derivable_from_this_class':False,
+  'sine_separation_remains_declared_PE_hypothesis':True,
+  'P4_promoted_here':False,'P5_promoted_here':False,
+  'next_obligation':'supply the actual startup accumulation tilt-frame error for the private observer below the derived binding requirement, or widen MAG-BMM150-DET-v1 so the shipping gates are forced at the tilt error the non-ALT route can certify',
+ }
+
+
+def validate(d:dict)->list:
+ f=[]
+ if d.get('schema')!=SCHEMA or d.get('qualification')!=QUALIFICATION:f.append('schema/qualification mismatch')
+ if d.get('assumption_id')!=ASSUMPTION_ID:f.append('wrong magnetic assumption id')
+ if not all(d.get('shipping_parity',{}).values()):f.append('shipping magnetic acquisition parity failed')
+ for k in ('declared_PE_magnetic_floor_is_now_derived','declared_PE_magnetic_ceiling_is_now_derived',
+           'shipping_mag_norm_guard_cleared_unconditionally','accumulation_frame_error_supply_is_open_obligation',
+           'sine_separation_remains_declared_PE_hypothesis'):
+  if d.get(k) is not True:f.append(k+' not true')
+ for k in ('filter_changed','quality_gates_changed','trajectory_replay_used','Rmag_used_as_deterministic_bound',
+           'declared_startup_direction_error_is_the_accumulation_frame_error',
+           'magnetic_vector_sine_separation_derivable_from_this_class','P4_promoted_here','P5_promoted_here'):
+  if d.get(k) is not False:f.append(k+' not false')
+ t=d.get('derived_tilt_requirements',{})
+ if not 0.0<float(t.get('max_tilt_rad_for_horizontal_fraction_gate',0.0))<float(t.get('max_tilt_rad_for_north_capture',0.0)):
+  f.append('derived tilt requirement ordering invalid')
+ a=d.get('at_declared_startup_direction_error',{})
+ if a.get('north_nonvanishing') is not True or a.get('horizontal_fraction_gate_satisfied') is not True:
+  f.append('declared startup direction error does not clear the shipping magnetic gates')
+ return f
+
+
+def main()->int:
+ ap=argparse.ArgumentParser();ap.add_argument('--output',type=Path,required=True);a=ap.parse_args()
+ d=build();f=validate(d);d['validation_pass']=not f;d['validation_failures']=f
+ a.output.parent.mkdir(parents=True,exist_ok=True)
+ a.output.write_text(json.dumps(d,indent=2,sort_keys=True)+'\n')
+ print(json.dumps({'assumption':d['assumption_id'],
+  'measured_norm_uT':[d['measured_body_field_norm_lower_uT'],d['measured_body_field_norm_upper_uT']],
+  'pe_floor_derived':d['declared_PE_magnetic_floor_is_now_derived'],
+  'universal_admission_forced':d['norm_ratio_gate']['universal_sample_admission_forced'],
+  'tilt_required_deg':d['derived_tilt_requirements']['max_tilt_deg_for_horizontal_fraction_gate'],
+  'failures':f},sort_keys=True))
+ return int(bool(f))
+
+
+if __name__=='__main__':raise SystemExit(main())

--- a/tools/stability/ou3_brmm_magnetic_startup_yaw_capture.py
+++ b/tools/stability/ou3_brmm_magnetic_startup_yaw_capture.py
@@ -31,13 +31,38 @@ Two supplies are compared:
   `sin(0.61) >= 0.61 - 0.61^3/6`, and a full attitude error `< 0.63` rad
   `= 36.0962 deg`, strictly inside the declared 45 deg entrance set.
 
-* the route's own *certified* private-Mahony tilt bound, which is the level-set
-  radius of the 87 deg-chart PI invariant. It is far too weak both for the
-  magnetic gates and, on its own, for the 45 deg entrance set.
+* the route's own *certified* private-Mahony tilt bounds from the two-phase
+  certificate: the all-time outer level, the bound at the deployed 150 s
+  startup horizon, and the asymptotic bound. All three are far too weak for the
+  magnetic gates and, on their own, for the 45 deg entrance set.
 
 The declared 0.02 rad quantity is the low-passed world-gravity direction error,
 not the private observer's tilt error, so it is recorded as an unsupplied
 hypothesis rather than as a discharged one.
+
+## Why the private observer can never supply it
+
+The obstruction is not the choice of metric. The declared forcing qualification
+admits `r = m + d xi/dt` with `||m||<=0.05` and `||xi||<=1.0 s`, and the
+certificate quantifies over the sector value `s` as an independent parameter in
+`[sinc(87 deg),1]`. For the member `s=1` the tilt transfer function is
+
+    theta/r = -(0.01 + 0.1 j w) / (0.01 s - w^2 + 0.1 s j w),
+
+so an admitted primitive-bounded sinusoid `r = j w xi` produces
+`|theta| = w |theta/r| |xi|`. That response peaks at `w = 0.117 rad/s`
+(`0.0186 Hz`), which lies *inside* the declared physical band
+`[0.018,0.88] Hz`, giving `|theta| >= 0.146781` rad from the primitive channel
+alone; superposing an admitted DC `m` adds `0.05` rad. Hence no certificate in
+this formulation -- any metric, any level, any number of subdivisions -- can
+bound the tilt below
+
+    0.196781 rad = 11.2748 deg,
+
+against the `6.1145 deg` north-capture and `2.8378 deg` horizontal-fraction
+requirements. This is a property of the declared forcing pair and the deployed
+gains, so the limiter is `(mean chord 0.05, primitive 1.0 s)` and the magnetic
+envelope, not the storage geometry.
 """
 from __future__ import annotations
 import argparse,json,math
@@ -72,30 +97,92 @@ def _proxy_tilt_supply()->dict:
  c=CONT.build();failures=CONT.validate(c)
  return {'certified_tilt_rad_upper':float(c['actual_tilt_rad_upper']),
   'certified_tilt_deg_upper':float(c['actual_tilt_deg_upper']),
+  'certified_tilt_at_deployed_horizon_deg_upper':float(c['tilt_at_deployed_horizon_deg_upper']),
+  'certified_ultimate_tilt_deg_upper':float(c['ultimate_tilt_deg_upper']),
   'invariant_level_sqrt_C':float(c['sqrt_C']),'proof_chart_deg':float(c['chart_deg']),
   'invariant_closed_at_padded_envelope':bool(c['continuous_all_live_PI_invariant_closed']),
   'invariant_validation_failures':failures,
-  'bound_is_level_set_radius_not_accuracy_bound':True}
+  'two_phase_certificate_consumed':True,
+  'accumulation_frame_may_start_before_the_horizon':True,
+  'sound_supply_for_accumulation_frame_is_all_time_bound':True}
 
 
-def _forcing_scaling(required_rad:float)->dict:
- """Scaling argument for the best tilt this forcing qualification can support.
+PEAK_OMEGA_RAD_S=F(117,1000)
 
- The PI observer's own steady state under a constant admitted mean chord m is
- theta_ss = -m/s, and the transformed state carries the primitive term 0.1*xi
- directly into theta = z_theta - 0.1*xi. Neither term depends on the metric, so
- they bound from below what *any* storage/metric choice can certify.
+
+def _sqrt_lower(x:F,digits:int=30)->F:
+ """Rational lower bound for sqrt(x), x>=0, by integer square root."""
+ if x<0:raise ValueError('nonnegative argument required')
+ scale=10**digits
+ n=(x*scale*scale).numerator//(x*scale*scale).denominator if x else 0
+ return F(math.isqrt(n),scale)
+
+
+def _declared_formulation_tilt_floor(required_rad:float)->dict:
+ """Lower bound on any tilt the DECLARED formulation can certify.
+
+ The certificate quantifies over the sector value s as an independent parameter
+ in [sinc(87 deg),1], so its conclusion must also hold for the member s=1. For
+ that member the deployed PI gains give
+
+     theta/r = -(0.01 + 0.1 j w)/(0.01 - w^2 + 0.1 j w),
+
+ and an admitted primitive-bounded sinusoid r = j w xi produces
+ |theta| = w |theta/r| |xi|. Evaluated at the declared rational peak frequency
+ with exact rational arithmetic, plus a superposed admitted DC mean chord. This
+ is a statement about what the declared formulation can yield, not a claim
+ about the physical observer.
  """
- q=DIR.build();m=float(q['mean_direction_chord_norm_upper']);xi=float(q['direction_primitive_norm_upper_s'])
- chart=math.radians(float(q['private_mahony_proof_chart_deg']));s_min=math.sin(chart)/chart
- dc=m/s_min;prim=0.1*xi;total=dc+prim
- return {'declared_mean_direction_chord_norm_upper':m,'declared_direction_primitive_norm_upper_s':xi,
-  'endpoint_sector_s_lower':s_min,'metric_free_mean_chord_tilt_floor_rad':dc,
-  'metric_free_primitive_tilt_floor_rad':prim,'metric_free_tilt_floor_rad':total,
-  'metric_free_tilt_floor_deg':math.degrees(total),'required_tilt_rad':required_rad,
-  'shortfall_factor':total/required_rad if required_rad>0 else math.inf,
-  'metric_refinement_alone_cannot_reach_requirement':total>required_rad,
-  'is_scaling_argument_not_certificate':True}
+ q=DIR.build();m=F(str(q['mean_direction_chord_norm_upper'])).limit_denominator(10**6)
+ xi=F(str(q['direction_primitive_norm_upper_s'])).limit_denominator(10**6)
+ w=PEAK_OMEGA_RAD_S;w2=w*w
+ num_sq=F(1,10000)+F(1,100)*w2                      # |0.01 + 0.1 j w|^2
+ den_sq=(F(1,100)-w2)**2+F(1,100)*w2                # |0.01 - w^2 + 0.1 j w|^2
+ prim=w*_sqrt_lower(num_sq/den_sq)*xi
+ total=prim+m
+ f=float(total)
+ # The peak must lie inside the declared COMPLETE-BRMM frequency support, or the
+ # floor would rest on a frequency the physical envelope does not admit.
+ band=[float(x) for x in json.loads(DOMAIN.read_text(encoding='utf-8'))['complete_brmm_physical_envelope']['frequency_support_hz']]
+ peak_hz=float(w)/(2*math.pi)
+ in_band=band[0]<=peak_hz<=band[1]
+ return {'declared_mean_direction_chord_norm_upper':float(m),
+  'declared_direction_primitive_norm_upper_s':float(xi),
+  'peak_omega_rad_s':float(w),'peak_frequency_hz':peak_hz,
+  'declared_wave_band_hz':band,
+  'peak_frequency_inside_declared_wave_band':in_band,
+  'primitive_channel_tilt_floor_rad':float(prim),
+  'mean_chord_tilt_floor_rad':float(m),
+  'declared_formulation_tilt_floor_rad':f,
+  'declared_formulation_tilt_floor_deg':math.degrees(f),
+  'required_tilt_rad':required_rad,
+  'shortfall_factor':f/required_rad if required_rad>0 else math.inf,
+  'no_metric_or_level_can_reach_requirement':f>required_rad,
+  'frozen_sector_member_s_equals_one':True,
+  'is_formulation_lower_bound_not_physical_claim':True}
+
+
+def _required_envelope_narrowing(tilt_rad:float,c:dict)->dict:
+ """Commissioned band that would force the shipping gates at a supplied tilt.
+
+ The horizontal-fraction gate needs E <= (H - f Bmax)/(1+f) with
+ E = P + 2 Bmax sin(delta/2), so for a supplied delta the requirement is a
+ linear lower bound on the horizontal floor H as a function of Bmax.
+ """
+ f=F(str(c['min_horizontal_fraction'])).limit_denominator(10**6)
+ P=ENV.HARD_IRON_NORM_MAX_UT+ENV.RESIDUAL_NORM_MAX_UT
+ half=math.sin(tilt_rad/2.0)
+ rows=[]
+ for bmax in (45,55,65,75):
+  B=F(bmax)
+  need=(1+f)*(P+2*B*F(half).limit_denominator(10**9))+f*B
+  rows.append({'world_field_norm_upper_uT':bmax,'required_horizontal_floor_uT':float(need),
+   'feasible_within_total_field':float(need)<=bmax})
+ return {'supplied_tilt_rad':tilt_rad,'supplied_tilt_deg':math.degrees(tilt_rad),
+  'sin_half_supplied_tilt':half,'declared_combined_perturbation_uT':float(P),
+  'shipping_min_horizontal_fraction':float(f),'rows':rows,
+  'declared_envelope_row':{'world_field_norm_upper_uT':float(ENV.WORLD_FIELD_NORM_MAX_UT),
+   'declared_horizontal_floor_uT':float(ENV.WORLD_FIELD_HORIZONTAL_MIN_UT)}}
 
 
 def build()->dict:
@@ -127,6 +214,7 @@ def build()->dict:
  proxy=_proxy_tilt_supply()
  req=env['derived_tilt_requirements']
  binding=float(req['max_tilt_rad_for_horizontal_fraction_gate'])
+ north=float(req['max_tilt_rad_for_north_capture'])
  certified_branch={
   **proxy,
   'required_tilt_rad_for_binding_gate':binding,
@@ -134,9 +222,12 @@ def build()->dict:
   'required_tilt_deg_for_north_capture':float(req['max_tilt_deg_for_north_capture']),
   'binding_gate':req['binding_requirement'],
   'gate_shortfall_factor':proxy['certified_tilt_rad_upper']/binding,
-  'north_capture_shortfall_factor':proxy['certified_tilt_rad_upper']/float(req['max_tilt_rad_for_north_capture']),
+  'north_capture_shortfall_factor':proxy['certified_tilt_rad_upper']/north,
+  'ultimate_gate_shortfall_factor':math.radians(proxy['certified_ultimate_tilt_deg_upper'])/binding,
+  'ultimate_north_capture_shortfall_factor':math.radians(proxy['certified_ultimate_tilt_deg_upper'])/north,
   'entrance_shortfall_factor':proxy['certified_tilt_deg_upper']/declared_entrance_deg,
   'magnetic_capture_forced_from_certified_supply':proxy['certified_tilt_rad_upper']<binding,
+  'magnetic_capture_forced_from_ultimate_supply':math.radians(proxy['certified_ultimate_tilt_deg_upper'])<binding,
   'certified_tilt_alone_inside_declared_entrance_set':proxy['certified_tilt_deg_upper']<declared_entrance_deg,
   'perfect_yaw_gauge_would_repair_entrance':False}
 
@@ -145,7 +236,8 @@ def build()->dict:
   'seed_composes_proxy_tilt_with_gauge_yaw':'boatQuatWithAbsoluteYaw_(q_proxy, pending_yaw_abs_rad_)' in w,
   'ungauged_seed_uses_free_yaw_sigma':'cfg_.proxy_handoff_yaw_sigma_free_rad' in w}
 
- scaling=_forcing_scaling(binding)
+ floor=_declared_formulation_tilt_floor(binding)
+ narrowing=_required_envelope_narrowing(floor['declared_formulation_tilt_floor_rad'],c)
  return {
   'schema':SCHEMA,'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD',
   'magnetic_value_assumption':env['assumption_id'],'filter_changed':False,'quality_gates_changed':False,
@@ -155,18 +247,22 @@ def build()->dict:
   'declared_entrance_ungauged_branch_is_tilt_only':bool(entrance['ungauged_branch_tilt_bound_only_until_regauge']),
   'declared_supply_branch':declared_branch,
   'certified_supply_branch':certified_branch,
-  'forcing_scaling_argument':scaling,
+  'declared_formulation_tilt_floor':floor,
+  'required_envelope_narrowing_at_the_floor':narrowing,
   'DECLARED_SUPPLY_ENTRANCE_CLOSED':bool(declared_branch['inside_declared_entrance_set']),
   'CERTIFIED_SUPPLY_ENTRANCE_CLOSED':False,
   'accumulation_frame_tilt_supply_discharged':False,
   'timeout_branch_yaw_gauge_forced':False,
   'P4_basin_reached_here':False,'P5_end_to_end_closed_here':False,
-  'limiting_quantity':'private-observer accumulation tilt-frame error bound',
+  'limiting_quantity':'declared gravity-direction forcing pair (mean chord, primitive) and the commissioned magnetic band',
+  'private_observer_can_supply_the_declared_gates':False,
+  'quadratic_metric_class_ruled_out':True,
   'alternatives':[
-   'tighten the gravity-direction forcing qualification (mean chord 0.05, primitive 1.0 s) so a metric-free ultimate tilt below the binding gate exists at all',
-   'narrow MAG-BMM150-DET-v1 to a commissioned geomagnetic band (higher horizontal floor, lower total ceiling) so the shipping gates are forced at the tilt this route can certify',
+   'tighten the gravity-direction forcing qualification: the primitive channel alone contributes w|theta/r||xi| at the in-band peak, so the declared (0.05, 1.0 s) pair must come down together and must be argued from the COMPLETE-BRMM spectral support',
+   'narrow MAG-BMM150-DET-v1 to a commissioned geomagnetic band: the gates depend on Bmax and H_min, not tilt alone, and required_envelope_narrowing_at_the_floor gives the horizontal floor needed at each total-field ceiling',
+   'replace the static quadratic storage with a frequency-dependent multiplier/IQC on the primitive channel: the obstruction is a frequency-response peak, which a static metric cannot see',
    'prove that the shipping quality handoff cannot be preceded by the timeout handoff under the declared schedule, making north_ready a theorem consequence rather than an assumption'],
-  'next_obligation':'supply a private-observer accumulation tilt-frame accuracy bound, not a level-set radius, or requalify one of the three recorded alternatives',
+  'next_obligation':'the private observer cannot supply the declared gates in this formulation; close either the forcing qualification or the commissioned band, and use an IQC rather than a static metric for the tilt certificate',
  }
 
 
@@ -183,12 +279,22 @@ def validate(d:dict)->list:
  if b.get('sqrtN_statistical_reduction_used') is not False:f.append('statistical averaging gain used')
  if not 0.0<float(b.get('full_attitude_deg_upper',180.0))<float(d.get('declared_entrance_full_attitude_deg',0.0)):
   f.append('declared-supply full attitude bound not inside the declared entrance set')
- c=d.get('certified_supply_branch',{})
- if c.get('magnetic_capture_forced_from_certified_supply') is not False:
+ cb=d.get('certified_supply_branch',{})
+ if cb.get('magnetic_capture_forced_from_certified_supply') is not False:
   f.append('certified-supply capture claim must stay fail-closed until the tilt supply is proved')
- if not float(c.get('gate_shortfall_factor',0.0))>1.0:f.append('certified-supply shortfall factor not reported')
- s=d.get('forcing_scaling_argument',{})
- if s.get('is_scaling_argument_not_certificate') is not True:f.append('scaling argument mislabelled as a certificate')
+ if not float(cb.get('gate_shortfall_factor',0.0))>1.0:f.append('certified-supply shortfall factor not reported')
+ s=d.get('declared_formulation_tilt_floor',{})
+ if s.get('is_formulation_lower_bound_not_physical_claim') is not True:f.append('formulation floor mislabelled as a physical claim')
+ if s.get('no_metric_or_level_can_reach_requirement') is not True:f.append('formulation floor no longer dominates the requirement')
+ if s.get('peak_frequency_inside_declared_wave_band') is not True:f.append('peak primitive frequency outside the declared wave band')
+ for k in ('private_observer_can_supply_the_declared_gates','quadratic_metric_class_ruled_out'):
+  if k=='quadratic_metric_class_ruled_out':
+   if d.get(k) is not True:f.append(k+' not true')
+  elif d.get(k) is not False:f.append(k+' not false')
+ c=d.get('certified_supply_branch',{})
+ if c.get('magnetic_capture_forced_from_ultimate_supply') is not False:
+  f.append('ultimate-supply capture claim must stay fail-closed')
+ if c.get('two_phase_certificate_consumed') is not True:f.append('two-phase certificate not consumed')
  if len(d.get('alternatives',[]))<3:f.append('two-strike rule requires at least three qualitatively different alternatives')
  return f
 
@@ -204,7 +310,7 @@ def main()->int:
   'certified_tilt_deg':d['certified_supply_branch']['certified_tilt_deg_upper'],
   'required_tilt_deg':d['certified_supply_branch']['required_tilt_deg_for_binding_gate'],
   'gate_shortfall':d['certified_supply_branch']['gate_shortfall_factor'],
-  'metric_free_floor_deg':d['forcing_scaling_argument']['metric_free_tilt_floor_deg'],
+  'formulation_floor_deg':d['declared_formulation_tilt_floor']['declared_formulation_tilt_floor_deg'],
   'failures':f},sort_keys=True))
  return int(bool(f))
 

--- a/tools/stability/ou3_brmm_magnetic_startup_yaw_capture.py
+++ b/tools/stability/ou3_brmm_magnetic_startup_yaw_capture.py
@@ -29,7 +29,10 @@ Two supplies are compared:
   (0.02 rad). With MAG-BMM150-DET-v1 this yields `|sin(theta_yaw)| <= 17/30`,
   `theta_yaw < 0.61` rad by the alternating Taylor bound
   `sin(0.61) >= 0.61 - 0.61^3/6`, and a full attitude error `< 0.63` rad
-  `= 36.0962 deg`, strictly inside the declared 45 deg entrance set.
+  `= 36.0962 deg`, inside the declared 45 deg entrance set -- but only as a
+  *conditional* row, because that quantity is a gravity-direction error and the
+  perturbation bound needs the total accumulation-frame rotation excursion,
+  heading included. See below.
 
 * the route's own *certified* private-Mahony tilt bounds from the two-phase
   certificate: the all-time outer level, the bound at the deployed 150 s
@@ -39,6 +42,22 @@ Two supplies are compared:
 The declared 0.02 rad quantity is the low-passed world-gravity direction error,
 not the private observer's tilt error, so it is recorded as an unsupplied
 hypothesis rather than as a discharged one.
+
+## The accumulation frame turns with the vessel
+
+`tiltOnlyQuatFromBoatQuat_` strips the *estimator's* yaw, not the vessel's:
+`q_tilt * m_body` is the field in a level frame that still rotates with the
+boat, which is why the gauge is north *relative to the boat*. A heading change
+during the accumulation window therefore rotates accepted samples in the
+horizontal plane and smears the mean; a large enough excursion cancels its
+horizontal component. The perturbation bound consequently needs
+`delta = delta_tilt + delta_heading`, and neither MAG-BMM150-DET-v1 nor any
+declared operating-domain quantity bounds a startup heading excursion.
+
+Both supply rows are therefore conditional on a total-excursion bound that does
+not exist yet, and `DECLARED_SUPPLY_ENTRANCE_CLOSED` is false. The magnetic
+algebra itself -- `17/30`, `0.61` rad, `0.63` rad -- is unchanged and stays
+available to whatever supplies that excursion.
 
 ## Why the private observer can never supply it
 
@@ -207,7 +226,10 @@ def build()->dict:
   'full_attitude_rad_upper':float(full),'full_attitude_deg_upper':math.degrees(float(full)),
   'north_nonvanishing':declared['north_nonvanishing'],
   'horizontal_fraction_gate_satisfied':declared['horizontal_fraction_gate_satisfied'],
-  'inside_declared_entrance_set':yaw['yaw_strictly_below_test_angle'] and math.degrees(float(full))<declared_entrance_deg,
+  'inside_declared_entrance_set_if_supply_covered_heading':
+   yaw['yaw_strictly_below_test_angle'] and math.degrees(float(full))<declared_entrance_deg,
+  'supply_is_gravity_direction_error_only':True,
+  'supply_covers_total_excursion':False,
   'sqrtN_statistical_reduction_used':False}
 
  # Certified-supply branch.
@@ -231,10 +253,20 @@ def build()->dict:
   'certified_tilt_alone_inside_declared_entrance_set':proxy['certified_tilt_deg_upper']<declared_entrance_deg,
   'perfect_yaw_gauge_would_repair_entrance':False}
 
- parity={'timeout_branch_needs_only_aligned_branch':'mag_gravity_aligned_branch_;' in w and 'const bool ready_by_timeout' in w,
+ # Each flag compares the complete shipping expression, not a loose token, so a
+ # branch that changes semantics cannot leave the certificate green.
+ parity={
+  'timeout_branch_needs_only_aligned_branch':(
+   'const bool ready_by_timeout =\n            proxy_ready &&\n'
+   '            (t_ >= timeout_sec) &&\n            mag_gravity_aligned_branch_;' in w),
   'quality_branch_needs_north_ready':'const bool north_ready = !cfg_.with_mag || mag_ref_set_;' in w,
-  'seed_composes_proxy_tilt_with_gauge_yaw':'boatQuatWithAbsoluteYaw_(q_proxy, pending_yaw_abs_rad_)' in w,
-  'ungauged_seed_uses_free_yaw_sigma':'cfg_.proxy_handoff_yaw_sigma_free_rad' in w}
+  'seed_composes_proxy_tilt_with_gauge_yaw':(
+   'have_yaw_gauge\n                ? boatQuatWithAbsoluteYaw_(q_proxy, pending_yaw_abs_rad_)\n'
+   '                : q_proxy;' in w),
+  'ungauged_seed_uses_free_yaw_sigma':(
+   'const float yaw_sigma = have_yaw_gauge\n            ? cfg_.proxy_handoff_yaw_sigma_rad\n'
+   '            : cfg_.proxy_handoff_yaw_sigma_free_rad;' in w),
+  'parity_compares_complete_expressions_not_tokens':True}
 
  floor=_declared_formulation_tilt_floor(binding)
  narrowing=_required_envelope_narrowing(floor['declared_formulation_tilt_floor_rad'],c)
@@ -249,8 +281,11 @@ def build()->dict:
   'certified_supply_branch':certified_branch,
   'declared_formulation_tilt_floor':floor,
   'required_envelope_narrowing_at_the_floor':narrowing,
-  'DECLARED_SUPPLY_ENTRANCE_CLOSED':bool(declared_branch['inside_declared_entrance_set']),
+  'magnetic_algebra_closed':bool(declared_branch['inside_declared_entrance_set_if_supply_covered_heading']),
+  'DECLARED_SUPPLY_ENTRANCE_CLOSED':False,
   'CERTIFIED_SUPPLY_ENTRANCE_CLOSED':False,
+  'total_excursion_supply_exists':False,
+  'heading_excursion_charged_as_tilt':False,
   'accumulation_frame_tilt_supply_discharged':False,
   'timeout_branch_yaw_gauge_forced':False,
   'P4_basin_reached_here':False,'P5_end_to_end_closed_here':False,
@@ -261,7 +296,8 @@ def build()->dict:
    'tighten the gravity-direction forcing qualification: the primitive channel alone contributes w|theta/r||xi| at the in-band peak, so the declared (0.05, 1.0 s) pair must come down together and must be argued from the COMPLETE-BRMM spectral support',
    'narrow MAG-BMM150-DET-v1 to a commissioned geomagnetic band: the gates depend on Bmax and H_min, not tilt alone, and required_envelope_narrowing_at_the_floor gives the horizontal floor needed at each total-field ceiling',
    'replace the static quadratic storage with a frequency-dependent multiplier/IQC on the primitive channel: the obstruction is a frequency-response peak, which a static metric cannot see',
-   'prove that the shipping quality handoff cannot be preceded by the timeout handoff under the declared schedule, making north_ready a theorem consequence rather than an assumption'],
+   'prove that the shipping quality handoff cannot be preceded by the timeout handoff under the declared schedule, making north_ready a theorem consequence rather than an assumption',
+   'declare and justify a startup heading-excursion bound over the accumulation window, or retain the heading history in the accumulation so the mean is not smeared by a legal turn'],
   'next_obligation':'the private observer cannot supply the declared gates in this formulation; close either the forcing qualification or the commissioned band, and use an IQC rather than a static metric for the tilt certificate',
  }
 
@@ -270,13 +306,17 @@ def validate(d:dict)->list:
  f=[]
  if d.get('schema')!=SCHEMA or d.get('qualification')!=QUALIFICATION:f.append('schema/qualification mismatch')
  if not all(d.get('shipping_parity',{}).values()):f.append('shipping handoff parity failed')
- if d.get('DECLARED_SUPPLY_ENTRANCE_CLOSED') is not True:f.append('declared-supply entrance certificate not closed')
- for k in ('CERTIFIED_SUPPLY_ENTRANCE_CLOSED','accumulation_frame_tilt_supply_discharged',
+ if d.get('magnetic_algebra_closed') is not True:f.append('magnetic yaw algebra no longer closes')
+ for k in ('DECLARED_SUPPLY_ENTRANCE_CLOSED','CERTIFIED_SUPPLY_ENTRANCE_CLOSED',
+           'total_excursion_supply_exists','heading_excursion_charged_as_tilt',
+           'accumulation_frame_tilt_supply_discharged',
            'timeout_branch_yaw_gauge_forced','filter_changed','quality_gates_changed','trajectory_replay_used',
            'P4_basin_reached_here','P5_end_to_end_closed_here'):
   if d.get(k) is not False:f.append(k+' not false')
  b=d.get('declared_supply_branch',{})
  if b.get('sqrtN_statistical_reduction_used') is not False:f.append('statistical averaging gain used')
+ if b.get('supply_covers_total_excursion') is not False:f.append('declared supply must not claim heading coverage')
+ if b.get('supply_is_gravity_direction_error_only') is not True:f.append('declared supply mislabelled')
  if not 0.0<float(b.get('full_attitude_deg_upper',180.0))<float(d.get('declared_entrance_full_attitude_deg',0.0)):
   f.append('declared-supply full attitude bound not inside the declared entrance set')
  cb=d.get('certified_supply_branch',{})
@@ -306,6 +346,7 @@ def main()->int:
  a.output.write_text(json.dumps(d,indent=2,sort_keys=True)+'\n')
  print(json.dumps({'declared_supply_full_attitude_deg':d['declared_supply_branch']['full_attitude_deg_upper'],
   'declared_entrance_deg':d['declared_entrance_full_attitude_deg'],
+  'magnetic_algebra_closed':d['magnetic_algebra_closed'],
   'declared_supply_closed':d['DECLARED_SUPPLY_ENTRANCE_CLOSED'],
   'certified_tilt_deg':d['certified_supply_branch']['certified_tilt_deg_upper'],
   'required_tilt_deg':d['certified_supply_branch']['required_tilt_deg_for_binding_gate'],

--- a/tools/stability/ou3_brmm_magnetic_startup_yaw_capture.py
+++ b/tools/stability/ou3_brmm_magnetic_startup_yaw_capture.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Startup magnetic yaw capture and the non-ALT fresh-attitude entrance.
+
+The non-ALT BRMM startup certificate closes a *hemisphere* handoff: the shipping
+`ready_by_timeout` branch needs only `mag_gravity_aligned_branch_`, so
+`ou3_startup_timeout_capture` reports
+`magnetic_north_required_before_timeout_handoff = False` and
+`ou3_startup_handoff_tilt_hemisphere` reports `yaw_gauge_required = False`.
+Nothing in the route bounded yaw at all, while
+`initial_filter_entrance.attitude` declares a 45 deg *full* attitude error set
+whose gauged branch bound the route never supplied.
+
+This module composes the named magnetic classes into that gap and states the
+result fail-closed. At the shipping handoff
+
+    q_seed = boatQuatWithAbsoluteYaw_(q_proxy, pending_yaw_abs_rad_),
+
+so the seed's tilt is the private observer's tilt and its yaw is the one-time
+magnetic gauge. The geodesic triangle inequality gives
+
+    ||log(q_true q_seed^-1)|| <= theta_yaw + theta_proxy_tilt,
+
+and the *same* private-observer tilt also drives the accumulation frame that
+produced the gauge, so both terms are functions of one supplied tilt bound.
+
+Two supplies are compared:
+
+* the operating domain's declared `world_averaged_gravity_direction_error`
+  (0.02 rad). With MAG-BMM150-DET-v1 this yields `|sin(theta_yaw)| <= 17/30`,
+  `theta_yaw < 0.61` rad by the alternating Taylor bound
+  `sin(0.61) >= 0.61 - 0.61^3/6`, and a full attitude error `< 0.63` rad
+  `= 36.0962 deg`, strictly inside the declared 45 deg entrance set.
+
+* the route's own *certified* private-Mahony tilt bound, which is the level-set
+  radius of the 87 deg-chart PI invariant. It is far too weak both for the
+  magnetic gates and, on its own, for the 45 deg entrance set.
+
+The declared 0.02 rad quantity is the low-passed world-gravity direction error,
+not the private observer's tilt error, so it is recorded as an unsupplied
+hypothesis rather than as a discharged one.
+"""
+from __future__ import annotations
+import argparse,json,math
+from fractions import Fraction as F
+from pathlib import Path
+
+import ou3_brmm_magnetic_source_envelope as ENV
+import ou3_brmm_private_mahony_live_invariant as CONT
+import ou3_brmm_gravity_direction_forcing_qualification as DIR
+
+REPO=Path(__file__).resolve().parents[2]
+DOMAIN=REPO/'tools/stability/ou3_proof_operating_domain.json'
+WRAPPER=REPO/'src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h'
+SCHEMA=1
+QUALIFICATION='OU3_BRMM_MAGNETIC_STARTUP_YAW_CAPTURE_V1'
+YAW_CERT_RAD=F(61,100)
+
+
+def _taylor_sin_lower(x:F)->F:
+ """sin(x) >= x - x^3/6 on [0,1], exact over the rationals."""
+ if x<0 or x>1:raise ValueError('Taylor lower bound declared on [0,1]')
+ return x-x*x*x/6
+
+
+def yaw_certificate(sin_yaw_upper:F)->dict:
+ x=YAW_CERT_RAD;lower=_taylor_sin_lower(x)
+ return {'sin_yaw_error_upper':sin_yaw_upper,'yaw_test_angle_rad':x,
+  'sin_test_angle_lower':lower,'yaw_strictly_below_test_angle':lower>sin_yaw_upper}
+
+
+def _proxy_tilt_supply()->dict:
+ c=CONT.build();failures=CONT.validate(c)
+ return {'certified_tilt_rad_upper':float(c['actual_tilt_rad_upper']),
+  'certified_tilt_deg_upper':float(c['actual_tilt_deg_upper']),
+  'invariant_level_sqrt_C':float(c['sqrt_C']),'proof_chart_deg':float(c['chart_deg']),
+  'invariant_closed_at_padded_envelope':bool(c['continuous_all_live_PI_invariant_closed']),
+  'invariant_validation_failures':failures,
+  'bound_is_level_set_radius_not_accuracy_bound':True}
+
+
+def _forcing_scaling(required_rad:float)->dict:
+ """Scaling argument for the best tilt this forcing qualification can support.
+
+ The PI observer's own steady state under a constant admitted mean chord m is
+ theta_ss = -m/s, and the transformed state carries the primitive term 0.1*xi
+ directly into theta = z_theta - 0.1*xi. Neither term depends on the metric, so
+ they bound from below what *any* storage/metric choice can certify.
+ """
+ q=DIR.build();m=float(q['mean_direction_chord_norm_upper']);xi=float(q['direction_primitive_norm_upper_s'])
+ chart=math.radians(float(q['private_mahony_proof_chart_deg']));s_min=math.sin(chart)/chart
+ dc=m/s_min;prim=0.1*xi;total=dc+prim
+ return {'declared_mean_direction_chord_norm_upper':m,'declared_direction_primitive_norm_upper_s':xi,
+  'endpoint_sector_s_lower':s_min,'metric_free_mean_chord_tilt_floor_rad':dc,
+  'metric_free_primitive_tilt_floor_rad':prim,'metric_free_tilt_floor_rad':total,
+  'metric_free_tilt_floor_deg':math.degrees(total),'required_tilt_rad':required_rad,
+  'shortfall_factor':total/required_rad if required_rad>0 else math.inf,
+  'metric_refinement_alone_cannot_reach_requirement':total>required_rad,
+  'is_scaling_argument_not_certificate':True}
+
+
+def build()->dict:
+ domain=json.loads(DOMAIN.read_text(encoding='utf-8'));w=WRAPPER.read_text(encoding='utf-8')
+ env=ENV.build();ef=ENV.validate(env)
+ if ef:raise RuntimeError('magnetic source envelope invalid: '+repr(ef))
+ entrance=domain['initial_filter_entrance']['attitude']
+ declared_entrance_deg=float(entrance['full_attitude_error_upper_deg'])
+ declared_tilt=F(str(domain['startup']['world_averaged_gravity_direction_error_upper_rad'])).limit_denominator(10**6)
+ c=ENV.shipping_constants()
+
+ # Declared-supply branch, exact over the rationals.
+ declared=ENV.derive(declared_tilt/2,c)
+ yaw=yaw_certificate(declared['sin_yaw_error_upper'])
+ full=YAW_CERT_RAD+declared_tilt
+ declared_branch={
+  'supplied_tilt_rad_upper':float(declared_tilt),'supplied_tilt_deg_upper':math.degrees(float(declared_tilt)),
+  'mean_perturbation_upper_uT':float(declared['mean_perturbation_upper_uT']),
+  'sin_yaw_error_upper_exact':f"{declared['sin_yaw_error_upper'].numerator}/{declared['sin_yaw_error_upper'].denominator}",
+  'sin_test_angle_lower':float(yaw['sin_test_angle_lower']),
+  'yaw_rad_upper':float(YAW_CERT_RAD),'yaw_deg_upper':math.degrees(float(YAW_CERT_RAD)),
+  'full_attitude_rad_upper':float(full),'full_attitude_deg_upper':math.degrees(float(full)),
+  'north_nonvanishing':declared['north_nonvanishing'],
+  'horizontal_fraction_gate_satisfied':declared['horizontal_fraction_gate_satisfied'],
+  'inside_declared_entrance_set':yaw['yaw_strictly_below_test_angle'] and math.degrees(float(full))<declared_entrance_deg,
+  'sqrtN_statistical_reduction_used':False}
+
+ # Certified-supply branch.
+ proxy=_proxy_tilt_supply()
+ req=env['derived_tilt_requirements']
+ binding=float(req['max_tilt_rad_for_horizontal_fraction_gate'])
+ certified_branch={
+  **proxy,
+  'required_tilt_rad_for_binding_gate':binding,
+  'required_tilt_deg_for_binding_gate':float(req['max_tilt_deg_for_horizontal_fraction_gate']),
+  'required_tilt_deg_for_north_capture':float(req['max_tilt_deg_for_north_capture']),
+  'binding_gate':req['binding_requirement'],
+  'gate_shortfall_factor':proxy['certified_tilt_rad_upper']/binding,
+  'north_capture_shortfall_factor':proxy['certified_tilt_rad_upper']/float(req['max_tilt_rad_for_north_capture']),
+  'entrance_shortfall_factor':proxy['certified_tilt_deg_upper']/declared_entrance_deg,
+  'magnetic_capture_forced_from_certified_supply':proxy['certified_tilt_rad_upper']<binding,
+  'certified_tilt_alone_inside_declared_entrance_set':proxy['certified_tilt_deg_upper']<declared_entrance_deg,
+  'perfect_yaw_gauge_would_repair_entrance':False}
+
+ parity={'timeout_branch_needs_only_aligned_branch':'mag_gravity_aligned_branch_;' in w and 'const bool ready_by_timeout' in w,
+  'quality_branch_needs_north_ready':'const bool north_ready = !cfg_.with_mag || mag_ref_set_;' in w,
+  'seed_composes_proxy_tilt_with_gauge_yaw':'boatQuatWithAbsoluteYaw_(q_proxy, pending_yaw_abs_rad_)' in w,
+  'ungauged_seed_uses_free_yaw_sigma':'cfg_.proxy_handoff_yaw_sigma_free_rad' in w}
+
+ scaling=_forcing_scaling(binding)
+ return {
+  'schema':SCHEMA,'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD',
+  'magnetic_value_assumption':env['assumption_id'],'filter_changed':False,'quality_gates_changed':False,
+  'trajectory_replay_used':False,'shipping_parity':parity,
+  'declared_entrance_full_attitude_deg':declared_entrance_deg,
+  'declared_entrance_gauged_branch_bound':bool(entrance['gauged_branch_full_attitude_bound']),
+  'declared_entrance_ungauged_branch_is_tilt_only':bool(entrance['ungauged_branch_tilt_bound_only_until_regauge']),
+  'declared_supply_branch':declared_branch,
+  'certified_supply_branch':certified_branch,
+  'forcing_scaling_argument':scaling,
+  'DECLARED_SUPPLY_ENTRANCE_CLOSED':bool(declared_branch['inside_declared_entrance_set']),
+  'CERTIFIED_SUPPLY_ENTRANCE_CLOSED':False,
+  'accumulation_frame_tilt_supply_discharged':False,
+  'timeout_branch_yaw_gauge_forced':False,
+  'P4_basin_reached_here':False,'P5_end_to_end_closed_here':False,
+  'limiting_quantity':'private-observer accumulation tilt-frame error bound',
+  'alternatives':[
+   'tighten the gravity-direction forcing qualification (mean chord 0.05, primitive 1.0 s) so a metric-free ultimate tilt below the binding gate exists at all',
+   'narrow MAG-BMM150-DET-v1 to a commissioned geomagnetic band (higher horizontal floor, lower total ceiling) so the shipping gates are forced at the tilt this route can certify',
+   'prove that the shipping quality handoff cannot be preceded by the timeout handoff under the declared schedule, making north_ready a theorem consequence rather than an assumption'],
+  'next_obligation':'supply a private-observer accumulation tilt-frame accuracy bound, not a level-set radius, or requalify one of the three recorded alternatives',
+ }
+
+
+def validate(d:dict)->list:
+ f=[]
+ if d.get('schema')!=SCHEMA or d.get('qualification')!=QUALIFICATION:f.append('schema/qualification mismatch')
+ if not all(d.get('shipping_parity',{}).values()):f.append('shipping handoff parity failed')
+ if d.get('DECLARED_SUPPLY_ENTRANCE_CLOSED') is not True:f.append('declared-supply entrance certificate not closed')
+ for k in ('CERTIFIED_SUPPLY_ENTRANCE_CLOSED','accumulation_frame_tilt_supply_discharged',
+           'timeout_branch_yaw_gauge_forced','filter_changed','quality_gates_changed','trajectory_replay_used',
+           'P4_basin_reached_here','P5_end_to_end_closed_here'):
+  if d.get(k) is not False:f.append(k+' not false')
+ b=d.get('declared_supply_branch',{})
+ if b.get('sqrtN_statistical_reduction_used') is not False:f.append('statistical averaging gain used')
+ if not 0.0<float(b.get('full_attitude_deg_upper',180.0))<float(d.get('declared_entrance_full_attitude_deg',0.0)):
+  f.append('declared-supply full attitude bound not inside the declared entrance set')
+ c=d.get('certified_supply_branch',{})
+ if c.get('magnetic_capture_forced_from_certified_supply') is not False:
+  f.append('certified-supply capture claim must stay fail-closed until the tilt supply is proved')
+ if not float(c.get('gate_shortfall_factor',0.0))>1.0:f.append('certified-supply shortfall factor not reported')
+ s=d.get('forcing_scaling_argument',{})
+ if s.get('is_scaling_argument_not_certificate') is not True:f.append('scaling argument mislabelled as a certificate')
+ if len(d.get('alternatives',[]))<3:f.append('two-strike rule requires at least three qualitatively different alternatives')
+ return f
+
+
+def main()->int:
+ ap=argparse.ArgumentParser();ap.add_argument('--output',type=Path,required=True);a=ap.parse_args()
+ d=build();f=validate(d);d['validation_pass']=not f;d['validation_failures']=f
+ a.output.parent.mkdir(parents=True,exist_ok=True)
+ a.output.write_text(json.dumps(d,indent=2,sort_keys=True)+'\n')
+ print(json.dumps({'declared_supply_full_attitude_deg':d['declared_supply_branch']['full_attitude_deg_upper'],
+  'declared_entrance_deg':d['declared_entrance_full_attitude_deg'],
+  'declared_supply_closed':d['DECLARED_SUPPLY_ENTRANCE_CLOSED'],
+  'certified_tilt_deg':d['certified_supply_branch']['certified_tilt_deg_upper'],
+  'required_tilt_deg':d['certified_supply_branch']['required_tilt_deg_for_binding_gate'],
+  'gate_shortfall':d['certified_supply_branch']['gate_shortfall_factor'],
+  'metric_free_floor_deg':d['forcing_scaling_argument']['metric_free_tilt_floor_deg'],
+  'failures':f},sort_keys=True))
+ return int(bool(f))
+
+
+if __name__=='__main__':raise SystemExit(main())

--- a/tools/stability/ou3_brmm_private_mahony_discrete_invariant.py
+++ b/tools/stability/ou3_brmm_private_mahony_discrete_invariant.py
@@ -2,8 +2,11 @@
 """Source-order binary32/discrete charge for the widened Mahony invariant.
 
 This certificate does not replay a trajectory. It takes the already validated
-87-degree continuous transformed PI invariant and charges the literal shipping
-Euler/quaternion evaluation at dt=5 ms. The fast-inverse-square-root scale is a
+87-degree continuous transformed PI invariant -- now the two-phase certificate,
+whose outer level is the one charged here -- and charges the literal shipping
+Euler/quaternion evaluation at dt=5 ms. The metric is read from the continuous
+certificate rather than hardcoded, so a change of `(p,c)` cannot silently leave
+a stale Cholesky row behind. The fast-inverse-square-root scale is a
 common positive quaternion scale and therefore does not rotate the attitude;
 only componentwise binary32 rounding after the common scaling is charged as an
 orientation perturbation.
@@ -37,7 +40,7 @@ def build():
  d=json.loads(DOMAIN.read_text());dt=float(d['configured_runtime']['imu_dt_s']);body=math.radians(float(d['normal_live']['body_rate_norm_upper_deg_s']))
  shell=FINV.all_positive_normal_normalized_norm2_enclosure();qn_lo=math.sqrt(shell.lo);qn_hi=math.sqrt(shell.hi)
  C=float(c['invariant_level_C']);P22=float(c['metric_P'][1][1]);det=float(c['metric_det']);xi=float(c['BRMM_direction_geometry']['direction_primitive_norm_upper_s']);mean=float(c['BRMM_direction_geometry']['mean_direction_chord_norm_upper'])
- ztheta=math.sqrt(C*P22/det);zbeta=math.sqrt(C/det);theta=ztheta+0.1*xi;beta=zbeta+0.01*xi
+ ztheta=math.sqrt(C*P22/det);zbeta=math.sqrt(C/det);beta=zbeta+0.01*xi
  half_g=0.5*qn_hi*qn_hi;half_err=qn_hi*half_g
  omega=body+beta+0.2*half_err
  half_rate=0.5*dt*omega
@@ -62,7 +65,8 @@ def build():
  integral_step_round=gamma(8)*(integral_mag+ki_increment)
  bias_rate_fp=integral_step_round/dt
  # Robustify continuous boundary margin against the extra d_g,d_b support.
- bias_row_norm=math.hypot(6.5,11.0)
+ R=c['metric_cholesky_R'];p_skew=-float(R[0][1]);c_scale=float(R[1][1])
+ bias_row_norm=math.hypot(p_skew,c_scale)
  fp_support=attitude_rate_fp+bias_row_norm*bias_rate_fp
  continuous_margin=float(c['boundary_validation']['strict_inward_margin_lower'])
  robust_margin=continuous_margin-2.0*fp_support
@@ -70,10 +74,14 @@ def build():
  smin=float(c['sector_sinc_lower'][0]);dg=float(d['startup']['effective_deterministic_gyro_transport_disturbance_upper_rad_s'])+attitude_rate_fp;db=float(d['startup']['effective_deterministic_bias_transport_disturbance_upper_rad_s2'])+bias_rate_fp
  ftheta=0.1*ztheta+zbeta+max(abs(0.01*smin-0.01),0.0)*xi+0.1*mean+dg
  fbeta=0.01*ztheta+0.001*xi+0.01*mean+db
- Rf1=ftheta+6.5*fbeta;Rf2=11.0*fbeta
+ Rf1=ftheta+p_skew*fbeta;Rf2=c_scale*fbeta
  euler_quadratic=dt*dt*(Rf1*Rf1+Rf2*Rf2)
- # From the continuous certificate convention dot(V)<=-2*sqrt(C)*margin.
- guaranteed_first_order_decrease=2.0*float(c['sqrt_C'])*robust_margin*dt
+ # With u=Rz, y=u/||u|| and M=R A_s R^-1,
+ #   dot(V) = C y'(M+M')y + 2 sqrt(C) y'Rw <= -sqrt(C) [sqrt(C) q - 2 sup],
+ # so the guaranteed first-order decrease carries ONE factor of sqrt(C), not
+ # two. The retired form used 2*sqrt(C)*margin and therefore claimed twice the
+ # decrease it had proved; the margin below is still comfortably positive.
+ guaranteed_first_order_decrease=float(c['sqrt_C'])*robust_margin*dt
  discrete_margin=guaranteed_first_order_decrease-euler_quadratic
  chart_margin=math.radians(float(c['chart_deg']))-float(c['actual_tilt_rad_upper'])
  # One-step angle rounding must fit comfortably inside geometric margin; the
@@ -81,7 +89,9 @@ def build():
  one_step_chart_round_margin=chart_margin-(raw_angle_round+norm_angle_round)
  closed=bool(robust_margin>0 and discrete_margin>0 and one_step_chart_round_margin>0)
  return {'schema':SCHEMA,'qualification':QUALIFICATION,'canonical_source':'COMPLETE_BRMM_NORMAL_LIVE_WORD','source_order_binary32_model':True,'trajectory_replay_used':False,'compiler_reassociation_or_FMA_closed':False,
-  'continuous_invariant_consumed':True,'dt_s':dt,'quaternion_norm_shell':[qn_lo,qn_hi],'half_error_norm_upper':half_err,'corrected_gyro_norm_upper_rad_s':omega,
+  'continuous_invariant_consumed':True,'metric_read_from_continuous_certificate':True,
+  'metric_skew_p':p_skew,'metric_scale_c':c_scale,
+  'first_order_decrease_carries_single_sqrt_C':True,'dt_s':dt,'quaternion_norm_shell':[qn_lo,qn_hi],'half_error_norm_upper':half_err,'corrected_gyro_norm_upper_rad_s':omega,
   'gamma24':gamma(24),'gamma8':gamma(8),'raw_quaternion_component_roundoff_upper':raw_component_round,'raw_orientation_roundoff_upper_rad':raw_angle_round,'normalization_multiply_orientation_roundoff_upper_rad':norm_angle_round,
   'equivalent_attitude_rate_roundoff_upper_rad_s':attitude_rate_fp,'equivalent_integral_bias_rate_roundoff_upper_rad_s2':bias_rate_fp,
   'continuous_boundary_margin_before_binary32':continuous_margin,'binary32_support_charge':fp_support,'continuous_boundary_margin_after_binary32':robust_margin,
@@ -93,7 +103,7 @@ def build():
 def validate(d):
  f=[]
  if d.get('schema')!=SCHEMA or d.get('qualification')!=QUALIFICATION:f.append('schema/qualification mismatch')
- for k in ('source_order_binary32_model','continuous_invariant_consumed','shipping_binary32_discrete_invariant_closed_conditionally_on_source_order'):
+ for k in ('source_order_binary32_model','continuous_invariant_consumed','metric_read_from_continuous_certificate','first_order_decrease_carries_single_sqrt_C','shipping_binary32_discrete_invariant_closed_conditionally_on_source_order'):
   if d.get(k) is not True:f.append(k+' not true')
  for k in ('trajectory_replay_used','compiler_reassociation_or_FMA_closed','toolchain_independent_binary32_invariant_closed','P4_promoted_here','P5_promoted_here'):
   if d.get(k) is not False:f.append(k+' not false')

--- a/tools/stability/ou3_brmm_private_mahony_live_invariant.py
+++ b/tools/stability/ou3_brmm_private_mahony_live_invariant.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validated all-Live PI invariant for the private Mahony observer.
+"""Two-phase all-Live PI certificate for the private Mahony observer.
 
 The widened BRMM source permits large instantaneous orbital acceleration, so the
 old proof that treated the normalized gravity-direction error as an arbitrary
@@ -18,38 +18,84 @@ Set z=x-B xi. Then
     zdot=A_s z + A_s B xi + B m + d,
 
 so the oscillatory primitive is retained as one bounded same-history source
-coordinate rather than replaced by an arbitrary r box. The existing exact
-quadratic metric P=R^T R is used at sqrt(C)=1.21. A rational stereographic
-cover of the boundary, outward interval arithmetic, and the endpoint sector
-s in [sinc(87 deg),1] prove strict inward flow. The actual tilt is recovered
-as theta=z_theta-0.1 xi and remains strictly below the 87 degree proof chart.
+coordinate rather than replaced by an arbitrary r box. The actual tilt is
+recovered as theta=z_theta-0.1 xi.
 
-The first-sample accelerometer seed angle is the source's own instantaneous
-gravity-direction angle `asin(||a_ng||/g)`, taken from the qualification module
-rather than frozen as a constant. At the padded 8.8 m/s^2 envelope that seed is
-1.1137 rad, and this certificate reports fail-closed: the level needed to
-contain the seed and the largest level that still fits inside the 87 degree
-chart form an empty window, so no level of this fixed metric closes the
-invariant for the padded family. See `admissible_level_window` in the output.
+## Why a single level failed and what replaced it
+
+The metric is `P=R^T R` with `R=[[1,-p],[0,c]]`, so `r_22=p^2+c^2` and
+`det P=c^2`. Writing `u=Rz`, `y=u/||u||` and `M=R A_s R^-1`,
+
+    Vdot = C y^T(M+M^T)y + 2 sqrt(C) y^T R w = -sqrt(C) [ sqrt(C) q - 2 sup ],
+
+with `q(y,s)=-y^T(M+M^T)y` and `sup` the support of the admitted forcing. Both
+`q` and `sup` are level-independent, so the boundary condition is a *lower*
+bound on the level,
+
+    sqrt(C) >= W_in := 2 sup_max / q_min,
+
+while the 87 degree proof chart imposes an *upper* bound `C r_22/c^2 <
+(chart - 0.1 xi)^2`, and containment of the first-sample accelerometer seed
+imposes a second lower bound `C >= C_seed`.
+
+At the padded 8.8 m/s^2 envelope the seed angle is `asin(8.8/g)=1.1137` rad and
+the previous metric `p=6.5, c=11` left those three bounds mutually
+unsatisfiable: the level needed for the seed was `1.8540056` against a chart
+ceiling of `1.4912551`. That is a failure of the *single-level* formulation, not
+of the enclosure -- the boundary flow still closed with margin `0.0357940`.
+
+This certificate replaces it with two nested levels of one better-conditioned
+metric. Because `Vdot<0` holds on *every* level with `sqrt(C)>=W_in`, not only
+on the certified boundary:
+
+* the outer level `C_out` contains the seed and lies inside the chart, so
+  `{V<=C_out}` is forward invariant and the observer never leaves the chart;
+* `W=sqrt(V)` obeys `Wdot <= -(q_min/2)(W-W_in)`, so the state enters the inner
+  level `C_in` exponentially with time constant `2/q_min`, giving a genuine
+  ultimate tilt bound instead of an outer level radius.
+
+Both levels are verified with the same rational stereographic boundary cover,
+outward interval arithmetic and the endpoint sector `s in [sinc(87 deg),1]`;
+`q` is affine and `sup` convex in `s`, so the margin is concave in `s` and
+endpoint checking is rigorous.
+
+The metric is chosen for seed containment and chart retention. It is *not*
+tuned toward the magnetic capture requirement: a non-promoting scan of the whole
+`(p,c)` class puts the best certifiable ultimate tilt near 41 deg, far above
+both the `6.1145 deg` north-capture and `2.8378 deg` horizontal-fraction
+requirements, so no member of this class supplies the magnetic gates. See
+`docs/ou3-proof-research-state.md`.
 """
 from __future__ import annotations
 import argparse,json,math
+from fractions import Fraction as F
 from pathlib import Path
-from ou3_interval import Interval
+from ou3_interval import Interval,down,up
 import ou3_validated_transcendentals as VT
 import ou3_brmm_gravity_direction_forcing_qualification as DIR
 
 REPO=Path(__file__).resolve().parents[2]
 DOMAIN=REPO/'tools/stability/ou3_proof_operating_domain.json'
 WRAPPER=REPO/'src/kalman_ou_iii/SeaStateFusionFilter_OU_III.h'
-SCHEMA=2
-QUALIFICATION='OU3_BRMM_PRIVATE_MAHONY_ALL_LIVE_PI_INVARIANT_V2'
-P11=1.0;P12=-6.5;P22=163.25;DET_P=121.0
-SQRT_C=1.21;C_LEVEL=SQRT_C*SQRT_C
+SCHEMA=3
+QUALIFICATION='OU3_BRMM_PRIVATE_MAHONY_TWO_PHASE_PI_INVARIANT_V3'
+
+# Metric R=[[1,-P_SKEW],[0,C_SCALE]] chosen for seed containment inside the
+# 87 degree chart. det P = C_SCALE^2 is unchanged from the retired metric.
+P_SKEW=F(3)
+C_SCALE=F(11)
+SQRT_C_OUT=F(133,100)
+SQRT_C_IN=F(1)
+# Rational upper bound for the seed angle asin(8.8/g), cross-verified below
+# against the validated sine rather than assumed.
+SEED_TILT_RAD_UPPER=F(111373,100000)
+CAPTURE_HORIZON_S=F(150)
 CELLS_PER_CHART=8192
 
 def I(x):return Interval.outward_bounds(float(x),float(x))
 def abs_upper(x):return max(abs(x.lo),abs(x.hi))
+def _r22():return P_SKEW*P_SKEW+C_SCALE*C_SCALE
+def _det():return C_SCALE*C_SCALE
 
 def _source_constants(domain):
  s=domain['startup'];live=domain['normal_live'];q=DIR.build();f=DIR.validate(q)
@@ -59,27 +105,29 @@ def _source_constants(domain):
   'bias_transport':float(s['effective_deterministic_bias_transport_disturbance_upper_rad_s2']),
   'initial_bias':float(s['initial_tangent_gyro_bias_norm_upper_rad_s']),
   'mean_chord':float(q['mean_direction_chord_norm_upper']),'xi':float(q['direction_primitive_norm_upper_s']),
-  'chart_deg':float(q['private_mahony_proof_chart_deg']),'instant_chord':float(q['instantaneous_direction_chord_upper']),
-  'seed_tilt':float(q['instantaneous_direction_angle_upper_rad'])}
+  'chart_deg':float(q['private_mahony_proof_chart_deg']),'instant_chord':float(q['instantaneous_direction_chord_upper'])}
 
 def _direction_bounds(c):
- # The seed angle is the source's own instantaneous gravity-direction angle.
- # The check is now a cross-verification: the validated sine of the derived seed
- # must enclose rho=||a_ng||/g, i.e. the seed really is asin(rho) and not a
- # constant that has fallen behind the padded envelope.
- rho=I(c['a_ng'])/I(c['g']);seed=c['seed_tilt'];sin_seed=VT.sin_point(seed)
+ # The declared rational seed bound must actually dominate the source's own
+ # instantaneous gravity-direction angle: sin is increasing on [0,pi/2], so
+ # sin(SEED_TILT_RAD_UPPER) >= rho = ||a_ng||/g certifies asin(rho) <= bound.
+ rho=I(c['a_ng'])/I(c['g']);seed=float(SEED_TILT_RAD_UPPER);sin_seed=VT.sin_point(seed)
  return {'rho_a_over_g':rho.as_list(),'instantaneous_direction_chord_upper':c['instant_chord'],
-  'initial_seed_tilt_rad_upper':seed,'initial_seed_tilt_deg_upper':math.degrees(seed),
-  'sin_initial_seed_bound':sin_seed.as_list(),
-  'initial_seed_angle_closed':sin_seed.lo<=rho.hi and sin_seed.hi>=rho.lo,
+  'seed_tilt_rad_upper':seed,'seed_tilt_deg_upper':math.degrees(seed),
+  'sin_seed_tilt_bound':sin_seed.as_list(),
+  'seed_tilt_dominates_source_angle':sin_seed.lo>=rho.hi,
   'mean_direction_chord_norm_upper':c['mean_chord'],
   'direction_primitive_norm_upper_s':c['xi'],'same_history_decomposition_retained':True}
 
 def _sector_lower(chart_deg):
  if chart_deg!=87.0:raise RuntimeError('certificate tied to 87 degree proof chart')
- pi=Interval.outward_bounds(3.141592653589793,3.141592653589794)
- theta=pi*I(29.0)/I(60.0)
+ theta=_chart_interval(chart_deg)
  return VT.sinc_interval(theta)
+
+def _chart_interval(chart_deg):
+ if chart_deg!=87.0:raise RuntimeError('certificate tied to 87 degree proof chart')
+ pi=Interval.outward_bounds(3.141592653589793,3.141592653589794)
+ return pi*I(29.0)/I(60.0)
 
 def _circle_cell(t,left):
  t2=t.square();den=I(1.0)+t2;y1=(I(1.0)-t2)/den
@@ -87,51 +135,120 @@ def _circle_cell(t,left):
  return y1,I(2.0)*t/den
 
 def _q_interval(y1,y2,s):
- si=I(s);m11=I(7.0/100.0)*si;m12=I(23.0/176.0)*si-I(1.0/11.0);m22=I(13.0/100.0)*si
+ """q = -y'(M+M')y with M = R A_s R^-1; affine in the sector value s."""
+ si=I(s);p=I(float(P_SKEW));cc=I(float(C_SCALE))
+ m11=I(0.02)*si*(I(10.0)-p)
+ m22=I(0.02)*p*si
+ m12=(p*si*(I(0.1)-I(0.01)*p)-I(1.0))/cc+I(0.01)*cc*si
  return m11*y1.square()+I(2.0)*m12*y1*y2+m22*y2.square()
 
 def _support_upper(y1,y2,s,c):
- si=I(s)
- lxi=(I(0.0035)*si-I(0.01))*y1 + I(0.011)*si*y2
- lm=-I(0.035)*y1-I(0.11)*y2
- lg=y1;lb=-I(6.5)*y1+I(11.0)*y2
+ """Support of R*(A_s B xi + B m + d) over the admitted same-history forcing."""
+ si=I(s);p=I(float(P_SKEW));cc=I(float(C_SCALE))
+ lxi=(I(0.01)*si-I(0.001)*p*si-I(0.01))*y1 + I(0.001)*cc*si*y2
+ lm=(-I(0.1)+I(0.01)*p)*y1 + (-I(0.01)*cc)*y2
+ lg=y1;lb=-p*y1+cc*y2
  return c['xi']*abs_upper(lxi)+c['mean_chord']*abs_upper(lm)+c['gyro_transport']*abs_upper(lg)+c['bias_transport']*abs_upper(lb)
 
-def _verify_boundary(c,sector_lower):
- worst=math.inf;worst_cell=None;checked=0
+def _verify_boundary(c,sector_lower,sqrt_c):
+ """Strict inward flow on {V = sqrt_c^2}: sqrt_c*q - 2*support > 0."""
+ worst=math.inf;worst_cell=None;checked=0;q_floor=math.inf;support_ceiling=0.0
  for left in (False,True):
   for j in range(CELLS_PER_CHART):
    lo=-1.0+2.0*j/CELLS_PER_CHART;hi=-1.0+2.0*(j+1)/CELLS_PER_CHART;t=Interval.outward_bounds(lo,hi);y1,y2=_circle_cell(t,left)
    for s in (sector_lower,1.0):
-    q=_q_interval(y1,y2,s);support=_support_upper(y1,y2,s,c);margin=SQRT_C*q.lo-2.0*support;checked+=1
+    q=_q_interval(y1,y2,s);support=_support_upper(y1,y2,s,c);margin=float(sqrt_c)*q.lo-2.0*support;checked+=1
+    if q.lo<q_floor:q_floor=q.lo
+    if support>support_ceiling:support_ceiling=support
     if margin<worst:worst=margin;worst_cell={'left_chart':left,'cell':j,'t':[lo,hi],'sector_s':s,'q_lower':q.lo,'support_upper':support,'margin_lower':margin}
- return {'cells_per_chart':CELLS_PER_CHART,'endpoint_sector_checks':2,'total_checks':checked,'worst':worst_cell,'strict_inward_margin_lower':worst,'closed':worst>0.0}
+ return {'cells_per_chart':CELLS_PER_CHART,'endpoint_sector_checks':2,'total_checks':checked,
+  'level_sqrt_C':float(sqrt_c),'q_lower_floor':q_floor,'support_upper_ceiling':support_ceiling,
+  'worst':worst_cell,'strict_inward_margin_lower':worst,'closed':worst>0.0}
+
+def _exp_neg_upper(x:float)->float:
+ """Outward upper bound for exp(-x), x>=0, by composing validated half-steps."""
+ if x<0:raise ValueError('nonnegative argument required')
+ n=max(1,int(math.ceil(x/0.5)))
+ step=VT.exp_point(-x/n)
+ acc=Interval.outward_bounds(1.0,1.0)
+ for _ in range(n):acc=acc*step
+ return acc.hi
+
+def _tilt_upper(level_sqrt:float,xi:float)->float:
+ """theta bound from a level: sqrt(C*r22/det) + 0.1*xi, outward rounded."""
+ scale=up(math.sqrt(up(float(_r22())/float(_det()))))
+ return up(up(level_sqrt*scale)+up(0.1*xi))
 
 def build():
- domain=json.loads(DOMAIN.read_text());wrapper=WRAPPER.read_text();c=_source_constants(domain);direction=_direction_bounds(c);sector=_sector_lower(c['chart_deg'])
- zth=c['seed_tilt']+0.1*c['xi'];zb=c['initial_bias']+0.01*c['xi']
- initial_metric_upper=P11*zth*zth+2*abs(P12)*zth*zb+P22*zb*zb;initial_inside=initial_metric_upper<C_LEVEL
- ztheta_sq=C_LEVEL*P22/DET_P;theta_upper=math.sqrt(ztheta_sq)+0.1*c['xi'];chart_rad=math.radians(c['chart_deg']);chart_contained=theta_upper<chart_rad
- # Largest level whose z-theta projection still fits strictly inside the chart.
- chart_level_upper=((chart_rad-0.1*c['xi'])**2)*DET_P/P22
- window={'level_lower_required_to_contain_seed':initial_metric_upper,
-  'level_upper_allowed_by_proof_chart':chart_level_upper,
-  'declared_level_C':C_LEVEL,
-  'window_nonempty':initial_metric_upper<chart_level_upper,
-  'emptiness_factor':initial_metric_upper/chart_level_upper}
- boundary=_verify_boundary(c,sector.lo)
+ domain=json.loads(DOMAIN.read_text());wrapper=WRAPPER.read_text()
+ c=_source_constants(domain);direction=_direction_bounds(c);sector=_sector_lower(c['chart_deg'])
+ r22=_r22();det=_det();xi=c['xi']
+ # Seed level, worst relative sign between the seed tilt and the initial bias.
+ zth=SEED_TILT_RAD_UPPER+F(1,10)*F(xi).limit_denominator(10**6)
+ zb=F(c['initial_bias']).limit_denominator(10**9)+F(1,100)*F(xi).limit_denominator(10**6)
+ c_seed=zth*zth+2*P_SKEW*zth*zb+r22*zb*zb
+ c_out=SQRT_C_OUT*SQRT_C_OUT;c_in=SQRT_C_IN*SQRT_C_IN
+ # Chart ceiling: theta-extent + 0.1*xi must stay strictly inside the chart.
+ chart=_chart_interval(c['chart_deg'])
+ chart_room=chart-I(0.1*xi)
+ c_chart_upper=down(chart_room.lo*chart_room.lo*float(det)/float(r22))
+ seed_contained=float(c_seed)<=float(c_out)
+ chart_contained=float(c_out)<c_chart_upper
+ outer=_verify_boundary(c,sector.lo,SQRT_C_OUT)
+ inner=_verify_boundary(c,sector.lo,SQRT_C_IN)
+ # Capture: Wdot <= -(q/2)(W - W_in) with W_in = 2*sup/q.
+ q_min=min(outer['q_lower_floor'],inner['q_lower_floor'])
+ support_max=max(outer['support_upper_ceiling'],inner['support_upper_ceiling'])
+ w_in=up(2.0*support_max/down(q_min))
+ rate=down(q_min/2.0)
+ w_out=float(SQRT_C_OUT)
+ decay=_exp_neg_upper(down(rate*float(CAPTURE_HORIZON_S)))
+ w_horizon=up(w_in+up(up(w_out-w_in)*decay))
+ inner_reached=w_in<=float(SQRT_C_IN)
+ outer_tilt=_tilt_upper(w_out,xi)
+ horizon_tilt=_tilt_upper(w_horizon,xi)
+ # W(t) -> W_in, so the asymptotic bound comes from the minimal certifiable
+ # level, not from the nested level whose boundary is separately verified.
+ ultimate_tilt=_tilt_upper(w_in,xi)
+ inner_level_tilt=_tilt_upper(float(SQRT_C_IN),xi)
+ chart_rad=chart.hi
  parity={'deployed_two_kp_0p2':'STARTUP_PROXY_TWO_KP_DEFAULT = 0.2f;' in wrapper,'deployed_two_ki_0p02':'STARTUP_PROXY_TWO_KI_DEFAULT = 0.02f;' in wrapper,'first_sample_accelerometer_seed':True}
- closed=bool(direction['initial_seed_angle_closed'] and direction['same_history_decomposition_retained'] and initial_inside and chart_contained and boundary['closed'])
+ closed=bool(direction['seed_tilt_dominates_source_angle'] and direction['same_history_decomposition_retained']
+  and seed_contained and chart_contained and outer['closed'] and inner['closed'] and inner_reached
+  and outer_tilt<chart_rad)
  return {'schema':SCHEMA,'qualification':QUALIFICATION,'source_generator':False,'trajectory_replay_used':False,'arbitrary_bounded_input_source_used':False,
   'same_BRMM_specific_force_direction_required':True,'same_BRMM_gyro_bias_forcing_required':True,'same_history_direction_primitive_required':True,
   'deployed_gain_parity':parity,'BRMM_direction_geometry':direction,'chart_deg':c['chart_deg'],'sector_sinc_lower':sector.as_list(),
-  'metric_P':[[P11,P12],[P12,P22]],'metric_det':DET_P,'metric_cholesky_R':[[1.0,-6.5],[0.0,11.0]],'invariant_level_C':C_LEVEL,'sqrt_C':SQRT_C,
-  'transformed_state':'z=x-B*xi','initial_metric_upper':initial_metric_upper,'initial_set_inside_invariant':initial_inside,
-  'admissible_level_window':window,
-  'z_tilt_projection_sq_upper':ztheta_sq,'actual_tilt_rad_upper':theta_upper,'actual_tilt_deg_upper':math.degrees(theta_upper),'chart_radius_rad':chart_rad,
-  'invariant_strictly_inside_87deg_chart':chart_contained,'invariant_strictly_inside_60deg_chart':False,'boundary_validation':boundary,
-  'continuous_all_live_PI_invariant_closed':closed,'shipping_binary32_discrete_invariant_closed':False,'complete_BRMM_family_materialized_here':False,'P3_promoted':False,
-  'next_obligation':'compose the exact binary32 Mahony step with this 87-degree correlated PI invariant and use its positive hemisphere margin to certify the 150 s timeout handoff'}
+  'metric_P':[[1.0,-float(P_SKEW)],[-float(P_SKEW),float(r22)]],'metric_det':float(det),
+  'metric_cholesky_R':[[1.0,-float(P_SKEW)],[0.0,float(C_SCALE)]],
+  'metric_skew_p':float(P_SKEW),'metric_scale_c':float(C_SCALE),
+  'invariant_level_C':float(c_out),'sqrt_C':float(SQRT_C_OUT),
+  'transformed_state':'z=x-B*xi',
+  'two_phase_levels':{'seed_level_required':float(c_seed),'outer_level_C':float(c_out),
+   'chart_level_ceiling':c_chart_upper,'inner_level_C':float(c_in),
+   'seed_contained_in_outer_level':seed_contained,'outer_level_inside_chart':chart_contained,
+   'chart_headroom_relative':down((c_chart_upper-float(c_out))/c_chart_upper),
+   'outer_boundary_margin_lower':outer['strict_inward_margin_lower'],
+   'inner_boundary_margin_lower':inner['strict_inward_margin_lower']},
+  'initial_metric_upper':float(c_seed),'initial_set_inside_invariant':seed_contained,
+  'capture':{'q_lower_floor':q_min,'support_upper_ceiling':support_max,
+   'minimal_certifiable_sqrt_level':w_in,'inner_level_above_minimal':inner_reached,
+   'contraction_rate_lower_per_s':rate,'time_constant_upper_s':up(2.0/down(q_min)),
+   'deployed_horizon_s':float(CAPTURE_HORIZON_S),'horizon_decay_upper':decay,
+   'sqrt_level_at_horizon_upper':w_horizon,
+   'monotone_decrease_above_inner_level':True,'capture_uses_deployed_timeout_as_hypothesis':False},
+  'actual_tilt_rad_upper':outer_tilt,'actual_tilt_deg_upper':math.degrees(outer_tilt),
+  'tilt_at_deployed_horizon_rad_upper':horizon_tilt,'tilt_at_deployed_horizon_deg_upper':math.degrees(horizon_tilt),
+  'ultimate_tilt_rad_upper':ultimate_tilt,'ultimate_tilt_deg_upper':math.degrees(ultimate_tilt),
+  'certified_inner_level_tilt_rad_upper':inner_level_tilt,'certified_inner_level_tilt_deg_upper':math.degrees(inner_level_tilt),
+  'chart_radius_rad':chart_rad,
+  'invariant_strictly_inside_87deg_chart':chart_contained and outer_tilt<chart_rad,
+  'invariant_strictly_inside_60deg_chart':False,
+  'boundary_validation':outer,'inner_boundary_validation':inner,
+  'continuous_all_live_PI_invariant_closed':closed,'shipping_binary32_discrete_invariant_closed':False,
+  'complete_BRMM_family_materialized_here':False,'P3_promoted':False,
+  'metric_tuned_toward_magnetic_requirement':False,
+  'next_obligation':'compose the exact binary32 Mahony step with these two levels and supply an accumulation tilt-frame bound the magnetic capture can consume; the quadratic-metric class cannot reach it'}
 
 def validate(d):
  f=[]
@@ -140,17 +257,35 @@ def validate(d):
   if d.get(k) is not True:f.append(k+' is not true')
  if not all(d.get('deployed_gain_parity',{}).values()):f.append('deployed Mahony gain parity failed')
  g=d.get('BRMM_direction_geometry',{})
- if g.get('initial_seed_angle_closed') is not True:f.append('initial seed angle not closed')
- wnd=d.get('admissible_level_window',{})
- if wnd.get('window_nonempty') is not True:
-  f.append('no metric level contains the seed inside the proof chart (emptiness factor %.6f)'%float(wnd.get('emptiness_factor',float('nan'))))
- b=d.get('boundary_validation',{})
- if b.get('closed') is not True or not float(b.get('strict_inward_margin_lower',-1))>0:f.append('Mahony boundary did not close')
+ if g.get('seed_tilt_dominates_source_angle') is not True:f.append('declared seed angle does not dominate the source angle')
+ lv=d.get('two_phase_levels',{})
+ for k in ('seed_contained_in_outer_level','outer_level_inside_chart'):
+  if lv.get(k) is not True:f.append(k+' is not true')
+ if not float(lv.get('chart_headroom_relative',-1.0))>0.0:f.append('outer level has no chart headroom')
+ for b in ('boundary_validation','inner_boundary_validation'):
+  x=d.get(b,{})
+  if x.get('closed') is not True or not float(x.get('strict_inward_margin_lower',-1))>0:f.append(b+' did not close')
+ cap=d.get('capture',{})
+ if cap.get('inner_level_above_minimal') is not True:f.append('inner level below the minimal certifiable level')
+ if not float(cap.get('contraction_rate_lower_per_s',0.0))>0.0:f.append('capture rate not positive')
+ if not float(cap.get('sqrt_level_at_horizon_upper',math.inf))<float(d.get('sqrt_C',0.0)):f.append('no strict decrease over the deployed horizon')
  if not float(d.get('actual_tilt_deg_upper',180))<87.0:f.append('actual tilt leaves proof chart')
- for k in ('source_generator','trajectory_replay_used','arbitrary_bounded_input_source_used','shipping_binary32_discrete_invariant_closed','complete_BRMM_family_materialized_here','P3_promoted'):
+ if not float(d.get('ultimate_tilt_deg_upper',180))<float(d.get('tilt_at_deployed_horizon_deg_upper',180))<float(d.get('actual_tilt_deg_upper',180)):f.append('tilt bounds are not ordered ultimate < horizon < all-time')
+ for k in ('source_generator','trajectory_replay_used','arbitrary_bounded_input_source_used','shipping_binary32_discrete_invariant_closed','complete_BRMM_family_materialized_here','P3_promoted','metric_tuned_toward_magnetic_requirement'):
   if d.get(k) is not False:f.append(k+' is not false')
  return list(dict.fromkeys(f))
 
 def main():
- ap=argparse.ArgumentParser();ap.add_argument('--output',type=Path,required=True);a=ap.parse_args();d=build();f=validate(d);d['validation_pass']=not f;d['validation_failures']=f;a.output.parent.mkdir(parents=True,exist_ok=True);a.output.write_text(json.dumps(d,indent=2,sort_keys=True)+'\n');print(json.dumps({'continuous_closed':d['continuous_all_live_PI_invariant_closed'],'chart_deg':d['chart_deg'],'actual_tilt_deg_upper':d['actual_tilt_deg_upper'],'initial_metric_upper':d['initial_metric_upper'],'C':d['invariant_level_C'],'boundary_margin':d['boundary_validation']['strict_inward_margin_lower'],'failures':f},sort_keys=True));return int(bool(f))
+ ap=argparse.ArgumentParser();ap.add_argument('--output',type=Path,required=True);a=ap.parse_args();d=build();f=validate(d);d['validation_pass']=not f;d['validation_failures']=f;a.output.parent.mkdir(parents=True,exist_ok=True);a.output.write_text(json.dumps(d,indent=2,sort_keys=True)+'\n')
+ print(json.dumps({'closed':d['continuous_all_live_PI_invariant_closed'],
+  'seed_deg':d['BRMM_direction_geometry']['seed_tilt_deg_upper'],
+  'levels':[d['two_phase_levels']['seed_level_required'],d['two_phase_levels']['outer_level_C'],d['two_phase_levels']['chart_level_ceiling']],
+  'chart_headroom':d['two_phase_levels']['chart_headroom_relative'],
+  'outer_margin':d['boundary_validation']['strict_inward_margin_lower'],
+  'inner_margin':d['inner_boundary_validation']['strict_inward_margin_lower'],
+  'tilt_all_time_deg':d['actual_tilt_deg_upper'],
+  'tilt_150s_deg':d['tilt_at_deployed_horizon_deg_upper'],
+  'tilt_ultimate_deg':d['ultimate_tilt_deg_upper'],
+  'failures':f},sort_keys=True))
+ return int(bool(f))
 if __name__=='__main__':raise SystemExit(main())

--- a/tools/stability/ou3_brmm_private_mahony_live_invariant.py
+++ b/tools/stability/ou3_brmm_private_mahony_live_invariant.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validated all-Live PI invariant for the private Mahony observer at a_m<=8.
+"""Validated all-Live PI invariant for the private Mahony observer.
 
 The widened BRMM source permits large instantaneous orbital acceleration, so the
 old proof that treated the normalized gravity-direction error as an arbitrary
@@ -23,6 +23,14 @@ quadratic metric P=R^T R is used at sqrt(C)=1.21. A rational stereographic
 cover of the boundary, outward interval arithmetic, and the endpoint sector
 s in [sinc(87 deg),1] prove strict inward flow. The actual tilt is recovered
 as theta=z_theta-0.1 xi and remains strictly below the 87 degree proof chart.
+
+The first-sample accelerometer seed angle is the source's own instantaneous
+gravity-direction angle `asin(||a_ng||/g)`, taken from the qualification module
+rather than frozen as a constant. At the padded 8.8 m/s^2 envelope that seed is
+1.1137 rad, and this certificate reports fail-closed: the level needed to
+contain the seed and the largest level that still fits inside the 87 degree
+chart form an empty window, so no level of this fixed metric closes the
+invariant for the padded family. See `admissible_level_window` in the output.
 """
 from __future__ import annotations
 import argparse,json,math
@@ -38,7 +46,6 @@ SCHEMA=2
 QUALIFICATION='OU3_BRMM_PRIVATE_MAHONY_ALL_LIVE_PI_INVARIANT_V2'
 P11=1.0;P12=-6.5;P22=163.25;DET_P=121.0
 SQRT_C=1.21;C_LEVEL=SQRT_C*SQRT_C
-INITIAL_TILT_RAD_UPPER=0.955
 CELLS_PER_CHART=8192
 
 def I(x):return Interval.outward_bounds(float(x),float(x))
@@ -52,13 +59,20 @@ def _source_constants(domain):
   'bias_transport':float(s['effective_deterministic_bias_transport_disturbance_upper_rad_s2']),
   'initial_bias':float(s['initial_tangent_gyro_bias_norm_upper_rad_s']),
   'mean_chord':float(q['mean_direction_chord_norm_upper']),'xi':float(q['direction_primitive_norm_upper_s']),
-  'chart_deg':float(q['private_mahony_proof_chart_deg']),'instant_chord':float(q['instantaneous_direction_chord_upper'])}
+  'chart_deg':float(q['private_mahony_proof_chart_deg']),'instant_chord':float(q['instantaneous_direction_chord_upper']),
+  'seed_tilt':float(q['instantaneous_direction_angle_upper_rad'])}
 
 def _direction_bounds(c):
- rho=I(c['a_ng'])/I(c['g']);sin_seed=VT.sin_point(INITIAL_TILT_RAD_UPPER)
+ # The seed angle is the source's own instantaneous gravity-direction angle.
+ # The check is now a cross-verification: the validated sine of the derived seed
+ # must enclose rho=||a_ng||/g, i.e. the seed really is asin(rho) and not a
+ # constant that has fallen behind the padded envelope.
+ rho=I(c['a_ng'])/I(c['g']);seed=c['seed_tilt'];sin_seed=VT.sin_point(seed)
  return {'rho_a_over_g':rho.as_list(),'instantaneous_direction_chord_upper':c['instant_chord'],
-  'initial_seed_tilt_rad_upper':INITIAL_TILT_RAD_UPPER,'sin_initial_seed_bound':sin_seed.as_list(),
-  'initial_seed_angle_closed':sin_seed.lo>rho.hi,'mean_direction_chord_norm_upper':c['mean_chord'],
+  'initial_seed_tilt_rad_upper':seed,'initial_seed_tilt_deg_upper':math.degrees(seed),
+  'sin_initial_seed_bound':sin_seed.as_list(),
+  'initial_seed_angle_closed':sin_seed.lo<=rho.hi and sin_seed.hi>=rho.lo,
+  'mean_direction_chord_norm_upper':c['mean_chord'],
   'direction_primitive_norm_upper_s':c['xi'],'same_history_decomposition_retained':True}
 
 def _sector_lower(chart_deg):
@@ -95,9 +109,16 @@ def _verify_boundary(c,sector_lower):
 
 def build():
  domain=json.loads(DOMAIN.read_text());wrapper=WRAPPER.read_text();c=_source_constants(domain);direction=_direction_bounds(c);sector=_sector_lower(c['chart_deg'])
- zth=INITIAL_TILT_RAD_UPPER+0.1*c['xi'];zb=c['initial_bias']+0.01*c['xi']
+ zth=c['seed_tilt']+0.1*c['xi'];zb=c['initial_bias']+0.01*c['xi']
  initial_metric_upper=P11*zth*zth+2*abs(P12)*zth*zb+P22*zb*zb;initial_inside=initial_metric_upper<C_LEVEL
  ztheta_sq=C_LEVEL*P22/DET_P;theta_upper=math.sqrt(ztheta_sq)+0.1*c['xi'];chart_rad=math.radians(c['chart_deg']);chart_contained=theta_upper<chart_rad
+ # Largest level whose z-theta projection still fits strictly inside the chart.
+ chart_level_upper=((chart_rad-0.1*c['xi'])**2)*DET_P/P22
+ window={'level_lower_required_to_contain_seed':initial_metric_upper,
+  'level_upper_allowed_by_proof_chart':chart_level_upper,
+  'declared_level_C':C_LEVEL,
+  'window_nonempty':initial_metric_upper<chart_level_upper,
+  'emptiness_factor':initial_metric_upper/chart_level_upper}
  boundary=_verify_boundary(c,sector.lo)
  parity={'deployed_two_kp_0p2':'STARTUP_PROXY_TWO_KP_DEFAULT = 0.2f;' in wrapper,'deployed_two_ki_0p02':'STARTUP_PROXY_TWO_KI_DEFAULT = 0.02f;' in wrapper,'first_sample_accelerometer_seed':True}
  closed=bool(direction['initial_seed_angle_closed'] and direction['same_history_decomposition_retained'] and initial_inside and chart_contained and boundary['closed'])
@@ -106,6 +127,7 @@ def build():
   'deployed_gain_parity':parity,'BRMM_direction_geometry':direction,'chart_deg':c['chart_deg'],'sector_sinc_lower':sector.as_list(),
   'metric_P':[[P11,P12],[P12,P22]],'metric_det':DET_P,'metric_cholesky_R':[[1.0,-6.5],[0.0,11.0]],'invariant_level_C':C_LEVEL,'sqrt_C':SQRT_C,
   'transformed_state':'z=x-B*xi','initial_metric_upper':initial_metric_upper,'initial_set_inside_invariant':initial_inside,
+  'admissible_level_window':window,
   'z_tilt_projection_sq_upper':ztheta_sq,'actual_tilt_rad_upper':theta_upper,'actual_tilt_deg_upper':math.degrees(theta_upper),'chart_radius_rad':chart_rad,
   'invariant_strictly_inside_87deg_chart':chart_contained,'invariant_strictly_inside_60deg_chart':False,'boundary_validation':boundary,
   'continuous_all_live_PI_invariant_closed':closed,'shipping_binary32_discrete_invariant_closed':False,'complete_BRMM_family_materialized_here':False,'P3_promoted':False,
@@ -117,7 +139,11 @@ def validate(d):
  for k in ('same_BRMM_specific_force_direction_required','same_BRMM_gyro_bias_forcing_required','same_history_direction_primitive_required','initial_set_inside_invariant','invariant_strictly_inside_87deg_chart','continuous_all_live_PI_invariant_closed'):
   if d.get(k) is not True:f.append(k+' is not true')
  if not all(d.get('deployed_gain_parity',{}).values()):f.append('deployed Mahony gain parity failed')
- if d.get('BRMM_direction_geometry',{}).get('initial_seed_angle_closed') is not True:f.append('initial seed angle not closed')
+ g=d.get('BRMM_direction_geometry',{})
+ if g.get('initial_seed_angle_closed') is not True:f.append('initial seed angle not closed')
+ wnd=d.get('admissible_level_window',{})
+ if wnd.get('window_nonempty') is not True:
+  f.append('no metric level contains the seed inside the proof chart (emptiness factor %.6f)'%float(wnd.get('emptiness_factor',float('nan'))))
  b=d.get('boundary_validation',{})
  if b.get('closed') is not True or not float(b.get('strict_inward_margin_lower',-1))>0:f.append('Mahony boundary did not close')
  if not float(d.get('actual_tilt_deg_upper',180))<87.0:f.append('actual tilt leaves proof chart')

--- a/tools/stability/ou3_fast_inv_sqrt_interval.py
+++ b/tools/stability/ou3_fast_inv_sqrt_interval.py
@@ -172,7 +172,12 @@ def validate(d: dict) -> list[str]:
         if d.get(key) is not True: failures.append(f"{key} is not true")
     for key in ("historical_4mps2_force_shell_used","ideal_inverse_sqrt_substituted","compiler_reassociation_or_FMA_closed","P3_promoted"):
         if d.get(key) is not False: failures.append(f"{key} is not false")
-    if float(d.get('normalization_shell_checks',{}).get('declared_non_gravitational_acceleration_cap_mps2',0))!=8.0: failures.append('physical force shell is not for 8 m/s^2')
+    # The cap is read from the operating domain by _physical_force_norm_bounds,
+    # so the check must track the declared padded envelope rather than pin the
+    # retired 8.0 m/s^2 surface.
+    declared=float(json.loads(DOMAIN.read_text(encoding='utf-8'))['normal_live']['non_gravitational_cog_acceleration_norm_upper_mps2'])
+    if float(d.get('normalization_shell_checks',{}).get('declared_non_gravitational_acceleration_cap_mps2',0))!=declared:
+        failures.append(f'physical force shell is not for the declared {declared} m/s^2 cap')
     return failures
 
 

--- a/tools/stability/ou3_vector_uco_certificate.py
+++ b/tools/stability/ou3_vector_uco_certificate.py
@@ -12,7 +12,14 @@ restricted to the following *operating-envelope hypothesis*:
 
 * each proof packet has nonzero specific-force and magnetic vectors;
 * their sine separation is at least 0.01 (about 0.57 deg);
-* body rate over the two-packet interval is at most 30 deg/s.
+* body rate over the two-packet interval is at most the padded COMPLETE-BRMM
+  ceiling of 35 deg/s.
+
+The body-rate hypothesis is bound to
+``ou3_brmm_complete_physical_envelope.BODY_RATE_NORM_MAX_DEG_S`` so that it
+cannot silently fall behind the padded physical envelope again.  It previously
+carried the unpadded 30 deg/s reference value, which made every declared
+COMPLETE-BRMM PE domain fail to refine this certificate.
 
 The norm floor is only 1e-3 in physical units.  The magnetic value is no stronger
 than the wrapper's own ``mag_init_min_mag_norm`` guard, and the acceleration
@@ -49,6 +56,7 @@ import re
 # Imported for its side effect: the contract module validates the source
 # domain at import time.
 import ou3_source_domain_contract as SOURCE  # noqa: F401
+import ou3_brmm_complete_physical_envelope as ENVELOPE
 
 REPO = Path(__file__).resolve().parents[2]
 WRAPPER = REPO / "src" / "kalman_ou_iii" / "SeaStateFusionFilter_OU_III.h"
@@ -61,7 +69,10 @@ SCHEMA = 1
 PE = {
     "specific_force_norm_lower_mps2": 1.0e-3,
     "vector_sine_separation_lower": 1.0e-2,
-    "body_rate_norm_upper_deg_s": 30.0,
+    # The padded COMPLETE-BRMM body-rate ceiling, not the unpadded 30 deg/s
+    # reference: a declared source domain may not exceed this certificate's own
+    # hypothesis, so the hypothesis must admit the whole padded family.
+    "body_rate_norm_upper_deg_s": ENVELOPE.BODY_RATE_NORM_MAX_DEG_S,
     "gyro_bias_time_scale_s": 1.0,
 }
 


### PR DESCRIPTION
## Research question

Can the new magnetometer theorem assumptions, so far used only on the ALT route, close the non-ALT (BRMM) route? ALT is not touched.

**Answer: no.** The magnetic *algebra* works, but every route to supplying it is now blocked by a quantified obstruction, and one of them is an exact impossibility. Along the way the padded-envelope startup obstruction is closed, which revives a large amount of dead proof machinery.

## Closed

**1. `declared PE does not refine vector certificate`** (open item 1 in the handover). A padding omission, not an enclosure defect: `ou3_vector_uco_certificate.PE` carried the *unpadded* `REFERENCE_BODY_RATE_DEG_S = 30.0` while every declared COMPLETE-BRMM domain carries the padded `BODY_RATE_NORM_MAX_DEG_S = 35.0`, so the refinement test fired on every call. The PE hypothesis is now bound to the envelope constant. Quantitative permission checked first: the two-packet bracket moves `0.98953 -> 0.98778`, `alpha_6` loses 0.353 %, declared `alpha6 = 1.0605504334607669e-4 > 0`, and `H18_information_lambda_min_lower` is unchanged at `4.253919518541475e-18`.

**2. Named magnetic classes on the non-ALT route**, own modules, no ALT import:

- `MAG-BMM150-DET-v1` — `20 <= ||B_W|| <= 75 uT`, horizontal `>= 15 uT`, `||b_HI|| <= 5 uT`, `||n_m|| <= 2 uT`, for `m_body = R_true B_W + b_HI + n_m`. `Rmag` is never a deterministic bound.
- `MAG-CALL-SCHEDULE-v1` — first post-Live `updateMag()` call `<= 0.04 s`, later gaps `<= 0.04 s` (25 Hz).

Closed by them: the declared magnetic PE band becomes a *consequence* (`||m_body||` in `[13, 82] uT`, so the declared 10/200 uT bounds follow and the shipping `mag_init_min_mag_norm` guard clears unconditionally); the startup yaw **algebra** (`|sin(theta_yaw)| <= 17/30`, `theta_yaw < 0.61 rad`, full attitude `< 0.63 rad = 36.0962 deg`, inside the declared 45 deg entrance set, no `1/sqrt(N)`); and the `H18 -> A21` release time **after north lock** (`<= 10.0 s`, by a case split on whether the 250-count or the strict 1 s guard binds last).

**3. Padded-envelope chart retention** — the startup obstruction, closed.

The single-level formulation was infeasible: with the seed angle read from the source's own `asin(8.8/9.80665) = 1.1137 rad` instead of the stale `0.955` constant, seed containment needed `C >= 1.8540056` while the 87 deg chart allowed `C < 1.4912551`. The boundary flow still closed with margin `0.0357940`, so the *formulation* was at fault.

The fix comes from noticing that in

```
dot(V) = C y'(M+M')y + 2 sqrt(C) y'Rw = -sqrt(C) [ sqrt(C) q - 2 sup ]
```

`q` and `sup` are **level-independent**. So inward flow is a *lower* bound on the level and holds on *every* level above `W_in = 2 sup_max/q_min` — not only on one certified boundary. One metric can then carry two nested levels with split roles. With `p=3, c=11` (`P=[[1,-3],[-3,130]]`, `det=121`):

| quantity | value |
|---|---|
| seed ≤ outer < chart ceiling | `1.6707881129` ≤ `1.7689` < `1.8726722863` |
| chart headroom | `5.5414 %` |
| outer / inner boundary margin | `0.0262974` / `0.0134738` |
| `q_min`, `sup_max`, `W_in` | `0.0387576`, `0.0166247`, `0.8578833` |
| capture rate, time constant | `0.0193788 /s`, `51.6029 s` |
| tilt: ultimate / 150 s / all-time | `56.6779` / `58.2102` / `84.7161 deg` |

The outer level is forward invariant and contains the seed, so the observer never leaves the chart; `W = sqrt(V)` obeys `dot(W) <= -(q_min/2)(W - W_in)`, so the state enters the inner level exponentially. The all-time number replaces a meaningless level radius of `86.2567 deg`.

**The dependent chain closes again**: the source-order binary32/discrete charge (`discrete_V_margin_lower = 1.518757e-4`), the frontend transition, `ou3_startup_timeout_capture` (branch margin `4.1379 deg`), and `ou3_p4_brmm_frontend_predecessor_invariant` — the `invariant` CI check that was red on `main`.

## The blockers

### A. The tilt floor is an exact impossibility

The private observer **cannot** supply the magnetic gates, and this is a property of the whole formulation rather than of a metric choice. The certificate quantifies over the sector value `s` as an independent parameter in `[sinc(87 deg), 1]`, so its conclusion must also hold for `s = 1`, where the deployed gains give

```
theta/r = -(0.01 + 0.1 j w) / (0.01 s - w^2 + 0.1 s j w)
```

An admitted primitive-bounded sinusoid `r = j w xi` gives `|theta| = w |theta/r| |xi|`, and that response **peaks inside the declared physical band** — at `0.117 rad/s = 0.0186 Hz` against `[0.018, 0.88] Hz` — contributing `0.14678877 rad`. Superposing an admitted DC mean chord on the linear `z`-dynamics adds `0.05 rad`. So no metric, level, or subdivision depth can certify a tilt below **`0.19678877 rad = 11.2752 deg`**, against `2.8378 deg` (binding) and `6.1145 deg` (north capture): shortfall `3.9732x` and `1.8440x`.

Certified supply for the record: all-time `84.7161 deg` (`29.8528x` / `13.8551x`), asymptotic `56.6779 deg` (`19.9725x` / `9.2695x`). The certified tilt alone exceeds the declared 45 deg entrance by `1.8826x`, so no yaw gauge, however accurate, repairs the entrance from this supply. A non-promoting `(p,c)` scan found nothing below about `41 deg`, so the static quadratic class is exhausted well short of the floor.

### B. The accumulation frame turns with the vessel

`tiltOnlyQuatFromBoatQuat_` strips the *estimator's* yaw, not the boat's — which is exactly why the gauge returns north *relative to the boat*. A legal heading excursion during the window rotates accepted samples in the horizontal plane and smears the mean; a large enough turn cancels its horizontal component. The parameter is therefore the **total** accumulation-frame rotation excursion `delta_tilt + delta_heading`, and nothing declared bounds the heading part. `DECLARED_SUPPLY_ENTRANCE_CLOSED` is **false**; the algebra survives as `magnetic_algebra_closed`.

### C. North lock gates the A21 release too

The only call site of the counter-owning inner method is `if (mag_ref_set_ && stage_ == Stage::Live) { impl_.updateMag(...); }`, so a host call schedule does not advance `mag_updates_applied_` until north lock, and on the admitted ungauged timeout path it never advances at all. `H18_A21_RELEASE_TIME_CLOSED_FROM_LIVE` is false. **The yaw gauge and the A21 release share one unmet prerequisite.**

### Also open

`MAG-BMM150-DET-v1` as declared does not force universal per-sample admission at `max_sample_norm_ratio_from_mean = 0.35` (needs `P <= 7 Bmin/47 = 2.9787 uT` against a declared `7 uT`); the `0.1` vector sine separation is not derivable from the class; the 150 s timeout branch still hands off with no yaw gauge; eventual A21 under an arbitrary external `acc_bias_hold_` is not claimed; and the `H18 -> A21` joint24 covariance transport is untouched.

## The payoff: the magnetic-envelope route is viable and quantified

The gates depend on `Bmax` and `H_min`, not on tilt alone (`E <= (H - f Bmax)/(1+f)` with `E = P + 2 Bmax sin(delta/2)`). At the `11.2752 deg` floor:

| `||B_W||` ceiling | required horizontal floor |
| --- | --- |
| 45 uT | 18.8833 uT |
| 55 uT | 21.4462 uT |
| 65 uT | 24.0092 uT |
| 75 uT | 26.5721 uT |

Every row is feasible within its own total field, so a commissioned mid-latitude class such as `||B_W|| <= 55 uT` with horizontal `>= 21.4462 uT` **would** force the gates — at the cost of excluding polar and very-strong-field installations. Remaining: a non-quadratic tilt certificate near the floor (an **IQC on the primitive channel**, since the obstruction is a frequency peak a static metric cannot see), that band narrowing, and a heading-excursion supply.

## Corrections made in this PR

Claims that were unsound and are retracted in place, with the retraction itself asserted in tests and CI:

1. the yaw/entrance certificate charged only tilt error into `E`, leaving a legal heading excursion uncharged (blocker B above);
2. the release certificate inferred the strict `> 1 s` guard from `(n-1)*gap_max`, an *upper* bound on elapsed time — 250 calls 1 ms apart clear the count at `0.249 s` with the shipping predicate still false;
3. the release certificate read parity from the *inner* method and missed the outer north-lock gate on its single call site (blocker C above);
4. the discrete Mahony charge claimed `2*sqrt(C)*margin` of first-order decrease where the derivation gives **one** factor of `sqrt(C)`; it also hardcoded the retired Cholesky row and now reads the metric from the continuous certificate;
5. an earlier `10.0855 deg` tilt floor used the sector value at the chart edge rather than at the small equilibrium and was not a defensible lower bound; replaced by the frequency-response argument above;
6. the four shipping-parity flags compared loose token presence and could stay green through a semantic change to the branch they certify; each now compares the complete assignment or condition.

Items 1–3 came from review (Codex P1, P2); each was verified against the shipping source before changing anything.

## Not changed

No shipping filter change, no quality-gate change, no replay or trajectory fitting, no statistical concentration, no operating-domain reduction to obtain PASS. P3 `delta` stays `1e-18`. `P4_PASS = false` and `P5_MAY_START = false`. ALT untouched.

## Validation

- After the review fixes: **72 tests, OK** across the magnetic certificates, the two-phase certificate, the discrete/binary32 charge, state-step, and the package-integrity/cleanup/naming/domain-contract gates. The magnetic suite alone is 24 tests.
- The `source-foundation` check's exact test list: **93 tests, OK**.
- Both workflows' inline assertions were executed locally against the real artifacts.
- `ruff check` clean on every added and modified file; the repo-wide count drops 127 → 126.
- No C/C++/Makefile change, so `make all` is not implicated.

**Pre-existing failures fixed here** because each blocked a check and each was the same class-D padding omission: `repository_total_Hs_upper_m` (`9.35` vs an assertion pinned to `8.5`, blocking `source-foundation`) and the `8.0 m/s^2` force-shell cap in `ou3_fast_inv_sqrt_interval` (blocking `complete-brmm-source`, despite that module declaring `physical_force_shell_derived_from_operating_domain`).

**Pre-existing and not addressed**: the repo-wide `ruff` gate (`python`) is red on `main` at 127 findings, and one P4 entry module fails with `qualified fresh-entry source failed` — a different root cause outside this PR's research question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZYyUKhvHchYViTdkfYexL